### PR TITLE
Fix `extendEnv` option not working with `shell` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function handleArgs(command, args, options) {
 	args = parsed.args;
 	options = parsed.options;
 
-	options = {
+	options = Object.assign({
 		maxBuffer: TEN_MEGABYTES,
 		buffer: true,
 		stripFinalNewline: true,
@@ -27,17 +27,17 @@ function handleArgs(command, args, options) {
 		localDir: options.cwd || process.cwd(),
 		encoding: 'utf8',
 		reject: true,
-		cleanup: true,
-		...options,
+		cleanup: true
+	}, options, {
 		windowsHide: true
-	};
+	});
 
 	if (options.extendEnv !== false) {
-		options.env = {...process.env, ...options.env};
+		options.env = Object.assign({}, process.env, options.env);
 	}
 
 	if (options.preferLocal) {
-		options.env = npmRunPath.env({...options, cwd: options.localDir});
+		options.env = npmRunPath.env(Object.assign({}, options, {cwd: options.localDir}));
 	}
 
 	// TODO: Remove in the next major release

--- a/index.js
+++ b/index.js
@@ -14,27 +14,31 @@ const stdio = require('./lib/stdio');
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
 function handleArgs(command, args, options) {
-	options = Object.assign({
-		extendEnv: true,
-		env: {}
-	}, options);
-
-	if (options.extendEnv) {
-		options.env = Object.assign({}, process.env, options.env);
-	}
-
 	const parsed = crossSpawn._parse(command, args, options);
+	command = parsed.command;
+	args = parsed.args;
+	options = parsed.options;
 
-	options = Object.assign({
+	options = {
 		maxBuffer: TEN_MEGABYTES,
 		buffer: true,
 		stripFinalNewline: true,
 		preferLocal: true,
-		localDir: parsed.options.cwd || process.cwd(),
+		localDir: options.cwd || process.cwd(),
 		encoding: 'utf8',
 		reject: true,
-		cleanup: true
-	}, parsed.options, {windowsHide: true});
+		cleanup: true,
+		...options,
+		windowsHide: true
+	};
+
+	if (options.extendEnv !== false) {
+		options.env = {...process.env, ...options.env};
+	}
+
+	if (options.preferLocal) {
+		options.env = npmRunPath.env({...options, cwd: options.localDir});
+	}
 
 	// TODO: Remove in the next major release
 	if (options.stripEof === false) {
@@ -43,26 +47,17 @@ function handleArgs(command, args, options) {
 
 	options.stdio = stdio(options);
 
-	if (options.preferLocal) {
-		options.env = npmRunPath.env(Object.assign({}, options, {cwd: options.localDir}));
-	}
-
 	if (options.detached) {
 		// #115
 		options.cleanup = false;
 	}
 
-	if (process.platform === 'win32' && path.basename(parsed.command) === 'cmd.exe') {
+	if (process.platform === 'win32' && path.basename(command) === 'cmd.exe') {
 		// #116
-		parsed.args.unshift('/q');
+		args.unshift('/q');
 	}
 
-	return {
-		command: parsed.command,
-		args: parsed.args,
-		options,
-		parsed
-	};
+	return {command, args, options, parsed};
 }
 
 function handleInput(spawned, input) {

--- a/test.js
+++ b/test.js
@@ -487,11 +487,11 @@ test('do not extend environment with `extendEnv: false` option', async t => {
 	]);
 });
 
-test('use extend environment with `extendEnv: true` option', async t => {
+test('use extend environment with `extendEnv: true` option and `shell: true`', async t => {
 	process.env.TEST = 'test';
 	const command = process.platform === 'win32' ? 'echo %TEST%' : 'echo $TEST';
-	const result = await m.shellSync(command, {env: {}, extendEnv: true});
-	t.is(result.stdout, 'test');
+	const stdout = await m.stdout(command, {shell: true, env: {}, extendEnv: true});
+	t.is(stdout, 'test');
 	delete process.env.TEST;
 });
 

--- a/test.js
+++ b/test.js
@@ -478,7 +478,7 @@ test('extend environment variables by default', async t => {
 	]);
 });
 
-test('do not extend environment with `extendEnv: false` option', async t => {
+test('do not extend environment with `extendEnv: false`', async t => {
 	const result = await m.stdout('environment', [], {env: {BAR: 'bar', PATH: process.env.PATH}, extendEnv: false});
 
 	t.deepEqual(result.split('\n'), [
@@ -487,7 +487,7 @@ test('do not extend environment with `extendEnv: false` option', async t => {
 	]);
 });
 
-test('use extend environment with `extendEnv: true` option and `shell: true`', async t => {
+test('use extend environment with `extendEnv: true` and `shell: true`', async t => {
 	process.env.TEST = 'test';
 	const command = process.platform === 'win32' ? 'echo %TEST%' : 'echo $TEST';
 	const stdout = await m.stdout(command, {shell: true, env: {}, extendEnv: true});

--- a/test.js
+++ b/test.js
@@ -478,13 +478,20 @@ test('extend environment variables by default', async t => {
 	]);
 });
 
-test('do not extend environment with `extendEnv` option', async t => {
+test('do not extend environment with `extendEnv: false` option', async t => {
 	const result = await m.stdout('environment', [], {env: {BAR: 'bar', PATH: process.env.PATH}, extendEnv: false});
 
 	t.deepEqual(result.split('\n'), [
 		'undefined',
 		'bar'
 	]);
+});
+
+test('use extend environment with `extendEnv: true` option', async t => {
+	process.env.TEST = 'test';
+	const result = await m.shellSync('echo $TEST', {env: {}, extendEnv: true});
+	t.is(result.stdout, 'test');
+	delete process.env.TEST;
 });
 
 test('do not buffer when streaming', async t => {

--- a/test.js
+++ b/test.js
@@ -489,7 +489,8 @@ test('do not extend environment with `extendEnv: false` option', async t => {
 
 test('use extend environment with `extendEnv: true` option', async t => {
 	process.env.TEST = 'test';
-	const result = await m.shellSync('echo $TEST', {env: {}, extendEnv: true});
+	const command = process.platform === 'win32' ? 'echo %TEST%' : 'echo $TEST';
+	const result = await m.shellSync(command, {env: {}, extendEnv: true});
 	t.is(result.stdout, 'test');
 	delete process.env.TEST;
 });


### PR DESCRIPTION
Fixes #183 

Options parsing was not correct for the `extendEnv` option which made it not work when combined with `shell: true` option.