### PR TITLE
Separate core options from execa-specific options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,80 @@ declare namespace execa {
 
 	interface CommonOptions<EncodingType> {
 		/**
+		Kill the spawned process when the parent process exits unless either:
+			- the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
+			- the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
+
+		@default true
+		*/
+		readonly cleanup?: boolean;
+
+		/**
+		Prefer locally installed binaries when looking for a binary to execute.
+
+		If you `$ npm install foo`, you can then `execa('foo')`.
+
+		@default true
+		*/
+		readonly preferLocal?: boolean;
+
+		/**
+		Preferred path to find locally installed binaries in (use with `preferLocal`).
+
+		@default process.cwd()
+		*/
+		readonly localDir?: string;
+
+		/**
+		Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
+
+		@default true
+		*/
+		readonly buffer?: boolean;
+
+		/**
+		Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+
+		@default 'pipe'
+		*/
+		readonly stdin?: StdioOption;
+
+		/**
+		Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+
+		@default 'pipe'
+		*/
+		readonly stdout?: StdioOption;
+
+		/**
+		Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+
+		@default 'pipe'
+		*/
+		readonly stderr?: StdioOption;
+
+		/**
+		Setting this to `false` resolves the promise with the error instead of rejecting it.
+
+		@default true
+		*/
+		readonly reject?: boolean;
+
+		/**
+		Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
+
+		@default true
+		*/
+		readonly stripFinalNewline?: boolean;
+
+		/**
+		Set to `false` if you don't want to extend the environment variables when providing the `env` property.
+
+		@default true
+		*/
+		readonly extendEnv?: boolean;
+
+		/**
 		Current working directory of the child process.
 
 		@default process.cwd()
@@ -26,13 +100,6 @@ declare namespace execa {
 		@default process.env
 		*/
 		readonly env?: NodeJS.ProcessEnv;
-
-		/**
-		Set to `false` if you don't want to extend the environment variables when providing the `env` property.
-
-		@default true
-		*/
-		readonly extendEnv?: boolean;
 
 		/**
 		Explicitly set the value of `argv[0]` sent to the child process. This will be set to `command` or `file` if not specified.
@@ -76,45 +143,6 @@ declare namespace execa {
 		readonly shell?: boolean | string;
 
 		/**
-		Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
-
-		@default true
-		*/
-		readonly stripFinalNewline?: boolean;
-
-		/**
-		Prefer locally installed binaries when looking for a binary to execute.
-
-		If you `$ npm install foo`, you can then `execa('foo')`.
-
-		@default true
-		*/
-		readonly preferLocal?: boolean;
-
-		/**
-		Preferred path to find locally installed binaries in (use with `preferLocal`).
-
-		@default process.cwd()
-		*/
-		readonly localDir?: string;
-
-		/**
-		Setting this to `false` resolves the promise with the error instead of rejecting it.
-
-		@default true
-		*/
-		readonly reject?: boolean;
-
-		/**
-		Kill the spawned process when the parent process exits unless either:
-			- the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
-			- the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
-
-		@default true
-		*/
-		readonly cleanup?: boolean;
-
-		/**
 		Specify the character encoding used to decode the `stdout` and `stderr` output. If set to `null`, then `stdout` and `stderr` will be a `Buffer` instead of a string.
 
 		@default 'utf8'
@@ -129,13 +157,6 @@ declare namespace execa {
 		readonly timeout?: number;
 
 		/**
-		Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
-
-		@default true
-		*/
-		readonly buffer?: boolean;
-
-		/**
 		Largest amount of data in bytes allowed on `stdout` or `stderr`. Default: 10MB.
 
 		@default 10000000
@@ -148,27 +169,6 @@ declare namespace execa {
 		@default 'SIGTERM'
 		*/
 		readonly killSignal?: string | number;
-
-		/**
-		Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-
-		@default 'pipe'
-		*/
-		readonly stdin?: StdioOption;
-
-		/**
-		Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-
-		@default 'pipe'
-		*/
-		readonly stdout?: StdioOption;
-
-		/**
-		Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-
-		@default 'pipe'
-		*/
-		readonly stderr?: StdioOption;
 
 		/**
 		If `true`, no quoting or escaping of arguments is done on Windows. Ignored on other platforms. This is set to `true` automatically when the `shell` option is `true`.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -69,31 +69,13 @@ try {
 	expectType<string | undefined>(execaError.signal);
 }
 
-execa('unicorns', {cwd: '.'});
-execa('unicorns', {env: {PATH: ''}});
-execa('unicorns', {extendEnv: false});
-execa('unicorns', {argv0: ''});
-execa('unicorns', {stdio: 'pipe'});
-execa('unicorns', {stdio: 'ignore'});
-execa('unicorns', {stdio: 'inherit'});
-execa('unicorns', {
-	stdio: ['pipe', 'ipc', 'ignore', 'inherit', process.stdin, 1, undefined]
-});
-execa('unicorns', {detached: true});
-execa('unicorns', {uid: 0});
-execa('unicorns', {gid: 0});
-execa('unicorns', {shell: true});
-execa('unicorns', {shell: '/bin/sh'});
-execa('unicorns', {stripFinalNewline: false});
+execa('unicorns', {cleanup: false});
 execa('unicorns', {preferLocal: false});
 execa('unicorns', {localDir: '.'});
-execa('unicorns', {reject: false});
-execa('unicorns', {cleanup: false});
-execa('unicorns', {timeout: 1000});
 execa('unicorns', {buffer: false});
-execa('unicorns', {maxBuffer: 1000});
-execa('unicorns', {killSignal: 'SIGTERM'});
-execa('unicorns', {killSignal: 9});
+execa('unicorns', {input: ''});
+execa('unicorns', {input: Buffer.from('')});
+execa('unicorns', {input: process.stdin});
 execa('unicorns', {stdin: 'pipe'});
 execa('unicorns', {stdin: 'ipc'});
 execa('unicorns', {stdin: 'ignore'});
@@ -115,10 +97,28 @@ execa('unicorns', {stderr: 'inherit'});
 execa('unicorns', {stderr: process.stderr});
 execa('unicorns', {stderr: 1});
 execa('unicorns', {stderr: undefined});
+execa('unicorns', {reject: false});
+execa('unicorns', {stripFinalNewline: false});
+execa('unicorns', {extendEnv: false});
+execa('unicorns', {cwd: '.'});
+execa('unicorns', {env: {PATH: ''}});
+execa('unicorns', {argv0: ''});
+execa('unicorns', {stdio: 'pipe'});
+execa('unicorns', {stdio: 'ignore'});
+execa('unicorns', {stdio: 'inherit'});
+execa('unicorns', {
+	stdio: ['pipe', 'ipc', 'ignore', 'inherit', process.stdin, 1, undefined]
+});
+execa('unicorns', {detached: true});
+execa('unicorns', {uid: 0});
+execa('unicorns', {gid: 0});
+execa('unicorns', {shell: true});
+execa('unicorns', {shell: '/bin/sh'});
+execa('unicorns', {timeout: 1000});
+execa('unicorns', {maxBuffer: 1000});
+execa('unicorns', {killSignal: 'SIGTERM'});
+execa('unicorns', {killSignal: 9});
 execa('unicorns', {windowsVerbatimArguments: true});
-execa('unicorns', {input: ''});
-execa('unicorns', {input: Buffer.from('')});
-execa('unicorns', {input: process.stdin});
 
 expectType<ExecaChildProcess<string>>(execa('unicorns'));
 expectType<ExecaReturnValue<string>>(await execa('unicorns'));

--- a/readme.md
+++ b/readme.md
@@ -311,7 +311,7 @@ Set to `false` if you don't want to extend the environment variables when provid
 
 ---
 
-Execa also accepts the below options which are the same options for [`child_process#spawn()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options)/[`child_process#exec()`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
+Execa also accepts the below options which are the same as the options for [`child_process#spawn()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options)/[`child_process#exec()`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
 
 #### cwd
 

--- a/readme.md
+++ b/readme.md
@@ -309,9 +309,9 @@ Default: `true`
 
 Set to `false` if you don't want to extend the environment variables when providing the `env` property.
 
-### options from child_process#spawn and child_process#exec
+---
 
-The same options as both [`child_process#spawn()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) and [`child_process#exec()`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) can also be used.
+Execa also accepts the below options which are passed directly to [`child_process#spawn()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options)/[`child_process#exec()`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
 
 #### cwd
 

--- a/readme.md
+++ b/readme.md
@@ -311,7 +311,7 @@ Set to `false` if you don't want to extend the environment variables when provid
 
 ---
 
-Execa also accepts the below options which are passed directly to [`child_process#spawn()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options)/[`child_process#exec()`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
+Execa also accepts the below options which are the same options for [`child_process#spawn()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options)/[`child_process#exec()`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
 
 #### cwd
 

--- a/readme.md
+++ b/readme.md
@@ -229,6 +229,90 @@ The signal that was used to terminate the process.
 
 Type: `object`
 
+#### cleanup
+
+Type: `boolean`<br>
+Default: `true`
+
+Kill the spawned process when the parent process exits unless either:
+	- the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
+	- the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
+
+#### preferLocal
+
+Type: `boolean`<br>
+Default: `true`
+
+Prefer locally installed binaries when looking for a binary to execute.<br>
+If you `$ npm install foo`, you can then `execa('foo')`.
+
+#### localDir
+
+Type: `string`<br>
+Default: `process.cwd()`
+
+Preferred path to find locally installed binaries in (use with `preferLocal`).
+
+#### buffer
+
+Type: `boolean`<br>
+Default: `true`
+
+Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
+
+#### input
+
+Type: `string | Buffer | stream.Readable`
+
+Write some input to the `stdin` of your binary.<br>
+Streams are not allowed when using the synchronous methods.
+
+#### stdin
+
+Type: `string | number | Stream | undefined`<br>
+Default: `pipe`
+
+Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+
+#### stdout
+
+Type: `string | number | Stream | undefined`<br>
+Default: `pipe`
+
+Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+
+#### stderr
+
+Type: `string | number | Stream | undefined`<br>
+Default: `pipe`
+
+Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+
+#### reject
+
+Type: `boolean`<br>
+Default: `true`
+
+Setting this to `false` resolves the promise with the error instead of rejecting it.
+
+#### stripFinalNewline
+
+Type: `boolean`<br>
+Default: `true`
+
+Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
+
+#### extendEnv
+
+Type: `boolean`<br>
+Default: `true`
+
+Set to `false` if you don't want to extend the environment variables when providing the `env` property.
+
+### options from child_process#spawn and child_process#exec
+
+The same options as both [`child_process#spawn()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) and [`child_process#exec()`](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback) can also be used.
+
 #### cwd
 
 Type: `string`<br>
@@ -241,14 +325,7 @@ Current working directory of the child process.
 Type: `object`<br>
 Default: `process.env`
 
-Environment key-value pairs. Extends automatically from `process.env`. Set `extendEnv` to `false` if you don't want this.
-
-#### extendEnv
-
-Type: `boolean`<br>
-Default: `true`
-
-Set to `false` if you don't want to extend the environment variables when providing the `env` property.
+Environment key-value pairs. Extends automatically from `process.env`. Set [`extendEnv`](#extendenv) to `false` if you don't want this.
 
 #### argv0
 
@@ -293,51 +370,6 @@ We recommend against using this option since it is:
 - slower, because of the additional shell interpretation.
 - unsafe, potentially allowing command injection.
 
-#### stripFinalNewline
-
-Type: `boolean`<br>
-Default: `true`
-
-Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
-
-#### preferLocal
-
-Type: `boolean`<br>
-Default: `true`
-
-Prefer locally installed binaries when looking for a binary to execute.<br>
-If you `$ npm install foo`, you can then `execa('foo')`.
-
-#### localDir
-
-Type: `string`<br>
-Default: `process.cwd()`
-
-Preferred path to find locally installed binaries in (use with `preferLocal`).
-
-#### input
-
-Type: `string | Buffer | stream.Readable`
-
-Write some input to the `stdin` of your binary.<br>
-Streams are not allowed when using the synchronous methods.
-
-#### reject
-
-Type: `boolean`<br>
-Default: `true`
-
-Setting this to `false` resolves the promise with the error instead of rejecting it.
-
-#### cleanup
-
-Type: `boolean`<br>
-Default: `true`
-
-Kill the spawned process when the parent process exits unless either:
-	- the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
-	- the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
-
 #### encoding
 
 Type: `string | null`<br>
@@ -352,13 +384,6 @@ Default: `0`
 
 If timeout is greater than `0`, the parent will send the signal identified by the `killSignal` property (the default is `SIGTERM`) if the child runs longer than timeout milliseconds.
 
-#### buffer
-
-Type: `boolean`<br>
-Default: `true`
-
-Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
-
 #### maxBuffer
 
 Type: `number`<br>
@@ -372,27 +397,6 @@ Type: `string | number`<br>
 Default: `SIGTERM`
 
 Signal value to be used when the spawned process will be killed.
-
-#### stdin
-
-Type: `string | number | Stream | undefined`<br>
-Default: `pipe`
-
-Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-
-#### stdout
-
-Type: `string | number | Stream | undefined`<br>
-Default: `pipe`
-
-Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-
-#### stderr
-
-Type: `string | number | Stream | undefined`<br>
-Default: `pipe`
-
-Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 
 #### windowsVerbatimArguments
 


### PR DESCRIPTION
Fixes #252 

I've also re-ordered the options in `index.test-d.ts` and `index.d.ts` accordingly.