### PR TITLE
Improve the API section of the readme

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -294,9 +294,7 @@ declare namespace execa {
 		): Promise<ExecaReturnValue<StdoutErrorType> | ResultType>;
 
 		/**
-		Cancel the subprocess.
-
-		Causes the promise to reject an error with a `.isCanceled = true` property, provided the process gets canceled. The process will not be canceled if it has already exited.
+		Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal). This is preferred when cancelling the child process execution as the error is more descriptive and [`childProcessResult.isCanceled`](#iscanceled) is set to `true`.
 		*/
 		cancel(): void;
 	}
@@ -362,7 +360,7 @@ declare const execa: {
 
 	@param file - The program/script to execute.
 	@param arguments - Arguments to pass to `file` on execution.
-	@returns The same result object as [`child_process.spawnSync`](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options).
+	@returns A result `Object` with `stdout` and `stderr` properties.
 	*/
 	sync(
 		file: string,

--- a/readme.md
+++ b/readme.md
@@ -122,9 +122,9 @@ Arguments should not be escaped nor quoted, except inside `command` where spaces
 
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 
-Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess). That instance:
+Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess) which:
   - is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult).
-  - expose the following additional methods and properties.
+  - exposes the following additional methods and properties.
 
 #### cancel()
 

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@
 - Higher max buffer. 10 MB instead of 200 KB.
 - [Executes locally installed binaries by name.](#preferlocal)
 - [Cleans up spawned processes when the parent process dies.](#cleanup)
-- [Get interleaved output](#execafile-arguments-options) from `stdout` and `stderr` similar to what is printed on the terminal. [*(Async only)*](#execasyncfile-arguments-options)
+- [Get interleaved output](#all) from `stdout` and `stderr` similar to what is printed on the terminal. [*(Async only)*](#execasyncfile-arguments-options)
 - [Can specify command and arguments as a single string without a shell](#execafile-arguments-options)
 - More descriptive errors.
 
@@ -122,21 +122,15 @@ Arguments should not be escaped nor quoted, except inside `command` where spaces
 
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 
-Returns a [`childProcess`](#childProcess).
-
-### childProcess
-
-[`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess).
-
-That instance is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult).
+Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess). That instance is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult).
 
 The following methods and properties are also available.
 
-#### childProcess.cancel()
+#### cancel()
 
-Same as `childProcess.kill()` but with a different error message and with `childProcessResult.isCanceled` set to `true`.
+Same as [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal) but with a different error message and with [`childProcessResult.isCanceled`](#iscanceled) set to `true`.
 
-#### childProcess.all
+#### all
 
 Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
@@ -151,71 +145,69 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 Type: `object|Error`
 
-Result of a child process execution.
+Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
 
-On failure this is also an `Error` instance.
-
-#### childProcessResult.exitCode
+#### exitCode
 
 Type: `number`
 
 The numeric exit code of the process that was run.
 
-#### childProcessResult.exitCodeName
+#### exitCodeName
 
 Type: `string`
 
 The textual exit code of the process that was run.
 
-#### childProcessResult.stdout
+#### stdout
 
 Type: `string|Buffer`
 
 The output of the process on stdout.
 
-#### childProcessResult.stderr
+#### stderr
 
 Type: `string|Buffer`
 
 The output of the process on stderr.
 
-#### childProcessResult.all
+#### all
 
 Type: `string|Buffer`
 
 The output of the process on both stdout and stderr. `undefined` if `execa.sync()` was used.
 
-#### childProcessResult.command
+#### command
 
 Type: `string`
 
 The command that was run.
 
-#### childProcessResult.failed
+#### failed
 
 Type: `boolean`
 
 Whether the process failed to run.
 
-#### childProcessResult.timedOut
+#### timedOut
 
 Type: `boolean`
 
 Whether the process timed out.
 
-#### childProcessResult.killed
+#### killed
 
 Type: `boolean`
 
 Whether the process was killed.
 
-#### childProcessResult.isCanceled
+#### isCanceled
 
 Type: `boolean`
 
 Whether the process was canceled.
 
-#### childProcessResult.signal
+#### signal
 
 Type: `string|undefined`
 

--- a/readme.md
+++ b/readme.md
@@ -123,8 +123,8 @@ Arguments should not be escaped nor quoted, except inside `command` where spaces
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 
 Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess). That instance:
-	- is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult).
-	- expose the following additional methods and properties.
+  - is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult).
+  - expose the following additional methods and properties.
 
 #### cancel()
 

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#c
 
 #### cancel()
 
-Same as [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal) but with a different error message and with [`childProcessResult.isCanceled`](#iscanceled) set to `true`.
+Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal). This is preferred when cancelling the child process execution as the error is more descriptive and [`childProcessResult.isCanceled`](#iscanceled) is set to `true`.
 
 #### all
 

--- a/readme.md
+++ b/readme.md
@@ -120,7 +120,7 @@ Arguments can be specified in either:
 
 Arguments should not be escaped nor quoted. Exception: inside `command`, spaces can be escaped with a backslash.
 
-Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
+Think of this as a mix of [`child_process.execFile()`](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback) and [`child_process.spawn(`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 ### childProcessResult
 
-Type: `object|Error`
+Type: `object | Error`
 
 Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
 
@@ -161,19 +161,19 @@ The textual exit code of the process that was run.
 
 #### stdout
 
-Type: `string|Buffer`
+Type: `string | Buffer`
 
 The output of the process on stdout.
 
 #### stderr
 
-Type: `string|Buffer`
+Type: `string | Buffer`
 
 The output of the process on stderr.
 
 #### all
 
-Type: `string|Buffer`
+Type: `string | Buffer`
 
 The output of the process on both stdout and stderr. `undefined` if `execa.sync()` was used.
 
@@ -209,7 +209,7 @@ Whether the process was canceled.
 
 #### signal
 
-Type: `string|undefined`
+Type: `string | undefined`
 
 The signal that was used to terminate the process.
 

--- a/readme.md
+++ b/readme.md
@@ -112,36 +112,114 @@ try {
 ### execa(file, [arguments], [options])
 ### execa(command, [options])
 
-Execute a file.
+Execute a file. Think of this as a mix of [`child_process.execFile()`](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback) and [`child_process.spawn()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 Arguments can be specified in either:
   - `arguments`: `execa('echo', ['unicorns'])`.
   - `command`: `execa('echo unicorns')`.
 
-Arguments should not be escaped nor quoted. Exception: inside `command`, spaces can be escaped with a backslash.
-
-Think of this as a mix of [`child_process.execFile()`](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback) and [`child_process.spawn(`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
+Arguments should not be escaped nor quoted, except inside `command` where spaces can be escaped with a backslash.
 
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 
-Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess) which is enhanced to be a `Promise`.
+Returns a [`childProcess`](#childProcess).
 
-It exposes an additional `.all` stream, with `stdout` and `stderr` interleaved.
+### childProcess
 
-The spawned process can be canceled with the `.cancel()` method on the promise, which causes the promise to reject an error with a `.isCanceled = true` property, provided the process gets canceled. The process will not be canceled if it has already exited.
+[`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess).
 
-The promise result is an `Object` with `stdout`, `stderr` and `all` properties.
+That instance is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult).
+
+The following methods and properties are also available.
+
+#### childProcess.cancel()
+
+Same as `childProcess.kill()` but with a different error message and with `childProcessResult.isCanceled` set to `true`.
+
+#### childProcess.all
+
+Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
 ### execa.sync(file, [arguments], [options])
 ### execa.sync(command, [options])
 
 Execute a file synchronously.
 
-Returns the same result object as [`child_process.spawnSync`](https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options).
+Returns or throws a [`childProcessResult`](#childProcessResult).
 
-It does not have the `.all` property that `execa()` has because the [underlying synchronous implementation](https://nodejs.org/api/child_process.html#child_process_child_process_execfilesync_file_args_options) only returns `stdout` and `stderr` at the end of the execution, so they cannot be interleaved.
+### childProcessResult
 
-This method throws an `Error` if the command fails.
+Type: `object|Error`
+
+Result of a child process execution.
+
+On failure this is also an `Error` instance.
+
+#### childProcessResult.exitCode
+
+Type: `number`
+
+The numeric exit code of the process that was run.
+
+#### childProcessResult.exitCodeName
+
+Type: `string`
+
+The textual exit code of the process that was run.
+
+#### childProcessResult.stdout
+
+Type: `string|Buffer`
+
+The output of the process on stdout.
+
+#### childProcessResult.stderr
+
+Type: `string|Buffer`
+
+The output of the process on stderr.
+
+#### childProcessResult.all
+
+Type: `string|Buffer`
+
+The output of the process on both stdout and stderr. `undefined` if `execa.sync()` was used.
+
+#### childProcessResult.command
+
+Type: `string`
+
+The command that was run.
+
+#### childProcessResult.failed
+
+Type: `boolean`
+
+Whether the process failed to run.
+
+#### childProcessResult.timedOut
+
+Type: `boolean`
+
+Whether the process timed out.
+
+#### childProcessResult.killed
+
+Type: `boolean`
+
+Whether the process was killed.
+
+#### childProcessResult.isCanceled
+
+Type: `boolean`
+
+Whether the process was canceled.
+
+#### childProcessResult.signal
+
+Type: `string|undefined`
+
+The signal that was used to terminate the process.
 
 ### options
 

--- a/readme.md
+++ b/readme.md
@@ -122,9 +122,9 @@ Arguments should not be escaped nor quoted, except inside `command` where spaces
 
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 
-Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess). That instance is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult).
-
-The following methods and properties are also available.
+Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess). That instance:
+  - is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult)
+	- expose the following additional methods and properties
 
 #### cancel()
 

--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ Arguments should not be escaped nor quoted, except inside `command` where spaces
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 
 Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess) which:
-  - is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult).
+  - is also a `Promise` resolving or rejecting with a [`childProcessResult`](#childProcessResult).
   - exposes the following additional methods and properties.
 
 #### cancel()

--- a/readme.md
+++ b/readme.md
@@ -123,8 +123,8 @@ Arguments should not be escaped nor quoted, except inside `command` where spaces
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 
 Returns a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess). That instance:
-  - is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult)
-	- expose the following additional methods and properties
+	- is also a `Promise` which resolves or rejects with a [`childProcessResult`](#childProcessResult).
+	- expose the following additional methods and properties.
 
 #### cancel()
 

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 ### childProcessResult
 
-Type: `object | Error`
+Type: `object`
 
 Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
 


### PR DESCRIPTION
This improves the `API` section:
  - the description of each property of the return/resolved value (or thrown/rejected error) was missing.
  - the return value of `execa.sync()` was wrong (it is not the same as the return value of `spawnSync()` although it has some common properties.
  - the extra methods and properties of the `child_process` instance returned by the main function are now separate.
  - the description of the main function has been improved.

To be more efficient, I will update the `index.d.ts` file after a first code review.