### PR TITLE
Fix Windows test related to `shell` option

### DIFF
--- a/test.js
+++ b/test.js
@@ -438,10 +438,8 @@ if (process.platform !== 'win32') {
 	test('cleanup false - SIGKILL', spawnAndKill, 'SIGKILL', false);
 }
 
-// See: https://github.com/sindresorhus/execa/issues/56
-const onlyWinFailing = test[process.platform === 'win32' ? 'failing' : 'serial'];
-onlyWinFailing('execa.shell() supports the `shell` option', async t => {
-	const {stdout} = await m.shell('noop foo', {
+test('execa.shell() supports the `shell` option', async t => {
+	const {stdout} = await m.shell('node fixtures/noop foo', {
 		shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash'
 	});
 	t.is(stdout, 'foo');


### PR DESCRIPTION
This fixes #56.

Using shabangs on Windows currently only works in non-shell mode, but not in shell mode (when `shell` option is either `true` or a string). This is [done through `cross-spawn`](https://github.com/moxystudio/node-cross-spawn/blob/master/lib/parse.js#L32). I think the current behavior is the correct behavior.

The original test failed because it tried to fire a shabang with `cmd.exe`. Instead I've fired the binary through `node` which works.