### PR TITLE
Make `error.killed` and `error.isCanceled` always boolean (not `undefined`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ function makeError(result, options) {
 	// it to `undefined`
 	error.signal = signal || undefined;
 	error.command = joinedCommand;
-	error.timedOut = Boolean(timedOut);
+	error.timedOut = timedOut;
 	error.isCanceled = isCanceled;
 
 	if ('all' in result) {
@@ -449,7 +449,9 @@ module.exports.sync = (command, args, options) => {
 	if (result.error || result.status !== 0 || result.signal !== null) {
 		const error = makeError(result, {
 			joinedCommand,
-			parsed
+			parsed,
+			timedOut: false,
+			isCanceled: false
 		});
 
 		if (!parsed.options.reject) {
@@ -466,7 +468,9 @@ module.exports.sync = (command, args, options) => {
 		exitCode: 0,
 		exitCodeName: 'SUCCESS',
 		failed: false,
+		killed: false,
 		command: joinedCommand,
-		timedOut: false
+		timedOut: false,
+		isCanceled: false
 	};
 };

--- a/test.js
+++ b/test.js
@@ -305,6 +305,16 @@ test('error.killed is false if process was killed indirectly', async t => {
 	t.false(error.killed);
 });
 
+test('result.killed is false if not killed', async t => {
+	const result = await execa('noop');
+	t.false(result.killed);
+});
+
+test('result.killed is false if not killed, in sync mode', t => {
+	const result = execa.sync('noop');
+	t.false(result.killed);
+});
+
 if (process.platform === 'darwin') {
 	test.cb('sanity check: child_process.exec also has killed.false if killed indirectly', t => {
 		const cp = childProcess.exec('forever', error => {
@@ -372,6 +382,11 @@ test('timeout does not kill the process if it does not time out', async t => {
 
 test('timedOut is false if no timeout was set', async t => {
 	const result = await execa('noop');
+	t.false(result.timedOut);
+});
+
+test('timedOut will be false if no timeout was set and zero exit code in sync mode', t => {
+	const result = execa.sync('noop');
 	t.false(result.timedOut);
 });
 
@@ -578,9 +593,24 @@ test('cancel method kills the subprocess', t => {
 	t.true(subprocess.killed);
 });
 
-test('result.isCanceled is false when spawned.cancel isn\'t called', async t => {
+test('result.isCanceled is false when spawned.cancel() isn\'t called (success)', async t => {
 	const result = await execa('noop');
 	t.false(result.isCanceled);
+});
+
+test('result.isCanceled is false when spawned.cancel() isn\'t called (failure)', async t => {
+	const error = await t.throwsAsync(execa('fail'));
+	t.false(error.isCanceled);
+});
+
+test('result.isCanceled is false when spawned.cancel() isn\'t called in sync mode (success)', t => {
+	const result = execa.sync('noop');
+	t.false(result.isCanceled);
+});
+
+test('result.isCanceled is false when spawned.cancel() isn\'t called in sync mode (failure)', t => {
+	const error = t.throws(() => execa.sync('fail'));
+	t.false(error.isCanceled);
 });
 
 test('calling cancel method throws an error with message "Command was canceled"', async t => {


### PR DESCRIPTION
The `killed` and `isCanceled` properties of `error` should always be `true` or `false`, not `undefined`. This makes the interface simpler and more predictable.

This PR solves the use cases where it could have been `undefined`, e.g. when using `execa.sync()`.

It also adds related tests.