### PR TITLE
Make error messages more consistent

### DIFF
--- a/fixtures/error-message.js
+++ b/fixtures/error-message.js
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-'use strict';
-console.log('stdout');
-console.error('stderr');
-process.exit(1);

--- a/index.js
+++ b/index.js
@@ -177,13 +177,14 @@ function makeError(result, options) {
 
 	const [exitCodeName, exitCode] = getCode(result, code);
 
-	if (!(error instanceof Error)) {
-		const message = [joinedCommand, stderr, stdout].filter(Boolean).join('\n');
+	const prefix = getErrorPrefix({timedOut, timeout, signal, exitCodeName, exitCode, isCanceled});
+	const message = `Command ${prefix}: ${joinedCommand}`;
+
+	if (error instanceof Error) {
+		error.message = `${message}${error.message}`;
+	} else {
 		error = new Error(message);
 	}
-
-	const prefix = getErrorPrefix({timedOut, timeout, signal, exitCodeName, exitCode, isCanceled});
-	error.message = `Command ${prefix}: ${error.message}`;
 
 	error.code = exitCode || exitCodeName;
 	error.exitCode = exitCode;

--- a/test.js
+++ b/test.js
@@ -12,8 +12,6 @@ import execa from '.';
 process.env.PATH = path.join(__dirname, 'fixtures') + path.delimiter + process.env.PATH;
 process.env.FOO = 'foo';
 
-const NO_NEWLINES_REGEXP = /^[^\n]*$/;
-const STDERR_STDOUT_REGEXP = /stderr[^]*stdout/;
 const TIMEOUT_REGEXP = /timed out after/;
 
 const getExitRegExp = exitMessage => new RegExp(`failed with exit code ${exitMessage}`);
@@ -61,32 +59,6 @@ test('stdout/stderr/all available on errors', async t => {
 	t.is(typeof error.stdout, 'string');
 	t.is(typeof error.stderr, 'string');
 	t.is(typeof error.all, 'string');
-});
-
-test('include stdout and stderr in errors for improved debugging', async t => {
-	await t.throwsAsync(execa('fixtures/error-message.js'), {message: STDERR_STDOUT_REGEXP, code: 1});
-});
-
-test('do not include in errors when `stdio` is set to `inherit`', async t => {
-	await t.throwsAsync(execa('fixtures/error-message.js', {stdio: 'inherit'}), {message: NO_NEWLINES_REGEXP});
-});
-
-test('do not include `stderr` and `stdout` in errors when set to `inherit`', async t => {
-	await t.throwsAsync(execa('fixtures/error-message.js', {stdout: 'inherit', stderr: 'inherit'}), {message: NO_NEWLINES_REGEXP});
-});
-
-test('do not include `stderr` and `stdout` in errors when `stdio` is set to `inherit`', async t => {
-	await t.throwsAsync(execa('fixtures/error-message.js', {stdio: [undefined, 'inherit', 'inherit']}), {message: NO_NEWLINES_REGEXP});
-});
-
-test('do not include `stdout` in errors when set to `inherit`', async t => {
-	const error = await t.throwsAsync(execa('fixtures/error-message.js', {stdout: 'inherit'}), {message: /stderr/});
-	t.notRegex(error.message, /stdout/);
-});
-
-test('do not include `stderr` in errors when set to `inherit`', async t => {
-	const error = await t.throwsAsync(execa('fixtures/error-message.js', {stderr: 'inherit'}), {message: /stdout/});
-	t.notRegex(error.message, /stderr/);
 });
 
 test('pass `stdout` to a file descriptor', async t => {
@@ -148,16 +120,9 @@ test('execa.sync() throws error if written to stderr', t => {
 	}, process.platform === 'win32' ? /'foo' is not recognized as an internal or external command/ : /spawnSync foo ENOENT/);
 });
 
-test('execa.sync() includes stdout and stderr in errors for improved debugging', t => {
-	t.throws(() => {
-		execa.sync('node', ['fixtures/error-message.js']);
-	}, {message: STDERR_STDOUT_REGEXP, code: 1});
-});
-
 test('skip throwing when using reject option in execa.sync()', t => {
-	const error = execa.sync('node', ['fixtures/error-message.js'], {reject: false});
-	t.is(typeof error.stdout, 'string');
-	t.is(typeof error.stderr, 'string');
+	const error = execa.sync('noop-err', ['foo'], {reject: false});
+	t.is(error.stderr, 'foo');
 });
 
 test('stripEof option (legacy)', async t => {

--- a/test.js
+++ b/test.js
@@ -117,7 +117,7 @@ test('execa.sync()', t => {
 test('execa.sync() throws error if written to stderr', t => {
 	t.throws(() => {
 		execa.sync('foo');
-	}, process.platform === 'win32' ? /'foo' is not recognized as an internal or external command/ : /spawnSync foo ENOENT/);
+	}, process.platform === 'win32' ? /Command failed with exit code 1/ : /spawnSync foo ENOENT/);
 });
 
 test('skip throwing when using reject option in execa.sync()', t => {
@@ -137,7 +137,7 @@ test('stripFinalNewline option', async t => {
 
 test('preferLocal option', async t => {
 	await execa('ava', ['--version'], {env: {PATH: ''}});
-	const errorRegExp = process.platform === 'win32' ? /not recognized/ : /spawn ava ENOENT/;
+	const errorRegExp = process.platform === 'win32' ? /Command failed with exit code 1/ : /spawn ava ENOENT/;
 	await t.throwsAsync(execa('ava', ['--version'], {preferLocal: false, env: {PATH: ''}}), errorRegExp);
 });
 

--- a/test.js
+++ b/test.js
@@ -117,7 +117,7 @@ test('execa.sync()', t => {
 test('execa.sync() throws error if written to stderr', t => {
 	t.throws(() => {
 		execa.sync('foo');
-	}, process.platform === 'win32' ? /Command failed with exit code 1/ : /spawnSync foo ENOENT/);
+	}, process.platform === 'win32' ? /failed with exit code 1/ : /spawnSync foo ENOENT/);
 });
 
 test('skip throwing when using reject option in execa.sync()', t => {
@@ -137,7 +137,7 @@ test('stripFinalNewline option', async t => {
 
 test('preferLocal option', async t => {
 	await execa('ava', ['--version'], {env: {PATH: ''}});
-	const errorRegExp = process.platform === 'win32' ? /Command failed with exit code 1/ : /spawn ava ENOENT/;
+	const errorRegExp = process.platform === 'win32' ? /failed with exit code 1/ : /spawn ava ENOENT/;
 	await t.throwsAsync(execa('ava', ['--version'], {preferLocal: false, env: {PATH: ''}}), errorRegExp);
 });
 


### PR DESCRIPTION
This makes `error.message` more consistent.

`execa` errors in the following cases:
  a) exit code is defined and is not `0`
  b) child process `error` event, or `stdin` `error` event
  c) signal termination (including `cancel()`)
  d) timeout
  e) stream error (separate issue: #228)

a) c) d) e) look consistent. However b):
  - prints `stdout` and `stderr`, as opposed to the others. This can also lead to unexpectedly (very) long error messages, which might create issues for some users. `error.stdout` and `error.stderr` can be used instead.
  - does not print the command, as opposed to the others.

This adjusts b) error message to the same format used by the other errors.

It turns out to cover this, I just had to remove unit tests but did not need to add new ones (could not think of one not already covered).