### PR TITLE
Do not output stderr and stdout on stdio inherit - fixes #70

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,8 @@ module.exports = (cmd, args, opts) => {
 
 		if (err || code !== 0 || signal !== null) {
 			if (!err) {
-				err = new Error(`Command failed: ${joinedCmd}\n${stderr}${stdout}`);
+				const output = parsed.opts.stdio === 'inherit' ? '' : `\n${stderr}${stdout}`;
+				err = new Error(`Command failed: ${joinedCmd}${output}`);
 				err.code = code < 0 ? errname(code) : code;
 			}
 

--- a/test.js
+++ b/test.js
@@ -42,6 +42,11 @@ test('include stdout and stderr in errors for improved debugging', async t => {
 	t.regex(err.message, /stderr/);
 });
 
+test('do not include in errors when `stdio` is set to `inherit`', async t => {
+	const err = await t.throws(m('fixtures/error-message.js', {stdio: 'inherit'}));
+	t.notRegex(err.message, /\\n/);
+});
+
 test('execa.shell()', async t => {
 	const {stdout} = await m.shell('node fixtures/noop foo');
 	t.is(stdout, 'foo');


### PR DESCRIPTION
Fixes #70 by not outputting `stderr` and `stdout` when `stdio` is set to `inherit`.