### PR TITLE
Remove dead code related to exit code names

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,19 +239,7 @@ function getErrorPrefix({timedOut, timeout, signal, exitCodeName, exitCode, isCa
 		return `was killed with ${signal}`;
 	}
 
-	if (exitCodeName !== undefined && exitCode !== undefined) {
-		return `failed with exit code ${exitCode} (${exitCodeName})`;
-	}
-
-	if (exitCodeName !== undefined) {
-		return `failed with exit code ${exitCodeName}`;
-	}
-
-	if (exitCode !== undefined) {
-		return `failed with exit code ${exitCode}`;
-	}
-
-	return 'failed';
+	return `failed with exit code ${exitCode} (${exitCodeName})`;
 }
 
 function joinCommand(command, args) {


### PR DESCRIPTION
We have added some logic to improve error messages, based on the child process termination.

Some of this logic is unreachable, so this is dead code and can be removed.

1) `exitCodeName` cannot be `undefined` when `exitCode` is defined. This is because (when missing) `exitCodeName` is retrieved using `util.getSystemErrorName(exitCode)`, and that function always returns a value. When the exit code wrong is wrong (e.g. `255`), it will return [`Unknown system error -255`](https://github.com/nodejs/node/blob/c476daf6d9397966e2a9c76de4d5f20724772718/lib/internal/util.js#L260).

2) `exitCode` cannot be `undefined` when `exitCodeName` is defined. This is because (when missing) `exitCode` is retrieve using `os.constants.errno[error.code]`. `error.code` is from `child_process.on('error')`. `error.code` is guaranteed to be a valid exit code, because it's set within Node.js not by users. I checked the Node.js source and it looks pretty solid. Exception: if user manually triggers `child_process.emit('error')` with an invalid `error.code`, but this seems like an edge case.

3) Both `signal`, `exitCode` and `exitCodeName` are `undefined`. This just cannot happen if you check our current logic.

This also [improves test coverage](https://coveralls.io/builds/23233590/source?filename=index.js#L238).