### PR TITLE
Use spawn instead of execFile

### DIFF
--- a/fixtures/error-message.js
+++ b/fixtures/error-message.js
@@ -2,4 +2,4 @@
 'use strict';
 console.log('stdout');
 console.error('stderr');
-process.exit(1);
+process.exit(2);

--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ module.exports.shell = function (cmd, opts) {
 	return handleShell(module.exports, cmd, opts);
 };
 
-module.exports.spawn = util.deprecate(module.exports, 'execa.spawn: just use execa instead.');
+module.exports.spawn = util.deprecate(module.exports, 'execa.spawn() is deprecated. Use execa() instead.');
 
 module.exports.sync = function (cmd, args, opts) {
 	var parsed = handleArgs(cmd, args, opts);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var childProcess = require('child_process');
+var util = require('util');
 var crossSpawnAsync = require('cross-spawn-async');
 var stripEof = require('strip-eof');
 var objectAssign = require('object-assign');
@@ -179,14 +180,7 @@ module.exports.shell = function (cmd, opts) {
 	return handleShell(module.exports, cmd, opts);
 };
 
-module.exports.spawn = function (cmd, args, opts) {
-	var parsed = handleArgs(cmd, args, opts);
-	var spawned = childProcess.spawn(parsed.cmd, parsed.args, parsed.opts);
-
-	crossSpawnAsync._enoent.hookChildProcess(spawned, parsed);
-
-	return spawned;
-};
+module.exports.spawn = util.deprecate(module.exports, 'execa.spawn: just use execa instead.');
 
 module.exports.sync = function (cmd, args, opts) {
 	var parsed = handleArgs(cmd, args, opts);

--- a/index.js
+++ b/index.js
@@ -205,10 +205,8 @@ module.exports.sync = function (cmd, args, opts) {
 
 	var result = childProcess.spawnSync(parsed.cmd, parsed.args, parsed.opts);
 
-	if (parsed.opts.stripEof) {
-		result.stdout = stripEof(result.stdout);
-		result.stderr = stripEof(result.stderr);
-	}
+	result.stdout = handleOutput(parsed.opts, result.stdout);
+	result.stderr = handleOutput(parsed.opts, result.stderr);
 
 	return result;
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   ],
   "dependencies": {
     "cross-spawn-async": "^2.1.1",
+    "get-stream": "^2.0.0",
     "is-stream": "^1.1.0",
     "npm-run-path": "^1.0.0",
     "object-assign": "^4.0.1",
@@ -55,7 +56,6 @@
     "ava": "*",
     "cat-names": "^1.0.2",
     "coveralls": "^2.11.9",
-    "get-stream": "^2.0.0",
     "nyc": "^6.4.0",
     "xo": "*"
   }

--- a/test.js
+++ b/test.js
@@ -34,7 +34,7 @@ test('stdout/stderr available on errors', async t => {
 });
 
 test('include stdout in errors for improved debugging', async t => {
-	const err = await t.throws(m('./fixtures/error-message.js'));
+	const err = await t.throws(m('fixtures/error-message.js'));
 	t.regex(err.message, /stdout/);
 });
 

--- a/test.js
+++ b/test.js
@@ -35,7 +35,7 @@ test('stdout/stderr available on errors', async t => {
 
 test('include stdout in errors for improved debugging', async t => {
 	const err = await t.throws(m('./fixtures/error-message.js'));
-	t.true(err.message.indexOf('stdout') !== -1);
+	t.regex(err.message, /stdout/);
 });
 
 test('execa.shell()', async t => {

--- a/test.js
+++ b/test.js
@@ -112,6 +112,11 @@ test('input option can be a Buffer - sync', async t => {
 	t.is(stdout, 'testing12');
 });
 
+test('opts.stdout:ignore - stdout will not collect data', async t => {
+	const {stdout} = await m('stdin', {input: 'hello', stdio: [null, 'ignore', null]});
+	t.is(stdout, null);
+});
+
 test('helpful error trying to provide an input stream in sync mode', t => {
 	t.throws(
 		() => m.sync('stdin', {input: new stream.PassThrough()}),


### PR DESCRIPTION
childProcess.execFile pays no attention `opts.stdio`. This means users can't set `stdio` options when calling `exca()`. You can set `stdio` options when calling `execa.spawn()`, but that does not return a promise.

Rather than having two separate methods `execa()` and `execa.spawn()` - I think we should work towards a single method that allows you to configure how it behaves via `stdio` options. `opts.stdio` or `opts.stdin`, etc; Those should determine whether or not the stream is buffered and made part of the promise result, or if they are just streamed (or sent to an Observable), or ignored. 

To that end, I've reimplemented much of the functionality of `child_process.execFile`. `execFile` is really just a wrapper around `spawn` anyways. It's main utility is that in concats `stdio` and `stdout`. Which is pretty easy for us to achieve on our own using `get-stream`.

This simplifies the API as we can pretty much deprecate `execa.spawn()`. And it offers more control over the behavior as well. Want to use streams/observables for `stdout` because you know it will contain lots of data and you don't want to waste memory buffering? Would it be nice if it still buffered `stderr` for you though? This makes that doable.

Remaining items to be feature complete with execFile:
- [ ] timeout support (should be easy to add back).
- [ ] errname resolution. See TODO note on that. I'm not sure we want to use `process.bind('uv')`. I don't really know what it does.
- [ ] some stream cleanup code (see childProces.execFile's internal `kill` method. It calls `stream.destroy()`. I am not sure how that will affect `get-stream`)
- [ ] add a bunch of tests around the logic copied out of child_process. The new code has nearly 100% coverage, but that's deceptive. Most of these aren't terribly consequential (Error properties: `message`, `killed`, `code`, etc).

Going forward, we'll still need to bikeshed on a few API details, like instead of just `ignore`, `pipe` and `inherit`, we should add `buffer` and `observable`.
