### PR TITLE
Fix `spawn undefined ENOENT` bug in Windows - fixes #35

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ function handleArgs(cmd, args, opts) {
 	return {
 		cmd: parsed.command,
 		args: parsed.args,
-		opts
+		opts,
+		parsed
 	};
 }
 
@@ -240,7 +241,7 @@ module.exports = (cmd, args, opts) => {
 		};
 	}), destroy);
 
-	crossSpawn._enoent.hookChildProcess(spawned, parsed);
+	crossSpawn._enoent.hookChildProcess(spawned, parsed.parsed);
 
 	handleInput(spawned, parsed.opts);
 


### PR DESCRIPTION
This should fix #35.

Tests will fail, will rebase once #77 is merged.

// @jamestalmage @kevva