### PR TITLE
Add `all` property to returned object

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+'use strict';
+
+process.stdout.write('1');
+process.stderr.write('2');
+process.stdout.write('3');

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 'use strict';
-var childProcess = require('child_process');
 var crossSpawnAsync = require('cross-spawn-async');
 var stripEof = require('strip-eof');
 var objectAssign = require('object-assign');
 var npmRunPath = require('npm-run-path');
 var pathKey = require('path-key')();
+var spawn = require('cross-spawn-async');
 var TEN_MEBIBYTE = 1024 * 1024 * 10;
 
 module.exports = function (cmd, args, opts) {
@@ -40,7 +40,7 @@ module.exports = function (cmd, args, opts) {
 		var all = '';
 		var out = '';
 		var err = '';
-		var spawned = childProcess.spawn(parsed.command, parsed.args, parsed.options);
+		var spawned = spawn(parsed.command, parsed.args, parsed.options);
 
 		spawned.stdout.setEncoding('utf8');
 		spawned.stderr.setEncoding('utf8');

--- a/index.js
+++ b/index.js
@@ -42,14 +42,17 @@ module.exports = function (cmd, args, opts) {
 		var err = '';
 		var spawned = childProcess.spawn(parsed.command, parsed.args, parsed.options);
 
+		spawned.stdout.setEncoding('utf8');
+		spawned.stderr.setEncoding('utf8');
+
 		spawned.stdout.on('data', function (data) {
-			out += data.toString();
-			all += data.toString();
+			out += data;
+			all += data;
 		});
 
 		spawned.stderr.on('data', function (data) {
-			err += data.toString();
-			all += data.toString();
+			err += data;
+			all += data;
 		});
 
 		spawned.on('error', function (error) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "local"
   ],
   "dependencies": {
-    "cross-spawn-async": "^2.1.1",
+    "cross-spawn-async": "^2.1.9",
     "npm-run-path": "^1.0.0",
     "object-assign": "^4.0.1",
     "path-key": "^1.0.0",

--- a/test.js
+++ b/test.js
@@ -51,7 +51,7 @@ test('all option gathers output in order', async t => {
 	t.is(all, '123');
 });
 
-test('all options gathers output in order on shell command', async t => {
-	const {all} = await m.shell('>&2 echo error; echo foo');
-	t.is(all, 'error\nfoo');
-});
+// test('all options gathers output in order on shell command', async t => {
+// 	const {all} = await m.shell('>&2 echo error; echo foo');
+// 	t.is(all, 'error\nfoo');
+// });

--- a/test.js
+++ b/test.js
@@ -12,12 +12,13 @@ test('buffer', async t => {
 	t.is(stdout.toString(), 'foo');
 });
 
-test('stdout/stderr available on errors', async t => {
+test('stdout/stderr/all available on errors', async t => {
 	try {
 		await m('exit', ['2']);
 	} catch (err) {
 		t.is(typeof err.stdout, 'string');
 		t.is(typeof err.stdout, 'string');
+		t.is(typeof err.all, 'string');
 	}
 });
 
@@ -43,4 +44,9 @@ test.serial('preferLocal option', async t => {
 	process.env.PATH = '';
 	await t.throws(m('cat-names', {preferLocal: false}), /spawn cat-names ENOENT/);
 	process.env.PATH = _path;
+});
+
+test('all', async t => {
+	const {all} = await m('./fixture.js');
+	t.is(all, '123');
 });

--- a/test.js
+++ b/test.js
@@ -51,7 +51,7 @@ test('all option gathers output in order', async t => {
 	t.is(all, '123');
 });
 
-// test('all options gathers output in order on shell command', async t => {
-// 	const {all} = await m.shell('>&2 echo error; echo foo');
-// 	t.is(all, 'error\nfoo');
-// });
+test('all options gathers output in order on shell command', async t => {
+	const {all} = await m.shell('rm a; head -n1 license');
+	t.is(all, 'rm: a: No such file or directory\nThe MIT License (MIT)');
+});

--- a/test.js
+++ b/test.js
@@ -46,7 +46,12 @@ test.serial('preferLocal option', async t => {
 	process.env.PATH = _path;
 });
 
-test('all', async t => {
+test('all option gathers output in order', async t => {
 	const {all} = await m('./fixture.js');
 	t.is(all, '123');
+});
+
+test('all options gathers output in order on shell command', async t => {
+	const {all} = await m.shell('>&2 echo error; echo foo');
+	t.is(all, 'error\nfoo');
 });


### PR DESCRIPTION
This fixes #1 by returning an additional `all` property that is just the `stderr` and `stdout` together, updating the readme, and adding two tests that test this feature.