### PR TITLE
Fix documentation of `execa.node()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -436,7 +436,7 @@ declare const execa: {
 	/**
 	Execute a Node.js script as a child process.
 
-	Same as `execa('node', [file, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
+	Same as `execa('node', [scriptPath, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
 		- the current Node version and options are used. This can be overridden using the `nodePath` and `nodeArguments` options.
 		- the `shell` option cannot be used
 		- an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)
@@ -451,12 +451,12 @@ declare const execa: {
 		options?: execa.NodeOptions
 	): execa.ExecaChildProcess;
 	node(
-		file: string,
+		scriptPath: string,
 		arguments?: readonly string[],
 		options?: execa.Options<null>
 	): execa.ExecaChildProcess<Buffer>;
-	node(file: string, options?: execa.Options): execa.ExecaChildProcess;
-	node(file: string, options?: execa.Options<null>): execa.ExecaChildProcess<Buffer>;
+	node(scriptPath: string, options?: execa.Options): execa.ExecaChildProcess;
+	node(scriptPath: string, options?: execa.Options<null>): execa.ExecaChildProcess<Buffer>;
 };
 
 export = execa;

--- a/index.d.ts
+++ b/index.d.ts
@@ -436,6 +436,11 @@ declare const execa: {
 	/**
 	Execute a Node.js script as a child process.
 
+	Same as `execa('node', [file, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
+		- the current Node version and options are used. This can be overridden using the `nodePath` and `nodeArguments` options.
+		- the `shell` option cannot be used
+		- an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)
+
 	@param scriptPath - Node.js script to execute.
 	@param arguments - Arguments to pass to `scriptPath` on execution.
 	@returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 Execute a Node.js script as a child process.
 
-Same as `execa('node', [file, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
+Same as `execa('node', [scriptPath, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
   - the current Node version and options are used. This can be overridden using the [`nodePath`](#nodepath-for-node-only) and [`nodeArguments`](#nodearguments-for-node-only) options.
   - the [`shell`](#shell) option cannot be used
   - an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)

--- a/readme.md
+++ b/readme.md
@@ -189,8 +189,8 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 Execute a Node.js script as a child process.
 
 Same as `execa('node', [file, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
-  - the [`nodePath`](#nodepath-for-node-only) and [`nodeArguments`](#nodearguments-for-node-only) options can be used
-  - the [`shell`](#shell) option cannot be used 
+  - the current Node version and options are used. This can be overridden using the [`nodePath`](#nodepath-for-node-only) and [`nodeArguments`](#nodearguments-for-node-only) options.
+  - the [`shell`](#shell) option cannot be used
   - an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)
 
 ### childProcessResult


### PR DESCRIPTION
This improves the documentation of `execa.node()` a little.

This also adds missing documentation in the TypeScript ambient file.

@GMartigny 	