### PR TITLE
Rename `nodeArguments` to `nodeOptions`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -203,11 +203,11 @@ declare namespace execa {
 		readonly nodePath?: string;
 
 		/**
-		List of string arguments passed to the Node.js executable.
+		List of [CLI options](https://nodejs.org/api/cli.html#cli_options) passed to the Node.js executable.
 
 		@default process.execArgv
 		*/
-		readonly nodeArguments?: string[];
+		readonly nodeOptions?: string[];
 	}
 
 	interface ExecaReturnBase<StdoutStderrType> {

--- a/index.js
+++ b/index.js
@@ -531,12 +531,12 @@ module.exports.node = (scriptPath, args, options = {}) => {
 
 	const stdioOption = stdio.node(options);
 
-	const {nodePath = process.execPath, nodeArguments = process.execArgv} = options;
+	const {nodePath = process.execPath, nodeOptions = process.execArgv} = options;
 
 	return execa(
 		nodePath,
 		[
-			...nodeArguments,
+			...nodeOptions,
 			scriptPath,
 			...(Array.isArray(args) ? args : [])
 		],

--- a/readme.md
+++ b/readme.md
@@ -189,7 +189,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 Execute a Node.js script as a child process.
 
 Same as `execa('node', [scriptPath, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
-  - the current Node version and options are used. This can be overridden using the [`nodePath`](#nodepath-for-node-only) and [`nodeArguments`](#nodearguments-for-node-only) options.
+  - the current Node version and options are used. This can be overridden using the [`nodePath`](#nodepath-for-node-only) and [`nodeOptions`](#nodeoptions-for-node-only) options.
   - the [`shell`](#shell) option cannot be used
   - an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)
 
@@ -454,12 +454,12 @@ Default: [`process.execPath`](https://nodejs.org/api/process.html#process_proces
 
 Node.js executable used to create the child process.
 
-#### nodeArguments *(for `.node()` only)*
+#### nodeOptions *(for `.node()` only)*
 
 Type: `string[]`<br>
 Default: [`process.execArgv`](https://nodejs.org/api/process.html#process_process_execargv)
 
-List of string arguments passed to the Node.js executable.
+List of [CLI options](https://nodejs.org/api/cli.html#cli_options) passed to the Node.js executable.
 
 ## Tips
 

--- a/test/node.js
+++ b/test/node.js
@@ -22,16 +22,16 @@ test('node correctly use nodePath', async t => {
 	const {stdout} = await execa.node(process.platform === 'win32' ? 'hello.cmd' : 'hello.sh', {
 		stdout: 'pipe',
 		nodePath: process.platform === 'win32' ? 'cmd.exe' : 'bash',
-		nodeArguments: process.platform === 'win32' ? ['/c'] : []
+		nodeOptions: process.platform === 'win32' ? ['/c'] : []
 	});
 
 	t.is(stdout, 'Hello World');
 });
 
-test('node pass on nodeArguments', async t => {
+test('node pass on nodeOptions', async t => {
 	const {stdout} = await execa.node('console.log("foo")', {
 		stdout: 'pipe',
-		nodeArguments: ['-e']
+		nodeOptions: ['-e']
 	});
 
 	t.is(stdout, 'foo');


### PR DESCRIPTION
I think the name `nodeArguments` makes it unclear it's about Node CLI flags, as opposed to the arguments passed to `node scriptPath.js ...`. 

Also this makes it more consistent with the way Node.js calls it [in the documentation](https://nodejs.org/api/cli.html).

@GMartigny 	