### PR TITLE
Add `/q` option to `cmd` as well as `cmd.exe` on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,8 @@ function handleArgs(command, args, options) {
 		options.cleanup = false;
 	}
 
-	if (process.platform === 'win32' && path.basename(command).startsWith('cmd')) {
+	const basename = path.basename(command);
+	if (process.platform === 'win32' && (basename === 'cmd' || basename === 'cmd.exe')) {
 		// #116
 		args.unshift('/q');
 	}

--- a/index.js
+++ b/index.js
@@ -60,8 +60,7 @@ function handleArgs(command, args, options) {
 		options.cleanup = false;
 	}
 
-	const basename = path.basename(command);
-	if (process.platform === 'win32' && (basename === 'cmd' || basename === 'cmd.exe')) {
+	if (process.platform === 'win32' && path.basename(command, '.exe') === 'cmd') {
 		// #116
 		args.unshift('/q');
 	}

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function handleArgs(command, args, options) {
 		options.cleanup = false;
 	}
 
-	if (process.platform === 'win32' && path.basename(command) === 'cmd.exe') {
+	if (process.platform === 'win32' && path.basename(command).startsWith('cmd')) {
 		// #116
 		args.unshift('/q');
 	}

--- a/test.js
+++ b/test.js
@@ -28,6 +28,7 @@ if (process.platform === 'win32') {
 		const {stdout} = await execa('hello.cmd');
 		t.is(stdout, 'Hello World');
 	});
+
 	test('execa() - run cmd command', async t => {
 		const {stdout} = await execa('cmd', ['/c', 'hello.cmd']);
 		t.is(stdout, 'Hello World');

--- a/test.js
+++ b/test.js
@@ -28,6 +28,10 @@ if (process.platform === 'win32') {
 		const {stdout} = await execa('hello.cmd');
 		t.is(stdout, 'Hello World');
 	});
+	test('execa() - run cmd command', async t => {
+		const {stdout} = await execa('cmd', ['/c', 'hello.cmd']);
+		t.is(stdout, 'Hello World');
+	});
 }
 
 test('buffer', async t => {


### PR DESCRIPTION
The `/q` option should be added whether the running command is `cmd.exe` or `cmd`.

