### PR TITLE
Improve error messages when an `error` event is emitted

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,6 +198,10 @@ function getErrorPrefix({timedOut, timeout, signal, exitCodeName, exitCode, isCa
 		return `was killed with ${signal}`;
 	}
 
+	if (exitCode === undefined) {
+		return 'failed';
+	}
+
 	return `failed with exit code ${exitCode} (${exitCodeName})`;
 }
 

--- a/index.js
+++ b/index.js
@@ -198,11 +198,11 @@ function getErrorPrefix({timedOut, timeout, signal, exitCodeName, exitCode, isCa
 		return `was killed with ${signal}`;
 	}
 
-	if (exitCode === undefined) {
-		return 'failed';
+	if (exitCode !== undefined) {
+		return `failed with exit code ${exitCode} (${exitCodeName})`;
 	}
 
-	return `failed with exit code ${exitCode} (${exitCodeName})`;
+	return 'failed';
 }
 
 function joinCommand(file, args = []) {

--- a/test.js
+++ b/test.js
@@ -65,11 +65,15 @@ test('stdout/stderr/all are undefined if ignored in sync mode', t => {
 	t.is(all, undefined);
 });
 
+const WRONG_COMMAND_STDERR = process.platform === 'win32' ?
+	'\'wrong\' is not recognized as an internal or external command,\r\noperable program or batch file.' :
+	'';
+
 test('stdout/stderr/all on process errors', async t => {
 	const {stdout, stderr, all} = await t.throwsAsync(execa('wrong command'));
 	t.is(stdout, '');
-	t.is(stderr, '');
-	t.is(all, '');
+	t.is(stderr, WRONG_COMMAND_STDERR);
+	t.is(all, WRONG_COMMAND_STDERR);
 });
 
 test('stdout/stderr/all on process errors, in sync mode', t => {
@@ -77,9 +81,7 @@ test('stdout/stderr/all on process errors, in sync mode', t => {
 		execa.sync('wrong command');
 	});
 	t.is(stdout, '');
-	t.is(stderr, process.platform === 'win32' ?
-		'\'wrong\' is not recognized as an internal or external command,\r\noperable program or batch file.' :
-		'');
+	t.is(stderr, WRONG_COMMAND_STDERR);
 	t.is(all, undefined);
 });
 

--- a/test.js
+++ b/test.js
@@ -194,6 +194,12 @@ test('input option can be a Buffer - sync', t => {
 	t.is(stdout, 'testing12');
 });
 
+test('child process errors are handled', async t => {
+	const child = execa('noop');
+	child.emit('error', new Error('test'));
+	await t.throwsAsync(child, /Command failed.*\ntest/);
+});
+
 test('opts.stdout:ignore - stdout will not collect data', async t => {
 	const {stdout} = await execa('stdin', {
 		input: 'hello',

--- a/test.js
+++ b/test.js
@@ -65,15 +65,11 @@ test('stdout/stderr/all are undefined if ignored in sync mode', t => {
 	t.is(all, undefined);
 });
 
-const WRONG_COMMAND_STDERR = process.platform === 'win32' ?
-	'\'wrong\' is not recognized as an internal or external command,\r\noperable program or batch file.' :
-	'';
-
 test('stdout/stderr/all on process errors', async t => {
 	const {stdout, stderr, all} = await t.throwsAsync(execa('wrong command'));
 	t.is(stdout, '');
-	t.is(stderr, WRONG_COMMAND_STDERR);
-	t.is(all, WRONG_COMMAND_STDERR);
+	t.is(stderr, '');
+	t.is(all, '');
 });
 
 test('stdout/stderr/all on process errors, in sync mode', t => {
@@ -81,7 +77,9 @@ test('stdout/stderr/all on process errors, in sync mode', t => {
 		execa.sync('wrong command');
 	});
 	t.is(stdout, '');
-	t.is(stderr, WRONG_COMMAND_STDERR);
+	t.is(stderr, process.platform === 'win32' ?
+		'\'wrong\' is not recognized as an internal or external command,\r\noperable program or batch file.' :
+		'');
 	t.is(all, undefined);
 });
 


### PR DESCRIPTION
When an `error` event is emitted directly on the child process, the error message is currently bad:

```js
const child = execa('echo');
child.emit('error', new Error('test'));
// Prints: Command failed with exit code undefined (undefined): echo \n test
child.catch(error => console.log(error.message)
```

This fixes that.