### PR TITLE
Make `stdout` and `stderr` properties `undefined` instead of `null`

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,8 +110,12 @@ function handleInput(spawned, input) {
 }
 
 function handleOutput(options, value) {
-	if (value && options.stripFinalNewline) {
-		value = stripFinalNewline(value);
+	if (typeof value !== 'string' && !Buffer.isBuffer(value)) {
+		return;
+	}
+
+	if (options.stripFinalNewline) {
+		return stripFinalNewline(value);
 	}
 
 	return value;

--- a/index.js
+++ b/index.js
@@ -109,9 +109,10 @@ function handleInput(spawned, input) {
 	}
 }
 
-function handleOutput(options, value) {
+function handleOutput(options, value, error) {
 	if (typeof value !== 'string' && !Buffer.isBuffer(value)) {
-		return;
+		// When `execa.sync()` errors, we normalize it to '' to mimic `execa()`
+		return error === undefined ? undefined : '';
 	}
 
 	if (options.stripFinalNewline) {
@@ -427,8 +428,8 @@ module.exports.sync = (command, args, options) => {
 	}
 
 	const result = childProcess.spawnSync(parsed.command, parsed.args, parsed.options);
-	result.stdout = handleOutput(parsed.options, result.stdout);
-	result.stderr = handleOutput(parsed.options, result.stderr);
+	result.stdout = handleOutput(parsed.options, result.stdout, result.error);
+	result.stderr = handleOutput(parsed.options, result.stderr, result.error);
 
 	if (result.error || result.status !== 0 || result.signal !== null) {
 		const error = makeError(result, {

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,8 @@ try {
 		command: 'wrong command',
 		exitCode: 2,
 		exitCodeName: 'ENOENT',
+		stdout: '',
+		stderr: '',
 		failed: true,
 		timedOut: false,
 		isCanceled: false,

--- a/readme.md
+++ b/readme.md
@@ -107,8 +107,6 @@ try {
 		command: 'wrong command',
 		exitCode: 2,
 		exitCodeName: 'ENOENT',
-		stdout: null,
-		stderr: null,
 		failed: true,
 		timedOut: false,
 		isCanceled: false,

--- a/test.js
+++ b/test.js
@@ -65,14 +65,14 @@ test('stdout/stderr/all are undefined if ignored in sync mode', t => {
 	t.is(all, undefined);
 });
 
-const WRONG_COMMAND_STDOUT = process.platform === 'win32' ?
+const WRONG_COMMAND_STDERR = process.platform === 'win32' ?
 	'\'wrong\' is not recognized as an internal or external command,\r\noperable program or batch file.' :
 	'';
 
 test('stdout/stderr/all on process errors', async t => {
 	const {stdout, stderr, all} = await t.throwsAsync(execa('wrong command'));
-	t.is(stdout, WRONG_COMMAND_STDOUT);
-	t.is(stderr, '');
+	t.is(stdout, '');
+	t.is(stderr, WRONG_COMMAND_STDERR);
 	t.is(all, '');
 });
 
@@ -80,8 +80,8 @@ test('stdout/stderr/all on process errors, in sync mode', t => {
 	const {stdout, stderr, all} = t.throws(() => {
 		execa.sync('wrong command');
 	});
-	t.is(stdout, WRONG_COMMAND_STDOUT);
-	t.is(stderr, '');
+	t.is(stdout, '');
+	t.is(stderr, WRONG_COMMAND_STDERR);
 	t.is(all, undefined);
 });
 

--- a/test.js
+++ b/test.js
@@ -65,9 +65,13 @@ test('stdout/stderr/all are undefined if ignored in sync mode', t => {
 	t.is(all, undefined);
 });
 
+const WRONG_COMMAND_STDOUT = process.platform === 'win32' ?
+	'\'wrong\' is not recognized as an internal or external command,\r\noperable program or batch file.' :
+	'';
+
 test('stdout/stderr/all on process errors', async t => {
 	const {stdout, stderr, all} = await t.throwsAsync(execa('wrong command'));
-	t.is(stdout, '');
+	t.is(stdout, WRONG_COMMAND_STDOUT);
 	t.is(stderr, '');
 	t.is(all, '');
 });
@@ -76,7 +80,7 @@ test('stdout/stderr/all on process errors, in sync mode', t => {
 	const {stdout, stderr, all} = t.throws(() => {
 		execa.sync('wrong command');
 	});
-	t.is(stdout, '');
+	t.is(stdout, WRONG_COMMAND_STDOUT);
 	t.is(stderr, '');
 	t.is(all, undefined);
 });

--- a/test.js
+++ b/test.js
@@ -65,6 +65,22 @@ test('stdout/stderr/all are undefined if ignored in sync mode', t => {
 	t.is(all, undefined);
 });
 
+test('stdout/stderr/all on procss errors', async t => {
+	const {stdout, stderr, all} = await t.throwsAsync(execa('wrong command'));
+	t.is(stdout, '');
+	t.is(stderr, '');
+	t.is(all, '');
+});
+
+test('stdout/stderr/all on procss errors, in sync mode', t => {
+	const {stdout, stderr, all} = t.throws(() => {
+		execa.sync('wrong command');
+	});
+	t.is(stdout, '');
+	t.is(stderr, '');
+	t.is(all, undefined);
+});
+
 test('pass `stdout` to a file descriptor', async t => {
 	const file = tempfile('.txt');
 	await execa('fixtures/noop', ['foo bar'], {stdout: fs.openSync(file, 'w')});

--- a/test.js
+++ b/test.js
@@ -65,14 +65,14 @@ test('stdout/stderr/all are undefined if ignored in sync mode', t => {
 	t.is(all, undefined);
 });
 
-test('stdout/stderr/all on procss errors', async t => {
+test('stdout/stderr/all on process errors', async t => {
 	const {stdout, stderr, all} = await t.throwsAsync(execa('wrong command'));
 	t.is(stdout, '');
 	t.is(stderr, '');
 	t.is(all, '');
 });
 
-test('stdout/stderr/all on procss errors, in sync mode', t => {
+test('stdout/stderr/all on process errors, in sync mode', t => {
 	const {stdout, stderr, all} = t.throws(() => {
 		execa.sync('wrong command');
 	});

--- a/test.js
+++ b/test.js
@@ -73,7 +73,7 @@ test('stdout/stderr/all on process errors', async t => {
 	const {stdout, stderr, all} = await t.throwsAsync(execa('wrong command'));
 	t.is(stdout, '');
 	t.is(stderr, WRONG_COMMAND_STDERR);
-	t.is(all, '');
+	t.is(all, WRONG_COMMAND_STDERR);
 });
 
 test('stdout/stderr/all on process errors, in sync mode', t => {

--- a/test.js
+++ b/test.js
@@ -51,6 +51,20 @@ test('stdout/stderr/all available on errors', async t => {
 	t.is(typeof error.all, 'string');
 });
 
+test('stdout/stderr/all are undefined if ignored', async t => {
+	const {stdout, stderr, all} = await execa('noop', {stdio: 'ignore'});
+	t.is(stdout, undefined);
+	t.is(stderr, undefined);
+	t.is(all, undefined);
+});
+
+test('stdout/stderr/all are undefined if ignored in sync mode', t => {
+	const {stdout, stderr, all} = execa.sync('noop', {stdio: 'ignore'});
+	t.is(stdout, undefined);
+	t.is(stderr, undefined);
+	t.is(all, undefined);
+});
+
 test('pass `stdout` to a file descriptor', async t => {
 	const file = tempfile('.txt');
 	await execa('fixtures/noop', ['foo bar'], {stdout: fs.openSync(file, 'w')});


### PR DESCRIPTION
The `stdout` and `stderr` properties can be `undefined` with `execa()`, e.g. when the option `stdout: 'ignore'` was used.

However with `execa.sync()`, it is `null` instead. This change increases consistency by setting those to `undefined` instead.