### PR TITLE
Add support for `finally()` in Node <10

### DIFF
--- a/index.js
+++ b/index.js
@@ -374,16 +374,13 @@ const execa = (file, args, options) => {
 	// eslint-disable-next-line promise/prefer-await-to-then
 	spawned.then = (onFulfilled, onRejected) => handlePromise().then(onFulfilled, onRejected);
 	spawned.catch = onRejected => handlePromise().catch(onRejected);
+	spawned.finally = onFinally => pFinally(handlePromise(), onFinally);
+
 	spawned.cancel = () => {
 		if (spawned.kill()) {
 			isCanceled = true;
 		}
 	};
-
-	// TOOD: Remove the `if`-guard when targeting Node.js 10
-	if (Promise.prototype.finally) {
-		spawned.finally = onFinally => handlePromise().finally(onFinally);
-	}
 
 	return spawned;
 };

--- a/index.js
+++ b/index.js
@@ -374,6 +374,7 @@ const execa = (file, args, options) => {
 	// eslint-disable-next-line promise/prefer-await-to-then
 	spawned.then = (onFulfilled, onRejected) => handlePromise().then(onFulfilled, onRejected);
 	spawned.catch = onRejected => handlePromise().catch(onRejected);
+	// TODO: Use native "finally" syntax when targeting Node.js 10
 	spawned.finally = onFinally => pFinally(handlePromise(), onFinally);
 
 	spawned.cancel = () => {

--- a/test.js
+++ b/test.js
@@ -576,41 +576,38 @@ test('removes exit handler on exit', async t => {
 	t.false(included);
 });
 
-// TOOD: Remove the `if`-guard when targeting Node.js 10
-if (Promise.prototype.finally) {
-	test('finally function is executed on success', async t => {
-		let isCalled = false;
-		const {stdout} = await execa('noop', ['foo']).finally(() => {
-			isCalled = true;
-		});
-		t.is(isCalled, true);
-		t.is(stdout, 'foo');
+test('finally function is executed on success', async t => {
+	let isCalled = false;
+	const {stdout} = await execa('noop', ['foo']).finally(() => {
+		isCalled = true;
 	});
+	t.is(isCalled, true);
+	t.is(stdout, 'foo');
+});
 
-	test('finally function is executed on failure', async t => {
-		let isError = false;
-		const {stdout, stderr} = await t.throwsAsync(execa('exit', ['2']).finally(() => {
-			isError = true;
-		}));
-		t.is(isError, true);
-		t.is(typeof stdout, 'string');
-		t.is(typeof stderr, 'string');
-	});
+test('finally function is executed on failure', async t => {
+	let isError = false;
+	const {stdout, stderr} = await t.throwsAsync(execa('exit', ['2']).finally(() => {
+		isError = true;
+	}));
+	t.is(isError, true);
+	t.is(typeof stdout, 'string');
+	t.is(typeof stderr, 'string');
+});
 
-	test('throw in finally function bubbles up on success', async t => {
-		const {message} = await t.throwsAsync(execa('noop', ['foo']).finally(() => {
-			throw new Error('called');
-		}));
-		t.is(message, 'called');
-	});
+test('throw in finally function bubbles up on success', async t => {
+	const {message} = await t.throwsAsync(execa('noop', ['foo']).finally(() => {
+		throw new Error('called');
+	}));
+	t.is(message, 'called');
+});
 
-	test('throw in finally bubbles up on error', async t => {
-		const {message} = await t.throwsAsync(execa('exit', ['2']).finally(() => {
-			throw new Error('called');
-		}));
-		t.is(message, 'called');
-	});
-}
+test('throw in finally bubbles up on error', async t => {
+	const {message} = await t.throwsAsync(execa('exit', ['2']).finally(() => {
+		throw new Error('called');
+	}));
+	t.is(message, 'called');
+});
 
 test('cancel method kills the subprocess', t => {
 	const subprocess = execa('node');


### PR DESCRIPTION
This adds support for the `finally()` method in Node <10. Previously this was only available in Node >=10.