### PR TITLE
Fix variable name bug (`master` failing)

### DIFF
--- a/index.js
+++ b/index.js
@@ -420,7 +420,7 @@ module.exports.sync = (file, args, options) => {
 		result = childProcess.spawnSync(parsed.file, parsed.args, parsed.options);
 	} catch (error) {
 		throw makeError({error, stdout: '', stderr: '', all: ''}, {
-			joinedCommand,
+			command,
 			parsed,
 			timedOut: false,
 			isCanceled: false,


### PR DESCRIPTION
#278 renamed `joinedCommand` to `command`

But #277 that just got merged added a new `joinedCommand` variable. I forgot to rebase the PR after #278  was merged. This leads to CI failing.

This PR fixes that.