### PR TITLE
Fix test for `options.localDir`

### DIFF
--- a/fixtures/local-dir/package.json
+++ b/fixtures/local-dir/package.json
@@ -1,5 +1,0 @@
-{
-	"dependencies": {
-		"self-path": "^1.0.0"
-	}
-}

--- a/test.js
+++ b/test.js
@@ -199,15 +199,12 @@ test.serial('preferLocal option', async t => {
 	process.env.PATH = _path;
 });
 
-test.serial('localDir option', async t => {
-	const cwd = 'fixtures/local-dir';
-	const bin = path.resolve(cwd, 'node_modules/.bin/self-path');
-
-	await execa('npm', ['install', '--no-package-lock'], {cwd});
-
-	const {stdout} = await execa(bin, {localDir: cwd});
-
-	t.is(path.relative(cwd, stdout), path.normalize('node_modules/self-path'));
+test('localDir option', async t => {
+	const command = process.platform === 'win32' ? 'echo %PATH%' : 'echo $PATH';
+	const {stdout} = await execa(command, {shell: true, localDir: '/test'});
+	const [firstPath] = stdout.split(path.delimiter);
+	const firstUnixPath = firstPath.replace(/\\/g, '/').replace(/^[^/]+/, '');
+	t.is(firstUnixPath, '/test/node_modules/.bin');
 });
 
 test('input option can be a String', async t => {

--- a/test.js
+++ b/test.js
@@ -202,9 +202,10 @@ test.serial('preferLocal option', async t => {
 test('localDir option', async t => {
 	const command = process.platform === 'win32' ? 'echo %PATH%' : 'echo $PATH';
 	const {stdout} = await execa(command, {shell: true, localDir: '/test'});
-	const [firstPath] = stdout.split(path.delimiter);
-	const firstUnixPath = firstPath.replace(/\\/g, '/').replace(/^[^/]+/, '');
-	t.is(firstUnixPath, '/test/node_modules/.bin');
+	const envPaths = stdout.split(path.delimiter).map(envPath =>
+		envPath.replace(/\\/g, '/').replace(/^[^/]+/, '')
+	);
+	t.true(envPaths.some(envPath => envPath === '/test/node_modules/.bin'));
 });
 
 test('input option can be a String', async t => {


### PR DESCRIPTION
This improves the unit test for `options.localDir`:
  - remove `test.serial()` and `npm install` to make the test much faster
  - use a simpler approach that only relies on checking the `$PATH` environment variable instead of firing a command.