### PR TITLE
Make killed property true regardless of how it was killed - fixes #52

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,6 +163,7 @@ module.exports = (cmd, args, opts) => {
 
 	const processDone = new Promise(resolve => {
 		spawned.on('exit', (code, signal) => {
+			spawned.killed = signal !== null;
 			cleanupTimeout();
 			resolve({code, signal});
 		});

--- a/test.js
+++ b/test.js
@@ -233,8 +233,19 @@ test('err.killed is true if process was killed directly', async t => {
 	t.true(err.killed);
 });
 
-// TODO: Should this really be the case, or should we improve on child_process?
-test('err.killed is false if process was killed indirectly', async t => {
+test('err.killed is true if process was killed indirectly', async t => {
+	const cp = m('forever');
+
+	setTimeout(() => {
+		process.kill(cp.pid);
+	}, 100);
+
+	const err = await t.throws(cp);
+
+	t.true(err.killed);
+});
+
+test('err.killed is false if process was killed indirectly with SIGINT', async t => {
 	const cp = m('forever');
 
 	setTimeout(() => {
@@ -243,7 +254,7 @@ test('err.killed is false if process was killed indirectly', async t => {
 
 	const err = await t.throws(cp);
 
-	t.false(err.killed);
+	t.true(err.killed);
 });
 
 if (process.platform === 'darwin') {


### PR DESCRIPTION
I looked into #52. I really need feedback on this though because I'm not sure if this is 100% correct. My idea is that if the process was exitted with a signal, this means it was killed by something and `killed` should be true.