### PR TITLE
Avoid relying on Node’s internals

### DIFF
--- a/lib/errname.js
+++ b/lib/errname.js
@@ -1,23 +1,29 @@
 'use strict';
-// The Node team wants to deprecate `process.bind(...)`.
-//   https://github.com/nodejs/node/pull/2768
-//
-// However, we need the 'uv' binding for errname support.
-// This is a defensive wrapper around it so `execa` will not fail entirely if it stops working someday.
-//
-// If this ever stops working. See: https://github.com/sindresorhus/execa/issues/31#issuecomment-215939939 for another possible solution.
+// Older verions of Node might not have `util.getSystemErrorName()`.
+// In that case, fall back to a deprecated internal.
+const util = require('util');
+
 let uv;
 
-try {
-	uv = process.binding('uv');
+if (typeof util.getSystemErrorName === 'function') {
+	module.exports = util.getSystemErrorName;
+} else {
+	try {
+		uv = process.binding('uv');
 
-	if (typeof uv.errname !== 'function') {
-		throw new TypeError('uv.errname is not a function');
+		if (typeof uv.errname !== 'function') {
+			throw new TypeError('uv.errname is not a function');
+		}
+	} catch (err) {
+		console.error('execa/lib/errname: unable to establish process.binding(\'uv\')', err);
+		uv = null;
 	}
-} catch (err) {
-	console.error('execa/lib/errname: unable to establish process.binding(\'uv\')', err);
-	uv = null;
+
+	module.exports = code => errname(uv, code);
 }
+
+// Used for testing the fallback behavior
+module.exports.__test__ = errname;
 
 function errname(uv, code) {
 	if (uv) {
@@ -31,7 +37,3 @@ function errname(uv, code) {
 	return `Unknown system error ${code}`;
 }
 
-module.exports = code => errname(uv, code);
-
-// Used for testing the fallback behavior
-module.exports.__test__ = errname;

--- a/test/errname.js
+++ b/test/errname.js
@@ -9,15 +9,14 @@ const fallback = code => errname.__test__(null, code);
 function makeTests(name, m, expected) {
 	test(`${name}: >=0 exit codes`, t => {
 		// Throws >= 0
-		t.throws(() => m(0), /err >= 0/);
-		t.throws(() => m(1), /err >= 0/);
-		t.throws(() => m('2'), /err >= 0/);
-		t.throws(() => m('foo'), /err >= 0/);
+		t.throws(() => m(0), /err >= 0|It must be a negative integer/);
+		t.throws(() => m(1), /err >= 0|It must be a negative integer/);
+		t.throws(() => m('2'), /err >= 0|must be of type number/);
+		t.throws(() => m('foo'), /err >= 0|must be of type number/);
 	});
 
 	test(`${name}: negative exit codes`, t => {
 		t.is(m(-2), expected);
-		t.is(m('-2'), expected);
 	});
 }
 


### PR DESCRIPTION
`process.binding()` is not a public API, and should
not be used.

Luckily, Node recently introduced an API that does
exactly what execa needs:
https://github.com/nodejs/node/pull/18186

So use that instead and keep the old path as a fallback.