### PR TITLE
return the child process instead of a promise.

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,10 +117,10 @@ module.exports = function (cmd, args, opts) {
 		handleInput(spawned, parsed.opts);
 	});
 
-	promise.kill = spawned.kill.bind(spawned);
-	promise.pid = spawned.pid;
+	spawned.then = promise.then.bind(promise);
+	spawned.catch = promise.catch.bind(promise);
 
-	return promise;
+	return spawned;
 };
 
 module.exports.shell = function (cmd, opts) {

--- a/readme.md
+++ b/readme.md
@@ -61,9 +61,9 @@ Execute a file.
 
 Same options as [`child_process.execFile`](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback).
 
-Returns a promise for a result object with `stdout` and `stderr` properties.
+Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess).
 
-The promise instance has a `pid` property (ID of the child process) and a `kill` method (for sending signals to the child process).
+The `child_process` instance is enhanced to also be promise for a result object with `stdout` and `stderr` properties.
 
 ### execa.shell(command, [options])
 
@@ -71,9 +71,9 @@ Execute a command through the system shell. Prefer `execa()` whenever possible, 
 
 Same options as [`child_process.exec`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback).
 
-Returns a promise for a result object with `stdout` and `stderr` properties.
+Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess).
 
-The promise instance has a `pid` property (ID of the child process) and a `kill` method (for sending signals to the child process).
+The `child_process` instance is enhanced to also be promise for a result object with `stdout` and `stderr` properties.
 
 ### execa.spawn(file, [arguments], [options])
 

--- a/test.js
+++ b/test.js
@@ -86,6 +86,12 @@ test('input can be a Stream', async t => {
 	t.is(stdout, 'howdy');
 });
 
+test('you can write to child.stdin', async t => {
+	const child = m('stdin');
+	child.stdin.end('unicorns');
+	t.is((await child).stdout, 'unicorns');
+});
+
 test('input option can be a String - sync', async t => {
 	const stdout = m.sync('stdin', {input: 'foobar'});
 	t.is(stdout, 'foobar');


### PR DESCRIPTION
We are guessing at the desired properties of the child-process object.

Instead, why not just copy over `.then` and `.catch` from the promise to `spawned` and return that.

This would allow stuff like this:

```js
var spawned = execa('./cli.js');
spawned.stdin.write('foo');
spawned.stdin.end();

const {stdout} = await spawned;
```