### PR TITLE
Increase delay of detached child process

### DIFF
--- a/test.js
+++ b/test.js
@@ -503,7 +503,7 @@ test('detach child process', async t => {
 
 	await m('detach', [file]);
 
-	await delay(2000);
+	await delay(5000);
 
 	t.is(fs.readFileSync(file, 'utf8'), 'foo\n');
 });


### PR DESCRIPTION
I'm not 100% sure, but because it worked in the initial PR and it works on my machine, I believe this is a flaky test. I increased the delay to 5 seconds instead of 2 and I hope it resolves the issue.

We could also introduce something like `pRetry` to have a more solid test.