### PR TITLE
Refactor `stdio` option

### DIFF
--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -8,7 +8,7 @@ const stdio = opts => {
 		return;
 	}
 
-	if (opts.stdio !== undefined && hasAlias(opts)) {
+	if (opts.stdio && hasAlias(opts)) {
 		throw new Error(`It's not possible to provide \`stdio\` in combination with one of ${aliases.map(alias => `\`${alias}\``).join(', ')}`);
 	}
 

--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -1,15 +1,15 @@
 'use strict';
-const alias = ['stdin', 'stdout', 'stderr'];
+const aliases = ['stdin', 'stdout', 'stderr'];
 
-const hasAlias = opts => alias.some(x => Boolean(opts[x]));
+const hasAlias = opts => aliases.some(alias => opts[alias] !== undefined);
 
 const stdio = opts => {
 	if (!opts) {
 		return;
 	}
 
-	if (opts.stdio && hasAlias(opts)) {
-		throw new Error(`It's not possible to provide \`stdio\` in combination with one of ${alias.map(x => `\`${x}\``).join(', ')}`);
+	if (opts.stdio !== undefined && hasAlias(opts)) {
+		throw new Error(`It's not possible to provide \`stdio\` in combination with one of ${aliases.map(alias => `\`${alias}\``).join(', ')}`);
 	}
 
 	if (typeof opts.stdio === 'string') {
@@ -23,15 +23,15 @@ const stdio = opts => {
 	}
 
 	const result = [];
-	const len = Math.max(stdio.length, alias.length);
+	const len = Math.max(stdio.length, aliases.length);
 
 	for (let i = 0; i < len; i++) {
 		let value;
 
 		if (stdio[i] !== undefined) {
 			value = stdio[i];
-		} else if (opts[alias[i]] !== undefined) {
-			value = opts[alias[i]];
+		} else if (opts[aliases[i]] !== undefined) {
+			value = opts[aliases[i]];
 		}
 
 		result[i] = value;

--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -8,36 +8,26 @@ const stdio = opts => {
 		return;
 	}
 
-	if (opts.stdio && hasAlias(opts)) {
+	const {stdio} = opts;
+
+	if (stdio === undefined) {
+		return aliases.map(alias => opts[alias]);
+	}
+
+	if (hasAlias(opts)) {
 		throw new Error(`It's not possible to provide \`stdio\` in combination with one of ${aliases.map(alias => `\`${alias}\``).join(', ')}`);
 	}
 
-	if (typeof opts.stdio === 'string') {
-		return opts.stdio;
+	if (typeof stdio === 'string') {
+		return stdio;
 	}
-
-	const stdio = opts.stdio || [];
 
 	if (!Array.isArray(stdio)) {
 		throw new TypeError(`Expected \`stdio\` to be of type \`string\` or \`Array\`, got \`${typeof stdio}\``);
 	}
 
-	const result = [];
-	const len = Math.max(stdio.length, aliases.length);
-
-	for (let i = 0; i < len; i++) {
-		let value;
-
-		if (stdio[i] !== undefined) {
-			value = stdio[i];
-		} else if (opts[aliases[i]] !== undefined) {
-			value = opts[aliases[i]];
-		}
-
-		result[i] = value;
-	}
-
-	return result;
+	const length = Math.max(stdio.length, aliases.length);
+	return Array.from({length}, (value, index) => stdio[index]);
 };
 
 module.exports = stdio;

--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -1,7 +1,7 @@
 'use strict';
 const aliases = ['stdin', 'stdout', 'stderr'];
 
-const hasAlias = opts => aliases.some(alias => opts[alias] !== undefined);
+const hasAlias = opts => aliases.some(alias => Boolean(opts[alias]));
 
 const stdio = opts => {
 	if (!opts) {

--- a/test/stdio.js
+++ b/test/stdio.js
@@ -56,6 +56,7 @@ test(stdioMacro, {stdio: {foo: 'bar'}}, new TypeError('Expected `stdio` to be of
 test(stdioMacro, {stdin: 'inherit', stdio: 'pipe'}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 test(stdioMacro, {stdin: 'inherit', stdio: ['pipe']}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 test(stdioMacro, {stdin: 'inherit', stdio: [undefined, 'pipe']}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
+test(stdioMacro, {stdin: 0, stdio: 'pipe'}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 
 const forkMacro = createMacro(stdio.node);
 

--- a/test/stdio.js
+++ b/test/stdio.js
@@ -56,7 +56,6 @@ test(stdioMacro, {stdio: {foo: 'bar'}}, new TypeError('Expected `stdio` to be of
 test(stdioMacro, {stdin: 'inherit', stdio: 'pipe'}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 test(stdioMacro, {stdin: 'inherit', stdio: ['pipe']}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 test(stdioMacro, {stdin: 'inherit', stdio: [undefined, 'pipe']}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
-test(stdioMacro, {stdin: 0, stdio: 'pipe'}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 
 const forkMacro = createMacro(stdio.node);
 


### PR DESCRIPTION
This refactors the code handling the `stdio` option. The behavior remains the same.