### PR TITLE
Improve `error.killed`

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ function getStream(process, stream, {encoding, buffer, maxBuffer}) {
 function makeError(result, options) {
 	const {stdout, stderr, code, signal} = result;
 	let {error} = result;
-	const {joinedCommand, timedOut, isCanceled, parsed: {options: {timeout}}} = options;
+	const {joinedCommand, timedOut, isCanceled, killed, parsed: {options: {timeout}}} = options;
 
 	const [exitCodeName, exitCode] = getCode(result, code);
 
@@ -195,10 +195,10 @@ function makeError(result, options) {
 	// `signal` emitted on `spawned.on('exit')` event can be `null`. We normalize
 	// it to `undefined`
 	error.signal = signal || undefined;
-	error.killed = signal !== null && !timedOut;
 	error.command = joinedCommand;
 	error.timedOut = Boolean(timedOut);
 	error.isCanceled = isCanceled;
+	error.killed = killed && !timedOut;
 
 	if ('all' in result) {
 		error.all = result.all;
@@ -365,7 +365,8 @@ const execa = (command, args, options) => {
 					joinedCommand,
 					parsed,
 					timedOut,
-					isCanceled
+					isCanceled,
+					killed: spawned.killed
 				});
 
 				if (!parsed.options.reject) {

--- a/index.js
+++ b/index.js
@@ -195,6 +195,7 @@ function makeError(result, options) {
 	// `signal` emitted on `spawned.on('exit')` event can be `null`. We normalize
 	// it to `undefined`
 	error.signal = signal || undefined;
+	error.killed = signal !== null && !timedOut;
 	error.command = joinedCommand;
 	error.timedOut = Boolean(timedOut);
 	error.isCanceled = isCanceled;
@@ -366,11 +367,6 @@ const execa = (command, args, options) => {
 					timedOut,
 					isCanceled
 				});
-
-				// TODO: missing some timeout logic for killed
-				// https://github.com/nodejs/node/blob/master/lib/child_process.js#L203
-				// error.killed = spawned.killed || killed;
-				error.killed = error.killed || spawned.killed;
 
 				if (!parsed.options.reject) {
 					return error;

--- a/test.js
+++ b/test.js
@@ -293,7 +293,7 @@ test('error.killed is true if process was killed directly', async t => {
 	t.true(error.killed);
 });
 
-test('error.killed is true if process was killed indirectly', async t => {
+test('error.killed is false if process was killed indirectly', async t => {
 	const cp = execa('forever');
 
 	process.kill(cp.pid, 'SIGINT');
@@ -301,7 +301,7 @@ test('error.killed is true if process was killed indirectly', async t => {
 	// `process.kill()` is emulated by Node.js on Windows
 	const message = process.platform === 'win32' ? /failed with exit code 1/ : /was killed with SIGINT/;
 	const error = await t.throwsAsync(cp, {message});
-	t.true(error.killed);
+	t.false(error.killed);
 });
 
 if (process.platform === 'darwin') {

--- a/test.js
+++ b/test.js
@@ -293,8 +293,7 @@ test('error.killed is true if process was killed directly', async t => {
 	t.true(error.killed);
 });
 
-// TODO: Should this really be the case, or should we improve on child_process?
-test('error.killed is false if process was killed indirectly', async t => {
+test('error.killed is true if process was killed indirectly', async t => {
 	const cp = execa('forever');
 
 	process.kill(cp.pid, 'SIGINT');
@@ -302,7 +301,7 @@ test('error.killed is false if process was killed indirectly', async t => {
 	// `process.kill()` is emulated by Node.js on Windows
 	const message = process.platform === 'win32' ? /failed with exit code 1/ : /was killed with SIGINT/;
 	const error = await t.throwsAsync(cp, {message});
-	t.false(error.killed);
+	t.true(error.killed);
 });
 
 if (process.platform === 'darwin') {
@@ -362,6 +361,7 @@ test('error.code is 4', code, 4);
 
 test('timeout kills the process if it times out', async t => {
 	const error = await t.throwsAsync(execa('forever', {timeout: 1, message: TIMEOUT_REGEXP}));
+	t.false(error.killed);
 	t.true(error.timedOut);
 });
 


### PR DESCRIPTION
This changes the conditions behind `error.killed`.

### a) `childProcess.kill()` was successfully called

`true` in core Node.js, `true` in `execa`. Unchanged.

### b) `process.kill(childProcess.pid)` was called

`false` in core Node.js, `false` in `execa`. Unchanged.

Ideally this should be `true`, but I am not sure that's possible. The issue is that Windows uses `exitCode: 1` and no `signal`, while Unix uses `exitCode: null` and `signal: 'SIGTERM'`. The difference is due to Node.js emulating termination signals on Windows. On Windows (with just `exitCode: 1`) it seems impossible to know whether the child process was killed externally.

One consequence of this is: while `process.kill(childProcess.pid)` will set `error.killed` to `false` on both Windows and Unix, the error message will be different: `was killed with SIGTERM` on Unix, `failed with exit code 1` on Windows.

### c) `timeout` was reached

`true` in core Node.js, `true` in `execa`. Changed to `false` with this PR. We have `error.timedOut` for this. This makes those boolean error properties orthogonal to each other.

### d) `maxBuffer` was reached

`true` in core Node.js, `false` in `execa`. Unchanged. We should add a property similar to `error.timedOut` but for `maxBuffer` instead. I can do it in a separate PR.

Note: this not does change `childProcess.killed`, which is a separate property and is `true` when `childProcess()` was successfully called (in both core Node.js and `execa`).