### PR TITLE
Reorder properties of results and errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -195,6 +195,11 @@ declare namespace execa {
 
 	interface ExecaReturnBase<StdoutStderrType> {
 		/**
+		The command that was run.
+		*/
+		command: string;
+
+		/**
 		The numeric exit code of the process that was run.
 		*/
 		exitCode: number;
@@ -220,16 +225,6 @@ declare namespace execa {
 		failed: boolean;
 
 		/**
-		The signal that was used to terminate the process.
-		*/
-		signal?: string;
-
-		/**
-		The command that was run.
-		*/
-		command: string;
-
-		/**
 		Whether the process timed out.
 		*/
 		timedOut: boolean;
@@ -238,6 +233,11 @@ declare namespace execa {
 		Whether the process was killed.
 		*/
 		killed: boolean;
+
+		/**
+		The signal that was used to terminate the process.
+		*/
+		signal?: string;
 	}
 
 	interface ExecaSyncReturnValue<StdoutErrorType = string>

--- a/index.js
+++ b/index.js
@@ -181,23 +181,24 @@ function makeError(result, options) {
 		error = new Error(message);
 	}
 
-	error.code = exitCode || exitCodeName;
+	error.command = joinedCommand;
 	error.exitCode = exitCode;
 	error.exitCodeName = exitCodeName;
+	error.code = exitCode || exitCodeName;
 	error.stdout = stdout;
 	error.stderr = stderr;
-	error.failed = true;
-	// `signal` emitted on `spawned.on('exit')` event can be `null`. We normalize
-	// it to `undefined`
-	error.signal = signal || undefined;
-	error.command = joinedCommand;
-	error.timedOut = timedOut;
-	error.isCanceled = isCanceled;
-	error.killed = killed && !timedOut;
 
 	if ('all' in result) {
 		error.all = result.all;
 	}
+
+	error.failed = true;
+	error.timedOut = timedOut;
+	error.isCanceled = isCanceled;
+	error.killed = killed && !timedOut;
+	// `signal` emitted on `spawned.on('exit')` event can be `null`. We normalize
+	// it to `undefined`
+	error.signal = signal || undefined;
 
 	return error;
 }
@@ -372,17 +373,17 @@ const execa = (command, args, options) => {
 			}
 
 			return {
+				command: joinedCommand,
+				exitCode: 0,
+				exitCodeName: 'SUCCESS',
+				code: 0,
 				stdout: result.stdout,
 				stderr: result.stderr,
 				all: result.all,
-				code: 0,
-				exitCode: 0,
-				exitCodeName: 'SUCCESS',
 				failed: false,
-				killed: false,
-				command: joinedCommand,
 				timedOut: false,
-				isCanceled: false
+				isCanceled: false,
+				killed: false
 			};
 		};
 
@@ -444,15 +445,15 @@ module.exports.sync = (command, args, options) => {
 	}
 
 	return {
-		stdout: result.stdout,
-		stderr: result.stderr,
-		code: 0,
+		command: joinedCommand,
 		exitCode: 0,
 		exitCodeName: 'SUCCESS',
+		code: 0,
+		stdout: result.stdout,
+		stderr: result.stderr,
 		failed: false,
-		killed: false,
-		command: joinedCommand,
 		timedOut: false,
-		isCanceled: false
+		isCanceled: false,
+		killed: false
 	};
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -15,14 +15,14 @@ try {
 	const unicornsResult = await execaPromise;
 	expectType<string>(unicornsResult.command);
 	expectType<string | number>(unicornsResult.code);
-	expectType<boolean>(unicornsResult.failed);
-	expectType<boolean>(unicornsResult.killed);
-	expectType<string | undefined>(unicornsResult.signal);
 	expectType<string>(unicornsResult.stderr);
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.all);
+	expectType<boolean>(unicornsResult.failed);
 	expectType<boolean>(unicornsResult.timedOut);
 	expectType<boolean>(unicornsResult.isCanceled);
+	expectType<boolean>(unicornsResult.killed);
+	expectType<string | undefined>(unicornsResult.signal);
 } catch (error) {
 	const execaError: ExecaError = error;
 
@@ -36,14 +36,14 @@ try {
 	const unicornsResult = execa.sync('unicorns');
 	expectType<string>(unicornsResult.command);
 	expectType<string | number>(unicornsResult.code);
-	expectType<boolean>(unicornsResult.failed);
-	expectType<boolean>(unicornsResult.killed);
-	expectType<string | undefined>(unicornsResult.signal);
 	expectType<string>(unicornsResult.stderr);
 	expectType<string>(unicornsResult.stdout);
-	expectType<boolean>(unicornsResult.timedOut);
 	expectError(unicornsResult.all);
+	expectType<boolean>(unicornsResult.failed);
+	expectType<boolean>(unicornsResult.timedOut);
 	expectError(unicornsResult.isCanceled);
+	expectType<boolean>(unicornsResult.killed);
+	expectType<string | undefined>(unicornsResult.signal);
 } catch (error) {
 	const execaError: ExecaSyncError = error;
 

--- a/readme.md
+++ b/readme.md
@@ -60,18 +60,22 @@ const execa = require('execa');
 		console.log(error);
 		/*
 		{
-			message: 'spawn wrong command ENOENT',
+			message: 'Command failed with exit code 2 (ENOENT): wrong command spawn wrong ENOENT',
 			errno: 'ENOENT',
-			code: 'ENOENT',
-			syscall: 'spawn wrong command',
-			path: 'wrong command',
-			killed: false,
+			code: 2,
+			syscall: 'spawn wrong',
+			path: 'wrong',
+			spawnargs: ['command'],
+			command: 'wrong command',
+			exitCode: 2,
+			exitCodeName: 'ENOENT',
 			stdout: '',
 			stderr: '',
+			all: '',
 			failed: true,
-			signal: null,
-			cmd: 'wrong command',
-			timedOut: false
+			timedOut: false,
+			isCanceled: false,
+			killed: false
 		}
 		*/
 	}
@@ -96,11 +100,20 @@ try {
 	console.log(error);
 	/*
 	{
-		message: 'spawnSync wrong command ENOENT',
+		message: 'Command failed with exit code 2 (ENOENT): wrong command spawnSync wrong ENOENT',
 		errno: 'ENOENT',
-		code: 'ENOENT',
-		syscall: 'spawnSync wrong command',
-		path: 'wrong command',
+		code: 2,
+		syscall: 'spawnSync wrong',
+		path: 'wrong',
+		spawnargs: ['command'],
+		command: 'wrong command',
+		exitCode: 2,
+		exitCodeName: 'ENOENT',
+		stdout: null,
+		stderr: null,
+		failed: true,
+		timedOut: false,
+		isCanceled: false
 	}
 	*/
 }
@@ -147,6 +160,12 @@ Type: `object`
 
 Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
 
+#### command
+
+Type: `string`
+
+The command that was run.
+
 #### exitCode
 
 Type: `number`
@@ -177,12 +196,6 @@ Type: `string | Buffer`
 
 The output of the process on both stdout and stderr. `undefined` if `execa.sync()` was used.
 
-#### command
-
-Type: `string`
-
-The command that was run.
-
 #### failed
 
 Type: `boolean`
@@ -195,17 +208,17 @@ Type: `boolean`
 
 Whether the process timed out.
 
-#### killed
-
-Type: `boolean`
-
-Whether the process was killed.
-
 #### isCanceled
 
 Type: `boolean`
 
 Whether the process was canceled.
+
+#### killed
+
+Type: `boolean`
+
+Whether the process was killed.
 
 #### signal
 


### PR DESCRIPTION
This re-orders the object properties in resolved results and rejected errors, to group them and put them in a more logical order.