### PR TITLE
Change `maxBuffer` default value from `10 MB` to `100 MB`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -159,7 +159,7 @@ declare namespace execa {
 		readonly timeout?: number;
 
 		/**
-		Largest amount of data in bytes allowed on `stdout` or `stderr`. Default: 10MB.
+		Largest amount of data in bytes allowed on `stdout` or `stderr`. Default: 100 MB.
 
 		@default 10000000
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -161,7 +161,7 @@ declare namespace execa {
 		/**
 		Largest amount of data in bytes allowed on `stdout` or `stderr`. Default: 100 MB.
 
-		@default 10000000
+		@default 100_000_000
 		*/
 		readonly maxBuffer?: number;
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const pFinally = require('p-finally');
 const onExit = require('signal-exit');
 const stdio = require('./lib/stdio');
 
-const TEN_MEGABYTES = 1000 * 1000 * 10;
+const DEFAULT_MAX_BUFFER = 1000 * 1000 * 100;
 const DEFAULT_FORCE_KILL_TIMEOUT = 1000 * 5;
 
 const SPACES_REGEXP = / +/g;
@@ -25,7 +25,7 @@ function handleArgs(file, args, options = {}) {
 	options = parsed.options;
 
 	options = {
-		maxBuffer: TEN_MEGABYTES,
+		maxBuffer: DEFAULT_MAX_BUFFER,
 		buffer: true,
 		stripFinalNewline: true,
 		preferLocal: true,

--- a/readme.md
+++ b/readme.md
@@ -411,7 +411,7 @@ If timeout is greater than `0`, the parent will send the signal identified by th
 #### maxBuffer
 
 Type: `number`<br>
-Default: `100000000` (100 MB)
+Default: `100_000_000` (100 MB)
 
 Largest amount of data in bytes allowed on `stdout` or `stderr`.
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@
 - [Strips the final newline](#stripfinalnewline) from the output so you don't have to do `stdout.trim()`.
 - Supports [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) binaries cross-platform.
 - [Improved Windows support.](https://github.com/IndigoUnited/node-cross-spawn#why)
-- Higher max buffer. 10 MB instead of 200 KB.
+- Higher max buffer. 100 MB instead of 200 KB.
 - [Executes locally installed binaries by name.](#preferlocal)
 - [Cleans up spawned processes when the parent process dies.](#cleanup)
 - [Get interleaved output](#all) from `stdout` and `stderr` similar to what is printed on the terminal. [*(Async only)*](#execasyncfile-arguments-options)
@@ -411,7 +411,7 @@ If timeout is greater than `0`, the parent will send the signal identified by th
 #### maxBuffer
 
 Type: `number`<br>
-Default: `10000000` (10MB)
+Default: `100000000` (100 MB)
 
 Largest amount of data in bytes allowed on `stdout` or `stderr`.
 


### PR DESCRIPTION
This increases the `maxBuffer` default value.

Some users encountered issues with processing images. The limit is really only meant to protect against abuse, but `100 MB` is not abuse.