### PR TITLE
Enhance error object in sync methods - fixes #98

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,7 +341,6 @@ module.exports.sync = (cmd, args, opts) => {
 		stderr: handleOutput(parsed.opts, result.stderr),
 		code: 0,
 		failed: false,
-		killed: false,
 		signal: null,
 		cmd: joinedCmd,
 		timedOut: false

--- a/index.js
+++ b/index.js
@@ -128,16 +128,62 @@ function getStream(process, stream, encoding, maxBuffer) {
 	});
 }
 
-module.exports = (cmd, args, opts) => {
+function makeError(result, options) {
+	const stdout = result.stdout;
+	const stderr = result.stderr;
+
+	let err = result.error;
+	const code = result.code;
+	const signal = result.signal;
+
+	const parsed = options.parsed;
+	const joinedCmd = options.joinedCmd;
+	const timedOut = options.timedOut || false;
+
+	if (!err) {
+		let output = '';
+
+		if (Array.isArray(parsed.opts.stdio)) {
+			if (parsed.opts.stdio[2] !== 'inherit') {
+				output += output.length > 0 ? stderr : `\n${stderr}`;
+			}
+
+			if (parsed.opts.stdio[1] !== 'inherit') {
+				output += `\n${stdout}`;
+			}
+		} else if (parsed.opts.stdio !== 'inherit') {
+			output = `\n${stderr}${stdout}`;
+		}
+
+		err = new Error(`Command failed: ${joinedCmd}${output}`);
+		err.code = code < 0 ? errname(code) : code;
+	}
+
+	err.stdout = stdout;
+	err.stderr = stderr;
+	err.failed = true;
+	err.signal = signal || null;
+	err.cmd = joinedCmd;
+	err.timedOut = timedOut;
+
+	return err;
+}
+
+function joinCmd(cmd, args) {
 	let joinedCmd = cmd;
 
 	if (Array.isArray(args) && args.length > 0) {
 		joinedCmd += ' ' + args.join(' ');
 	}
 
+	return joinedCmd;
+}
+
+module.exports = (cmd, args, opts) => {
 	const parsed = handleArgs(cmd, args, opts);
 	const encoding = parsed.opts.encoding;
 	const maxBuffer = parsed.opts.maxBuffer;
+	const joinedCmd = joinCmd(cmd, args);
 
 	let spawned;
 	try {
@@ -179,13 +225,13 @@ module.exports = (cmd, args, opts) => {
 
 		spawned.on('error', err => {
 			cleanupTimeout();
-			resolve({err});
+			resolve({error: err});
 		});
 
 		if (spawned.stdin) {
 			spawned.stdin.on('error', err => {
 				cleanupTimeout();
-				resolve({err});
+				resolve({error: err});
 			});
 		}
 	});
@@ -206,48 +252,24 @@ module.exports = (cmd, args, opts) => {
 		getStream(spawned, 'stderr', encoding, maxBuffer)
 	]).then(arr => {
 		const result = arr[0];
-		const stdout = arr[1];
-		const stderr = arr[2];
-
-		let err = result.err;
-		const code = result.code;
-		const signal = result.signal;
+		result.stdout = arr[1];
+		result.stderr = arr[2];
 
 		if (removeExitHandler) {
 			removeExitHandler();
 		}
 
-		if (err || code !== 0 || signal !== null) {
-			if (!err) {
-				let output = '';
-
-				if (Array.isArray(parsed.opts.stdio)) {
-					if (parsed.opts.stdio[2] !== 'inherit') {
-						output += output.length > 0 ? stderr : `\n${stderr}`;
-					}
-
-					if (parsed.opts.stdio[1] !== 'inherit') {
-						output += `\n${stdout}`;
-					}
-				} else if (parsed.opts.stdio !== 'inherit') {
-					output = `\n${stderr}${stdout}`;
-				}
-
-				err = new Error(`Command failed: ${joinedCmd}${output}`);
-				err.code = code < 0 ? errname(code) : code;
-			}
+		if (result.error || result.code !== 0 || result.signal !== null) {
+			const err = makeError(result, {
+				joinedCmd,
+				parsed,
+				timedOut
+			});
 
 			// TODO: missing some timeout logic for killed
 			// https://github.com/nodejs/node/blob/master/lib/child_process.js#L203
 			// err.killed = spawned.killed || killed;
 			err.killed = err.killed || spawned.killed;
-
-			err.stdout = stdout;
-			err.stderr = stderr;
-			err.failed = true;
-			err.signal = signal || null;
-			err.cmd = joinedCmd;
-			err.timedOut = timedOut;
 
 			if (!parsed.opts.reject) {
 				return err;
@@ -257,8 +279,8 @@ module.exports = (cmd, args, opts) => {
 		}
 
 		return {
-			stdout: handleOutput(parsed.opts, stdout),
-			stderr: handleOutput(parsed.opts, stderr),
+			stdout: handleOutput(parsed.opts, result.stdout),
+			stderr: handleOutput(parsed.opts, result.stderr),
 			code: 0,
 			failed: false,
 			killed: false,
@@ -292,21 +314,38 @@ module.exports.shell = (cmd, opts) => handleShell(module.exports, cmd, opts);
 
 module.exports.sync = (cmd, args, opts) => {
 	const parsed = handleArgs(cmd, args, opts);
+	const joinedCmd = joinCmd(cmd, args);
 
 	if (isStream(parsed.opts.input)) {
 		throw new TypeError('The `input` option cannot be a stream in sync mode');
 	}
 
 	const result = childProcess.spawnSync(parsed.cmd, parsed.args, parsed.opts);
+	result.code = result.status;
 
-	if (result.error || result.status !== 0) {
-		throw (result.error || new Error(result.stderr === '' ? result.stdout : result.stderr));
+	if (result.error || result.status !== 0 || result.signal !== null) {
+		const err = makeError(result, {
+			joinedCmd,
+			parsed
+		});
+
+		if (!parsed.opts.reject) {
+			return err;
+		}
+
+		throw err;
 	}
 
-	result.stdout = handleOutput(parsed.opts, result.stdout);
-	result.stderr = handleOutput(parsed.opts, result.stderr);
-
-	return result;
+	return {
+		stdout: handleOutput(parsed.opts, result.stdout),
+		stderr: handleOutput(parsed.opts, result.stderr),
+		code: 0,
+		failed: false,
+		killed: false,
+		signal: null,
+		cmd: joinedCmd,
+		timedOut: false
+	};
 };
 
 module.exports.shellSync = (cmd, opts) => handleShell(module.exports.sync, cmd, opts);

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,24 @@ execa.shell('exit 3').catch(error => {
 	}
 	*/
 });
+
+// example of catching an error with a sync method
+try {
+	execa.shellSync('exit 3');
+} catch (err) {
+	console.log(err);
+	/*
+	{
+		message: 'Command failed: /bin/sh -c exit 3'
+		code: 3,
+		signal: null,
+		cmd: '/bin/sh -c exit 3',
+		stdout: '',
+		stderr: '',
+		timedOut: false
+	}
+	*/
+}
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -104,9 +104,35 @@ test('execa.sync() throws error if written to stderr', t => {
 	t.throws(() => m.sync('foo'), process.platform === 'win32' ? /'foo' is not recognized as an internal or external command/ : 'spawnSync foo ENOENT');
 });
 
+test('execa.sync() includes stdout and stderr in errors for improved debugging', t => {
+	const err = t.throws(() => m.sync('node', ['fixtures/error-message.js']));
+	t.regex(err.message, /stdout/);
+	t.regex(err.message, /stderr/);
+	t.is(err.code, 1);
+});
+
+test('skip throwing when using reject option in execa.sync()', t => {
+	const err = m.sync('node', ['fixtures/error-message.js'], {reject: false});
+	t.is(typeof err.stdout, 'string');
+	t.is(typeof err.stderr, 'string');
+});
+
 test('execa.shellSync()', t => {
 	const {stdout} = m.shellSync('node fixtures/noop foo');
 	t.is(stdout, 'foo');
+});
+
+test('execa.shellSync() includes stdout and stderr in errors for improved debugging', t => {
+	const err = t.throws(() => m.shellSync('node fixtures/error-message.js'));
+	t.regex(err.message, /stdout/);
+	t.regex(err.message, /stderr/);
+	t.is(err.code, 1);
+});
+
+test('skip throwing when using reject option in execa.shellSync()', t => {
+	const err = m.shellSync('node fixtures/error-message.js', {reject: false});
+	t.is(typeof err.stdout, 'string');
+	t.is(typeof err.stderr, 'string');
 });
 
 test('stripEof option', async t => {


### PR DESCRIPTION
This PR fixes #98 by enhancing the error object in the `sync` methods just like we did in the async methods.

I also believe we should extract the utility functions like `handleArgs`, `handleInput`, ... to a `utils` file or something to make the `index` file a little lighter and easier to process by people.