### PR TITLE
Fix non-executable execution with `input` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function handleArgs(command, args, options = {}) {
 }
 
 function handleInput(spawned, input) {
-	if (input === undefined) {
+	if (input === undefined || spawned.stdin === undefined) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ function handleArgs(command, args, options = {}) {
 }
 
 function handleInput(spawned, input) {
+	// Checking for stdin is workaround for https://github.com/nodejs/node/issues/26852 on nodejs v10, v11, v12
 	if (input === undefined || spawned.stdin === undefined) {
 		return;
 	}

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function handleArgs(command, args, options = {}) {
 }
 
 function handleInput(spawned, input) {
-	// Checking for stdin is workaround for https://github.com/nodejs/node/issues/26852 on nodejs v10, v11, v12
+	// Checking for stdin is workaround for https://github.com/nodejs/node/issues/26852 on Node.js 10 and 12
 	if (input === undefined || spawned.stdin === undefined) {
 		return;
 	}

--- a/test.js
+++ b/test.js
@@ -336,6 +336,12 @@ if (process.platform !== 'win32') {
 		const cp = execa('non-executable');
 		await t.throwsAsync(cp);
 	});
+
+	test('execa() rejects with correct error and doesn\'t throw if running non-executable with input', async t => {
+		await t.throwsAsync(() => {
+			return execa('non-executable', {input: 'Hey!'});
+		}, /EACCES/);
+	});
 }
 
 test('error.killed is true if process was killed directly', async t => {

--- a/test.js
+++ b/test.js
@@ -338,9 +338,7 @@ if (process.platform !== 'win32') {
 	});
 
 	test('execa() rejects with correct error and doesn\'t throw if running non-executable with input', async t => {
-		await t.throwsAsync(() => {
-			return execa('non-executable', {input: 'Hey!'});
-		}, /EACCES/);
+		await t.throwsAsync(execa('non-executable', {input: 'Hey!'}), /EACCES/);
 	});
 }
 


### PR DESCRIPTION
`execa` throws internal error instead of rejecting with proper error when running non-executable with input.

fixes #166

Failing test: https://travis-ci.org/sindresorhus/execa/builds/528756511?utm_source=github_status&utm_medium=notification

Added test, fixed the problem.