### PR TITLE
Add link to `gulp-execa`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -426,7 +426,7 @@ subprocess.stdout.pipe(process.stdout);
 ```
 
 
-## See also
+## Related
 
 - [`gulp-execa`](https://github.com/ehmicky/gulp-execa): Gulp plugin for `execa`
 

--- a/readme.md
+++ b/readme.md
@@ -428,7 +428,7 @@ subprocess.stdout.pipe(process.stdout);
 
 ## Related
 
-- [`gulp-execa`](https://github.com/ehmicky/gulp-execa): Gulp plugin for `execa`
+- [gulp-execa](https://github.com/ehmicky/gulp-execa) - Gulp plugin for `execa`
 
 
 ## Maintainers

--- a/readme.md
+++ b/readme.md
@@ -426,6 +426,11 @@ subprocess.stdout.pipe(process.stdout);
 ```
 
 
+## See also
+
+- [`gulp-execa`](https://github.com/ehmicky/gulp-execa): Gulp plugin for `execa`
+
+
 ## Maintainers
 
 - [Sindre Sorhus](https://github.com/sindresorhus)


### PR DESCRIPTION
This adds a link to [`gulp-execa`](https://github.com/ehmicky/gulp-execa), which is a Gulp plugin I created around `execa`.

Why is a Gulp plugin needed, as opposed to calling `execa()` directly? `gulp-execa` adds Gulp-friendly features such as:
  - shortcut task creation syntax: `const outdated = task('npm outdated')` instead of `const outdated = () => execa('npm outdated')`
  - tweaks default values for some options to make them more Gulp-friendly. Notably, by default `stdout` and `stderr` are printed on the console.
  - prints the command and its arguments on the console (this can be turned off)
  - better reporting of errors by using [`plugin-error`](https://github.com/gulpjs/plugin-error)

Finally there is a stream mode, that executes commands over a files stream. I added this feature because there are some legitimate use cases, but I've also [added warnings](https://github.com/ehmicky/gulp-execa/blob/master/docs/API.md#streamfunction-options) that in the majority of cases, users should not use this method, because it creates lots of child processes.

Also to be noted: there are around 15 Gulp plugins with the same purpose. But all of them are directly calling `child_process.spawn()` of `child_process.exec()`. None is using `execa`. So they are all missing the features brought by `execa`, including better Windows support, shebangs and local binaries. Some do a little of it, but it does not go very far.