### PR TITLE
added a failure test case

### DIFF
--- a/fixtures/npminfo
+++ b/fixtures/npminfo
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const execa = require('..');
+
+process.env.http_proxy = 'http:/127.0.0.1:8080';
+process.env.https_proxy = 'http:/127.0.0.1:8080';
+
+console.log('npm info start');
+const output = execa.sync('npm', ['info', 'execa']);
+console.log('npm info end');

--- a/test.js
+++ b/test.js
@@ -380,6 +380,12 @@ test('timeout will kill the process early', async t => {
 	t.not(error.code, 22);
 });
 
+test('timeout will kill the npm info process', async t => {
+  const error = await t.throws(m('npminfo', [], { timeout: 1500 }));
+  t.true(error.timedOut);
+});
+
+
 test('timeout will not kill the process early', async t => {
 	const error = await t.throws(m('delay', ['3000', '22'], {timeout: 30000}));
 


### PR DESCRIPTION
when the network in down, npm info will no work.
but when I add timeout option to execa, it does not kill the npm info process.

here is a test case of it.