### PR TITLE
Fix shape of exceptions thrown by `execa.sync()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -415,7 +415,19 @@ module.exports.sync = (file, args, options) => {
 		throw new TypeError('The `input` option cannot be a stream in sync mode');
 	}
 
-	const result = childProcess.spawnSync(parsed.file, parsed.args, parsed.options);
+	let result;
+	try {
+		result = childProcess.spawnSync(parsed.file, parsed.args, parsed.options);
+	} catch (error) {
+		throw makeError({error, stdout: '', stderr: '', all: ''}, {
+			joinedCommand,
+			parsed,
+			timedOut: false,
+			isCanceled: false,
+			killed: false
+		});
+	}
+
 	result.stdout = handleOutput(parsed.options, result.stdout, result.error);
 	result.stderr = handleOutput(parsed.options, result.stderr, result.error);
 

--- a/test.js
+++ b/test.js
@@ -294,10 +294,10 @@ test('child_process.spawn() errors are propagated', async t => {
 });
 
 test('child_process.spawnSync() errors are propagated with a correct shape', t => {
-	const {exitCodeName} = t.throws(() => {
+	const {failed} = t.throws(() => {
 		execa.sync('noop', {timeout: -1});
 	});
-	t.is(exitCodeName, 'ERR_OUT_OF_RANGE');
+	t.true(failed);
 });
 
 test('maxBuffer affects stdout', async t => {

--- a/test.js
+++ b/test.js
@@ -293,11 +293,11 @@ test('child_process.spawn() errors are propagated', async t => {
 	t.is(exitCodeName, process.platform === 'win32' ? 'ENOTSUP' : 'EINVAL');
 });
 
-test('child_process.spawnSync() errors are propagated', t => {
+test('child_process.spawnSync() errors are propagated with a correct shape', t => {
 	const {exitCodeName} = t.throws(() => {
-		execa.sync('noop', {uid: -1});
+		execa.sync('noop', {timeout: -1});
 	});
-	t.is(exitCodeName, process.platform === 'win32' ? 'ENOTSUP' : 'EINVAL');
+	t.is(exitCodeName, 'ERR_OUT_OF_RANGE');
 });
 
 test('maxBuffer affects stdout', async t => {


### PR DESCRIPTION
When some options like `timeout` are invalid, `child_process.spawnSync()` throws synchronously. When this happens, the exception thrown does not use the same shape as the other execa errors. 

This PR fixes this.

Note: the options that make `child_process.spawnSync()` and `child_process.spawn()` throw are different. For example `uid: -1` makes `spawn()` throw but not `spawnSync()`. This is the opposite for `timeout: -1`. Because of this, the tests were wrong, which is why this bug was not caught.