### PR TITLE
Throw error in sync method - fixes #66

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,6 +231,10 @@ module.exports.sync = (cmd, args, opts) => {
 
 	const result = childProcess.spawnSync(parsed.cmd, parsed.args, parsed.opts);
 
+	if (result.error || result.status !== 0) {
+		throw (result.error || new Error(result.stderr === '' ? result.stdout : result.stderr));
+	}
+
 	result.stdout = handleOutput(parsed.opts, result.stdout);
 	result.stderr = handleOutput(parsed.opts, result.stderr);
 

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,8 @@ Same options as [`child_process.execFileSync`](https://nodejs.org/api/child_proc
 
 Returns the same result object as [`child_process.spawnSync`](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options).
 
+This method throws an `Error` if the command fails.
+
 ### execa.shellSync(file, [options])
 
 Execute a command synchronously through the system shell.

--- a/test.js
+++ b/test.js
@@ -57,6 +57,10 @@ test('execa.sync()', t => {
 	t.is(stdout, 'foo');
 });
 
+test('execa.sync() throws error if written to stderr', t => {
+	t.throws(() => m.sync('foo'), process.platform === 'win32' ? /'foo' is not recognized as an internal or external command/ : 'spawnSync foo ENOENT');
+});
+
 test('execa.shellSync()', t => {
 	const {stdout} = m.shellSync('node fixtures/noop foo');
 	t.is(stdout, 'foo');


### PR DESCRIPTION
This should fix #66 by throwing an `Error` object if something is written to `stderr`. Also added a test for this.