### PR TITLE
Detached child process should not kill child - fixes #115

### DIFF
--- a/fixtures/detach
+++ b/fixtures/detach
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const execa = require('..');
+
+const fd = fs.openSync(process.argv[2], 'w');
+
+const cp = execa('noop', ['foo'], {
+	detached: true,
+	stdio: ['ignore', fd]
+});
+cp.unref();
+
+process.exit();

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function handleArgs(cmd, args, opts) {
 	}
 
 	if (opts.detached) {
-		// https://github.com/sindresorhus/execa/issues/115
+		// #115
 		opts.cleanup = false;
 	}
 

--- a/index.js
+++ b/index.js
@@ -54,6 +54,11 @@ function handleArgs(cmd, args, opts) {
 		opts.env = npmRunPath.env(Object.assign({}, opts, {cwd: opts.localDir}));
 	}
 
+	if (opts.detached) {
+		// https://github.com/sindresorhus/execa/issues/115
+		opts.cleanup = false;
+	}
+
 	return {
 		cmd: parsed.command,
 		args: parsed.args,

--- a/test.js
+++ b/test.js
@@ -489,3 +489,18 @@ test('do not buffer when streaming', async t => {
 
 	t.is(result, '....................\n');
 });
+
+test('detach child process', async t => {
+	const file = tempfile('.txt');
+	const fd = fs.openSync(file, 'w');
+
+	const cp = m('noop', ['foo'], {
+		detached: true,
+		stdio: ['ignore', fd]
+	});
+	cp.unref();
+
+	await delay(5000);
+
+	t.is(fs.readFileSync(file, 'utf8'), 'foo\n');
+});

--- a/test.js
+++ b/test.js
@@ -492,15 +492,10 @@ test('do not buffer when streaming', async t => {
 
 test('detach child process', async t => {
 	const file = tempfile('.txt');
-	const fd = fs.openSync(file, 'w');
 
-	const cp = m('noop', ['foo'], {
-		detached: true,
-		stdio: ['ignore', fd]
-	});
-	cp.unref();
+	await m('detach', [file]);
 
-	await delay(5000);
+	await delay(2000);
 
 	t.is(fs.readFileSync(file, 'utf8'), 'foo\n');
 });


### PR DESCRIPTION
This PR solves #115.

The test however is not 100% representive with the bug because the parent process (the test) is not being killed. This means that even without the fix in `index.js`, the test still passes. I looked into working around this test issue, but couldn't find a way to do it.