### PR TITLE
Fix tests on Mac

### DIFF
--- a/test.js
+++ b/test.js
@@ -289,8 +289,8 @@ test('execa() returns a promise with kill() and pid', t => {
 });
 
 test('child_process.spawn() errors are propagated', async t => {
-	const {exitCodeName} = await t.throwsAsync(execa('noop', {uid: -1}));
-	t.is(exitCodeName, process.platform === 'win32' ? 'ENOTSUP' : 'EINVAL');
+	const {failed} = await t.throwsAsync(execa('noop', {uid: -1}));
+	t.true(failed);
 });
 
 test('child_process.spawnSync() errors are propagated with a correct shape', t => {


### PR DESCRIPTION
This fixes [a test that fails](https://travis-ci.org/sindresorhus/execa/jobs/544329143) on Mac.

That test does not need to know the specifics of the thrown error, it just need to check that it was thrown and looks like an execa error (as opposed to a core Node.js error).