### PR TITLE
Fix `killSignal` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports = (cmd, args, opts) => {
 		timeoutId = setTimeout(() => {
 			timeoutId = null;
 			timedOut = true;
-			spawned.kill(parsed.killSignal);
+			spawned.kill(parsed.opts.killSignal);
 		}, parsed.opts.timeout);
 	}
 

--- a/test.js
+++ b/test.js
@@ -284,13 +284,13 @@ if (process.platform !== 'win32') {
 
 		t.is(err.signal, 'SIGTERM');
 	});
+
+	test('custom err.signal', async t => {
+		const err = await t.throws(m('delay', ['3000', '0'], {killSignal: 'SIGHUP', timeout: 1500}));
+
+		t.is(err.signal, 'SIGHUP');
+	});
 }
-
-test('custom err.signal', async t => {
-	const err = await t.throws(m('delay', ['3000', '0'], {killSignal: 'SIGHUP', timeout: 1500}));
-
-	t.is(err.signal, 'SIGHUP');
-});
 
 test('result.signal is null for successful execution', async t => {
 	t.is((await m('noop')).signal, null);

--- a/test.js
+++ b/test.js
@@ -286,6 +286,12 @@ if (process.platform !== 'win32') {
 	});
 }
 
+test('custom err.signal', async t => {
+	const err = await t.throws(m('delay', ['3000', '0'], {killSignal: 'SIGHUP', timeout: 1500}));
+
+	t.is(err.signal, 'SIGHUP');
+});
+
 test('result.signal is null for successful execution', async t => {
 	t.is((await m('noop')).signal, null);
 });


### PR DESCRIPTION
`parsed.killSignal` will always be `undefined`.