### PR TITLE
Fix `error.timedOut` not working with `execa.sync()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -431,7 +431,7 @@ module.exports.sync = (command, args, options) => {
 		const error = makeError(result, {
 			joinedCommand,
 			parsed,
-			timedOut: false,
+			timedOut: result.error && result.error.errno === 'ETIMEDOUT',
 			isCanceled: false,
 			killed: result.signal !== null
 		});

--- a/test.js
+++ b/test.js
@@ -394,7 +394,9 @@ test('timeout kills the process if it times out', async t => {
 });
 
 test('timeout kills the process if it times out, in sync mode', async t => {
-	const {killed, timedOut} = await t.throws(() => execa.sync('forever', {timeout: 1, message: TIMEOUT_REGEXP}));
+	const {killed, timedOut} = await t.throws(() => {
+		execa.sync('forever', {timeout: 1, message: TIMEOUT_REGEXP});
+	});
 	t.false(killed);
 	t.true(timedOut);
 });

--- a/test.js
+++ b/test.js
@@ -393,6 +393,12 @@ test('timeout kills the process if it times out', async t => {
 	t.true(error.timedOut);
 });
 
+test('timeout kills the process if it times out, in sync mode', async t => {
+	const {killed, timedOut} = await t.throws(() => execa.sync('forever', {timeout: 1, message: TIMEOUT_REGEXP}));
+	t.false(killed);
+	t.true(timedOut);
+});
+
 test('timeout does not kill the process if it does not time out', async t => {
 	const error = await execa('delay', ['500'], {timeout: 1e8});
 	t.false(error.timedOut);


### PR DESCRIPTION
When `execa.sync()` times out because of the `timeout` option, `error.timedOut` is still `false`.

This PR fixes this.