### PR TITLE
Remove deprecated option `stripEof`

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,11 +86,6 @@ function handleArgs(command, args, options = {}) {
 		});
 	}
 
-	// TODO: Remove in the next major release
-	if (options.stripEof === false) {
-		options.stripFinalNewline = false;
-	}
-
 	options.stdio = stdio(options);
 
 	if (process.platform === 'win32' && path.basename(command, '.exe') === 'cmd') {

--- a/test.js
+++ b/test.js
@@ -120,11 +120,6 @@ test('skip throwing when using reject option in sync mode', t => {
 	t.is(error.exitCode, 2);
 });
 
-test('stripEof option (legacy)', async t => {
-	const {stdout} = await execa('noop', ['foo'], {stripEof: false});
-	t.is(stdout, 'foo\n');
-});
-
 test('stripFinalNewline option', async t => {
 	const {stdout} = await execa('noop', ['foo'], {stripFinalNewline: false});
 	t.is(stdout, 'foo\n');


### PR DESCRIPTION
The `stripEof` was renamed to `stripFinalNewline`, and marked as deprecated.