### PR TITLE
Fix `options.detached` test

### DIFF
--- a/fixtures/detach
+++ b/fixtures/detach
@@ -1,13 +1,8 @@
 #!/usr/bin/env node
-const fs = require('fs');
+'use strict';
+
 const execa = require('..');
 
-const fd = fs.openSync(process.argv[2], 'w');
-
-const cp = execa('noop', ['foo'], {
-	detached: true,
-	stdio: ['ignore', fd]
-});
-cp.unref();
-
+const subprocess = execa('node', ['./fixtures/forever'], {detached: true});
+console.log(subprocess.pid);
 process.exit();

--- a/fixtures/forever
+++ b/fixtures/forever
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 'use strict';
 
-setTimeout(() => {}, 20000);
+setTimeout(() => {}, 1e8);

--- a/test.js
+++ b/test.js
@@ -581,13 +581,12 @@ test('do not buffer when streaming', async t => {
 });
 
 test('detach child process', async t => {
-	const file = tempfile('.txt');
+	const {stdout} = await execa('detach');
+	const pid = Number(stdout);
+	t.true(Number.isInteger(pid));
+	t.true(isRunning(pid));
 
-	await execa('detach', [file]);
-
-	await delay(5000);
-
-	t.is(fs.readFileSync(file, 'utf8'), 'foo\n');
+	process.kill(pid, 'SIGKILL');
 });
 
 // See #128


### PR DESCRIPTION
This fixes the unit test for `options.detached`. The current test keeps failing on CI.

The new test takes a different approach, where we only check if a detached process is running after its parent exited, by using the `is-running` library.