### PR TITLE
Remove some unused code (`Math.abs()` on exit codes)

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ function getCode({error = {}}, code) {
 	}
 
 	if (Number.isInteger(code)) {
-		return [util.getSystemErrorName(-Math.abs(code)), Math.abs(code)];
+		return [util.getSystemErrorName(code), code];
 	}
 
 	return [];

--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ function getCode({error = {}}, code) {
 	}
 
 	if (Number.isInteger(code)) {
-		return [util.getSystemErrorName(code), code];
+		return [util.getSystemErrorName(-code), code];
 	}
 
 	return [];


### PR DESCRIPTION
`Math.abs()` is used on the `code` returned by `child_process.on('exit', (code, signal) => {})`.

However [`code` is always positive](https://github.com/nodejs/node/blob/master/lib/internal/child_process.js#L247).