### PR TITLE
[BREAKING] for consistency return a result object from `execa.sync()` instead of string - fixes #19

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,9 +143,14 @@ module.exports.sync = function (cmd, args, opts) {
 		throw new TypeError('The `input` option cannot be a stream in sync mode');
 	}
 
-	var out = childProcess.execFileSync(parsed.cmd, parsed.args, parsed.opts);
+	var result = childProcess.spawnSync(parsed.cmd, parsed.args, parsed.opts);
 
-	return handleOutput(parsed.opts, out);
+	if (parsed.opts.stripEof) {
+		result.stdout = stripEof(result.stdout);
+		result.stderr = stripEof(result.stderr);
+	}
+
+	return result;
 };
 
 module.exports.shellSync = function (cmd, opts) {

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ Execute a file synchronously.
 
 Same options as [`child_process.execFileSync`](https://nodejs.org/api/child_process.html#child_process_child_process_execfilesync_file_args_options), except the default encoding is `utf8` instead of `buffer`.
 
-Returns `stdout`.
+Returns the same result object as [`child_process.spawnSync`](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options).
 
 ### execa.shellSync(file, [options])
 
@@ -95,7 +95,7 @@ Execute a command synchronously through the system shell.
 
 Same options as [`child_process.execSync`](https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options), except the default encoding is `utf8` instead of `buffer`.
 
-Returns `stdout`.
+Returns the same result object as [`child_process.spawnSync`](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options).
 
 ### options
 

--- a/test.js
+++ b/test.js
@@ -39,12 +39,12 @@ test('execa.spawn()', async t => {
 });
 
 test('execa.sync()', t => {
-	const stdout = m.sync('noop', ['foo']);
+	const {stdout} = m.sync('noop', ['foo']);
 	t.is(stdout, 'foo');
 });
 
 test('execa.shellSync()', t => {
-	const stdout = m.shellSync('node fixtures/noop foo');
+	const {stdout} = m.shellSync('node fixtures/noop foo');
 	t.is(stdout, 'foo');
 });
 
@@ -87,12 +87,12 @@ test('input can be a Stream', async t => {
 });
 
 test('input option can be a String - sync', async t => {
-	const stdout = m.sync('stdin', {input: 'foobar'});
+	const {stdout} = m.sync('stdin', {input: 'foobar'});
 	t.is(stdout, 'foobar');
 });
 
 test('input option can be a Buffer - sync', async t => {
-	const stdout = m.sync('stdin', {input: new Buffer('testing12', 'utf8')});
+	const {stdout} = m.sync('stdin', {input: new Buffer('testing12', 'utf8')});
 	t.is(stdout, 'testing12');
 });
 


### PR DESCRIPTION
Includes commits from #18, so avoid merging until after that is, and I can rebase.