### PR TITLE
Do not buffer when streams are used - fixes #84

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,13 +267,8 @@ module.exports = (cmd, args, opts) => {
 
 	handleInput(spawned, parsed.opts);
 
-	spawned.then = (onfulfilled, onrejected) => {
-		return handlePromise().then(onfulfilled, onrejected);
-	};
-
-	spawned.catch = onrejected => {
-		return handlePromise().catch(onrejected);
-	};
+	spawned.then = (onfulfilled, onrejected) => handlePromise().then(onfulfilled, onrejected);
+	spawned.catch = onrejected => handlePromise().catch(onrejected);
 
 	return spawned;
 };

--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ module.exports = (cmd, args, opts) => {
 		}
 	}
 
-	const promise = pFinally(Promise.all([
+	const handlePromise = () => pFinally(Promise.all([
 		processDone,
 		getStream(spawned, 'stdout', encoding, maxBuffer),
 		getStream(spawned, 'stderr', encoding, maxBuffer)
@@ -267,8 +267,13 @@ module.exports = (cmd, args, opts) => {
 
 	handleInput(spawned, parsed.opts);
 
-	spawned.then = promise.then.bind(promise);
-	spawned.catch = promise.catch.bind(promise);
+	spawned.then = (onfulfilled, onrejected) => {
+		return handlePromise().then(onfulfilled, onrejected);
+	};
+
+	spawned.catch = onrejected => {
+		return handlePromise().catch(onrejected);
+	};
 
 	return spawned;
 };

--- a/test.js
+++ b/test.js
@@ -448,3 +448,9 @@ test('do not extend environment with `envExtend` option', async t => {
 		'bar'
 	]);
 });
+
+test('do not buffer when streaming', async t => {
+	const result = await getStream(m('max-buffer', ['stdout', '21'], {maxBuffer: 10}).stdout);
+
+	t.is(result, '....................\n');
+});


### PR DESCRIPTION
Alternative implementation to #94. Didn't wrote tests for it yet because I have no time now. Just wanted to get feedback in case I missed something. Guess this should work because the promise is now lazy instead of eager.