### PR TITLE
Small refactoring on `cleanup` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,6 +267,7 @@ const execa = (file, args, options) => {
 		return promise;
 	})();
 
+	// TODO: Use native "finally" syntax when targeting Node.js 10
 	const processDone = pFinally(new Promise(resolve => {
 		spawned.on('exit', (code, signal) => {
 			if (timedOut) {

--- a/index.js
+++ b/index.js
@@ -267,10 +267,8 @@ const execa = (file, args, options) => {
 		return promise;
 	})();
 
-	const processDone = new Promise(resolve => {
+	const processDone = pFinally(new Promise(resolve => {
 		spawned.on('exit', (code, signal) => {
-			cleanup();
-
 			if (timedOut) {
 				resolvable.resolve([
 					{code, signal}, '', '', ''
@@ -281,17 +279,15 @@ const execa = (file, args, options) => {
 		});
 
 		spawned.on('error', error => {
-			cleanup();
 			resolve({error});
 		});
 
 		if (spawned.stdin) {
 			spawned.stdin.on('error', error => {
-				cleanup();
 				resolve({error});
 			});
 		}
-	});
+	}), cleanup);
 
 	function destroy() {
 		if (spawned.stdout) {


### PR DESCRIPTION
This is a small code refactoring that puts all `cleanup()` in a single place.

This uses `pFinally` instead of `then()` because that promise might be rejected in the future (I've got an upcoming PR that does that).