### PR TITLE
Fix test for exit code 1 on windows

### DIFF
--- a/fixtures/error-message.js
+++ b/fixtures/error-message.js
@@ -2,4 +2,4 @@
 'use strict';
 console.log('stdout');
 console.error('stderr');
-process.exit(2);
+process.exit(1);

--- a/test.js
+++ b/test.js
@@ -40,6 +40,7 @@ test('include stdout and stderr in errors for improved debugging', async t => {
 	const err = await t.throws(m('fixtures/error-message.js'));
 	t.regex(err.message, /stdout/);
 	t.regex(err.message, /stderr/);
+	t.is(err.code, 1);
 });
 
 test('execa.shell()', async t => {


### PR DESCRIPTION
The error code was bumped in https://github.com/sindresorhus/execa/pull/27#issuecomment-215011451 because it caused the `spawn undefined ENOENT`. So I reverted it back and tested the error code as well in the test.

// @schnittstabil