### PR TITLE
Add new catchphrase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "execa",
 	"version": "1.0.0",
-	"description": "A better `child_process`",
+	"description": "Process execution for humans",
 	"license": "MIT",
 	"repository": "sindresorhus/execa",
 	"author": {

--- a/readme.md
+++ b/readme.md
@@ -3,10 +3,12 @@
 
 [![Build Status](https://travis-ci.org/sindresorhus/execa.svg?branch=master)](https://travis-ci.org/sindresorhus/execa) [![Coverage Status](https://coveralls.io/repos/github/sindresorhus/execa/badge.svg?branch=master)](https://coveralls.io/github/sindresorhus/execa?branch=master)
 
-> A better [`child_process`](https://nodejs.org/api/child_process.html)
+> Process execution for humans
 
 
 ## Why
+
+This improves [`child_process`](https://nodejs.org/api/child_process.html) methods with:
 
 - Promise interface.
 - [Strips the final newline](#stripfinalnewline) from the output so you don't have to do `stdout.trim()`.

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 
 ## Why
 
-This improves [`child_process`](https://nodejs.org/api/child_process.html) methods with:
+This package improves [`child_process`](https://nodejs.org/api/child_process.html) methods with:
 
 - Promise interface.
 - [Strips the final newline](#stripfinalnewline) from the output so you don't have to do `stdout.trim()`.


### PR DESCRIPTION
Fixes #255

This adds the new catchphrase for execa: `Process execution for humans`.

Thanks @migg24 for suggesting it!

I cannot edit the GitHub repository description, so you would need to update it @sindresorhus.