### PR TITLE
Improve test for `options.preferLocal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
 	"devDependencies": {
 		"@types/node": "^11.12.2",
 		"ava": "^1.4.1",
-		"cat-names": "^2.0.0",
 		"coveralls": "^3.0.3",
 		"delay": "^4.1.0",
 		"is-running": "^2.1.0",

--- a/test.js
+++ b/test.js
@@ -184,19 +184,9 @@ test('stripFinalNewline option', async t => {
 	t.is(stdout, 'foo\n');
 });
 
-test.serial('preferLocal option', async t => {
-	t.true((await execa('cat-names')).stdout.length > 2);
-
-	if (process.platform === 'win32') {
-		// TODO: figure out how to make the below not hang on Windows
-		return;
-	}
-
-	// Account for npm adding local binaries to the PATH
-	const _path = process.env.PATH;
-	process.env.PATH = '';
-	await t.throwsAsync(execa('cat-names', {preferLocal: false}), /spawn .* ENOENT/);
-	process.env.PATH = _path;
+test('preferLocal option', async t => {
+	await execa('ava', ['--version'], {env: {PATH: ''}});
+	await t.throwsAsync(execa('ava', ['--version'], {preferLocal: false, env: {PATH: ''}}), /spawn .* ENOENT/);
 });
 
 test.serial('localDir option', async t => {

--- a/test.js
+++ b/test.js
@@ -186,7 +186,8 @@ test('stripFinalNewline option', async t => {
 
 test('preferLocal option', async t => {
 	await execa('ava', ['--version'], {env: {PATH: ''}});
-	await t.throwsAsync(execa('ava', ['--version'], {preferLocal: false, env: {PATH: ''}}), /spawn .* ENOENT/);
+	const errorRegExp = process.platform === 'win32' ? /not recognized/ : /spawn ava ENOENT/;
+	await t.throwsAsync(execa('ava', ['--version'], {preferLocal: false, env: {PATH: ''}}), errorRegExp);
 });
 
 test.serial('localDir option', async t => {


### PR DESCRIPTION
This improves the test for `options.preferLocal`:
  - makes it work on Windows
  - simplifies it
  - removes `cat-names` dependency
  - removes `test.serial()`, i.e. make tests faster