### PR TITLE
Add TODO comment about `spawned.stdin` bug being fixed in Node.js 12

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function handleArgs(command, args, options = {}) {
 
 function handleInput(spawned, input) {
 	// Checking for stdin is workaround for https://github.com/nodejs/node/issues/26852
-	// TODO: remove `|| spawned.stdin === undefined` once we drop support for Node <=12.2.0
+	// TODO: Remove `|| spawned.stdin === undefined` once we drop support for Node.js <=12.2.0
 	if (input === undefined || spawned.stdin === undefined) {
 		return;
 	}

--- a/index.js
+++ b/index.js
@@ -97,7 +97,8 @@ function handleArgs(command, args, options = {}) {
 }
 
 function handleInput(spawned, input) {
-	// Checking for stdin is workaround for https://github.com/nodejs/node/issues/26852 on Node.js 10 and 12
+	// Checking for stdin is workaround for https://github.com/nodejs/node/issues/26852
+	// TODO: remove `|| spawned.stdin === undefined` once we drop support for Node <=12.2.0
 	if (input === undefined || spawned.stdin === undefined) {
 		return;
 	}


### PR DESCRIPTION
#212 will not be needed anymore after the next release of Node.js (`12.3.0` probably). This was fixed in Node.js [by this PR](https://github.com/nodejs/node/pull/27696).

This adds a `TODO` comment to remove it once we drop support for Node.js `<= 12.2.0`. Granted this won't be in the immediate future :)