### PR TITLE
Fix not being able to escape more than one space in commands

### DIFF
--- a/fixtures/command with space
+++ b/fixtures/command with space
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+'use strict';
+console.log(process.argv.slice(2).join('\n'));

--- a/index.js
+++ b/index.js
@@ -25,11 +25,11 @@ function handleEscaping(tokens, token, index) {
 
 	const previousToken = tokens[tokens.length - 1];
 
-	if (!previousToken.endsWith('\\')) {
-		return [...tokens, token];
+	if (previousToken.endsWith('\\')) {
+		return [...tokens.slice(0, -1), `${previousToken.slice(0, -1)} ${token}`];
 	}
 
-	return [...tokens.slice(0, -1), `${previousToken.slice(0, -1)} ${token}`];
+	return [...tokens, token];
 }
 
 function parseCommand(command, args = []) {

--- a/index.js
+++ b/index.js
@@ -23,13 +23,13 @@ function handleEscaping(tokens, token, index) {
 		return [token];
 	}
 
-	const previousToken = tokens[index - 1];
+	const lastToken = tokens[tokens.length - 1];
 
-	if (!previousToken.endsWith('\\')) {
+	if (!lastToken.endsWith('\\')) {
 		return [...tokens, token];
 	}
 
-	return [...tokens.slice(0, index - 1), `${previousToken.slice(0, -1)} ${token}`];
+	return [...tokens.slice(0, -1), `${lastToken.slice(0, -1)} ${token}`];
 }
 
 function parseCommand(command, args = []) {

--- a/index.js
+++ b/index.js
@@ -23,13 +23,13 @@ function handleEscaping(tokens, token, index) {
 		return [token];
 	}
 
-	const lastToken = tokens[tokens.length - 1];
+	const previousToken = tokens[tokens.length - 1];
 
-	if (!lastToken.endsWith('\\')) {
+	if (!previousToken.endsWith('\\')) {
 		return [...tokens, token];
 	}
 
-	return [...tokens.slice(0, -1), `${lastToken.slice(0, -1)} ${token}`];
+	return [...tokens.slice(0, -1), `${previousToken.slice(0, -1)} ${token}`];
 }
 
 function parseCommand(command, args = []) {

--- a/test.js
+++ b/test.js
@@ -123,6 +123,11 @@ test('escape other whitespaces in string arguments', async t => {
 	t.is(stdout, 'foo\tbar');
 });
 
+test('allow escaping spaces in commands', async t => {
+	const {stdout} = await execa('./fixtures/command\\ with\\ space foo bar');
+	t.is(stdout, 'foo\nbar');
+});
+
 test('allow escaping spaces in string arguments', async t => {
 	const {stdout} = await execa('node fixtures/echo foo\\ bar');
 	t.is(stdout, 'foo bar');


### PR DESCRIPTION
`execa('path\\ space')` works, but not `execa('path\\ with\\ multiple\\ spaces')`. This PR fixes this.