### PR TITLE
Add `buffer` option to be able to disable buffering

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function handleShell(fn, cmd, opts) {
 	return fn(file, args, opts);
 }
 
-function getStream({process, stream, encoding, buffer, maxBuffer}) {
+function getStream(process, stream, {encoding, buffer, maxBuffer}) {
 	if (!process[stream]) {
 		return null;
 	}
@@ -267,8 +267,8 @@ module.exports = (cmd, args, opts) => {
 
 	const handlePromise = () => pFinally(Promise.all([
 		processDone,
-		getStream({process: spawned, stream: 'stdout', encoding, buffer, maxBuffer}),
-		getStream({process: spawned, stream: 'stderr', encoding, buffer, maxBuffer})
+		getStream(spawned, 'stdout', {encoding, buffer, maxBuffer}),
+		getStream(spawned, 'stderr', {encoding, buffer, maxBuffer})
 	]).then(arr => {
 		const result = arr[0];
 		result.stdout = arr[1];

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function handleArgs(cmd, args, opts) {
 
 	opts = Object.assign({
 		maxBuffer: TEN_MEGABYTES,
+		buffer: true,
 		stripEof: true,
 		preferLocal: true,
 		localDir: parsed.options.cwd || process.cwd(),
@@ -117,14 +118,14 @@ function handleShell(fn, cmd, opts) {
 	return fn(file, args, opts);
 }
 
-function getStream(process, stream, encoding, maxBuffer) {
+function getStream(process, stream, encoding, buffer, maxBuffer) {
 	if (!process[stream]) {
 		return null;
 	}
 
 	let ret;
 
-	if (maxBuffer === null) {
+	if (!buffer) {
 		ret = new Promise((resolve, reject) => {
 			process[stream]
 				.once('end', resolve)
@@ -196,7 +197,7 @@ function joinCmd(cmd, args) {
 
 module.exports = (cmd, args, opts) => {
 	const parsed = handleArgs(cmd, args, opts);
-	const {encoding, maxBuffer} = parsed.opts;
+	const {encoding, buffer, maxBuffer} = parsed.opts;
 	const joinedCmd = joinCmd(cmd, args);
 
 	let spawned;
@@ -266,8 +267,8 @@ module.exports = (cmd, args, opts) => {
 
 	const handlePromise = () => pFinally(Promise.all([
 		processDone,
-		getStream(spawned, 'stdout', encoding, maxBuffer),
-		getStream(spawned, 'stderr', encoding, maxBuffer)
+		getStream(spawned, 'stdout', encoding, buffer, maxBuffer),
+		getStream(spawned, 'stderr', encoding, buffer, maxBuffer)
 	]).then(arr => {
 		const result = arr[0];
 		result.stdout = arr[1];

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ function handleShell(fn, cmd, opts) {
 	return fn(file, args, opts);
 }
 
-function getStream(process, stream, encoding, buffer, maxBuffer) {
+function getStream({process, stream, encoding, buffer, maxBuffer}) {
 	if (!process[stream]) {
 		return null;
 	}
@@ -267,8 +267,8 @@ module.exports = (cmd, args, opts) => {
 
 	const handlePromise = () => pFinally(Promise.all([
 		processDone,
-		getStream(spawned, 'stdout', encoding, buffer, maxBuffer),
-		getStream(spawned, 'stderr', encoding, buffer, maxBuffer)
+		getStream({process: spawned, stream: 'stdout', encoding, buffer, maxBuffer}),
+		getStream({process: spawned, stream: 'stderr', encoding, buffer, maxBuffer})
 	]).then(arr => {
 		const result = arr[0];
 		result.stdout = arr[1];

--- a/index.js
+++ b/index.js
@@ -126,7 +126,13 @@ function getStream(process, stream, encoding, maxBuffer) {
 
 	let ret;
 
-	if (encoding) {
+	if (maxBuffer === null) {
+		ret = new Promise((resolve, reject) => {
+			process[stream]
+				.once('end', resolve)
+				.once('error', reject);
+		});
+	} else if (encoding) {
 		ret = _getStream(process[stream], {
 			encoding,
 			maxBuffer

--- a/readme.md
+++ b/readme.md
@@ -242,10 +242,11 @@ If timeout is greater than `0`, the parent will send the signal identified by th
 
 #### maxBuffer
 
-Type: `number`<br>
+Type: `number` `null`<br>
 Default: `10000000` (10MB)
 
-Largest amount of data in bytes allowed on `stdout` or `stderr`.
+Largest amount of data in bytes allowed on `stdout` or `stderr`. Pass `null` to disable buffering completely.<br>
+When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise is not be resolved/rejected until they have completed.
 
 #### killSignal
 

--- a/readme.md
+++ b/readme.md
@@ -252,13 +252,19 @@ Default: `0`
 
 If timeout is greater than `0`, the parent will send the signal identified by the `killSignal` property (the default is `SIGTERM`) if the child runs longer than timeout milliseconds.
 
+#### buffer
+
+Type: `boolean`<br>
+Default: `true`
+
+Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
+
 #### maxBuffer
 
-Type: `number` `null`<br>
+Type: `number`<br>
 Default: `10000000` (10MB)
 
-Largest amount of data in bytes allowed on `stdout` or `stderr`. Pass `null` to disable buffering completely.<br>
-When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
+Largest amount of data in bytes allowed on `stdout` or `stderr`.
 
 #### killSignal
 

--- a/readme.md
+++ b/readme.md
@@ -246,7 +246,7 @@ Type: `number` `null`<br>
 Default: `10000000` (10MB)
 
 Largest amount of data in bytes allowed on `stdout` or `stderr`. Pass `null` to disable buffering completely.<br>
-When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise is not be resolved/rejected until they have completed.
+When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
 
 #### killSignal
 

--- a/test.js
+++ b/test.js
@@ -239,8 +239,8 @@ test('maxBuffer affects stderr', async t => {
 	await t.notThrows(m('max-buffer', ['stderr', '12'], {maxBuffer: 12}));
 });
 
-test('do not buffer stdout when `maxBuffer` set to `null`', async t => {
-	const promise = m('max-buffer', ['stdout', '10'], {maxBuffer: null});
+test('do not buffer stdout when `buffer` set to `false`', async t => {
+	const promise = m('max-buffer', ['stdout', '10'], {buffer: false});
 	const [result, stdout] = await Promise.all([
 		promise,
 		getStream(promise.stdout)
@@ -250,8 +250,8 @@ test('do not buffer stdout when `maxBuffer` set to `null`', async t => {
 	t.is(stdout, '.........\n');
 });
 
-test('do not buffer stderr when `maxBuffer` set to `null`', async t => {
-	const promise = m('max-buffer', ['stderr', '10'], {maxBuffer: null});
+test('do not buffer stderr when `buffer` set to `false`', async t => {
+	const promise = m('max-buffer', ['stderr', '10'], {buffer: false});
 	const [result, stderr] = await Promise.all([
 		promise,
 		getStream(promise.stderr)

--- a/test.js
+++ b/test.js
@@ -380,7 +380,7 @@ test('err.code is 3', code, 3);
 test('err.code is 4', code, 4);
 
 test('timeout will kill the process early', async t => {
-	const err = await t.throws(m('delay', ['3000', '0'], {timeout: 1500}));
+	const err = await t.throws(m('delay', ['60000', '0'], {timeout: 1500}));
 
 	t.true(err.timedOut);
 	t.not(err.code, 22);

--- a/test.js
+++ b/test.js
@@ -239,6 +239,28 @@ test('maxBuffer affects stderr', async t => {
 	await t.notThrows(m('max-buffer', ['stderr', '12'], {maxBuffer: 12}));
 });
 
+test('do not buffer stdout when `maxBuffer` set to `null`', async t => {
+	const promise = m('max-buffer', ['stdout', '10'], {maxBuffer: null});
+	const [result, stdout] = await Promise.all([
+		promise,
+		getStream(promise.stdout)
+	]);
+
+	t.is(result.stdout, undefined);
+	t.is(stdout, '.........\n');
+});
+
+test('do not buffer stderr when `maxBuffer` set to `null`', async t => {
+	const promise = m('max-buffer', ['stderr', '10'], {maxBuffer: null});
+	const [result, stderr] = await Promise.all([
+		promise,
+		getStream(promise.stderr)
+	]);
+
+	t.is(result.stderr, undefined);
+	t.is(stderr, '.........\n');
+});
+
 test('skip throwing when using reject option', async t => {
 	const err = await m('exit', ['2'], {reject: false});
 	t.is(typeof err.stdout, 'string');


### PR DESCRIPTION
Fixes #127 

The issue describes adding a `buffer: false` option, which seemed to be in conflict with the `maxBuffer` option that's already supported, so rather than adding a new option this PR disables buffering of stdio when `maxBuffer: null` is used.