### PR TITLE
Refactor `kill()` again

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,7 +226,9 @@ function setKillTimeout(kill, signal, options, killResult) {
 	}
 
 	const timeout = getForceKillAfterTimeout(options);
-	setTimeout(() => kill('SIGKILL'), timeout).unref();
+	setTimeout(() => {
+		kill('SIGKILL');
+	}, timeout).unref();
 }
 
 function shouldForceKill(signal, {forceKill}, killResult) {

--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ function isSigterm(signal) {
 
 function getForceKillAfterTimeout({forceKillAfter = DEFAULT_FORCE_KILL_TIMEOUT}) {
 	if (!Number.isInteger(forceKillAfter) || forceKillAfter < 0) {
-		throw new TypeError(`Option 'forceKillAfter' ${forceKillAfter} should be a positive integer`);
+		throw new TypeError(`Expected the \`forceKillAfter\` option to be a non-negative integer, got \`${forceKillAfter}\` (${typeof forceKillAfter})`);
 	}
 
 	return forceKillAfter;

--- a/index.js
+++ b/index.js
@@ -240,12 +240,12 @@ function isSigterm(signal) {
 		(typeof signal === 'string' && signal.toUpperCase() === 'SIGTERM');
 }
 
-function getForceKillAfterTimeout({forceKillAfter}) {
-	if (Number.isInteger(forceKillAfter)) {
-		return forceKillAfter;
+function getForceKillAfterTimeout({forceKillAfter = DEFAULT_FORCE_KILL_TIMEOUT}) {
+	if (!Number.isInteger(forceKillAfter) || forceKillAfter < 0) {
+		throw new TypeError(`Option 'forceKillAfter' ${forceKillAfter} should be a positive integer`);
 	}
 
-	return DEFAULT_FORCE_KILL_TIMEOUT;
+	return forceKillAfter;
 }
 
 const execa = (file, args, options) => {

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const onExit = require('signal-exit');
 const stdio = require('./lib/stdio');
 
 const TEN_MEGABYTES = 1000 * 1000 * 10;
+const DEFAULT_FORCE_KILL_TIMEOUT = 1000 * 5;
 
 const SPACES_REGEXP = / +/g;
 
@@ -244,8 +245,6 @@ function getForceKillAfterTimeout({forceKillAfter}) {
 
 	return DEFAULT_FORCE_KILL_TIMEOUT;
 }
-
-const DEFAULT_FORCE_KILL_TIMEOUT = 5000;
 
 const execa = (file, args, options) => {
 	const parsed = handleArgs(file, args, options);

--- a/test.js
+++ b/test.js
@@ -179,11 +179,13 @@ if (process.platform !== 'win32') {
 	test('.kill() `forceKillAfter` should not be a float', t => {
 		t.throws(() => {
 			execa('noop').kill('SIGTERM', {forceKillAfter: 0.5});
-		}, TypeError);
+		}, {instanceOf: TypeError, message: /non-negative integer/});
 	});
 
 	test('.kill() `forceKillAfter` should not be negative', t => {
-		t.throws(() => execa('noop').kill('SIGTERM', {forceKillAfter: -1}), TypeError);
+		t.throws(() => {
+			execa('noop').kill('SIGTERM', {forceKillAfter: -1});
+		}, {instanceOf: TypeError, message: /non-negative integer/});
 	});
 }
 

--- a/test.js
+++ b/test.js
@@ -177,7 +177,9 @@ if (process.platform !== 'win32') {
 	});
 
 	test('.kill() `forceKillAfter` should not be a float', t => {
-		t.throws(() => execa('noop').kill('SIGTERM', {forceKillAfter: 0.5}), TypeError);
+		t.throws(() => {
+			execa('noop').kill('SIGTERM', {forceKillAfter: 0.5});
+		}, TypeError);
 	});
 
 	test('.kill() `forceKillAfter` should not be negative', t => {

--- a/test.js
+++ b/test.js
@@ -175,6 +175,14 @@ if (process.platform !== 'win32') {
 		const {signal} = await t.throwsAsync(subprocess);
 		t.is(signal, 'SIGKILL');
 	});
+
+	test('.kill() `forceKillAfter` should not be a float', t => {
+		t.throws(() => execa('noop').kill('SIGTERM', {forceKillAfter: 0.5}), TypeError);
+	});
+
+	test('.kill() `forceKillAfter` should not be negative', t => {
+		t.throws(() => execa('noop').kill('SIGTERM', {forceKillAfter: -1}), TypeError);
+	});
 }
 
 test('stripFinalNewline: true', async t => {

--- a/test.js
+++ b/test.js
@@ -301,8 +301,8 @@ test('execa() returns a promise with kill() and pid', t => {
 });
 
 test('child_process.spawn() errors are propagated', async t => {
-	const {exitCodeName} = await t.throwsAsync(execa('noop', {uid: -1}));
-	t.is(exitCodeName, process.platform === 'win32' ? 'ENOTSUP' : 'EINVAL');
+	const {failed} = await t.throwsAsync(execa('noop', {uid: -1}));
+	t.true(failed);
 });
 
 test('child_process.spawnSync() errors are propagated with a correct shape', t => {


### PR DESCRIPTION
This is a follow-up to #272 adding more refactoring to `kill()`.

@zokker13 	