### PR TITLE
Remove `execa.stdout()` and `execa.stderr()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -356,46 +356,6 @@ declare const execa: {
 	>;
 
 	/**
-	Same as `execa()`, but returns only `stdout`.
-
-	@param file - The program/script to execute.
-	@param arguments - Arguments to pass to `file` on execution.
-	@returns The contents of the executed process' `stdout`.
-	*/
-	stdout(
-		file: string,
-		arguments?: readonly string[],
-		options?: execa.Options
-	): Promise<string>;
-	stdout(
-		file: string,
-		arguments?: readonly string[],
-		options?: execa.Options<null>
-	): Promise<Buffer>;
-	stdout(file: string, options?: execa.Options): Promise<string>;
-	stdout(file: string, options?: execa.Options<null>): Promise<Buffer>;
-
-	/**
-	Same as `execa()`, but returns only `stderr`.
-
-	@param file - The program/script to execute.
-	@param arguments - Arguments to pass to `file` on execution.
-	@returns The contents of the executed process' `stderr`.
-	*/
-	stderr(
-		file: string,
-		arguments?: readonly string[],
-		options?: execa.Options
-	): Promise<string>;
-	stderr(
-		file: string,
-		arguments?: readonly string[],
-		options?: execa.Options<null>
-	): Promise<Buffer>;
-	stderr(file: string, options?: execa.Options): Promise<string>;
-	stderr(file: string, options?: execa.Options<null>): Promise<Buffer>;
-
-	/**
 	Execute a file synchronously.
 
 	This method throws an `Error` if the command fails.

--- a/index.js
+++ b/index.js
@@ -420,18 +420,6 @@ const execa = (command, args, options) => {
 
 module.exports = execa;
 
-// TODO: set `stderr: 'ignore'` when that option is implemented
-module.exports.stdout = async (...args) => {
-	const {stdout} = await execa(...args);
-	return stdout;
-};
-
-// TODO: set `stdout: 'ignore'` when that option is implemented
-module.exports.stderr = async (...args) => {
-	const {stderr} = await execa(...args);
-	return stderr;
-};
-
 module.exports.sync = (command, args, options) => {
 	const parsed = handleArgs(command, args, options);
 	const joinedCommand = joinCommand(command, args);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -114,20 +114,6 @@ expectType<ExecaReturnValue<Buffer>>(
 	await execa('unicorns', ['foo'], {encoding: null})
 );
 
-expectType<Promise<string>>(execa.stdout('unicorns'));
-expectType<string>(await execa.stdout('unicorns'));
-expectType<string>(await execa.stdout('unicorns', {encoding: 'utf8'}));
-expectType<Buffer>(await execa.stdout('unicorns', {encoding: null}));
-expectType<string>(await execa.stdout('unicorns', ['foo'], {encoding: 'utf8'}));
-expectType<Buffer>(await execa.stdout('unicorns', ['foo'], {encoding: null}));
-
-expectType<Promise<string>>(execa.stderr('unicorns'));
-expectType<string>(await execa.stderr('unicorns'));
-expectType<string>(await execa.stderr('unicorns', {encoding: 'utf8'}));
-expectType<Buffer>(await execa.stderr('unicorns', {encoding: null}));
-expectType<string>(await execa.stderr('unicorns', ['foo'], {encoding: 'utf8'}));
-expectType<Buffer>(await execa.stderr('unicorns', ['foo'], {encoding: null}));
-
 expectType<ExecaSyncReturnValue<string>>(execa.sync('unicorns'));
 expectType<ExecaSyncReturnValue<string>>(
 	execa.sync('unicorns', {encoding: 'utf8'})

--- a/readme.md
+++ b/readme.md
@@ -131,16 +131,6 @@ The spawned process can be canceled with the `.cancel()` method on the promise, 
 
 The promise result is an `Object` with `stdout`, `stderr` and `all` properties.
 
-### execa.stdout(file, [arguments], [options])
-### execa.stdout(command, [options])
-
-Same as `execa()`, but returns only `stdout`.
-
-### execa.stderr(file, [arguments], [options])
-### execa.stderr(command, [options])
-
-Same as `execa()`, but returns only `stderr`.
-
 ### execa.sync(file, [arguments], [options])
 ### execa.sync(command, [options])
 

--- a/test.js
+++ b/test.js
@@ -39,16 +39,6 @@ test('buffer', async t => {
 	t.is(stdout.toString(), 'foo');
 });
 
-test('execa.stdout()', async t => {
-	const stdout = await execa.stdout('noop', ['foo']);
-	t.is(stdout, 'foo');
-});
-
-test('execa.stderr()', async t => {
-	const stderr = await execa.stderr('noop-err', ['foo']);
-	t.is(stderr, 'foo');
-});
-
 test.serial('result.all shows both `stdout` and `stderr` intermixed', async t => {
 	const result = await execa('noop-132');
 	t.is(result.all, '132');
@@ -473,27 +463,27 @@ if (process.platform !== 'win32') {
 }
 
 test('use environment variables by default', async t => {
-	const result = await execa.stdout('environment');
+	const {stdout} = await execa('environment');
 
-	t.deepEqual(result.split('\n'), [
+	t.deepEqual(stdout.split('\n'), [
 		'foo',
 		'undefined'
 	]);
 });
 
 test('extend environment variables by default', async t => {
-	const result = await execa.stdout('environment', [], {env: {BAR: 'bar'}});
+	const {stdout} = await execa('environment', [], {env: {BAR: 'bar'}});
 
-	t.deepEqual(result.split('\n'), [
+	t.deepEqual(stdout.split('\n'), [
 		'foo',
 		'bar'
 	]);
 });
 
 test('do not extend environment with `extendEnv: false`', async t => {
-	const result = await execa.stdout('environment', [], {env: {BAR: 'bar', PATH: process.env.PATH}, extendEnv: false});
+	const {stdout} = await execa('environment', [], {env: {BAR: 'bar', PATH: process.env.PATH}, extendEnv: false});
 
-	t.deepEqual(result.split('\n'), [
+	t.deepEqual(stdout.split('\n'), [
 		'undefined',
 		'bar'
 	]);
@@ -514,7 +504,7 @@ test('can use `options.shell: string`', async t => {
 test('use extend environment with `extendEnv: true` and `shell: true`', async t => {
 	process.env.TEST = 'test';
 	const command = process.platform === 'win32' ? 'echo %TEST%' : 'echo $TEST';
-	const stdout = await execa.stdout(command, {shell: true, env: {}, extendEnv: true});
+	const {stdout} = await execa(command, {shell: true, env: {}, extendEnv: true});
 	t.is(stdout, 'test');
 	delete process.env.TEST;
 });


### PR DESCRIPTION
Fixes #220 

This removes `execa.stdout()` and `execa.stderr()`. Instead users can do:

```js
const { stdout } = await execa(...)
```

This makes the API simpler, and reduce code size.