### PR TITLE
Add a logo

### DIFF
--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 139.8342 37.638888"
+   height="37.638889mm"
+   width="139.8342mm">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-42.954417,-52.001016)"
+     id="layer1">
+    <g
+       id="flowRoot815"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       transform="scale(0.26458333)" />
+    <path
+       id="path941-6-1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.33332825px;line-height:1.25;font-family:'ISL_FADE TO BLAK';-inkscape-font-specification:'ISL_FADE TO BLAK';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       d="m 93.986267,62.001016 c -8.182482,8.819443 0,0 -8.182482,8.819443 l 8.182482,8.819444 h 4.801698 l -8.182485,-8.819444 8.182485,-8.819443 z" />
+    <g
+       id="flowRoot823"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       transform="matrix(0.26458333,0,0,0.26458333,52.387527,0)"
+       aria-label="execa">
+      <path
+         id="path939"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.33332825px;font-family:'ISL_FADE TO BLAK';-inkscape-font-specification:'ISL_FADE TO BLAK'"
+         d="M 2.1425781,301.00121 V 234.33455 H 82.142575 v 13.33333 H 15.475911 v 13.33334 h 53.333331 v 13.33333 H 15.475911 v 13.33333 h 66.666664 v 13.33333 z" />
+      <path
+         id="path943"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.33332825px;font-family:'ISL_FADE TO BLAK';-inkscape-font-specification:'ISL_FADE TO BLAK'"
+         d="m 188.60091,287.697 v -53.36245 h 79.99999 v 13.33333 h -66.66666 v 13.33334 h 53.33333 v 13.33333 h -53.33333 v 15.33333 c -9.03948,0 -4.99013,0.0291 -13.33333,0.0291 z" />
+      <path
+         id="path945"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.33332825px;font-family:'ISL_FADE TO BLAK';-inkscape-font-specification:'ISL_FADE TO BLAK'"
+         d="m 281.83008,234.33455 h 80 v 13.33333 h -66.66667 v 40 h 66.66667 v 13.33333 h -80 z" />
+      <path
+         id="path947"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.33332825px;font-family:'ISL_FADE TO BLAK';-inkscape-font-specification:'ISL_FADE TO BLAK'"
+         d="m 422.46664,234.33455 32.59259,66.66666 h -14.81481 l -25.18519,-51.48148 -25.18518,51.48148 h -14.81482 l 32.5926,-66.66666 z" />
+    </g>
+    <path
+       id="path945-2"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.33332825px;line-height:1.25;font-family:'ISL_FADE TO BLAK';-inkscape-font-specification:'ISL_FADE TO BLAK';letter-spacing:0px;word-spacing:0px;fill:#66cc33;fill-opacity:1;stroke:none;stroke-width:0.26458538"
+       d="m 102.28815,76.105223 h 21.14713 V 79.633 h -21.167 c 0,-2.741709 0.0199,-1.92416 0.0199,-3.527777 z" />
+    <path
+       id="path941-6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.33332825px;line-height:1.25;font-family:'ISL_FADE TO BLAK';-inkscape-font-specification:'ISL_FADE TO BLAK';letter-spacing:0px;word-spacing:0px;fill:#66cc33;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       d="m 82.422998,62.001016 c 8.182482,8.819443 0,0 8.182482,8.819443 l -8.182482,8.819444 H 77.6213 L 85.803785,70.820459 77.6213,62.001016 Z" />
+  </g>
+</svg>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/ehmicky/execa/feature/logo/logo.svg?sanitize=true" width="500"/>
+<img src="logo/logo.svg" width="500">
 
 [![Build Status](https://travis-ci.org/sindresorhus/execa.svg?branch=master)](https://travis-ci.org/sindresorhus/execa) [![Coverage Status](https://coveralls.io/repos/github/sindresorhus/execa/badge.svg?branch=master)](https://coveralls.io/github/sindresorhus/execa?branch=master)
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/ehmicky/execa/feature/logo/logo.svg?sanitize=true" width="600"/>
+<img src="https://raw.githubusercontent.com/ehmicky/execa/feature/logo/logo.svg?sanitize=true" width="500"/>
 
 [![Build Status](https://travis-ci.org/sindresorhus/execa.svg?branch=master)](https://travis-ci.org/sindresorhus/execa) [![Coverage Status](https://coveralls.io/repos/github/sindresorhus/execa/badge.svg?branch=master)](https://coveralls.io/github/sindresorhus/execa?branch=master)
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-# execa [![Build Status](https://travis-ci.org/sindresorhus/execa.svg?branch=master)](https://travis-ci.org/sindresorhus/execa) [![Coverage Status](https://coveralls.io/repos/github/sindresorhus/execa/badge.svg?branch=master)](https://coveralls.io/github/sindresorhus/execa?branch=master)
+<img src="https://raw.githubusercontent.com/ehmicky/execa/feature/logo/logo.svg?sanitize=true" width="600"/>
+
+[![Build Status](https://travis-ci.org/sindresorhus/execa.svg?branch=master)](https://travis-ci.org/sindresorhus/execa) [![Coverage Status](https://coveralls.io/repos/github/sindresorhus/execa/badge.svg?branch=master)](https://coveralls.io/github/sindresorhus/execa?branch=master)
 
 > A better [`child_process`](https://nodejs.org/api/child_process.html)
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-<img src="logo/logo.svg" width="500">
+<img src="logo.svg" width="500">
 
 [![Build Status](https://travis-ci.org/sindresorhus/execa.svg?branch=master)](https://travis-ci.org/sindresorhus/execa) [![Coverage Status](https://coveralls.io/repos/github/sindresorhus/execa/badge.svg?branch=master)](https://coveralls.io/github/sindresorhus/execa?branch=master)
 


### PR DESCRIPTION
This adds a logo I just made:

![execa_white](https://user-images.githubusercontent.com/8136211/55554595-7a3e9f00-56e3-11e9-8e3a-eb546254515e.png)

The green parts are representing the `>_` symbols often used to represent Unix shell prompts.

Green-on-black is a common color scheme for terminals. That shade of green is also one of the Node.js official shades of green.

The font is [ISL Fade to Blak](https://www.dafont.com/isl-fade-to-blak.font) and is in the public domain.