### PR TITLE
Make `error.killed` more consistent

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ function makeError(result, options) {
 	error.failed = true;
 	error.timedOut = timedOut;
 	error.isCanceled = isCanceled;
-	error.killed = killed && !timedOut;
+	error.killed = Boolean(killed) && !timedOut;
 	// `signal` emitted on `spawned.on('exit')` event can be `null`. We normalize
 	// it to `undefined`
 	error.signal = signal || undefined;

--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ function makeError(result, options) {
 	error.failed = true;
 	error.timedOut = timedOut;
 	error.isCanceled = isCanceled;
-	error.killed = Boolean(killed) && !timedOut;
+	error.killed = killed && !timedOut;
 	// `signal` emitted on `spawned.on('exit')` event can be `null`. We normalize
 	// it to `undefined`
 	error.signal = signal || undefined;
@@ -432,7 +432,8 @@ module.exports.sync = (command, args, options) => {
 			joinedCommand,
 			parsed,
 			timedOut: false,
-			isCanceled: false
+			isCanceled: false,
+			killed: result.signal !== null
 		});
 
 		if (!parsed.options.reject) {

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,8 @@ try {
 		stderr: null,
 		failed: true,
 		timedOut: false,
-		isCanceled: false
+		isCanceled: false,
+		killed: false
 	}
 	*/
 }

--- a/test.js
+++ b/test.js
@@ -318,6 +318,16 @@ test('result.killed is false if not killed, in sync mode', t => {
 	t.false(result.killed);
 });
 
+test('result.killed is false on process error', async t => {
+	const {killed} = await t.throwsAsync(execa('wrong command'));
+	t.false(killed);
+});
+
+test('result.killed is false on process error, in sync mode', t => {
+	const {killed} = t.throws(() => execa.sync('wrong command'));
+	t.false(killed);
+});
+
 if (process.platform === 'darwin') {
 	test.cb('sanity check: child_process.exec also has killed.false if killed indirectly', t => {
 		const cp = childProcess.exec('forever', error => {

--- a/test.js
+++ b/test.js
@@ -141,7 +141,9 @@ test('stripFinalNewline in sync mode', t => {
 });
 
 test('stripFinalNewline in sync mode on failure', t => {
-	const {stderr} = t.throws(() => execa.sync('noop-throw', ['foo'], {stripFinalNewline: true}));
+	const {stderr} = t.throws(() => {
+		execa.sync('noop-throw', ['foo'], {stripFinalNewline: true});
+	});
 	t.is(stderr, 'foo');
 });
 
@@ -324,7 +326,9 @@ test('result.killed is false on process error', async t => {
 });
 
 test('result.killed is false on process error, in sync mode', t => {
-	const {killed} = t.throws(() => execa.sync('wrong command'));
+	const {killed} = t.throws(() => {
+		execa.sync('wrong command');
+	});
 	t.false(killed);
 });
 
@@ -623,7 +627,9 @@ test('result.isCanceled is false when spawned.cancel() isn\'t called in sync mod
 });
 
 test('result.isCanceled is false when spawned.cancel() isn\'t called in sync mode (failure)', t => {
-	const error = t.throws(() => execa.sync('fail'));
+	const error = t.throws(() => {
+		execa.sync('fail');
+	});
 	t.false(error.isCanceled);
 });
 


### PR DESCRIPTION
`error.killed` is always `true` or `false` with `execa()`.

But with `execa.sync()`, it can also be `undefined` sometimes, e.g. on `ENOENT`. This PR ensures `error.killed` is always a boolean. 

Details:
  - `spawn()` returns a `childProcess` with [`childProcess.killed`](https://github.com/nodejs/node/blob/master/lib/internal/child_process.js#L446)
  - `spawnSync()` does not return this, but we can emulate most of the cases by checking the `signal` property.

Tests are added for this as well.