### PR TITLE
Upgrade cross-spawn

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,10 @@ function handleArgs(cmd, args, opts) {
 			args,
 			options: opts,
 			file: cmd,
-			original: cmd
+			original: {
+				cmd,
+				args
+			}
 		};
 	} else {
 		parsed = crossSpawn._parse(cmd, args, opts);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "local"
   ],
   "dependencies": {
-    "cross-spawn": "^5.0.1",
+    "cross-spawn": "^6.0.0",
     "get-stream": "^3.0.0",
     "is-stream": "^1.1.0",
     "npm-run-path": "^2.0.0",


### PR DESCRIPTION
This PR upgrates to cross-spawn v6, see https://github.com/moxystudio/node-cross-spawn/blob/master/CHANGELOG.md, a courtesy to @sindresorhus.

Some findings:

- There's custom code that handles shell and shellSync but you could use `options.shell` from cross-spawn, which basically does what it's currently being done but is a bit more robust. See: https://github.com/moxystudio/node-cross-spawn/blob/master/lib/parse.js#L66
- Related to the point above, any code handling `__winShell` could be removed

I didn't want to mess up to much but I hope it helps.