### PR TITLE
Improve a readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -332,9 +332,10 @@ const subprocess = execa('echo', ['foo']);
 
 subprocess.stdout.pipe(process.stdout);
 
-subprocess.then(({ stdout }) => {
+(async () => {
+	const {stdout} = await subprocess;
 	console.log('child output:', stdout);
-});
+})();
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -327,14 +327,13 @@ Let's say you want to show the output of a child process in real-time while also
 
 ```js
 const execa = require('execa');
-const getStream = require('get-stream');
 
-const stream = execa('echo', ['foo']).stdout;
+const subprocess = execa('echo', ['foo']);
 
-stream.pipe(process.stdout);
+subprocess.stdout.pipe(process.stdout);
 
-getStream(stream).then(value => {
-	console.log('child output:', value);
+subprocess.then(({ stdout }) => {
+	console.log('child output:', stdout);
 });
 ```
 


### PR DESCRIPTION
This improves the example at the end of the `README`. The example does not need to use `get-stream` since `execa.then()` already uses it under the hood.