### PR TITLE
add `execa.stdout()` shortcut

### DIFF
--- a/fixtures/noop-err
+++ b/fixtures/noop-err
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+'use strict';
+console.error(process.argv[2]);

--- a/index.js
+++ b/index.js
@@ -123,6 +123,20 @@ module.exports = function (cmd, args, opts) {
 	return spawned;
 };
 
+module.exports.stdout = function () {
+	// TODO: set `stderr: 'ignore'` when that option is implemented
+	return module.exports.apply(null, arguments).then(function (x) {
+		return x.stdout;
+	});
+};
+
+module.exports.stderr = function () {
+	// TODO: set `stdout: 'ignore'` when that option is implemented
+	return module.exports.apply(null, arguments).then(function (x) {
+		return x.stderr;
+	});
+};
+
 module.exports.shell = function (cmd, opts) {
 	return handleShell(module.exports, cmd, opts);
 };

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,14 @@ Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#c
 
 The `child_process` instance is enhanced to also be promise for a result object with `stdout` and `stderr` properties.
 
+### execa.stdout(file, [arguments], [options])
+
+Same as `execa()`, but returns only `stdout`.
+
+### execa.stderr(file, [arguments], [options])
+
+Same as `execa()`, but returns only `stderr`.
+
 ### execa.shell(command, [options])
 
 Execute a command through the system shell. Prefer `execa()` whenever possible, as it's both faster and safer.

--- a/test.js
+++ b/test.js
@@ -17,6 +17,16 @@ test('buffer', async t => {
 	t.is(stdout.toString(), 'foo');
 });
 
+test('execa.stdout()', async t => {
+	const stdout = await m.stdout('noop', ['foo']);
+	t.is(stdout, 'foo');
+});
+
+test('execa.stderr()', async t => {
+	const stderr = await m.stderr('noop-err', ['foo']);
+	t.is(stderr, 'foo');
+});
+
 test('stdout/stderr available on errors', async t => {
 	const err = await t.throws(m('exit', ['2']));
 	t.is(typeof err.stdout, 'string');


### PR DESCRIPTION
Not sure about this one. The thinking is that stdout is the most common use-case so might be nice to have a shortcut for it. This is not about the amount of characters, as that's mostly the same, but rather clarity.

Example:

```js
test(async t => {
	t.is((await execa('./cli.js')).stdout, 'foo');
});
```

```js
test(async t => {
	t.is(await execa.stdout('./cli.js'), 'foo');
});
```

You can see how the second one is more readable because of less parens.

-

@kevva @SamVerschueren @jamestalmage @novemberborn Could use your opion 🙌