### PR TITLE
Rename variables in `stdio` file

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const getStream = require('get-stream');
 const mergeStream = require('merge-stream');
 const pFinally = require('p-finally');
 const onExit = require('signal-exit');
-const stdio = require('./lib/stdio');
+const normalizeStdio = require('./lib/stdio');
 
 const DEFAULT_MAX_BUFFER = 1000 * 1000 * 100;
 const DEFAULT_FORCE_KILL_TIMEOUT = 1000 * 5;
@@ -51,7 +51,7 @@ const handleArgs = (file, args, options = {}) => {
 		});
 	}
 
-	options.stdio = stdio(options);
+	options.stdio = normalizeStdio(options);
 
 	if (process.platform === 'win32' && path.basename(file, '.exe') === 'cmd') {
 		// #116
@@ -529,7 +529,7 @@ module.exports.node = (scriptPath, args, options = {}) => {
 		args = [];
 	}
 
-	const stdioOption = stdio.node(options);
+	const stdioOption = normalizeStdio.node(options);
 
 	const {nodePath = process.execPath, nodeOptions = process.execArgv} = options;
 

--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -34,19 +34,19 @@ module.exports = normalizeStdio;
 
 // `ipc` is pushed unless it is already present
 module.exports.node = opts => {
-	const stdioOption = normalizeStdio(opts);
+	const stdio = normalizeStdio(opts);
 
-	if (stdioOption === 'ipc') {
+	if (stdio === 'ipc') {
 		return 'ipc';
 	}
 
-	if (stdioOption === undefined || typeof stdioOption === 'string') {
-		return [stdioOption, stdioOption, stdioOption, 'ipc'];
+	if (stdio === undefined || typeof stdio === 'string') {
+		return [stdio, stdio, stdio, 'ipc'];
 	}
 
-	if (stdioOption.includes('ipc')) {
-		return stdioOption;
+	if (stdio.includes('ipc')) {
+		return stdio;
 	}
 
-	return [...stdioOption, 'ipc'];
+	return [...stdio, 'ipc'];
 };

--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -3,7 +3,7 @@ const aliases = ['stdin', 'stdout', 'stderr'];
 
 const hasAlias = opts => aliases.some(alias => opts[alias] !== undefined);
 
-const stdio = opts => {
+const normalizeStdio = opts => {
 	if (!opts) {
 		return;
 	}
@@ -30,11 +30,11 @@ const stdio = opts => {
 	return Array.from({length}, (value, index) => stdio[index]);
 };
 
-module.exports = stdio;
+module.exports = normalizeStdio;
 
 // `ipc` is pushed unless it is already present
 module.exports.node = opts => {
-	const stdioOption = stdio(opts);
+	const stdioOption = normalizeStdio(opts);
 
 	if (stdioOption === 'ipc') {
 		return 'ipc';

--- a/test/stdio.js
+++ b/test/stdio.js
@@ -1,11 +1,11 @@
 import util from 'util';
 import test from 'ava';
-import stdio from '../lib/stdio';
+import normalizeStdio from '../lib/stdio';
 
 const macro = (t, input, expected, func) => {
 	if (expected instanceof Error) {
 		t.throws(() => {
-			stdio(input);
+			normalizeStdio(input);
 		}, expected.message);
 		return;
 	}
@@ -15,7 +15,7 @@ const macro = (t, input, expected, func) => {
 
 const macroTitle = name => (title, input) => `${name} ${(util.inspect(input))}`;
 
-const stdioMacro = (...args) => macro(...args, stdio);
+const stdioMacro = (...args) => macro(...args, normalizeStdio);
 stdioMacro.title = macroTitle('execa()');
 
 test(stdioMacro, undefined, undefined);
@@ -47,7 +47,7 @@ test(stdioMacro, {stdin: 'inherit', stdio: ['pipe']}, new Error('It\'s not possi
 test(stdioMacro, {stdin: 'inherit', stdio: [undefined, 'pipe']}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 test(stdioMacro, {stdin: 0, stdio: 'pipe'}, new Error('It\'s not possible to provide `stdio` in combination with one of `stdin`, `stdout`, `stderr`'));
 
-const forkMacro = (...args) => macro(...args, stdio.node);
+const forkMacro = (...args) => macro(...args, normalizeStdio.node);
 forkMacro.title = macroTitle('execa.fork()');
 
 test(forkMacro, undefined, [undefined, undefined, undefined, 'ipc']);


### PR DESCRIPTION
This is a small refactoring which only renames variables to make it more consistent. The word `stdio` at the moment is used both the normalizing function and for the option itself, which is a little confusing (and creates variable shadowing).