### PR TITLE
add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ node_js:
   - '5'
   - '4'
   - '0.12'
-after_success: npm run coveralls
+after_script:
+  - 'cat coverage/lcov.info | ./node_modules/.bin/coveralls'

--- a/fixtures/fail
+++ b/fixtures/fail
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+process.exit(2);

--- a/fixtures/forever
+++ b/fixtures/forever
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+'use strict';
+
+setTimeout(function () {}, 20000);

--- a/index.js
+++ b/index.js
@@ -163,13 +163,13 @@ module.exports = function (cmd, args, opts) {
 			if (!err) {
 				err = new Error('Command failed: ' + joinedCmd + '\n' + stderr + stdout);
 
-				// TODO: missing some timeout logic for killed
-				// https://github.com/nodejs/node/blob/master/lib/child_process.js#L203
-				// err.killed = spawned.killed || killed;
-				err.killed = spawned.killed;
-
 				err.code = code < 0 ? errname(code) : code;
 			}
+
+			// TODO: missing some timeout logic for killed
+			// https://github.com/nodejs/node/blob/master/lib/child_process.js#L203
+			// err.killed = spawned.killed || killed;
+			err.killed = err.killed || spawned.killed;
 
 			err.stdout = stdout;
 			err.stderr = stderr;

--- a/index.js
+++ b/index.js
@@ -135,6 +135,12 @@ function processDone(spawned) {
 }
 
 module.exports = function (cmd, args, opts) {
+	var joinedCmd = cmd;
+
+	if (Array.isArray(args) && args.length) {
+		joinedCmd += ' ' + args.join(' ');
+	}
+
 	var parsed = handleArgs(cmd, args, opts);
 	var encoding = parsed.opts.encoding;
 	var maxBuffer = parsed.opts.maxBuffer;
@@ -154,12 +160,6 @@ module.exports = function (cmd, args, opts) {
 		var signal = result.signal;
 
 		if (err || code !== 0 || signal !== null) {
-			var joinedCmd = cmd;
-
-			if (Array.isArray(args) && args.length) {
-				joinedCmd += ' ' + args.join(' ');
-			}
-
 			if (!err) {
 				err = new Error('Command failed: ' + joinedCmd + '\n' + stderr + stdout);
 
@@ -174,6 +174,8 @@ module.exports = function (cmd, args, opts) {
 			err.stdout = stdout;
 			err.stderr = stderr;
 			err.failed = true;
+			err.signal = signal || null;
+			err.cmd = joinedCmd;
 
 			if (!parsed.opts.reject) {
 				return err;
@@ -186,7 +188,10 @@ module.exports = function (cmd, args, opts) {
 			stdout: handleOutput(parsed.opts, stdout),
 			stderr: handleOutput(parsed.opts, stderr),
 			code: 0,
-			failed: false
+			failed: false,
+			killed: false,
+			signal: null,
+			cmd: joinedCmd
 		};
 	});
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=0.12"
   },
   "scripts": {
-    "test": "xo && nyc ava --serial"
+    "test": "xo && nyc ava"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=0.12"
   },
   "scripts": {
-    "test": "xo && nyc ava"
+    "test": "xo && nyc ava --serial"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "node": ">=0.12"
   },
   "scripts": {
-    "test": "xo && nyc ava",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls"
+    "test": "xo && nyc ava"
   },
   "files": [
     "index.js",
@@ -59,5 +58,16 @@
     "coveralls": "^2.11.9",
     "nyc": "^6.4.0",
     "xo": "*"
+  },
+  "nyc": {
+    "reporter": [
+      "text",
+      "lcov"
+    ],
+    "exclude": [
+      "**/fixtures/**",
+      "**/test.js",
+      "**/test/**"
+    ]
   }
 }

--- a/test.js
+++ b/test.js
@@ -5,8 +5,6 @@ import test from 'ava';
 import getStream from 'get-stream';
 import m from './';
 
-const isWindows = process.platform === 'win32';
-
 process.env.PATH = path.join(__dirname, 'fixtures') + path.delimiter + process.env.PATH;
 
 test('execa()', async t => {
@@ -193,7 +191,7 @@ test('err.killed is false if process was killed indirectly', async t => {
 	t.false(err.killed);
 });
 
-if (!isWindows) {
+if (process.platform === 'darwin') {
 	test.cb('sanity check: child_process.exec also has killed.false if killed indirectly', t => {
 		const cp = childProcess.exec('forever', err => {
 			t.truthy(err);
@@ -205,7 +203,9 @@ if (!isWindows) {
 			process.kill(cp.pid, 'SIGINT');
 		}, 100);
 	});
+}
 
+if (process.platform !== 'win32') {
 	test('err.signal is SIGINT', async t => {
 		const cp = m('forever');
 

--- a/test.js
+++ b/test.js
@@ -195,7 +195,7 @@ test('err.killed is false if process was killed indirectly', async t => {
 
 if (!isWindows) {
 	test.cb('sanity check: child_process.exec also has killed.false if killed indirectly', t => {
-		const cp = childProcess.exec(process.execPath, [path.join(__dirname, 'fixtures', 'forever')], err => {
+		const cp = childProcess.exec('forever', err => {
 			t.truthy(err);
 			t.false(err.killed);
 			t.end();

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import stream from 'stream';
+import childProcess from 'child_process';
 import test from 'ava';
 import getStream from 'get-stream';
 import m from './';
@@ -33,9 +34,10 @@ test('stdout/stderr available on errors', async t => {
 	t.is(typeof err.stderr, 'string');
 });
 
-test('include stdout in errors for improved debugging', async t => {
+test('include stdout and stderr in errors for improved debugging', async t => {
 	const err = await t.throws(m('fixtures/error-message.js'));
 	t.regex(err.message, /stdout/);
+	t.regex(err.message, /stderr/);
 });
 
 test('execa.shell()', async t => {
@@ -163,3 +165,110 @@ test(`use relative path with '..' chars`, async t => {
 	const {stdout} = await m(pathViaParentDir, ['foo']);
 	t.is(stdout, 'foo');
 });
+
+test('err.killed is true if process was killed directly', async t => {
+	const cp = m('forever');
+
+	setTimeout(function () {
+		cp.kill();
+	}, 100);
+
+	const err = await t.throws(cp);
+
+	t.true(err.killed);
+});
+
+// TODO: Should this really be the case, or should we improve on child_process?
+test('err.killed is false if process was killed indirectly', async t => {
+	const cp = m('forever');
+
+	setTimeout(function () {
+		process.kill(cp.pid, 'SIGINT');
+	}, 100);
+
+	const err = await t.throws(cp);
+
+	t.false(err.killed);
+});
+
+test.cb('sanity check: child_process.exec also has killed.false if killed indirectly', t => {
+	const cp = childProcess.exec(path.join(__dirname, 'fixtures', 'forever'), err => {
+		t.truthy(err);
+		t.false(err.killed);
+		t.end();
+	});
+
+	setTimeout(function () {
+		process.kill(cp.pid, 'SIGINT');
+	}, 100);
+});
+
+test('err.signal is SIGINT', async t => {
+	const cp = m('forever');
+
+	setTimeout(function () {
+		process.kill(cp.pid, 'SIGINT');
+	}, 100);
+
+	const err = await t.throws(cp);
+
+	t.is(err.signal, 'SIGINT');
+});
+
+test('err.signal is SIGTERM', async t => {
+	const cp = m('forever');
+
+	setTimeout(function () {
+		process.kill(cp.pid, 'SIGTERM');
+	}, 100);
+
+	const err = await t.throws(cp);
+
+	t.is(err.signal, 'SIGTERM');
+});
+
+test('result.signal is null for successful execution', async t => {
+	t.is((await m('noop')).signal, null);
+});
+
+test('result.signal is null if process failed, but was not killed', async t => {
+	const err = await t.throws(m('exit', [2]));
+	t.is(err.signal, null);
+});
+
+async function code(t, num) {
+	const err = await t.throws(m('exit', [`${num}`]));
+
+	t.is(err.code, num);
+}
+
+test('err.code is 1', code, 1);
+test('err.code is 2', code, 2);
+test('err.code is 3', code, 3);
+
+async function errorMessage(t, expected, ...args) {
+	const err = await t.throws(m('exit', args));
+
+	t.regex(err.message, expected);
+}
+
+errorMessage.title = (message, expected) => `err.message matches: ${expected}`;
+
+test(errorMessage, /Command failed: exit 1 foo bar/, 1, 'foo', 'bar');
+test(errorMessage, /Command failed: exit 2 baz quz/, 2, 'baz', 'quz');
+
+async function cmd(t, expected, ...args) {
+	const err = await t.throws(m('fail', args));
+
+	t.is(err.cmd, `fail${expected}`);
+
+	const result = await m('noop', args);
+
+	t.is(result.cmd, `noop${expected}`);
+}
+
+cmd.title = (message, expected) => `cmd is: ${JSON.stringify(expected)}`;
+
+test(cmd, ' foo bar', 'foo', 'bar');
+test(cmd, ' baz quz', 'baz', 'quz');
+test(cmd, '');


### PR DESCRIPTION
Fixes #34

- Adds some tests for functionality copied from `child_process` in #27.
- Normalises the result and error objects further. Each now has `killed`, `signal` and `cmd` properties.
- NYC was not ignoring the `fixtures` directory. Fixed that, and configured nyc in package.json instead of via CLI.