### PR TITLE
Add `execa.all()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,6 +368,11 @@ module.exports.stderr = async (...args) => {
 	return stderr;
 };
 
+module.exports.all = async (...args) => {
+	const {all} = await module.exports(...args);
+	return all;
+};
+
 module.exports.shell = (command, options) => handleShell(module.exports, command, options);
 
 module.exports.sync = (command, args, options) => {

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,10 @@ Same as `execa()`, but returns only `stdout`.
 
 Same as `execa()`, but returns only `stderr`.
 
+### execa.all(file, [arguments], [options])
+
+Same as `execa()`, but returns only `all`.
+
 ### execa.shell(command, [options])
 
 Execute a command through the system shell. Prefer `execa()` whenever possible, as it's both faster and safer.

--- a/test.js
+++ b/test.js
@@ -46,6 +46,11 @@ test('execa.stderr()', async t => {
 	t.is(stderr, 'foo');
 });
 
+test.serial('execa.all()', async t => {
+	const all = await execa.all('noop-132');
+	t.is(all, '132');
+});
+
 test.serial('result.all shows both `stdout` and `stderr` intermixed', async t => {
 	const result = await execa('noop-132');
 	t.is(result.all, '132');


### PR DESCRIPTION
This is a follow up on #171 by @tomsotte.

`options.all` was added but we forgot to also add `execa.all()`.