### PR TITLE
Remove `error.code`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -242,10 +242,6 @@ declare namespace execa {
 
 	interface ExecaSyncReturnValue<StdoutErrorType = string>
 		extends ExecaReturnBase<StdoutErrorType> {
-		/**
-		The exit code of the process that was run.
-		*/
-		code: number;
 	}
 
 	interface ExecaReturnValue<StdoutErrorType = string>
@@ -268,11 +264,6 @@ declare namespace execa {
 		The error message.
 		*/
 		message: string;
-
-		/**
-		The exit code (either numeric or textual) of the process that was run.
-		*/
-		code: number | string;
 	}
 
 	interface ExecaError<StdoutErrorType = string>

--- a/index.js
+++ b/index.js
@@ -166,9 +166,9 @@ function getStream(process, stream, {encoding, buffer, maxBuffer}) {
 }
 
 function makeError(result, options) {
-	const {stdout, stderr, code, signal} = result;
+	const {stdout, stderr, signal} = result;
 	let {error} = result;
-	const {joinedCommand, timedOut, isCanceled, killed, parsed: {options: {timeout}}} = options;
+	const {code, joinedCommand, timedOut, isCanceled, killed, parsed: {options: {timeout}}} = options;
 
 	const [exitCodeName, exitCode] = getCode(result, code);
 
@@ -356,6 +356,7 @@ const execa = (command, args, options) => {
 
 			if (result.error || result.code !== 0 || result.signal !== null) {
 				const error = makeError(result, {
+					code: result.code,
 					joinedCommand,
 					parsed,
 					timedOut,
@@ -422,12 +423,12 @@ module.exports.sync = (command, args, options) => {
 	}
 
 	const result = childProcess.spawnSync(parsed.command, parsed.args, parsed.options);
-	result.code = result.status;
 	result.stdout = handleOutput(parsed.options, result.stdout);
 	result.stderr = handleOutput(parsed.options, result.stderr);
 
 	if (result.error || result.status !== 0 || result.signal !== null) {
 		const error = makeError(result, {
+			code: result.status,
 			joinedCommand,
 			parsed,
 			timedOut: false,

--- a/index.js
+++ b/index.js
@@ -182,9 +182,9 @@ function makeError(result, options) {
 	}
 
 	error.command = joinedCommand;
+	delete error.code;
 	error.exitCode = exitCode;
 	error.exitCodeName = exitCodeName;
-	error.code = exitCode || exitCodeName;
 	error.stdout = stdout;
 	error.stderr = stderr;
 
@@ -374,7 +374,6 @@ const execa = (command, args, options) => {
 				command: joinedCommand,
 				exitCode: 0,
 				exitCodeName: 'SUCCESS',
-				code: 0,
 				stdout: result.stdout,
 				stderr: result.stderr,
 				all: result.all,
@@ -446,7 +445,6 @@ module.exports.sync = (command, args, options) => {
 		command: joinedCommand,
 		exitCode: 0,
 		exitCodeName: 'SUCCESS',
-		code: 0,
 		stdout: result.stdout,
 		stderr: result.stderr,
 		failed: false,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -14,7 +14,6 @@ try {
 
 	const unicornsResult = await execaPromise;
 	expectType<string>(unicornsResult.command);
-	expectType<string | number>(unicornsResult.code);
 	expectType<number>(unicornsResult.exitCode);
 	expectType<string>(unicornsResult.exitCodeName);
 	expectType<string>(unicornsResult.stdout);
@@ -29,7 +28,6 @@ try {
 	const execaError: ExecaError = error;
 
 	expectType<string>(execaError.message);
-	expectType<number | string>(execaError.code);
 	expectType<number>(execaError.exitCode);
 	expectType<string>(execaError.exitCodeName);
 	expectType<string>(execaError.stdout);
@@ -45,7 +43,6 @@ try {
 try {
 	const unicornsResult = execa.sync('unicorns');
 	expectType<string>(unicornsResult.command);
-	expectType<string | number>(unicornsResult.code);
 	expectType<number>(unicornsResult.exitCode);
 	expectType<string>(unicornsResult.exitCodeName);
 	expectType<string>(unicornsResult.stdout);
@@ -60,7 +57,6 @@ try {
 	const execaError: ExecaSyncError = error;
 
 	expectType<string>(execaError.message);
-	expectType<number | string>(execaError.code);
 	expectType<number>(execaError.exitCode);
 	expectType<string>(execaError.exitCodeName);
 	expectType<string>(execaError.stdout);

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,6 @@ const execa = require('execa');
 		{
 			message: 'Command failed with exit code 2 (ENOENT): wrong command spawn wrong ENOENT',
 			errno: 'ENOENT',
-			code: 2,
 			syscall: 'spawn wrong',
 			path: 'wrong',
 			spawnargs: ['command'],
@@ -102,7 +101,6 @@ try {
 	{
 		message: 'Command failed with exit code 2 (ENOENT): wrong command spawnSync wrong ENOENT',
 		errno: 'ENOENT',
-		code: 2,
 		syscall: 'spawnSync wrong',
 		path: 'wrong',
 		spawnargs: ['command'],

--- a/test.js
+++ b/test.js
@@ -258,13 +258,12 @@ test('allow unknown exit code', async t => {
 });
 
 test('execa() returns code and failed properties', async t => {
-	const {code, exitCode, exitCodeName, failed} = await execa('noop', ['foo']);
-	t.is(code, 0);
+	const {exitCode, exitCodeName, failed} = await execa('noop', ['foo']);
 	t.is(exitCode, 0);
 	t.is(exitCodeName, 'SUCCESS');
 	t.false(failed);
 
-	const error = await t.throwsAsync(execa('exit', ['2']), {code: 2, message: getExitRegExp('2')});
+	const error = await t.throwsAsync(execa('exit', ['2']), {message: getExitRegExp('2')});
 	t.is(error.exitCode, 2);
 	const expectedName = process.platform === 'win32' ? 'Unknown system error -2' : 'ENOENT';
 	t.is(error.exitCodeName, expectedName);
@@ -364,14 +363,14 @@ test('result.signal is undefined if process failed, but was not killed', async t
 	t.is(error.signal, undefined);
 });
 
-async function code(t, num) {
-	const error = await t.throwsAsync(execa('exit', [`${num}`]), {code: num, message: getExitRegExp(num)});
-	t.is(error.exitCode, num);
+async function testExitCode(t, num) {
+	const {exitCode} = await t.throwsAsync(execa('exit', [`${num}`]), {message: getExitRegExp(num)});
+	t.is(exitCode, num);
 }
 
-test('error.code is 2', code, 2);
-test('error.code is 3', code, 3);
-test('error.code is 4', code, 4);
+test('error.exitCode is 2', testExitCode, 2);
+test('error.exitCode is 3', testExitCode, 3);
+test('error.exitCode is 4', testExitCode, 4);
 
 test('timeout kills the process if it times out', async t => {
 	const error = await t.throwsAsync(execa('forever', {timeout: 1, message: TIMEOUT_REGEXP}));


### PR DESCRIPTION
`error.code` is deprecated in favor of `error.exitCode` and `error.exitCodeName`. This PR removes it from the TypeScript definition.

I am not sure whether unknown properties are an issue with TypeScript. If they are, feel free to close this PR.