### PR TITLE
[DO NOT MERGE]: proof of concept - #14 alternative

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,19 @@ function handleShell(fn, cmd, opts) {
 	return fn(file, args, opts);
 }
 
+function extendPromise(promise, property) {
+	Object.defineProperty(promise, property, {
+		configurable: true,
+		get: function () {
+			var value = promise.then(function (result) {
+				return result[property];
+			});
+			Object.defineProperty(promise, property, {value: value});
+			return value;
+		}
+	});
+}
+
 module.exports = function (cmd, args, opts) {
 	var spawned;
 
@@ -119,6 +132,9 @@ module.exports = function (cmd, args, opts) {
 
 	promise.kill = spawned.kill.bind(spawned);
 	promise.pid = spawned.pid;
+
+	extendPromise(promise, 'stdout');
+	extendPromise(promise, 'stderr');
 
 	return promise;
 };

--- a/test.js
+++ b/test.js
@@ -103,6 +103,16 @@ test('helpful error trying to provide an input stream in sync mode', t => {
 	);
 });
 
+test('stdout is attached as a promise for the property', async t => {
+	const stdout = await m('stdin', [], {input: 'hello'}).stdout;
+	t.is(stdout, 'hello');
+});
+
+test('still works the other way', async t => {
+	const {stdout} = await m('stdin', [], {input: 'hello'});
+	t.is(stdout, 'hello');
+});
+
 test('execa() returns a promise with kill() and pid', t => {
 	const promise = m('noop', ['foo']);
 	t.is(typeof promise.kill, 'function');


### PR DESCRIPTION
Implements an alternative to #14.

This conflicts with #18, since there would be a namespace conflict for `stdin`, `stdout`, etc, if we did this.

If we think #18 is valuable, then #14 is the better solution for shortcutting access to `stdin` (because it does not conflict)..