### PR TITLE
Improve `cleanup` option (code quality, tests, documentation)

### DIFF
--- a/fixtures/sub-process
+++ b/fixtures/sub-process
@@ -3,5 +3,6 @@
 const execa = require('..');
 
 const cleanup = process.argv[2] === 'true';
-const subprocess = execa('node', ['./fixtures/forever'], {cleanup});
+const detached = process.argv[3] === 'true';
+const subprocess = execa('node', ['./fixtures/forever'], {cleanup, detached});
 process.send(subprocess.pid);

--- a/fixtures/sub-process-exit
+++ b/fixtures/sub-process-exit
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+'use strict';
+const execa = require('..');
+
+const cleanup = process.argv[2] === 'true';
+const detached = process.argv[3] === 'true';
+execa('node', ['./fixtures/noop'], {cleanup, detached});

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,6 +102,7 @@ declare namespace execa {
 
 		/**
 		Keep track of the spawned process and `kill` it when the parent process exits.
+		Kill the spawned process when the parent process exits unless either the spawned process is detached, or the parent process is terminated abruptly.
 
 		@default true
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,8 +101,9 @@ declare namespace execa {
 		readonly reject?: boolean;
 
 		/**
-		Keep track of the spawned process and `kill` it when the parent process exits.
-		Kill the spawned process when the parent process exits unless either the spawned process is detached, or the parent process is terminated abruptly.
+		Kill the spawned process when the parent process exits unless either:
+			- the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
+			- the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
 
 		@default true
 		*/

--- a/index.js
+++ b/index.js
@@ -93,11 +93,6 @@ function handleArgs(command, args, options = {}) {
 
 	options.stdio = stdio(options);
 
-	if (options.detached) {
-		// #115
-		options.cleanup = false;
-	}
-
 	if (process.platform === 'win32' && path.basename(command, '.exe') === 'cmd') {
 		// #116
 		args.unshift('/q');
@@ -264,8 +259,9 @@ const execa = (command, args, options) => {
 		return Promise.reject(error);
 	}
 
+	// #115
 	let removeExitHandler;
-	if (parsed.options.cleanup) {
+	if (parsed.options.cleanup && !parsed.options.detached) {
 		removeExitHandler = onExit(() => {
 			spawned.kill();
 		});

--- a/readme.md
+++ b/readme.md
@@ -279,7 +279,7 @@ Default: `true`
 
 Kill the spawned process when the parent process exits unless either:
   - the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
-  - the parent process is terminated abruptly, e.g. with `SIGKILL` (as opposed to `SIGTERM` or a normal exit)
+  - the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
 
 #### encoding
 

--- a/readme.md
+++ b/readme.md
@@ -277,7 +277,9 @@ Setting this to `false` resolves the promise with the error instead of rejecting
 Type: `boolean`<br>
 Default: `true`
 
-Keep track of the spawned process and `kill` it when the parent process exits.
+Kill the spawned process when the parent process exits unless either:
+  - the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
+  - the parent process is terminated abruptly, e.g. with `SIGKILL` (as opposed to `SIGTERM` or a normal exit)
 
 #### encoding
 

--- a/readme.md
+++ b/readme.md
@@ -278,8 +278,8 @@ Type: `boolean`<br>
 Default: `true`
 
 Kill the spawned process when the parent process exits unless either:
-  - the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
-  - the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
+	- the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
+	- the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
 
 #### encoding
 

--- a/test.js
+++ b/test.js
@@ -498,6 +498,10 @@ async function spawnAndKill(t, signal, cleanup, detached, isKilled) {
 
 	t.false(isRunning(subprocess.pid));
 	t.is(isRunning(pid), !isKilled);
+
+	if (!isKilled) {
+		process.kill(pid, 'SIGKILL');
+	}
 }
 
 // Without `options.cleanup`:


### PR DESCRIPTION
This improves the `cleanup` option, but does not change its behavior:
  - small code simplification
  - added tests for `options.detached: true` (before only `options.detached: false` was tested)
  - fix tests not properly cleaning up created processes (i.e. memory leak)
  - improve option description on `README`