### PR TITLE
Add fork method - fixes #65

### DIFF
--- a/fixtures/ipc-process
+++ b/fixtures/ipc-process
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+'use strict';
+process.on('message', m => {
+	if (m === 'ping') {
+		process.send('pong');
+	} else {
+		process.send('rainbow');
+	}
+});

--- a/fixtures/ipc-process.js
+++ b/fixtures/ipc-process.js
@@ -1,8 +1,7 @@
-#!/usr/bin/env node
 'use strict';
 process.on('message', m => {
 	if (m === 'ping') {
-		process.send('pong');
+		process.send(process.argv[2] || 'pong');
 	} else {
 		process.send('rainbow');
 	}

--- a/index.js
+++ b/index.js
@@ -278,6 +278,20 @@ module.exports = (cmd, args, opts) => {
 	return spawned;
 };
 
+module.exports.fork = function (cmd, args, opts) {
+	opts = Object.assign({
+		stdio: 'ipc'
+	}, opts);
+
+	if (opts.stdio === 'ipc') {
+		opts.stdio = [0, 1, 2, 'ipc'];
+	}
+
+	// TODO throw `new TypeError('Forked processes must have an IPC channel')` if no IPC channel is provided
+	// TODO throw `new Error('Child process can have only one IPC pipe')` when multiple IPC channels are provided
+	return module.exports(cmd, args, opts);
+};
+
 module.exports.stdout = function () {
 	// TODO: set `stderr: 'ignore'` when that option is implemented
 	return module.exports.apply(null, arguments).then(x => x.stdout);

--- a/test.js
+++ b/test.js
@@ -109,11 +109,30 @@ test('execa.shellSync()', t => {
 	t.is(stdout, 'foo');
 });
 
+test('execa.fork() throws error when no IPC channel is provided', t => {
+	t.throws(() => m.fork('fixtures/ipc-process.js', {stdio: ['pipe']}), 'Forked processes must have an IPC channel');
+});
+
+test('execa.fork() throws error when multiple IPC channels are provided', t => {
+	t.throws(() => m.fork('fixtures/ipc-process.js', {stdio: ['ipc', 'ipc']}), 'Child process can have only one IPC pipe');
+});
+
 test.cb('execa.fork()', t => {
-	const cp = m.fork('fixtures/ipc-process');
+	const cp = m.fork('fixtures/ipc-process.js');
 
 	cp.on('message', m => {
 		t.is(m, 'pong');
+		t.end();
+	});
+
+	cp.send('ping');
+});
+
+test.cb('execa.fork() with arguments', t => {
+	const cp = m.fork('fixtures/ipc-process.js', ['foo']);
+
+	cp.on('message', m => {
+		t.is(m, 'foo');
 		t.end();
 	});
 

--- a/test.js
+++ b/test.js
@@ -109,6 +109,17 @@ test('execa.shellSync()', t => {
 	t.is(stdout, 'foo');
 });
 
+test.cb('execa.fork()', t => {
+	const cp = m.fork('fixtures/ipc-process');
+
+	cp.on('message', m => {
+		t.is(m, 'pong');
+		t.end();
+	});
+
+	cp.send('ping');
+});
+
 test('stripEof option', async t => {
 	const {stdout} = await m('noop', ['foo'], {stripEof: false});
 	t.is(stdout, 'foo\n');


### PR DESCRIPTION
It's a start for the `execa.fork` method. Still need some extra work though but would like some feedback at the initial approach.

One thing I noticed with the `stdio` option of the original `child_process.fork` method is that it looks like it ignores the option whenever it's a string. So passing `ignore` to `stdio` results in `[0, 1, 2, 'ipc']`. Even passing `stdio: 'foo'` results in the same behaviour.