### PR TITLE
Fix Execa crashing when the wrong version of `readable-stream` is installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,7 +332,8 @@ const execa = (command, args, options) => {
 			spawned.stderr.destroy();
 		}
 
-		if (spawned.all) {
+		// TODO: Remove `&& spawned.all.destroy` once https://github.com/grncdr/merge-stream/issues/37 is fixed
+		if (spawned.all && spawned.all.destroy) {
 			spawned.all.destroy();
 		}
 	}


### PR DESCRIPTION
Execa crashes when users have a specific dependency tree installed, which somehow resolves `readable-stream` to the wrong version:

```js
> await execa('echo')
Thrown:
TypeError: spawned.all.destroy is not a function
    at destroy (/home/code/node_modules/gulp-execa/node_modules/execa/index.js:335:16)
    at /home/code/node_modules/p-finally/index.js:7:12
    at new Promise (<anonymous>
```

This is due to an old version of `readable-stream` being used. This is not an issue for most users, but I managed to trigger this in my own packages.

This only happens when `readable-stream@2.2.*` is used instead of `readable-stream@2.3.*`. `readable-stream` [is used by `merge-stream`](https://github.com/grncdr/merge-stream/blob/1b33da64b219dcc8bf33645953c32a6fd9e3b36d/index.js#L3) which we use for the `all` option.

`merge-stream` uses the [semver range `^2.0.1`](https://github.com/grncdr/merge-stream/blob/1b33da64b219dcc8bf33645953c32a6fd9e3b36d/package.json#L15) so this should not be a problem. However I somehow managed to have the wrong version installed inside my dependency tree, probably because of wrong deduping:

```
$ npm ls readable-stream
autoserver@0.5.0 /home/ether/code/autoserver
├─┬ ava@1.4.1
│ └─┬ chokidar@2.1.5
│   ├─┬ UNMET OPTIONAL DEPENDENCY fsevents@1.2.7
│   │ └─┬ UNMET OPTIONAL DEPENDENCY node-pre-gyp@0.10.3
│   │   └─┬ UNMET OPTIONAL DEPENDENCY npmlog@4.1.2
│   │     └─┬ UNMET OPTIONAL DEPENDENCY are-we-there-yet@1.1.5
│   │       └── UNMET OPTIONAL DEPENDENCY readable-stream@2.3.6 
│   └─┬ readdirp@2.2.1
│     └── readable-stream@2.2.7  deduped
├─┬ gulp@4.0.2
│ ├─┬ gulp-cli@2.2.0
│ │ └─┬ concat-stream@1.6.2
│ │   └── readable-stream@2.2.7  deduped
│ └─┬ vinyl-fs@3.0.3
│   ├─┬ glob-stream@6.1.0
│   │ ├─┬ ordered-read-streams@1.0.1
│   │ │ └── readable-stream@2.2.7  deduped
│   │ └── readable-stream@2.2.7  deduped
│   ├─┬ lazystream@1.0.0
│   │ └── readable-stream@2.2.7  deduped
│   ├─┬ lead@1.0.0
│   │ └─┬ flush-write-stream@1.1.1
│   │   └── readable-stream@2.3.6 
│   ├─┬ pumpify@1.5.1
│   │ └─┬ duplexify@3.7.1
│   │   └── readable-stream@2.2.7  deduped
│   ├── readable-stream@2.3.6 
│   ├─┬ through2@2.0.5
│   │ └── readable-stream@2.3.6 
│   └─┬ vinyl@2.2.0
│     └─┬ cloneable-readable@1.1.2
│       └── readable-stream@2.3.6 
├─┬ gulp-execa@0.3.1
│ └─┬ execa@1.0.0 (github:sindresorhus/execa#c8a53da6748885423f73812580afd59699b36e31)
│   └─┬ merge-stream@1.0.1
│     └── readable-stream@2.2.7  deduped
├─┬ gulp-shared-tasks@0.27.72
│ ├─┬ eslint-plugin-html@5.0.5
│ │ └─┬ htmlparser2@3.10.1
│ │   └── readable-stream@3.3.0 
│ ├─┬ gulp-prettier@2.1.0
│ │ └─┬ through2@3.0.1
│ │   └── readable-stream@2.2.7  deduped
│ └─┬ jscpd@2.0.15
│   └─┬ level@5.0.1
│     └─┬ level-packager@5.0.1
│       └─┬ levelup@4.0.1
│         └─┬ level-iterator-stream@4.0.1
│           └── readable-stream@3.3.0 
└─┬ mongodb@2.2.36
  └── readable-stream@2.2.7
```

`npm install` or removing `package-lock.json` does not fix `readable-stream` to the correct version. 

The good news is that the latest version of `merge-stream` does not use `readable-stream` at all, so that fixes this bug. However that version is not published to npm yet (I have published [an issue](https://github.com/grncdr/merge-stream/issues/37)).