### PR TITLE
`cross-spawn-async` => `cross-spawn`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 var childProcess = require('child_process');
 var util = require('util');
-var crossSpawnAsync = require('cross-spawn-async');
+var crossSpawn = require('cross-spawn');
 var stripEof = require('strip-eof');
 var objectAssign = require('object-assign');
 var npmRunPath = require('npm-run-path');
@@ -24,7 +24,7 @@ function handleArgs(cmd, args, opts) {
 			original: cmd
 		};
 	} else {
-		parsed = crossSpawnAsync._parse(cmd, args, opts);
+		parsed = crossSpawn._parse(cmd, args, opts);
 	}
 
 	opts = objectAssign({
@@ -183,7 +183,7 @@ module.exports = function (cmd, args, opts) {
 		};
 	});
 
-	crossSpawnAsync._enoent.hookChildProcess(spawned, parsed);
+	crossSpawn._enoent.hookChildProcess(spawned, parsed);
 
 	handleInput(spawned, parsed.opts);
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "local"
   ],
   "dependencies": {
-    "cross-spawn-async": "^2.1.1",
+    "cross-spawn": "^3.0.0",
     "get-stream": "^2.2.0",
     "is-stream": "^1.1.0",
     "npm-run-path": "^1.0.0",


### PR DESCRIPTION
The synchronous stuff was removed from `cross-spawn` as of `3.0.0` so we should be able to use that package now without having to worry about the build toolchain upon install that `spawnSync` needed.