### PR TITLE
Add `execa.command()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -368,6 +368,37 @@ declare const execa: {
 		file: string,
 		options?: execa.SyncOptions<null>
 	): execa.ExecaSyncReturnValue<Buffer>;
+
+	/**
+	Same as `execa()` except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execa.command('echo unicorns')`.
+
+	If the file or an argument contains spaces, they must be escaped with backslashes. Otherwise no escaping/quoting is needed.
+
+	@param command - The program/script to execute and its arguments.
+	@returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
+
+	@example
+	```
+	import execa from 'execa';
+
+	(async () => {
+		const {stdout} = await execa.command('echo unicorns');
+		console.log(stdout);
+		//=> 'unicorns'
+	})();
+	```
+	*/
+	command(command: string, options?: execa.Options): execa.ExecaChildProcess;
+	command(command: string, options?: execa.Options<null>): execa.ExecaChildProcess<Buffer>;
+
+	/**
+	Same as `execa.command()` but synchronously.
+
+	@param command - The program/script to execute and its arguments.
+	@returns A result `Object` with `stdout` and `stderr` properties.
+	*/
+	commandSync(command: string, options?: execa.SyncOptions): execa.ExecaSyncReturnValue;
+	commandSync(command: string, options?: execa.SyncOptions<null>): execa.ExecaSyncReturnValue<Buffer>;
 };
 
 export = execa;

--- a/index.d.ts
+++ b/index.d.ts
@@ -392,7 +392,7 @@ declare const execa: {
 	command(command: string, options?: execa.Options<null>): execa.ExecaChildProcess<Buffer>;
 
 	/**
-	Same as `execa.command()` but synchronously.
+	Same as `execa.command()` but synchronous.
 
 	@param command - The program/script to execute and its arguments.
 	@returns A result `Object` with `stdout` and `stderr` properties.

--- a/index.d.ts
+++ b/index.d.ts
@@ -372,7 +372,7 @@ declare const execa: {
 	/**
 	Same as `execa()` except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execa.command('echo unicorns')`.
 
-	If the file or an argument contains spaces, they must be escaped with backslashes. Otherwise no escaping/quoting is needed.
+	If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `__dirname` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
 
 	@param command - The program/script to execute and its arguments.
 	@returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.

--- a/index.js
+++ b/index.js
@@ -17,9 +17,9 @@ const TEN_MEGABYTES = 1000 * 1000 * 10;
 
 const SPACES_REGEXP = / +/g;
 
-function handleArgs(command, args, options = {}) {
-	const parsed = crossSpawn._parse(command, args, options);
-	command = parsed.command;
+function handleArgs(file, args, options = {}) {
+	const parsed = crossSpawn._parse(file, args, options);
+	file = parsed.command;
 	args = parsed.args;
 	options = parsed.options;
 
@@ -52,12 +52,12 @@ function handleArgs(command, args, options = {}) {
 
 	options.stdio = stdio(options);
 
-	if (process.platform === 'win32' && path.basename(command, '.exe') === 'cmd') {
+	if (process.platform === 'win32' && path.basename(file, '.exe') === 'cmd') {
 		// #116
 		args.unshift('/q');
 	}
 
-	return {command, args, options, parsed};
+	return {command: file, args, options, parsed};
 }
 
 function handleInput(spawned, input) {
@@ -201,18 +201,18 @@ function getErrorPrefix({timedOut, timeout, signal, exitCodeName, exitCode, isCa
 	return `failed with exit code ${exitCode} (${exitCodeName})`;
 }
 
-function joinCommand(command, args = []) {
+function joinCommand(file, args = []) {
 	if (!Array.isArray(args)) {
-		return command;
+		return file;
 	}
 
-	return [command, ...args].join(' ');
+	return [file, ...args].join(' ');
 }
 
-const execa = (command, args, options) => {
-	const parsed = handleArgs(command, args, options);
+const execa = (file, args, options) => {
+	const parsed = handleArgs(file, args, options);
 	const {encoding, buffer, maxBuffer} = parsed.options;
-	const joinedCommand = joinCommand(command, args);
+	const joinedCommand = joinCommand(file, args);
 
 	let spawned;
 	try {
@@ -384,9 +384,9 @@ const execa = (command, args, options) => {
 
 module.exports = execa;
 
-module.exports.sync = (command, args, options) => {
-	const parsed = handleArgs(command, args, options);
-	const joinedCommand = joinCommand(command, args);
+module.exports.sync = (file, args, options) => {
+	const parsed = handleArgs(file, args, options);
+	const joinedCommand = joinCommand(file, args);
 
 	if (isStream(parsed.options.input)) {
 		throw new TypeError('The `input` option cannot be a stream in sync mode');

--- a/index.js
+++ b/index.js
@@ -17,37 +17,7 @@ const TEN_MEGABYTES = 1000 * 1000 * 10;
 
 const SPACES_REGEXP = / +/g;
 
-// Allow spaces to be escaped by a backslash if not meant as a delimiter
-function handleEscaping(tokens, token, index) {
-	if (index === 0) {
-		return [token];
-	}
-
-	const previousToken = tokens[tokens.length - 1];
-
-	if (previousToken.endsWith('\\')) {
-		return [...tokens.slice(0, -1), `${previousToken.slice(0, -1)} ${token}`];
-	}
-
-	return [...tokens, token];
-}
-
-function parseCommand(command) {
-	return command
-		.trim()
-		.split(SPACES_REGEXP)
-		.reduce(handleEscaping, []);
-}
-
 function handleArgs(command, args, options = {}) {
-	if (args && !Array.isArray(args) && typeof args === 'object') {
-		options = args;
-	}
-
-	if (!options.shell && command.includes(' ') && !Array.isArray(args)) {
-		[command, ...args] = parseCommand(command);
-	}
-
 	const parsed = crossSpawn._parse(command, args, options);
 	command = parsed.command;
 	args = parsed.args;
@@ -454,4 +424,43 @@ module.exports.sync = (command, args, options) => {
 		isCanceled: false,
 		killed: false
 	};
+};
+
+// Allow spaces to be escaped by a backslash if not meant as a delimiter
+function handleEscaping(tokens, token, index) {
+	if (index === 0) {
+		return [token];
+	}
+
+	const previousToken = tokens[tokens.length - 1];
+
+	if (previousToken.endsWith('\\')) {
+		return [...tokens.slice(0, -1), `${previousToken.slice(0, -1)} ${token}`];
+	}
+
+	return [...tokens, token];
+}
+
+function parseCommand(command) {
+	return command
+		.trim()
+		.split(SPACES_REGEXP)
+		.reduce(handleEscaping, []);
+}
+
+function parseCommand(command) {
+	return command
+		.trim()
+		.split(SPACES_REGEXP)
+		.reduce(handleEscaping, []);
+}
+
+module.exports.command = (command, options) => {
+	const [file, ...args] = parseCommand(command);
+	return execa(file, args, {...options, shell: false});
+};
+
+module.exports.command.sync = (command, options) => {
+	const [file, ...args] = parseCommand(command);
+	return execa.sync(file, args, {...options, shell: false});
 };

--- a/index.js
+++ b/index.js
@@ -448,13 +448,6 @@ function parseCommand(command) {
 		.reduce(handleEscaping, []);
 }
 
-function parseCommand(command) {
-	return command
-		.trim()
-		.split(SPACES_REGEXP)
-		.reduce(handleEscaping, []);
-}
-
 module.exports.command = (command, options) => {
 	const [file, ...args] = parseCommand(command);
 	return execa(file, args, {...options, shell: false});

--- a/index.js
+++ b/index.js
@@ -32,26 +32,20 @@ function handleEscaping(tokens, token, index) {
 	return [...tokens, token];
 }
 
-function parseCommand(command, args = []) {
-	if (args.length !== 0) {
-		throw new Error('Arguments cannot be inside `command` when also specified as an array of strings');
-	}
-
-	const [file, ...extraArgs] = command
+function parseCommand(command) {
+	return command
 		.trim()
 		.split(SPACES_REGEXP)
 		.reduce(handleEscaping, []);
-	return [file, extraArgs];
 }
 
 function handleArgs(command, args, options = {}) {
-	if (args && !Array.isArray(args)) {
+	if (args && !Array.isArray(args) && typeof args === 'object') {
 		options = args;
-		args = [];
 	}
 
-	if (!options.shell && command.includes(' ')) {
-		[command, args] = parseCommand(command, args);
+	if (!options.shell && command.includes(' ') && !Array.isArray(args)) {
+		[command, ...args] = parseCommand(command);
 	}
 
 	const parsed = crossSpawn._parse(command, args, options);

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function handleArgs(file, args, options = {}) {
 		args.unshift('/q');
 	}
 
-	return {command: file, args, options, parsed};
+	return {file, args, options, parsed};
 }
 
 function handleInput(spawned, input) {
@@ -216,7 +216,7 @@ const execa = (file, args, options) => {
 
 	let spawned;
 	try {
-		spawned = childProcess.spawn(parsed.command, parsed.args, parsed.options);
+		spawned = childProcess.spawn(parsed.file, parsed.args, parsed.options);
 	} catch (error) {
 		return Promise.reject(error);
 	}
@@ -392,7 +392,7 @@ module.exports.sync = (file, args, options) => {
 		throw new TypeError('The `input` option cannot be a stream in sync mode');
 	}
 
-	const result = childProcess.spawnSync(parsed.command, parsed.args, parsed.options);
+	const result = childProcess.spawnSync(parsed.file, parsed.args, parsed.options);
 	result.stdout = handleOutput(parsed.options, result.stdout, result.error);
 	result.stderr = handleOutput(parsed.options, result.stderr, result.error);
 

--- a/index.js
+++ b/index.js
@@ -450,10 +450,10 @@ function parseCommand(command) {
 
 module.exports.command = (command, options) => {
 	const [file, ...args] = parseCommand(command);
-	return execa(file, args, {...options, shell: false});
+	return execa(file, args, options);
 };
 
-module.exports.command.sync = (command, options) => {
+module.exports.commandSync = (command, options) => {
 	const [file, ...args] = parseCommand(command);
-	return execa.sync(file, args, {...options, shell: false});
+	return execa.sync(file, args, options);
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -146,3 +146,16 @@ expectType<ExecaSyncReturnValue<string>>(
 expectType<ExecaSyncReturnValue<Buffer>>(
 	execa.sync('unicorns', ['foo'], {encoding: null})
 );
+
+expectType<ExecaChildProcess<string>>(execa.command('unicorns'));
+expectType<ExecaReturnValue<string>>(await execa.command('unicorns'));
+expectType<ExecaReturnValue<string>>(await execa.command('unicorns', {encoding: 'utf8'}));
+expectType<ExecaReturnValue<Buffer>>(await execa.command('unicorns', {encoding: null}));
+expectType<ExecaReturnValue<string>>(await execa.command('unicorns foo', {encoding: 'utf8'}));
+expectType<ExecaReturnValue<Buffer>>(await execa.command('unicorns foo', {encoding: null}));
+
+expectType<ExecaSyncReturnValue<string>>(execa.commandSync('unicorns'));
+expectType<ExecaSyncReturnValue<string>>(execa.commandSync('unicorns', {encoding: 'utf8'}));
+expectType<ExecaSyncReturnValue<Buffer>>(execa.commandSync('unicorns', {encoding: null}));
+expectType<ExecaSyncReturnValue<string>>(execa.commandSync('unicorns foo', {encoding: 'utf8'}));
+expectType<ExecaSyncReturnValue<Buffer>>(execa.commandSync('unicorns foo', {encoding: null}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -153,6 +153,7 @@ expectType<ExecaReturnValue<string>>(await execa.command('unicorns', {encoding: 
 expectType<ExecaReturnValue<Buffer>>(await execa.command('unicorns', {encoding: null}));
 expectType<ExecaReturnValue<string>>(await execa.command('unicorns foo', {encoding: 'utf8'}));
 expectType<ExecaReturnValue<Buffer>>(await execa.command('unicorns foo', {encoding: null}));
+
 expectType<ExecaSyncReturnValue<string>>(execa.commandSync('unicorns'));
 expectType<ExecaSyncReturnValue<string>>(execa.commandSync('unicorns', {encoding: 'utf8'}));
 expectType<ExecaSyncReturnValue<Buffer>>(execa.commandSync('unicorns', {encoding: null}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -153,7 +153,6 @@ expectType<ExecaReturnValue<string>>(await execa.command('unicorns', {encoding: 
 expectType<ExecaReturnValue<Buffer>>(await execa.command('unicorns', {encoding: null}));
 expectType<ExecaReturnValue<string>>(await execa.command('unicorns foo', {encoding: 'utf8'}));
 expectType<ExecaReturnValue<Buffer>>(await execa.command('unicorns foo', {encoding: null}));
-
 expectType<ExecaSyncReturnValue<string>>(execa.commandSync('unicorns'));
 expectType<ExecaSyncReturnValue<string>>(execa.commandSync('unicorns', {encoding: 'utf8'}));
 expectType<ExecaSyncReturnValue<Buffer>>(execa.commandSync('unicorns', {encoding: null}));

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@
 - [Executes locally installed binaries by name.](#preferlocal)
 - [Cleans up spawned processes when the parent process dies.](#cleanup)
 - [Get interleaved output](#all) from `stdout` and `stderr` similar to what is printed on the terminal. [*(Async only)*](#execasyncfile-arguments-options)
-- [Can specify command and arguments as a single string without a shell](#execafile-arguments-options)
+- [Can specify command and arguments as a single string without a shell](#execacommandcommand-options)
 - More descriptive errors.
 
 

--- a/readme.md
+++ b/readme.md
@@ -149,7 +149,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 ### execa.command(command, [options])
 
-Same as [`execa()`](https://github.com/sindresorhus/execa#execafile-arguments-options) except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execa('echo unicorns')`.
+Same as [`execa()`](https://github.com/sindresorhus/execa#execafile-arguments-options) except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execa.command('echo unicorns')`.
 
 If the file or an argument contains spaces, they must be escaped with a backslash. Otherwise, no escaping/quoting is needed.
 

--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 Same as [`execa()`](#execafile-arguments-options) except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execa.command('echo unicorns')`.
 
-If the file or an argument contains spaces, they must be escaped with backslashes. Otherwise no escaping/quoting is needed.
+If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `__dirname` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
 
 ### execa.commandSync(command, [options])
 

--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,7 @@ If the file or an argument contains spaces, they must be escaped with backslashe
 
 ### execa.commandSync(command, [options])
 
-Same as [`execa.command()`](#execacommand-command-options) but synchronously.
+Same as [`execa.command()`](#execacommand-command-options) but synchronous.
 
 Returns or throws a [`childProcessResult`](#childProcessResult).
 

--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ Execute a file. Think of this as a mix of [`child_process.execFile()`](https://n
 
 Arguments can be specified in either:
   - `arguments`: `execa('echo', ['unicorns'])`. No escaping/quoting is needed.
-  - `command`: `execa('echo unicorns')`. No escaping/quoting is needed, except significant spaces which must be escaped with a backlash.
+  - `command`: `execa('echo unicorns')`. No escaping/quoting is needed, except significant spaces which must be escaped with a backslash.
 
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 

--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 Same as [`execa()`](https://github.com/sindresorhus/execa#execafile-arguments-options) except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execa.command('echo unicorns')`.
 
-If the file or an argument contains spaces, they must be escaped with a backslash. Otherwise, no escaping/quoting is needed.
+If the file or an argument contains spaces, they must be escaped with a backslash. Otherwise no escaping/quoting is needed.
 
 The [`shell`](#shell) option cannot be used.
 

--- a/readme.md
+++ b/readme.md
@@ -121,16 +121,14 @@ try {
 
 ## API
 
-### execa(file, [arguments], [options])
+### execa(file, arguments, [options])
 ### execa(command, [options])
 
 Execute a file. Think of this as a mix of [`child_process.execFile()`](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback) and [`child_process.spawn()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 Arguments can be specified in either:
-  - `arguments`: `execa('echo', ['unicorns'])`.
-  - `command`: `execa('echo unicorns')`.
-
-Arguments should not be escaped nor quoted, except inside `command` where spaces can be escaped with a backslash.
+  - `arguments`: `execa('echo', ['unicorns'])`. No escaping/quoting is needed.
+  - `command`: `execa('echo unicorns')`. No escaping/quoting is needed, except significant spaces which must be escaped with a backlash.
 
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 

--- a/readme.md
+++ b/readme.md
@@ -339,7 +339,7 @@ Environment key-value pairs. Extends automatically from `process.env`. Set [`ext
 
 Type: `string`
 
-Explicitly set the value of `argv[0]` sent to the child process. This will be set to `command` or `file` if not specified.
+Explicitly set the value of `argv[0]` sent to the child process. This will be set to `file` if not specified.
 
 #### stdio
 
@@ -371,7 +371,7 @@ Sets the group identity of the process.
 Type: `boolean | string`<br>
 Default: `false`
 
-If `true`, runs `command` inside of a shell. Uses `/bin/sh` on UNIX and `cmd.exe` on Windows. A different shell can be specified as a string. The shell should understand the `-c` switch on UNIX or `/d /s /c` on Windows.
+If `true`, runs `file` inside of a shell. Uses `/bin/sh` on UNIX and `cmd.exe` on Windows. A different shell can be specified as a string. The shell should understand the `-c` switch on UNIX or `/d /s /c` on Windows.
 
 We recommend against using this option since it is:
 - not cross-platform, encouraging shell-specific syntax.

--- a/readme.md
+++ b/readme.md
@@ -149,7 +149,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 ### execa.command(command, [options])
 
-Same as [`execa()`](https://github.com/sindresorhus/execa#execafile-arguments-options) except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execa.command('echo unicorns')`.
+Same as [`execa()`](#execafile-arguments-options) except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execa.command('echo unicorns')`.
 
 If the file or an argument contains spaces, they must be escaped with a backslash. Otherwise no escaping/quoting is needed.
 
@@ -157,7 +157,7 @@ The [`shell`](#shell) option cannot be used.
 
 ### execa.command.sync(command, [options])
 
-Same as [`execa.command()`](https://github.com/sindresorhus/execa#execacommand-command-options) but synchronously.
+Same as [`execa.command()`](#execacommand-command-options) but synchronously.
 
 Returns or throws a [`childProcessResult`](#childProcessResult).
 

--- a/readme.md
+++ b/readme.md
@@ -153,9 +153,7 @@ Same as [`execa()`](#execafile-arguments-options) except both file and arguments
 
 If the file or an argument contains spaces, they must be escaped with backslashes. Otherwise no escaping/quoting is needed.
 
-The [`shell`](#shell) option cannot be used.
-
-### execa.command.sync(command, [options])
+### execa.commandSync(command, [options])
 
 Same as [`execa.command()`](#execacommand-command-options) but synchronously.
 

--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 Same as [`execa()`](#execafile-arguments-options) except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execa.command('echo unicorns')`.
 
-If the file or an argument contains spaces, they must be escaped with a backslash. Otherwise no escaping/quoting is needed.
+If the file or an argument contains spaces, they must be escaped with backslashes. Otherwise no escaping/quoting is needed.
 
 The [`shell`](#shell) option cannot be used.
 

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ const execa = require('execa');
 
 	// Catching an error
 	try {
-		await execa('wrong command');
+		await execa('wrong', ['command']);
 	} catch (error) {
 		console.log(error);
 		/*
@@ -94,7 +94,7 @@ const execa = require('execa');
 
 // Catching an error with a sync method
 try {
-	execa.sync('wrong command');
+	execa.sync('wrong', ['command']);
 } catch (error) {
 	console.log(error);
 	/*
@@ -122,13 +122,10 @@ try {
 ## API
 
 ### execa(file, arguments, [options])
-### execa(command, [options])
 
 Execute a file. Think of this as a mix of [`child_process.execFile()`](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback) and [`child_process.spawn()`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
-Arguments can be specified in either:
-  - `arguments`: `execa('echo', ['unicorns'])`. No escaping/quoting is needed.
-  - `command`: `execa('echo unicorns')`. No escaping/quoting is needed, except significant spaces which must be escaped with a backslash.
+No escaping/quoting is needed.
 
 Unless the [`shell`](#shell) option is used, no shell interpreter (Bash, `cmd.exe`, etc.) is used, so shell features such as variables substitution (`echo $PATH`) are not allowed.
 
@@ -145,9 +142,22 @@ Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#chi
 Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
 ### execa.sync(file, [arguments], [options])
-### execa.sync(command, [options])
 
 Execute a file synchronously.
+
+Returns or throws a [`childProcessResult`](#childProcessResult).
+
+### execa.command(command, [options])
+
+Same as [`execa()`](https://github.com/sindresorhus/execa#execafile-arguments-options) except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execa('echo unicorns')`.
+
+If the file or an argument contains spaces, they must be escaped with a backslash. Otherwise, no escaping/quoting is needed.
+
+The [`shell`](#shell) option cannot be used.
+
+### execa.command.sync(command, [options])
+
+Same as [`execa.command()`](https://github.com/sindresorhus/execa#execacommand-command-options) but synchronously.
 
 Returns or throws a [`childProcessResult`](#childProcessResult).
 

--- a/test.js
+++ b/test.js
@@ -107,8 +107,13 @@ test('allow string arguments in synchronous mode', t => {
 	t.is(stdout, 'foo\nbar');
 });
 
-test('forbid string arguments together with array arguments', async t => {
-	await t.throwsAsync(execa('node fixtures/echo foo bar', ['foo', 'bar']));
+test('allow commands with spaces and array arguments', async t => {
+	const {stdout} = await execa('./fixtures/command with space', ['foo', 'bar']);
+	t.is(stdout, 'foo\nbar');
+});
+
+test('forbid commands with spaces and no array arguments', async t => {
+	await t.throwsAsync(execa('./fixtures/command with space'));
 });
 
 test('ignore consecutive spaces in string arguments', async t => {

--- a/test.js
+++ b/test.js
@@ -107,10 +107,8 @@ test('allow string arguments in synchronous mode', t => {
 	t.is(stdout, 'foo\nbar');
 });
 
-test('forbid string arguments together with array arguments', t => {
-	t.throws(() => {
-		execa('node fixtures/echo foo bar', ['foo', 'bar']);
-	}, /Arguments cannot be inside/);
+test('forbid string arguments together with array arguments', async t => {
+	await t.throwsAsync(execa('node fixtures/echo foo bar', ['foo', 'bar']));
 });
 
 test('ignore consecutive spaces in string arguments', async t => {

--- a/test.js
+++ b/test.js
@@ -714,3 +714,43 @@ test('calling cancel method on a process which has been killed does not make err
 	const {isCanceled} = await t.throwsAsync(subprocess);
 	t.false(isCanceled);
 });
+
+test('allow commands with spaces and no array arguments', async t => {
+	const {stdout} = await execa('./fixtures/command with space');
+	t.is(stdout, '');
+});
+
+test('allow commands with spaces and array arguments', async t => {
+	const {stdout} = await execa('./fixtures/command with space', ['foo', 'bar']);
+	t.is(stdout, 'foo\nbar');
+});
+
+test('execa.command()', async t => {
+	const {stdout} = await execa.command('node fixtures/echo foo bar');
+	t.is(stdout, 'foo\nbar');
+});
+
+test('execa.command() ignores consecutive spaces', async t => {
+	const {stdout} = await execa.command('node fixtures/echo foo    bar');
+	t.is(stdout, 'foo\nbar');
+});
+
+test('execa.command() allows escaping spaces', async t => {
+	const {stdout} = await execa.command('node fixtures/echo foo\\ bar');
+	t.is(stdout, 'foo bar');
+});
+
+test('execa.command() escapes other whitespaces', async t => {
+	const {stdout} = await execa.command('node fixtures/echo foo\tbar');
+	t.is(stdout, 'foo\tbar');
+});
+
+test('execa.command() trims', async t => {
+	const {stdout} = await execa.command('  node fixtures/echo foo bar  ');
+	t.is(stdout, 'foo\nbar');
+});
+
+test('execa.command.sync()', t => {
+	const {stdout} = execa.command.sync('node fixtures/echo foo bar');
+	t.is(stdout, 'foo\nbar');
+});

--- a/test.js
+++ b/test.js
@@ -97,50 +97,6 @@ test('pass `stderr` to a file descriptor', async t => {
 	t.is(fs.readFileSync(file, 'utf8'), 'foo bar\n');
 });
 
-test('allow string arguments', async t => {
-	const {stdout} = await execa('node fixtures/echo foo bar');
-	t.is(stdout, 'foo\nbar');
-});
-
-test('allow string arguments in synchronous mode', t => {
-	const {stdout} = execa.sync('node fixtures/echo foo bar');
-	t.is(stdout, 'foo\nbar');
-});
-
-test('allow commands with spaces and array arguments', async t => {
-	const {stdout} = await execa('./fixtures/command with space', ['foo', 'bar']);
-	t.is(stdout, 'foo\nbar');
-});
-
-test('forbid commands with spaces and no array arguments', async t => {
-	await t.throwsAsync(execa('./fixtures/command with space'));
-});
-
-test('ignore consecutive spaces in string arguments', async t => {
-	const {stdout} = await execa('node fixtures/echo foo    bar');
-	t.is(stdout, 'foo\nbar');
-});
-
-test('escape other whitespaces in string arguments', async t => {
-	const {stdout} = await execa('node fixtures/echo foo\tbar');
-	t.is(stdout, 'foo\tbar');
-});
-
-test('allow escaping spaces in commands', async t => {
-	const {stdout} = await execa('./fixtures/command\\ with\\ space foo bar');
-	t.is(stdout, 'foo\nbar');
-});
-
-test('allow escaping spaces in string arguments', async t => {
-	const {stdout} = await execa('node fixtures/echo foo\\ bar');
-	t.is(stdout, 'foo bar');
-});
-
-test('trim string arguments', async t => {
-	const {stdout} = await execa('  node fixtures/echo foo bar  ');
-	t.is(stdout, 'foo\nbar');
-});
-
 test('execa.sync()', t => {
 	const {stdout} = execa.sync('noop', ['foo']);
 	t.is(stdout, 'foo');
@@ -735,7 +691,12 @@ test('execa.command() ignores consecutive spaces', async t => {
 	t.is(stdout, 'foo\nbar');
 });
 
-test('execa.command() allows escaping spaces', async t => {
+test('execa.command() allows escaping spaces in commands', async t => {
+	const {stdout} = await execa.command('./fixtures/command\\ with\\ space foo bar');
+	t.is(stdout, 'foo\nbar');
+});
+
+test('execa.command() allows escaping spaces in arguments', async t => {
 	const {stdout} = await execa.command('node fixtures/echo foo\\ bar');
 	t.is(stdout, 'foo bar');
 });

--- a/test.js
+++ b/test.js
@@ -712,6 +712,6 @@ test('execa.command() trims', async t => {
 });
 
 test('execa.command.sync()', t => {
-	const {stdout} = execa.command.sync('node fixtures/echo foo bar');
+	const {stdout} = execa.commandSync('node fixtures/echo foo bar');
 	t.is(stdout, 'foo\nbar');
 });


### PR DESCRIPTION
This PR is a follow-up on #182 which allowed specifying the command and its arguments as a single string. 

It improves the common case where the program contains a space in its path. For example on Windows `C:\Program Files\node\node.exe`. 

With `execa(command, [array], [options])`, when:
  1) `command` contains a space
  2) `array` is defined
  3) `options.shell` is not `true`

Then:
  - former behavior: an exception is thrown.
  - new behavior: `command` is handled as a command with a space in its path.
 
```js
// Success
execa('echo hello')
// Fail
execa('echo hello', ['world'])
// Success
execa('echo hello', {shell: true})

// Fail
execa('C:\\Program Files\\node\\node.exe')
// Success
execa('C:\\Program Files\\node\\node.exe', [])
// Success
execa('C:\\Program\\ Files\\node\\node.exe')
```

I've fixed the tests. No changes need to be done to the `README` since it already implies that no spaces escaping is needed for programs containing a space in their path.