### PR TITLE
Make errors more consistent

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,13 @@ const execa = (file, args, options) => {
 	try {
 		spawned = childProcess.spawn(parsed.file, parsed.args, parsed.options);
 	} catch (error) {
-		return Promise.reject(error);
+		return Promise.reject(makeError({error, stdout: '', stderr: '', all: ''}, {
+			joinedCommand,
+			parsed,
+			timedOut: false,
+			isCanceled: false,
+			killed: false
+		}));
 	}
 
 	// #115

--- a/test.js
+++ b/test.js
@@ -217,6 +217,18 @@ test('execa() returns a promise with kill() and pid', t => {
 	t.is(typeof pid, 'number');
 });
 
+test('child_process.spawn() errors are propagated', async t => {
+	const {exitCodeName} = await t.throwsAsync(execa('noop', {uid: -1}));
+	t.is(exitCodeName, process.platform === 'win32' ? 'ENOTSUP' : 'EINVAL');
+});
+
+test('child_process.spawnSync() errors are propagated', t => {
+	const {exitCodeName} = t.throws(() => {
+		execa.sync('noop', {uid: -1});
+	});
+	t.is(exitCodeName, process.platform === 'win32' ? 'ENOTSUP' : 'EINVAL');
+});
+
 test('maxBuffer affects stdout', async t => {
 	await t.throwsAsync(execa('max-buffer', ['stdout', '11'], {maxBuffer: 10}), /stdout maxBuffer exceeded/);
 	await t.notThrowsAsync(execa('max-buffer', ['stdout', '10'], {maxBuffer: 10}));


### PR DESCRIPTION
When the underlying `child_process.spawn()` throws synchronously, the promise rejected by `execa()` has a different shape than other errors. This fixes it.

No documentation not TypeScript types needs to be added since it merely adjust the code behavior to what's already documented.