### PR TITLE
Add localDir option to specify location of locally installed binaries

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,13 +32,14 @@ function handleArgs(cmd, args, opts) {
 		maxBuffer: TEN_MEGABYTES,
 		stripEof: true,
 		preferLocal: true,
+		localDir: parsed.options.cwd || process.cwd(),
 		encoding: 'utf8',
 		reject: true,
 		cleanup: true
 	}, parsed.options);
 
 	if (opts.preferLocal) {
-		opts.env = npmRunPath.env(opts);
+		opts.env = npmRunPath.env(Object.assign({}, opts, {cwd: opts.localDir}));
 	}
 
 	return {

--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,13 @@ Default: `true`
 Prefer locally installed binaries when looking for a binary to execute.<br>
 If you `$ npm install foo`, you can then `execa('foo')`.
 
+#### localDir
+
+Type: `string`<br>
+Default: `process.cwd()`
+
+Preferred path to find locally installed binaries in (use with `preferLocal`).
+
 #### input
 
 Type: `string` `Buffer` `ReadableStream`


### PR DESCRIPTION
closes #72
- add localDir option that is passed to `npmRunPath`