### PR TITLE
reimplement errname lookup.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var npmRunPath = require('npm-run-path');
 var isStream = require('is-stream');
 var _getStream = require('get-stream');
 var pathKey = require('path-key')();
+var errname = require('./lib/errname');
 var TEN_MEBIBYTE = 1024 * 1024 * 10;
 
 function handleArgs(cmd, args, opts) {
@@ -159,10 +160,7 @@ module.exports = function (cmd, args, opts) {
 				// err.killed = spawned.killed || killed;
 				err.killed = spawned.killed;
 
-				// TODO: child_process applies the following logic for resolving the code:
-				// var uv = process.bind('uv');
-				// ex.code = code < 0 ? uv.errname(code) : code;
-				err.code = code;
+				err.code = code < 0 ? errname(code) : code;
 			}
 
 			err.stdout = stdout;

--- a/lib/errname.js
+++ b/lib/errname.js
@@ -1,0 +1,38 @@
+'use strict';
+// The Node team wants to deprecate `process.bind(...)`.
+//   https://github.com/nodejs/node/pull/2768
+//
+// However, we need the 'uv' binding for errname support.
+// This is a defensive wrapper around it so `execa` will not fail entirely if it stops working someday.
+//
+// If this ever stops working. See: https://github.com/sindresorhus/execa/issues/31#issuecomment-215939939 for another possible solution.
+var uv;
+
+try {
+	uv = process.binding('uv');
+	if (typeof uv.errname !== 'function') {
+		throw new Error('uv.errname is not a function');
+	}
+} catch (e) {
+	console.error('execa/lib/errname: unable to establish process.binding("uv")', e);
+	uv = null;
+}
+
+function errname(uv, code) {
+	if (uv) {
+		return uv.errname(code);
+	}
+
+	if (!(code < 0)) {
+		throw new Error('err >= 0');
+	}
+
+	return 'UNKNOWN CODE: ' + code;
+}
+
+module.exports = function getErrname(code) {
+	return errname(uv, code);
+};
+
+// used for testing the fallback behavior.
+module.exports._test = errname;

--- a/lib/errname.js
+++ b/lib/errname.js
@@ -10,11 +10,12 @@ var uv;
 
 try {
 	uv = process.binding('uv');
+
 	if (typeof uv.errname !== 'function') {
 		throw new Error('uv.errname is not a function');
 	}
-} catch (e) {
-	console.error('execa/lib/errname: unable to establish process.binding("uv")', e);
+} catch (err) {
+	console.error('execa/lib/errname: unable to establish process.binding(\'uv\')', err);
 	uv = null;
 }
 
@@ -27,7 +28,7 @@ function errname(uv, code) {
 		throw new Error('err >= 0');
 	}
 
-	return 'UNKNOWN CODE: ' + code;
+	return 'Unknown system error ' + code;
 }
 
 module.exports = function getErrname(code) {
@@ -35,4 +36,4 @@ module.exports = function getErrname(code) {
 };
 
 // used for testing the fallback behavior.
-module.exports._test = errname;
+module.exports.__test__ = errname;

--- a/test/errname.js
+++ b/test/errname.js
@@ -1,8 +1,8 @@
-import os from 'os';
 import test from 'ava';
 import errname from '../lib/errname';
 
-const isWin = os.platform() === 'win32';
+const isWin = process.platform === 'win32';
+const majorVersion = Number(process.version.substr(1).split('.')[0]);
 
 // simulates failure to capture process.binding('uv');
 function fallback(code) {
@@ -10,16 +10,21 @@ function fallback(code) {
 }
 
 function makeTests(name, m, expected) {
-	test(name, t => {
+	test(`${name}: >=0 exit codes`, t => {
 		// throws >= 0
 		t.throws(() => m(0), /err >= 0/);
 		t.throws(() => m(1), /err >= 0/);
 		t.throws(() => m('2'), /err >= 0/);
 		t.throws(() => m('foo'), /err >= 0/);
-
-		t.is(m(-2), expected);
-		t.is(m('-2'), expected);
 	});
+
+	if (!(isWin && majorVersion < 1)) {
+		// causes process.exit() on Node 0.12 for Windows.
+		test(`${name}: negative exit codes`, t => {
+			t.is(m(-2), expected);
+			t.is(m('-2'), expected);
+		});
+	}
 }
 
 const unknown = 'Unknown system error -2';

--- a/test/errname.js
+++ b/test/errname.js
@@ -1,0 +1,23 @@
+import test from 'ava';
+import errname from '../lib/errname';
+
+// simulates failure to capture process.binding('uv');
+function fallback(code) {
+	return errname._test(null, code);
+}
+
+function makeTests(name, m, expected) {
+	test(name, t => {
+		// throws >= 0
+		t.throws(() => m(0), /err >= 0/);
+		t.throws(() => m(1), /err >= 0/);
+		t.throws(() => m('2'), /err >= 0/);
+		t.throws(() => m('foo'), /err >= 0/);
+
+		t.is(m(-2), expected);
+		t.is(m('-2'), expected);
+	});
+}
+
+makeTests('native', errname, 'ENOENT');
+makeTests('fallback', fallback, 'UNKNOWN CODE: -2');

--- a/test/errname.js
+++ b/test/errname.js
@@ -1,9 +1,12 @@
+import os from 'os';
 import test from 'ava';
 import errname from '../lib/errname';
 
+const isWin = os.platform() === 'win32';
+
 // simulates failure to capture process.binding('uv');
 function fallback(code) {
-	return errname._test(null, code);
+	return errname.__test__(null, code);
 }
 
 function makeTests(name, m, expected) {
@@ -19,5 +22,7 @@ function makeTests(name, m, expected) {
 	});
 }
 
-makeTests('native', errname, 'ENOENT');
-makeTests('fallback', fallback, 'UNKNOWN CODE: -2');
+const unknown = 'Unknown system error -2';
+
+makeTests('native', errname, isWin ? unknown : 'ENOENT');
+makeTests('fallback', fallback, unknown);


### PR DESCRIPTION
Fixes #31

I can not for the life of me figure out how to create a test that actually triggers the affected code in `index.js`. I can't create a negative error code in a way that causes `!err` to be true.