### PR TITLE
add option to prefer locally installed binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,14 @@
   ],
   "dependencies": {
     "cross-spawn-async": "^2.1.1",
+    "npm-run-path": "^1.0.0",
     "object-assign": "^4.0.1",
+    "path-key": "^1.0.0",
     "strip-eof": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",
+    "cat-names": "^1.0.2",
     "xo": "*"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@
 - Supports [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) binaries cross-platform.
 - [Improved Windows support.](https://github.com/IndigoUnited/node-cross-spawn-async#why)
 - Higher max buffer. 10 MB instead of 200 KB.
+- [Executes locally installed binaries by name.](#preferlocal)
 
 
 ## Install
@@ -76,10 +77,18 @@ Additional exposed options:
 
 #### stripEof
 
-Type: `boolean`  
+Type: `boolean`<br>
 Default: `true`
 
 [Strip EOF](https://github.com/sindresorhus/strip-eof) (last newline) from the output.
+
+#### preferLocal
+
+Type: `boolean`<br>
+Default: `true`
+
+Prefer locally installed binaries when looking for a binary to execute.<br>
+If you `$ npm install foo`, you can then `execa('foo')`.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -21,12 +21,22 @@ test('stdout/stderr available on errors', async t => {
 	}
 });
 
+test('execa.shell()', async t => {
+	const {stdout} = await fn.shell('echo foo');
+	t.is(stdout, 'foo');
+});
+
 test('stripEof option', async t => {
 	const {stdout} = await fn('echo', ['foo'], {stripEof: false});
 	t.is(stdout, 'foo\n');
 });
 
-test('execa.shell()', async t => {
-	const {stdout} = await fn.shell('echo foo');
-	t.is(stdout, 'foo');
+test.serial('preferLocal option', async t => {
+	t.true((await fn('cat-names')).stdout.length > 2);
+
+	// account for npm adding local binaries to the PATH
+	const _path = process.env.PATH;
+	process.env.PATH = '';
+	await t.throws(fn('cat-names', {preferLocal: false}), /spawn cat-names ENOENT/);
+	process.env.PATH = _path;
 });


### PR DESCRIPTION
This enables you to `execa('foo')` if you `$ npm install foo` it.

Some open questions:

- Should it be enabled by default? That would really be the nicest solution, but not sure about the consequences and whether there are some downsides I haven't thought of.
- What should the option be named? I would like something better than current. Put your bikeshedding hats on.