### PR TITLE
Separate original error message with a newline

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,7 +176,7 @@ function makeError(result, options) {
 	const message = `Command ${prefix}: ${joinedCommand}`;
 
 	if (error instanceof Error) {
-		error.message = `${message}${error.message}`;
+		error.message = `${message}\n${error.message}`;
 	} else {
 		error = new Error(message);
 	}


### PR DESCRIPTION
When a child process terminated because an `error` event has been sent to it (or to `stdin`), which is not so common, we keep the original error message. This PR puts that message on the next line.
 
At the moment:

```js
> (await execa('wrong command', { reject: false })).message
Command failed with exit code 2 (ENOENT): wrong commandspawn wrong ENOENT
```

With this PR, this is now:

```js
> (await execa('wrong command', { reject: false })).message
Command failed with exit code 2 (ENOENT): wrong command
spawn wrong ENOENT
```