### PR TITLE
Fix execa.shell on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,20 @@ var TEN_MEBIBYTE = 1024 * 1024 * 10;
 
 module.exports = function (cmd, args, opts) {
 	return new Promise(function (resolve, reject) {
-		var parsed = crossSpawnAsync._parse(cmd, args, opts);
+		var parsed;
+
+		if (opts && opts.__winShell === true) {
+			delete opts.__winShell;
+			parsed = {
+				command: cmd,
+				args: args,
+				options: opts,
+				file: cmd,
+				original: cmd
+			};
+		} else {
+			parsed = crossSpawnAsync._parse(cmd, args, opts);
+		}
 
 		opts = objectAssign({
 			maxBuffer: TEN_MEBIBYTE,
@@ -58,6 +71,7 @@ module.exports.shell = function (cmd, opts) {
 	opts = objectAssign({}, opts);
 
 	if (process.platform === 'win32') {
+		opts.__winShell = true;
 		file = process.env.comspec || 'cmd.exe';
 		args = ['/s', '/c', '"' + cmd + '"'];
 		opts.windowsVerbatimArguments = true;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ module.exports = function (cmd, args, opts) {
 	return new Promise(function (resolve, reject) {
 		var parsed;
 
-		if (opts && process.platform === 'win32') {
+		if (opts && opts.__winShell === true) {
+			delete opts.__winShell;
 			parsed = {
 				command: cmd,
 				args: args,
@@ -70,6 +71,7 @@ module.exports.shell = function (cmd, opts) {
 	opts = objectAssign({}, opts);
 
 	if (process.platform === 'win32') {
+		opts.__winShell = true;
 		file = process.env.comspec || 'cmd.exe';
 		args = ['/s', '/c', '"' + cmd + '"'];
 		opts.windowsVerbatimArguments = true;

--- a/index.js
+++ b/index.js
@@ -10,8 +10,7 @@ module.exports = function (cmd, args, opts) {
 	return new Promise(function (resolve, reject) {
 		var parsed;
 
-		if (opts && opts.__winShell === true) {
-			delete opts.__winShell;
+		if (opts && process.platform === 'win32') {
 			parsed = {
 				command: cmd,
 				args: args,
@@ -71,7 +70,6 @@ module.exports.shell = function (cmd, opts) {
 	opts = objectAssign({}, opts);
 
 	if (process.platform === 'win32') {
-		opts.__winShell = true;
 		file = process.env.comspec || 'cmd.exe';
 		args = ['/s', '/c', '"' + cmd + '"'];
 		opts.windowsVerbatimArguments = true;


### PR DESCRIPTION
When you're trying pass `cmd` as command and command as one of the arguments into the `crossSpawnAsync._parse` it makes some terrible things.

Because [`crossSpawnAsync._parse`](https://github.com/IndigoUnited/node-cross-spawn-async/blob/master/lib/parse.js#L111-L112) also adds command as one of the arguments and then uses `cmd` as the command.

After all these steps, this:
C:\Windows\system32\cmd.exe /s /c "echo unicorns"
turns to this:
C:\Windows\system32\cmd.exe /s /c ""C:\Windows\system32\cmd.exe" "/s" "/c" "\"echo unicorns\"""

This PR fix it and closes #8.