### PR TITLE
Remove exit handler on exit

### DIFF
--- a/test.js
+++ b/test.js
@@ -521,6 +521,6 @@ test('removes exit handler on exit', async t => {
     child.on('exit', resolve);
 	});
 
-	const included = ee.listeners('exit').includes(listener);
+	const included = ee.listeners('exit').indexOf(listener) !== -1;
 	t.false(included);
 });

--- a/test.js
+++ b/test.js
@@ -517,8 +517,8 @@ test('removes exit handler on exit', async t => {
 	const listener = ee.listeners('exit').pop();
 
 	await new Promise((resolve, reject) => {
-    child.on('error', reject);
-    child.on('exit', resolve);
+		child.on('error', reject);
+		child.on('exit', resolve);
 	});
 
 	const included = ee.listeners('exit').indexOf(listener) !== -1;

--- a/test.js
+++ b/test.js
@@ -507,3 +507,20 @@ test('detach child process', async t => {
 
 	t.is(fs.readFileSync(file, 'utf8'), 'foo\n');
 });
+
+// https://github.com/sindresorhus/execa/issues/128
+test('removes exit handler on exit', async t => {
+	// TODO this relies on signal-exit internals
+	const ee = process.__signal_exit_emitter__;
+
+	const child = m('noop');
+	const listener = ee.listeners('exit').pop();
+
+	await new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('exit', resolve);
+	});
+
+	const included = ee.listeners('exit').includes(listener);
+	t.false(included);
+});

--- a/test.js
+++ b/test.js
@@ -508,9 +508,9 @@ test('detach child process', async t => {
 	t.is(fs.readFileSync(file, 'utf8'), 'foo\n');
 });
 
-// https://github.com/sindresorhus/execa/issues/128
+// See #128
 test('removes exit handler on exit', async t => {
-	// TODO this relies on signal-exit internals
+	// FIXME: This relies on `signal-exit` internals
 	const ee = process.__signal_exit_emitter__;
 
 	const child = m('noop');


### PR DESCRIPTION
Always call `removeExitHandler()` when the spawned process exits, not only if `.then()` is called.

There was already the `cleanupTimeout()` function that was called whenever the spawned process exited, so I repurposed that to clean up everything.

Fixes #128