### PR TITLE
Refactor `timeout` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -325,7 +325,7 @@ function handleSpawned(spawned, context) {
 	});
 }
 
-const setupTimeout = function (spawned, {timeout, killSignal}, context) {
+const setupTimeout = (spawned, {timeout, killSignal}, context) => {
 	if (timeout > 0) {
 		context.timeoutId = setTimeout(() => {
 			Object.assign(context, {timeoutId: undefined, timedOut: true});


### PR DESCRIPTION
This refactors the `timeout` option handling. This does not change behavior.

With this PR and the upcoming ones, I am trying to split up the main `execa()` function into smaller functions. The main function partially relies on closure state, so I had to introduce a `context` object passed around instead.