### PR TITLE
Fix extending from process.env when no env option is provided - fixes #101

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,16 @@ const TEN_MEGABYTES = 1000 * 1000 * 10;
 function handleArgs(cmd, args, opts) {
 	let parsed;
 
-	if (opts && opts.env && opts.extendEnv !== false) {
+	opts = Object.assign({
+		extendEnv: true,
+		env: {}
+	}, opts);
+
+	if (opts.extendEnv) {
 		opts.env = Object.assign({}, process.env, opts.env);
 	}
 
-	if (opts && opts.__winShell === true) {
+	if (opts.__winShell === true) {
 		delete opts.__winShell;
 		parsed = {
 			command: cmd,

--- a/test.js
+++ b/test.js
@@ -431,6 +431,15 @@ if (process.platform !== 'win32') {
 	});
 }
 
+test('use environment variables by default', async t => {
+	const result = await m.stdout('environment');
+
+	t.deepEqual(result.split('\n'), [
+		'foo',
+		'undefined'
+	]);
+});
+
 test('extend environment variables by default', async t => {
 	const result = await m.stdout('environment', [], {env: {BAR: 'bar'}});
 


### PR DESCRIPTION
Refactored the `opts` checks a little bit so it is more clear on what is going on. Fixes #101