### PR TITLE
Allow the `shell` option with `execa.node()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -544,8 +544,7 @@ module.exports.node = (scriptPath, args, options) => {
 			stdin: undefined,
 			stdout: undefined,
 			stderr: undefined,
-			stdio: stdioOption,
-			shell: false
+			stdio: stdioOption
 		}
 	);
 };

--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,6 @@ Execute a Node.js script as a child process.
 
 Same as `execa('node', [file, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
   - the [`nodePath`](#nodepath-for-node-only) and [`nodeArguments`](#nodearguments-for-node-only) options can be used
-  - the [`shell`](#shell) option cannot be used 
   - an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)
 
 ### childProcessResult


### PR DESCRIPTION
As discussed before, users should avoid the `shell` option whenever possible.

However I don't think the `shell` option is worse with `execa.node()` than with `execa()`. For example, some users might want to do things like:

```js
execa.node('file.js', ['$RANDOM'], {shell: true})
```

This PR removes the fact that `shell` is always `false` with `execa.node()`. This makes:
  - `execa.node()` more orthogonal with the rest of the features
  - `execa.node()` documentation a little simpler

Let me know what you think of this.

@GMartigny 	