### PR TITLE
Upgrade `merge-stream` from `1.0.1` to `2.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"cross-spawn": "^6.0.5",
 		"get-stream": "^5.0.0",
 		"is-stream": "^2.0.0",
-		"merge-stream": "^1.0.1",
+		"merge-stream": "^2.0.0",
 		"npm-run-path": "^3.0.0",
 		"p-finally": "^1.0.0",
 		"signal-exit": "^3.0.2",


### PR DESCRIPTION
We use that library in the `all` options.

The new [major release](https://github.com/grncdr/merge-stream/compare/v1.0.1...v2.0.0) removes the dependency on `readable-stream`. That module had several issues, including the one described in #259. 