### PR TITLE
Fix XO tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,15 +141,12 @@ function getStream(process, stream, encoding, maxBuffer) {
 }
 
 function makeError(result, options) {
-	const stdout = result.stdout;
-	const stderr = result.stderr;
+	const {stdout, stderr} = result;
 
 	let err = result.error;
-	const code = result.code;
-	const signal = result.signal;
+	const {code, signal} = result;
 
-	const parsed = options.parsed;
-	const joinedCmd = options.joinedCmd;
+	const {parsed, joinedCmd} = options;
 	const timedOut = options.timedOut || false;
 
 	if (!err) {
@@ -193,8 +190,7 @@ function joinCmd(cmd, args) {
 
 module.exports = (cmd, args, opts) => {
 	const parsed = handleArgs(cmd, args, opts);
-	const encoding = parsed.opts.encoding;
-	const maxBuffer = parsed.opts.maxBuffer;
+	const {encoding, maxBuffer} = parsed.opts;
 	const joinedCmd = joinCmd(cmd, args);
 
 	let spawned;

--- a/index.js
+++ b/index.js
@@ -76,9 +76,7 @@ function handleArgs(cmd, args, opts) {
 	};
 }
 
-function handleInput(spawned, opts) {
-	const input = opts.input;
-
+function handleInput(spawned, input) {
 	if (input === null || input === undefined) {
 		return;
 	}
@@ -306,7 +304,7 @@ module.exports = (cmd, args, opts) => {
 
 	crossSpawn._enoent.hookChildProcess(spawned, parsed.parsed);
 
-	handleInput(spawned, parsed.opts);
+	handleInput(spawned, parsed.opts.input);
 
 	spawned.then = (onfulfilled, onrejected) => handlePromise().then(onfulfilled, onrejected);
 	spawned.catch = onrejected => handlePromise().catch(onrejected);

--- a/index.js
+++ b/index.js
@@ -308,14 +308,14 @@ module.exports = (cmd, args, opts) => {
 	return spawned;
 };
 
-module.exports.stdout = function () {
+module.exports.stdout = function (...args) {
 	// TODO: set `stderr: 'ignore'` when that option is implemented
-	return module.exports.apply(null, arguments).then(x => x.stdout);
+	return module.exports(...args).then(x => x.stdout);
 };
 
-module.exports.stderr = function () {
+module.exports.stderr = function (...args) {
 	// TODO: set `stdout: 'ignore'` when that option is implemented
-	return module.exports.apply(null, arguments).then(x => x.stderr);
+	return module.exports(...args).then(x => x.stderr);
 };
 
 module.exports.shell = (cmd, opts) => handleShell(module.exports, cmd, opts);


### PR DESCRIPTION
For the most part, I’ve switched to object destructuring where applicable. For [`handleInput()`](https://github.com/sindresorhus/execa/blob/v0.10.0/index.js#L79-L91), I’ve changed the parameters to directly receive `input` (since none of the other `opts` were being used). Finally, I’ve switched to rest parameters and the spread operator for `execa.stdout()` and `execa.stderr()` (which call execa again).

By the way, this definitely breaks Node.js v4 support but I’m guessing you’ll be dropping this version in the next release anyway.