### PR TITLE
Do not allow `stdin: 0` combined with `stdio`

### DIFF
--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -1,7 +1,7 @@
 'use strict';
 const aliases = ['stdin', 'stdout', 'stderr'];
 
-const hasAlias = opts => aliases.some(alias => Boolean(opts[alias]));
+const hasAlias = opts => aliases.some(alias => opts[alias] !== undefined);
 
 const stdio = opts => {
 	if (!opts) {

--- a/test/stdio.js
+++ b/test/stdio.js
@@ -45,6 +45,7 @@ test(stdioMacro, {stdio: {foo: 'bar'}}, new TypeError('Expected `stdio` to be of
 test(stdioMacro, {stdin: 'inherit', stdio: 'pipe'}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 test(stdioMacro, {stdin: 'inherit', stdio: ['pipe']}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 test(stdioMacro, {stdin: 'inherit', stdio: [undefined, 'pipe']}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
+test(stdioMacro, {stdin: 0, stdio: 'pipe'}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 
 const forkMacro = (...args) => macro(...args, stdio.node);
 forkMacro.title = macroTitle('execa.fork()');


### PR DESCRIPTION
User should not be allowed to used both `stdin` and `stdio`. However this is currently possible when `stdin` is `0`.

This fixes that.