### PR TITLE
Improve error handling of streams

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,8 @@ declare namespace execa {
 		/**
 		Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
 
+		If the spawned process fails, `error.stdout`, `error.stderr` and `error.all` will contain the buffered data.
+
 		@default true
 		*/
 		readonly buffer?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,7 +41,7 @@ declare namespace execa {
 		/**
 		Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
 
-		If the spawned process fails, `error.stdout`, `error.stderr` and `error.all` will contain the buffered data.
+		If the spawned process fails, `error.stdout`, `error.stderr`, and `error.all` will contain the buffered data.
 
 		@default true
 		*/

--- a/index.js
+++ b/index.js
@@ -106,14 +106,18 @@ function makeAllStream(spawned) {
 	return mixed;
 }
 
-function getBufferedData(stream, streamPromise) {
+async function getBufferedData(stream, streamPromise) {
 	if (!stream) {
 		return;
 	}
 
 	stream.destroy();
 
-	return streamPromise.catch(error => error.bufferedData);
+	try {
+		return await streamPromise;
+	} catch (error) {
+		return error.bufferedData;
+	}
 }
 
 function getStream(process, stream, {encoding, buffer, maxBuffer}) {

--- a/index.js
+++ b/index.js
@@ -106,6 +106,16 @@ function makeAllStream(spawned) {
 	return mixed;
 }
 
+function getBufferedData(stream, streamPromise) {
+	if (!stream) {
+		return;
+	}
+
+	stream.destroy();
+
+	return streamPromise.catch(error => error.bufferedData);
+}
+
 function getStream(process, stream, {encoding, buffer, maxBuffer}) {
 	if (!process[stream]) {
 		return;
@@ -129,11 +139,7 @@ function getStream(process, stream, {encoding, buffer, maxBuffer}) {
 		ret = _getStream.buffer(process[stream], {maxBuffer});
 	}
 
-	return ret.catch(error => {
-		error.stream = stream;
-		error.message = `${stream} ${error.message}`;
-		throw error;
-	});
+	return ret;
 }
 
 function makeError(result, options) {
@@ -161,6 +167,10 @@ function makeError(result, options) {
 
 	if ('all' in result) {
 		error.all = result.all;
+	}
+
+	if ('bufferedData' in error) {
+		delete error.bufferedData;
 	}
 
 	error.failed = true;
@@ -325,35 +335,23 @@ const execa = (file, args, options) => {
 		}
 	}), cleanup);
 
-	function destroy() {
-		if (spawned.stdout) {
-			spawned.stdout.destroy();
-		}
-
-		if (spawned.stderr) {
-			spawned.stderr.destroy();
-		}
-
-		if (spawned.all) {
-			spawned.all.destroy();
-		}
-	}
-
 	const handlePromise = () => {
-		const processComplete = Promise.all([
-			processDone,
-			getStream(spawned, 'stdout', {encoding, buffer, maxBuffer}),
-			getStream(spawned, 'stderr', {encoding, buffer, maxBuffer}),
-			getStream(spawned, 'all', {encoding, buffer, maxBuffer: maxBuffer * 2})
-		]);
+		const stdoutPromise = getStream(spawned, 'stdout', {encoding, buffer, maxBuffer});
+		const stderrPromise = getStream(spawned, 'stderr', {encoding, buffer, maxBuffer});
+		const allPromise = getStream(spawned, 'all', {encoding, buffer, maxBuffer: maxBuffer * 2});
 
 		const finalize = async () => {
 			let results;
 			try {
-				results = await processComplete;
+				results = await Promise.all([processDone, stdoutPromise, stderrPromise, allPromise]);
 			} catch (error) {
-				const {stream, code, signal} = error;
-				results = [{error, stream, code, signal}, '', '', ''];
+				const {code, signal} = error;
+				results = await Promise.all([
+					{error, code, signal},
+					getBufferedData(spawned.stdout, stdoutPromise),
+					getBufferedData(spawned.stderr, stderrPromise),
+					getBufferedData(spawned.all, allPromise)
+				]);
 			}
 
 			const [result, stdout, stderr, all] = results;
@@ -392,8 +390,7 @@ const execa = (file, args, options) => {
 			};
 		};
 
-		// TODO: Use native "finally" syntax when targeting Node.js 10
-		return pFinally(finalize(), destroy);
+		return finalize();
 	};
 
 	crossSpawn._enoent.hookChildProcess(spawned, parsed.parsed);

--- a/readme.md
+++ b/readme.md
@@ -282,7 +282,7 @@ Default: `true`
 
 Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
 
-If the spawned process fails, [`error.stdout`](#stdout), [`error.stderr`](#stderr) and [`error.all`](#all) will contain the buffered data.
+If the spawned process fails, [`error.stdout`](#stdout), [`error.stderr`](#stderr), and [`error.all`](#all) will contain the buffered data.
 
 #### input
 

--- a/readme.md
+++ b/readme.md
@@ -282,6 +282,8 @@ Default: `true`
 
 Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
 
+If the spawned process fails, [`error.stdout`](#stdout), [`error.stderr`](#stderr) and [`error.all`](#all) will contain the buffered data.
+
 #### input
 
 Type: `string | Buffer | stream.Readable`


### PR DESCRIPTION
Fixes #228. The issue was that errors on stdin/stdout/stderr were not reported the same way as other errors.

It also adds:
  - `error.stdout` or `error.stderr` set with the buffered data when that stream failed
  - `error.stream` set with the name of the failing stream
  - better `error.message` on stream errors

# Issues

If one stream errors, we do not want to wait for other streams to complete, for the same reason as #270, i.e. those streams might take a long time to complete (or never complete). However this creates the following issues:
1) we can only get the buffered data of the failing stream, not the other streams. `get-stream` does not seem to allow to retrieve the currently buffered data.
2) several streams might fail at the same time when they rely on the same underlying file/TTY. In that case, there's a race condition where `error.stream` will be set tot the first stream to report an error.
3) `all` will always fail right before `stdout` or `stderr`, taking precedence over them.

Possible solutions for each of those issues:
1) Make the other streams fail by emitting an `error` event on them. Not implemented yet.
2) Wait for one macrotask (`setImmediate()`) and check if other streams have failed. Not implemented yet.
3) Ignore errors on `all`. This PR currently implements this.