### PR TITLE
Support single string input without using the `shell` option

### DIFF
--- a/fixtures/echo
+++ b/fixtures/echo
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+'use strict';
+console.log(process.argv.slice(2).join('\n'))

--- a/index.js
+++ b/index.js
@@ -15,6 +15,17 @@ const stdio = require('./lib/stdio');
 
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
+const SPACES_REGEXP = / +/g;
+
+function parseCommand(command, args = []) {
+	const [file, ...extraArgs] = command
+		.trim()
+		.split(SPACES_REGEXP)
+		.reduce(handleEscaping, []);
+	const newArgs = [...extraArgs, ...args];
+	return [file, newArgs];
+}
+
 function handleArgs(command, args, options = {}) {
 	if (args && !Array.isArray(args)) {
 		options = args;
@@ -76,17 +87,6 @@ function handleArgs(command, args, options = {}) {
 
 	return {command, args, options, parsed};
 }
-
-function parseCommand(command, args = []) {
-	const [file, ...extraArgs] = command
-		.trim()
-		.split(SPACES_REGEXP)
-		.reduce(handleEscaping, []);
-	const newArgs = [...extraArgs, ...args];
-	return [file, newArgs];
-}
-
-const SPACES_REGEXP = / +/g;
 
 // Allow spaces to be escaped by a backslash if not meant as a delimiter
 const handleEscaping = function (tokens, token, index) {

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function handleArgs(command, args, options = {}) {
 		options.cleanup = false;
 	}
 
-	if (process.platform === 'win32' && path.basename(command, 'exe') === 'cmd') {
+	if (process.platform === 'win32' && path.basename(command, '.exe') === 'cmd') {
 		// #116
 		args.unshift('/q');
 	}

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function handleArgs(command, args, options) {
 		buffer: true,
 		stripFinalNewline: true,
 		preferLocal: true,
-		localDir: parsed.options.cwd || process.cwd(),
+		localDir: options.cwd || process.cwd(),
 		encoding: 'utf8',
 		reject: true,
 		cleanup: true,
@@ -71,9 +71,9 @@ function handleArgs(command, args, options) {
 		options.cleanup = false;
 	}
 
-	if (process.platform === 'win32' && path.basename(parsed.command, 'exe') === 'cmd') {
+	if (process.platform === 'win32' && path.basename(command, 'exe') === 'cmd') {
 		// #116
-		parsed.args.unshift('/q');
+		args.unshift('/q');
 	}
 
 	return {command, args, options, parsed};

--- a/index.js
+++ b/index.js
@@ -92,10 +92,10 @@ const handleEscaping = function (tokens, token, index) {
 	const previousToken = tokens[index - 1];
 
 	if (!previousToken.endsWith('\\')) {
-		return tokens.concat(token);
+		return [...tokens, token];
 	}
 
-	return tokens.slice(0, index - 1).concat(`${previousToken.slice(0, -1)} ${token}`);
+	return [...tokens.slice(0, index - 1), `${previousToken.slice(0, -1)} ${token}`];
 };
 
 function handleInput(spawned, input) {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const TEN_MEGABYTES = 1000 * 1000 * 10;
 const SPACES_REGEXP = / +/g;
 
 // Allow spaces to be escaped by a backslash if not meant as a delimiter
-const handleEscaping = (tokens, token, index) => {
+function handleEscaping(tokens, token, index) {
 	if (index === 0) {
 		return [token];
 	}
@@ -30,7 +30,7 @@ const handleEscaping = (tokens, token, index) => {
 	}
 
 	return [...tokens.slice(0, index - 1), `${previousToken.slice(0, -1)} ${token}`];
-};
+}
 
 function parseCommand(command, args = []) {
 	if (args.length !== 0) {

--- a/index.js
+++ b/index.js
@@ -18,12 +18,15 @@ const TEN_MEGABYTES = 1000 * 1000 * 10;
 const SPACES_REGEXP = / +/g;
 
 function parseCommand(command, args = []) {
+	if (args.length !== 0) {
+		throw new Error('Arguments cannot be inside `command` when also specified as an array of strings');
+	}
+
 	const [file, ...extraArgs] = command
 		.trim()
 		.split(SPACES_REGEXP)
 		.reduce(handleEscaping, []);
-	const newArgs = [...extraArgs, ...args];
-	return [file, newArgs];
+	return [file, extraArgs];
 }
 
 function handleArgs(command, args, options = {}) {

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function handleArgs(command, args, options = {}) {
 }
 
 // Allow spaces to be escaped by a backslash if not meant as a delimiter
-const handleEscaping = function (tokens, token, index) {
+const handleEscaping = (tokens, token, index) => {
 	if (index === 0) {
 		return [token];
 	}

--- a/index.js
+++ b/index.js
@@ -15,13 +15,11 @@ const stdio = require('./lib/stdio');
 
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
-function handleArgs(command, args, options) {
+function handleArgs(command, args, options = {}) {
 	if (args && !Array.isArray(args)) {
 		options = args;
-		args = null;
+		args = [];
 	}
-
-	options = options || {};
 
 	if (!options.shell && command.includes(' ')) {
 		[command, args] = parseCommand(command, args);

--- a/index.js
+++ b/index.js
@@ -17,6 +17,21 @@ const TEN_MEGABYTES = 1000 * 1000 * 10;
 
 const SPACES_REGEXP = / +/g;
 
+// Allow spaces to be escaped by a backslash if not meant as a delimiter
+const handleEscaping = (tokens, token, index) => {
+	if (index === 0) {
+		return [token];
+	}
+
+	const previousToken = tokens[index - 1];
+
+	if (!previousToken.endsWith('\\')) {
+		return [...tokens, token];
+	}
+
+	return [...tokens.slice(0, index - 1), `${previousToken.slice(0, -1)} ${token}`];
+};
+
 function parseCommand(command, args = []) {
 	if (args.length !== 0) {
 		throw new Error('Arguments cannot be inside `command` when also specified as an array of strings');
@@ -90,21 +105,6 @@ function handleArgs(command, args, options = {}) {
 
 	return {command, args, options, parsed};
 }
-
-// Allow spaces to be escaped by a backslash if not meant as a delimiter
-const handleEscaping = (tokens, token, index) => {
-	if (index === 0) {
-		return [token];
-	}
-
-	const previousToken = tokens[index - 1];
-
-	if (!previousToken.endsWith('\\')) {
-		return [...tokens, token];
-	}
-
-	return [...tokens.slice(0, index - 1), `${previousToken.slice(0, -1)} ${token}`];
-};
 
 function handleInput(spawned, input) {
 	if (input === undefined) {

--- a/index.js
+++ b/index.js
@@ -73,12 +73,12 @@ function handleArgs(command, args, options) {
 }
 
 function parseCommand(command, args = []) {
-	const [newCommand, ...extraArgs] = command
+	const [file, ...extraArgs] = command
 		.trim()
 		.split(SPACES_REGEXP)
 		.reduce(handleEscaping, []);
 	const newArgs = [...extraArgs, ...args];
-	return [newCommand, newArgs];
+	return [file, newArgs];
 }
 
 const SPACES_REGEXP = / +/g;

--- a/index.js
+++ b/index.js
@@ -16,6 +16,13 @@ const stdio = require('./lib/stdio');
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
 function handleArgs(command, args, options) {
+	if (args && !Array.isArray(args)) {
+		options = args;
+		args = null;
+	}
+
+	options = options || {};
+
 	if (!options.shell && command.includes(' ')) {
 		[command, args] = parseCommand(command, args);
 	}
@@ -30,7 +37,7 @@ function handleArgs(command, args, options) {
 		buffer: true,
 		stripFinalNewline: true,
 		preferLocal: true,
-		localDir: options.cwd || process.cwd(),
+		localDir: parsed.options.cwd || process.cwd(),
 		encoding: 'utf8',
 		reject: true,
 		cleanup: true,
@@ -64,9 +71,9 @@ function handleArgs(command, args, options) {
 		options.cleanup = false;
 	}
 
-	if (process.platform === 'win32' && path.basename(command, '.exe') === 'cmd') {
+	if (process.platform === 'win32' && path.basename(parsed.command, 'exe') === 'cmd') {
 		// #116
-		args.unshift('/q');
+		parsed.args.unshift('/q');
 	}
 
 	return {command, args, options, parsed};

--- a/readme.md
+++ b/readme.md
@@ -130,9 +130,9 @@ try {
 
 ## API
 
-### execa(command, [arguments], [options])
+### execa(file | command, [arguments], [options])
 
-Execute a file.
+Execute a `file`.
 
 Arguments can be specified either inside `command` (a string) or `arguments` (an array of strings). When specified inside `command`, spaces can be escaped with a backslash. Otherwise arguments need neither escaping nor quoting.
 
@@ -146,11 +146,11 @@ The spawned process can be canceled with the `.cancel()` method on the promise, 
 
 The promise result is an `Object` with `stdout`, `stderr` and `all` properties.
 
-### execa.stdout(command, [arguments], [options])
+### execa.stdout(file | command, [arguments], [options])
 
 Same as `execa()`, but returns only `stdout`.
 
-### execa.stderr(command, [arguments], [options])
+### execa.stderr(file | command, [arguments], [options])
 
 Same as `execa()`, but returns only `stderr`.
 
@@ -162,7 +162,7 @@ Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#c
 
 The `child_process` instance is enhanced to also be promise for a result object with `stdout` and `stderr` properties.
 
-### execa.sync(command, [arguments], [options])
+### execa.sync(file | command, [arguments], [options])
 
 Execute a file synchronously.
 

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,11 @@ try {
 
 Execute a file.
 
-Arguments can be specified either inside `command` (a string) or `arguments` (an array of strings). When specified inside `command`, spaces can be escaped with a backslash. Otherwise arguments need neither escaping nor quoting.
+Arguments can be specified either:
+	- `arguments`: `execa('echo', ['unicorns'])`.
+  - `command`: `execa('echo unicorns')`.
+
+Arguments should not be escaped nor quoted. Exception: inside `command`, spaces can be escaped with a backslash.
 
 Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
 

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ Arguments should not be escaped nor quoted. Exception: inside `command`, spaces 
 
 Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
 
-As opposed to [`execa.shell()`](#execashellcommand-options), no shell interpreter (Bash, `cmd.exe`, etc.) is used, so you cannot use shell features such as variables substitution `echo $PATH`.
+As opposed to [`execa.shell()`](#execashellcommand-options), no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution `echo $PATH` are not allowed.
 
 Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess) which is enhanced to be a `Promise`.
 

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,8 @@ Arguments should not be escaped nor quoted. Exception: inside `command`, spaces 
 
 Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
 
+As opposed to [`execa.shell()`](#execashellcommand-options), no shell interpreter (Bash, `cmd.exe`, etc.) is used, so you cannot use shell features such as variables substitution `echo $PATH`.
+
 Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess) which is enhanced to be a `Promise`.
 
 It exposes an additional `.all` stream, with `stdout` and `stderr` interleaved.

--- a/readme.md
+++ b/readme.md
@@ -115,7 +115,8 @@ try {
 
 ## API
 
-### execa(file | command, [arguments], [options])
+### execa(file, [arguments], [options])
+### execa(command, [options])
 
 Execute a file.
 
@@ -131,11 +132,13 @@ The spawned process can be canceled with the `.cancel()` method on the promise, 
 
 The promise result is an `Object` with `stdout`, `stderr` and `all` properties.
 
-### execa.stdout(file | command, [arguments], [options])
+### execa.stdout(file, [arguments], [options])
+### execa.stdout(command, [options])
 
 Same as `execa()`, but returns only `stdout`.
 
-### execa.stderr(file | command, [arguments], [options])
+### execa.stderr(file, [arguments], [options])
+### execa.stderr(command, [options])
 
 Same as `execa()`, but returns only `stderr`.
 
@@ -147,7 +150,8 @@ Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#c
 
 The `child_process` instance is enhanced to also be promise for a result object with `stdout` and `stderr` properties.
 
-### execa.sync(file | command, [arguments], [options])
+### execa.sync(file, [arguments], [options])
+### execa.sync(command, [options])
 
 Execute a file synchronously.
 

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ try {
 Execute a file.
 
 Arguments can be specified either:
-	- `arguments`: `execa('echo', ['unicorns'])`.
+  - `arguments`: `execa('echo', ['unicorns'])`.
   - `command`: `execa('echo unicorns')`.
 
 Arguments should not be escaped nor quoted. Exception: inside `command`, spaces can be escaped with a backslash.

--- a/readme.md
+++ b/readme.md
@@ -56,21 +56,6 @@ const execa = require('execa');
 	const {stdout} = await execa.shell('echo unicorns');
 	//=> 'unicorns'
 
-	// Cancelling a spawned process
-	const subprocess = execa('node');
-	setTimeout(() => { spawned.cancel() }, 1000);
-	try {
-		await subprocess;
-	} catch (error) {
-		console.log(subprocess.killed); // true
-		console.log(error.isCanceled); // true
-	}
-
-	// Run a command as a string without a shell
-	const {stdout} = await execa('echo unicorns');
-	//=> 'unicorns'
-
-
 	// Catching an error
 	try {
 		await execa.shell('exit 3');

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ Arguments should not be escaped nor quoted. Exception: inside `command`, spaces 
 
 Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
 
-As opposed to [`execa.shell()`](#execashellcommand-options), no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution `echo $PATH` are not allowed.
+As opposed to [`execa.shell()`](#execashellcommand-options), no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 
 Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess) which is enhanced to be a `Promise`.
 

--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ try {
 
 ### execa(file | command, [arguments], [options])
 
-Execute a `file`.
+Execute a file.
 
 Arguments can be specified either inside `command` (a string) or `arguments` (an array of strings). When specified inside `command`, spaces can be escaped with a backslash. Otherwise arguments need neither escaping nor quoting.
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ const execa = require('execa');
 	execa('echo', ['unicorns']).stdout.pipe(process.stdout);
 
 
-	// Run a shell command as a string
+	// Run a shell command
 	const {stdout} = await execa.shell('echo unicorns');
 	//=> 'unicorns'
 

--- a/readme.md
+++ b/readme.md
@@ -134,9 +134,7 @@ try {
 
 Execute a file.
 
-Arguments can be specified either inside `command` (a string) or `arguments`
-(an array of strings). When specified inside `command`, spaces can be escaped
-with a backslash. Otherwise arguments need neither escaping nor quoting.
+Arguments can be specified either inside `command` (a string) or `arguments` (an array of strings). When specified inside `command`, spaces can be escaped with a backslash. Otherwise arguments need neither escaping nor quoting.
 
 Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
 
@@ -158,8 +156,7 @@ Same as `execa()`, but returns only `stderr`.
 
 ### execa.shell(command, [options])
 
-Execute a command through the system shell. Prefer `execa()` whenever possible,
-as it's faster, safer and more cross-platform.
+Execute a command through the system shell. Prefer `execa()` whenever possible, as it's faster, safer and more cross-platform.
 
 Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess).
 

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ try {
 
 Execute a file.
 
-Arguments can be specified either:
+Arguments can be specified in either:
   - `arguments`: `execa('echo', ['unicorns'])`.
   - `command`: `execa('echo unicorns')`.
 

--- a/test.js
+++ b/test.js
@@ -102,32 +102,32 @@ test('pass `stderr` to a file descriptor', async t => {
 });
 
 test('allow string arguments', async t => {
-	const {stdout} = await execa('node fixtures/echo foo bar');
+	const stdout = await execa.stdout('node fixtures/echo foo bar');
 	t.is(stdout, 'foo\nbar');
 });
 
 test('allow string arguments together with array arguments', async t => {
-	const {stdout} = await execa('node fixtures/echo foo bar', ['foo', 'bar']);
+	const stdout = await execa.stdout('node fixtures/echo foo bar', ['foo', 'bar']);
 	t.is(stdout, 'foo\nbar\nfoo\nbar');
 });
 
 test('ignore consecutive spaces in string arguments', async t => {
-	const {stdout} = await execa('node fixtures/echo foo    bar');
+	const stdout = await execa.stdout('node fixtures/echo foo    bar');
 	t.is(stdout, 'foo\nbar');
 });
 
 test('escape other whitespaces in string arguments', async t => {
-	const {stdout} = await execa('node fixtures/echo foo\tbar');
+	const stdout = await execa.stdout('node fixtures/echo foo\tbar');
 	t.is(stdout, 'foo\tbar');
 });
 
 test('allow escaping spaces in string arguments', async t => {
-	const {stdout} = await execa('node fixtures/echo foo\\ bar');
+	const stdout = await execa.stdout('node fixtures/echo foo\\ bar');
 	t.is(stdout, 'foo bar');
 });
 
 test('trim string arguments', async t => {
-	const {stdout} = await execa('  node fixtures/echo foo bar  ');
+	const stdout = await execa.stdout('  node fixtures/echo foo bar  ');
 	t.is(stdout, 'foo\nbar');
 });
 

--- a/test.js
+++ b/test.js
@@ -103,27 +103,27 @@ test('pass `stderr` to a file descriptor', async t => {
 
 test('allow string arguments', async t => {
 	const {stdout} = await m('fixtures/echo foo bar');
-	t.is(stdout, 'foo\nbar')
+	t.is(stdout, 'foo\nbar');
 });
 
 test('allow string arguments together with array arguments', async t => {
 	const {stdout} = await m('fixtures/echo foo bar', ['foo', 'bar']);
-	t.is(stdout, 'foo\nbar\nfoo\nbar')
+	t.is(stdout, 'foo\nbar\nfoo\nbar');
 });
 
 test('ignore consecutive spaces in string arguments', async t => {
 	const {stdout} = await m('fixtures/echo foo    bar');
-	t.is(stdout, 'foo\nbar')
+	t.is(stdout, 'foo\nbar');
 });
 
 test('escape other whitespaces in string arguments', async t => {
 	const {stdout} = await m('fixtures/echo foo\tbar');
-	t.is(stdout, 'foo\tbar')
+	t.is(stdout, 'foo\tbar');
 });
 
 test('allow escaping spaces in string arguments', async t => {
 	const {stdout} = await m('fixtures/echo foo\\ bar');
-	t.is(stdout, 'foo bar')
+	t.is(stdout, 'foo bar');
 });
 
 test('execa.shell()', async t => {

--- a/test.js
+++ b/test.js
@@ -111,9 +111,8 @@ test('allow string arguments in synchronous mode', t => {
 	t.is(stdout, 'foo\nbar');
 });
 
-test('allow string arguments together with array arguments', async t => {
-	const {stdout} = await execa('node fixtures/echo foo bar', ['foo', 'bar']);
-	t.is(stdout, 'foo\nbar\nfoo\nbar');
+test('forbid string arguments together with array arguments', t => {
+	t.throws(() => execa('node fixtures/echo foo bar', ['foo', 'bar']), /Arguments cannot be inside/);
 });
 
 test('ignore consecutive spaces in string arguments', async t => {

--- a/test.js
+++ b/test.js
@@ -102,27 +102,27 @@ test('pass `stderr` to a file descriptor', async t => {
 });
 
 test('allow string arguments', async t => {
-	const {stdout} = await m('fixtures/echo foo bar');
+	const {stdout} = await m('node fixtures/echo foo bar');
 	t.is(stdout, 'foo\nbar');
 });
 
 test('allow string arguments together with array arguments', async t => {
-	const {stdout} = await m('fixtures/echo foo bar', ['foo', 'bar']);
+	const {stdout} = await m('node fixtures/echo foo bar', ['foo', 'bar']);
 	t.is(stdout, 'foo\nbar\nfoo\nbar');
 });
 
 test('ignore consecutive spaces in string arguments', async t => {
-	const {stdout} = await m('fixtures/echo foo    bar');
+	const {stdout} = await m('node fixtures/echo foo    bar');
 	t.is(stdout, 'foo\nbar');
 });
 
 test('escape other whitespaces in string arguments', async t => {
-	const {stdout} = await m('fixtures/echo foo\tbar');
+	const {stdout} = await m('node fixtures/echo foo\tbar');
 	t.is(stdout, 'foo\tbar');
 });
 
 test('allow escaping spaces in string arguments', async t => {
-	const {stdout} = await m('fixtures/echo foo\\ bar');
+	const {stdout} = await m('node fixtures/echo foo\\ bar');
 	t.is(stdout, 'foo bar');
 });
 

--- a/test.js
+++ b/test.js
@@ -101,6 +101,31 @@ test('pass `stderr` to a file descriptor', async t => {
 	t.is(fs.readFileSync(file, 'utf8'), 'foo bar\n');
 });
 
+test('allow string arguments', async t => {
+	const {stdout} = await m('fixtures/echo foo bar');
+	t.is(stdout, 'foo\nbar')
+});
+
+test('allow string arguments together with array arguments', async t => {
+	const {stdout} = await m('fixtures/echo foo bar', ['foo', 'bar']);
+	t.is(stdout, 'foo\nbar\nfoo\nbar')
+});
+
+test('ignore consecutive spaces in string arguments', async t => {
+	const {stdout} = await m('fixtures/echo foo    bar');
+	t.is(stdout, 'foo\nbar')
+});
+
+test('escape other whitespaces in string arguments', async t => {
+	const {stdout} = await m('fixtures/echo foo\tbar');
+	t.is(stdout, 'foo\tbar')
+});
+
+test('allow escaping spaces in string arguments', async t => {
+	const {stdout} = await m('fixtures/echo foo\\ bar');
+	t.is(stdout, 'foo bar')
+});
+
 test('execa.shell()', async t => {
 	const {stdout} = await execa.shell('node fixtures/noop foo');
 	t.is(stdout, 'foo');

--- a/test.js
+++ b/test.js
@@ -102,32 +102,32 @@ test('pass `stderr` to a file descriptor', async t => {
 });
 
 test('allow string arguments', async t => {
-	const stdout = await execa.stdout('node fixtures/echo foo bar');
+	const {stdout} = await execa('node fixtures/echo foo bar');
 	t.is(stdout, 'foo\nbar');
 });
 
 test('allow string arguments together with array arguments', async t => {
-	const stdout = await execa.stdout('node fixtures/echo foo bar', ['foo', 'bar']);
+	const {stdout} = await execa('node fixtures/echo foo bar', ['foo', 'bar']);
 	t.is(stdout, 'foo\nbar\nfoo\nbar');
 });
 
 test('ignore consecutive spaces in string arguments', async t => {
-	const stdout = await execa.stdout('node fixtures/echo foo    bar');
+	const {stdout} = await execa('node fixtures/echo foo    bar');
 	t.is(stdout, 'foo\nbar');
 });
 
 test('escape other whitespaces in string arguments', async t => {
-	const stdout = await execa.stdout('node fixtures/echo foo\tbar');
+	const {stdout} = await execa('node fixtures/echo foo\tbar');
 	t.is(stdout, 'foo\tbar');
 });
 
 test('allow escaping spaces in string arguments', async t => {
-	const stdout = await execa.stdout('node fixtures/echo foo\\ bar');
+	const {stdout} = await execa('node fixtures/echo foo\\ bar');
 	t.is(stdout, 'foo bar');
 });
 
 test('trim string arguments', async t => {
-	const stdout = await execa.stdout('  node fixtures/echo foo bar  ');
+	const {stdout} = await execa('  node fixtures/echo foo bar  ');
 	t.is(stdout, 'foo\nbar');
 });
 

--- a/test.js
+++ b/test.js
@@ -106,6 +106,11 @@ test('allow string arguments', async t => {
 	t.is(stdout, 'foo\nbar');
 });
 
+test('allow string arguments in synchronous mode', t => {
+	const {stdout} = execa.sync('node fixtures/echo foo bar');
+	t.is(stdout, 'foo\nbar');
+});
+
 test('allow string arguments together with array arguments', async t => {
 	const {stdout} = await execa('node fixtures/echo foo bar', ['foo', 'bar']);
 	t.is(stdout, 'foo\nbar\nfoo\nbar');

--- a/test.js
+++ b/test.js
@@ -102,27 +102,27 @@ test('pass `stderr` to a file descriptor', async t => {
 });
 
 test('allow string arguments', async t => {
-	const {stdout} = await m('node fixtures/echo foo bar');
+	const {stdout} = await execa('node fixtures/echo foo bar');
 	t.is(stdout, 'foo\nbar');
 });
 
 test('allow string arguments together with array arguments', async t => {
-	const {stdout} = await m('node fixtures/echo foo bar', ['foo', 'bar']);
+	const {stdout} = await execa('node fixtures/echo foo bar', ['foo', 'bar']);
 	t.is(stdout, 'foo\nbar\nfoo\nbar');
 });
 
 test('ignore consecutive spaces in string arguments', async t => {
-	const {stdout} = await m('node fixtures/echo foo    bar');
+	const {stdout} = await execa('node fixtures/echo foo    bar');
 	t.is(stdout, 'foo\nbar');
 });
 
 test('escape other whitespaces in string arguments', async t => {
-	const {stdout} = await m('node fixtures/echo foo\tbar');
+	const {stdout} = await execa('node fixtures/echo foo\tbar');
 	t.is(stdout, 'foo\tbar');
 });
 
 test('allow escaping spaces in string arguments', async t => {
-	const {stdout} = await m('node fixtures/echo foo\\ bar');
+	const {stdout} = await execa('node fixtures/echo foo\\ bar');
 	t.is(stdout, 'foo bar');
 });
 

--- a/test.js
+++ b/test.js
@@ -126,6 +126,11 @@ test('allow escaping spaces in string arguments', async t => {
 	t.is(stdout, 'foo bar');
 });
 
+test('trim string arguments', async t => {
+	const {stdout} = await execa('  node fixtures/echo foo bar  ');
+	t.is(stdout, 'foo\nbar');
+});
+
 test('execa.shell()', async t => {
 	const {stdout} = await execa.shell('node fixtures/noop foo');
 	t.is(stdout, 'foo');


### PR DESCRIPTION
Fix #176 

This allows passing command+arguments as a single string with `execa()` without using the `shell` option:

```js
execa('eslint *.js *.yml --ignore-path=.gitignore --fix --cache --format=codeframe --max-warnings=0')
```

Instead of:

```js
execa('eslint', ['*.js', '*.yml', '--ignore-path=.gitignore', '--fix', '--cache', '--format=codeframe', '--max-warnings=0'])
```

This is not only for convenience, the main goal is actually to make `execa` more secure, cross-platform and faster. The reason is: many users might be tempted to use `execa.shell()` for the convenience of specifying command and arguments inside a single string, because it feels closer to typing in a terminal. However `execa.shell()` involves using a shell interpreter which is:

* less secure: it allows for [command injection](https://www.owasp.org/index.php/Command_Injection) by passing arguments like `$(rm -rf /)` or `&& rm -rf /`
* less cross-platform: it encourages using [shell-specific features](https://twitter.com/ehmicky/status/1098980276787732480) such as globbing, single quote escaping or even semicolons which won't work on `cmd.exe`.
* slower as it goes through an extra step (the shell interpreter)

Giving users the possibility to do this without `execa.shell()` prevents this issue.

Like `execa()` (and the underlying `child_process.spawn()`) arguments do not need any escaping/quoting. One exception: spaces can be escaped with a backslash if not meant as an arguments delimiter.