### PR TITLE
Remove `try`/`catch` inside `kill()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,9 +247,7 @@ const execa = (file, args, options) => {
 				options.forceKillAfter :
 				5000;
 			setTimeout(() => {
-				try {
-					originalKill('SIGKILL');
-				} catch (_) {}
+				originalKill('SIGKILL');
 			}, forceKillAfter).unref();
 		}
 


### PR DESCRIPTION
There are only two ways `childProcess.kill()` might throw:
  1) invalid [`signal` argument](https://github.com/nodejs/node/blob/7e18c650de419ae98511be3c7bc54b34efc6d3d4/lib/internal/util.js#L220)
  2) `signal` not supported by current OS (see [here](https://github.com/nodejs/node/blob/7e18c650de419ae98511be3c7bc54b34efc6d3d4/lib/internal/child_process.js#L474) and [there](https://github.com/libuv/libuv/blob/c5593b51dc98715f7f32a919301b5801ebf1a8ce/src/win/process.c#L1232))
 
Both conditions cannot happen with `kill('SIGKILL')`, since that signal is supported on all OS.
When the child process has already exited, `kill()` returns `false`.

So the `try`/`catch` wrapping `kill('SIGKILL')` is not needed.

@zokker13 	