### PR TITLE
Reimplement stream cleanup behavior from node core. Fixes #32

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "get-stream": "^2.2.0",
     "is-stream": "^1.1.0",
     "npm-run-path": "^2.0.0",
+    "p-finally": "^1.0.0",
     "signal-exit": "^3.0.0",
     "strip-eof": "^1.0.0"
   },


### PR DESCRIPTION
I'm not sure how to write a meaningful test for this, as I'm not sure how to end a process without the streams also being destroyed for me.