### PR TITLE
Refactor `stdio` option for `execa.node()`

### DIFF
--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -42,20 +42,24 @@ const stdio = opts => {
 
 module.exports = stdio;
 
+// Default stdio value is `pipe` instead of `inherit`
+// `ipc` is also pushed unless it is already present
 module.exports.node = opts => {
-	const defaultOption = 'pipe';
+	let stdioOption = stdio(opts) || 'pipe';
 
-	let stdioOption = stdio(opts || {stdio: defaultOption});
+	if (stdioOption === 'ipc') {
+		return 'ipc';
+	}
 
 	if (typeof stdioOption === 'string') {
-		stdioOption = [...new Array(3)].fill(stdioOption);
-	} else if (Array.isArray(stdioOption)) {
-		stdioOption = stdioOption.map((channel = defaultOption) => channel);
+		return [stdioOption, stdioOption, stdioOption, 'ipc'];
 	}
 
-	if (!stdioOption.includes('ipc')) {
-		stdioOption.push('ipc');
+	stdioOption = stdioOption.map((channel = 'pipe') => channel);
+
+	if (stdioOption.includes('ipc')) {
+		return stdioOption;
 	}
 
-	return stdioOption;
+	return [...stdioOption, 'ipc'];
 };

--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -44,13 +44,13 @@ module.exports = stdio;
 
 // `ipc` is also pushed unless it is already present
 module.exports.node = opts => {
-	const stdioOption = stdio(opts) || 'pipe';
+	const stdioOption = stdio(opts);
 
 	if (stdioOption === 'ipc') {
 		return 'ipc';
 	}
 
-	if (typeof stdioOption === 'string') {
+	if (stdioOption === undefined || typeof stdioOption === 'string') {
 		return [stdioOption, stdioOption, stdioOption, 'ipc'];
 	}
 

--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -42,10 +42,9 @@ const stdio = opts => {
 
 module.exports = stdio;
 
-// Default stdio value is `pipe` instead of `inherit`
 // `ipc` is also pushed unless it is already present
 module.exports.node = opts => {
-	let stdioOption = stdio(opts) || 'pipe';
+	const stdioOption = stdio(opts) || 'pipe';
 
 	if (stdioOption === 'ipc') {
 		return 'ipc';
@@ -54,8 +53,6 @@ module.exports.node = opts => {
 	if (typeof stdioOption === 'string') {
 		return [stdioOption, stdioOption, stdioOption, 'ipc'];
 	}
-
-	stdioOption = stdioOption.map((channel = 'pipe') => channel);
 
 	if (stdioOption.includes('ipc')) {
 		return stdioOption;

--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -42,7 +42,7 @@ const stdio = opts => {
 
 module.exports = stdio;
 
-// `ipc` is also pushed unless it is already present
+// `ipc` is pushed unless it is already present
 module.exports.node = opts => {
 	const stdioOption = stdio(opts);
 

--- a/test/stdio.js
+++ b/test/stdio.js
@@ -59,7 +59,7 @@ test(stdioMacro, {stdin: 'inherit', stdio: [undefined, 'pipe']}, new Error('It\'
 
 const forkMacro = createMacro(stdio.node);
 
-test(forkMacro, undefined, ['pipe', 'pipe', 'pipe', 'ipc']);
+test(forkMacro, undefined, [undefined, undefined, undefined, 'ipc']);
 test(forkMacro, {stdio: 'ignore'}, ['ignore', 'ignore', 'ignore', 'ipc']);
 test(forkMacro, {stdio: 'ipc'}, 'ipc');
 test(forkMacro, {stdio: [0, 1, 2]}, [0, 1, 2, 'ipc']);

--- a/test/stdio.js
+++ b/test/stdio.js
@@ -67,6 +67,7 @@ test(forkMacro, {stdio: [0, 1, 2, 3]}, [0, 1, 2, 3, 'ipc']);
 test(forkMacro, {stdio: [0, 1, 2, 'ipc']}, [0, 1, 2, 'ipc']);
 
 test(forkMacro, {stdio: [0, 1, undefined]}, [0, 1, undefined, 'ipc']);
+test(forkMacro, {stdio: [0, 1, 2, undefined]}, [0, 1, 2, undefined, 'ipc']);
 test(forkMacro, {stdout: 'ignore'}, [undefined, 'ignore', undefined, 'ipc']);
 test(forkMacro, {stdout: 'ignore', stderr: 'ignore'}, [undefined, 'ignore', 'ignore', 'ipc']);
 

--- a/test/stdio.js
+++ b/test/stdio.js
@@ -66,9 +66,9 @@ test(forkMacro, {stdio: [0, 1, 2]}, [0, 1, 2, 'ipc']);
 test(forkMacro, {stdio: [0, 1, 2, 3]}, [0, 1, 2, 3, 'ipc']);
 test(forkMacro, {stdio: [0, 1, 2, 'ipc']}, [0, 1, 2, 'ipc']);
 
-test(forkMacro, {stdio: [0, 1, undefined]}, [0, 1, 'pipe', 'ipc']);
-test(forkMacro, {stdout: 'ignore'}, ['pipe', 'ignore', 'pipe', 'ipc']);
-test(forkMacro, {stdout: 'ignore', stderr: 'ignore'}, ['pipe', 'ignore', 'ignore', 'ipc']);
+test(forkMacro, {stdio: [0, 1, undefined]}, [0, 1, undefined, 'ipc']);
+test(forkMacro, {stdout: 'ignore'}, [undefined, 'ignore', undefined, 'ipc']);
+test(forkMacro, {stdout: 'ignore', stderr: 'ignore'}, [undefined, 'ignore', 'ignore', 'ipc']);
 
 test(forkMacro, {stdio: {foo: 'bar'}}, new TypeError('Expected `stdio` to be of type `string` or `Array`, got `object`'));
 test(forkMacro, {stdin: 'inherit', stdio: 'pipe'}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));

--- a/test/stdio.js
+++ b/test/stdio.js
@@ -61,10 +61,12 @@ const forkMacro = createMacro(stdio.node);
 
 test(forkMacro, undefined, ['pipe', 'pipe', 'pipe', 'ipc']);
 test(forkMacro, {stdio: 'ignore'}, ['ignore', 'ignore', 'ignore', 'ipc']);
+test(forkMacro, {stdio: 'ipc'}, 'ipc');
 test(forkMacro, {stdio: [0, 1, 2]}, [0, 1, 2, 'ipc']);
 test(forkMacro, {stdio: [0, 1, 2, 3]}, [0, 1, 2, 3, 'ipc']);
 test(forkMacro, {stdio: [0, 1, 2, 'ipc']}, [0, 1, 2, 'ipc']);
 
+test(forkMacro, {stdio: [0, 1, undefined]}, [0, 1, 'pipe', 'ipc']);
 test(forkMacro, {stdout: 'ignore'}, ['pipe', 'ignore', 'pipe', 'ipc']);
 test(forkMacro, {stdout: 'ignore', stderr: 'ignore'}, ['pipe', 'ignore', 'ignore', 'ipc']);
 


### PR DESCRIPTION
This is a refactoring of the `stdio` option handling for `execa.node()`. 

It also fixes one bug: `undefined` descriptors beyond the first three were converted to `pipe`. Those should be kept as `undefined` instead. See [Node.js documentation](https://nodejs.org/api/child_process.html#child_process_options_stdio):

```
null, undefined - Use default value. For stdio fds 0, 1, and 2 (in other words, stdin, stdout, and stderr) a pipe is created. For fd 3 and up, the default is 'ignore'.
```

This does not change behavior otherwise. 

Some code comments and tests are added too.

@GMartigny 	