### PR TITLE
Improve/refactor `.cancel()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,8 +308,6 @@ const spawnedCancel = (spawned, context) => {
 	if (killResult) {
 		context.isCanceled = true;
 	}
-
-	return killResult;
 };
 
 const handleSpawned = (spawned, context) => {

--- a/index.js
+++ b/index.js
@@ -303,8 +303,11 @@ const getForceKillAfterTimeout = ({forceKillAfterTimeout = true}) => {
 };
 
 const spawnedCancel = (spawned, context) => {
-	context.isCanceled = true;
-	spawned.kill();
+	const killResult = spawned.kill();
+
+	if (killResult) {
+		context.isCanceled = true;
+	}
 };
 
 const handleSpawned = (spawned, context) => {

--- a/index.js
+++ b/index.js
@@ -302,6 +302,16 @@ const getForceKillAfterTimeout = ({forceKillAfterTimeout = true}) => {
 	return forceKillAfterTimeout;
 };
 
+const spawnedCancel = (spawned, context) => {
+	const killResult = spawned.kill();
+
+	if (killResult) {
+		context.isCanceled = true;
+	}
+
+	return killResult;
+};
+
 const handleSpawned = (spawned, context) => {
 	return new Promise((resolve, reject) => {
 		spawned.on('exit', (code, signal) => {
@@ -374,11 +384,10 @@ const execa = (file, args, options) => {
 		);
 	}
 
-	const kill = spawned.kill.bind(spawned);
-	spawned.kill = spawnedKill.bind(null, kill);
+	const context = {timedOut: false, isCanceled: false};
 
-	const context = {timedOut: false};
-	let isCanceled = false;
+	spawned.kill = spawnedKill.bind(null, spawned.kill.bind(spawned));
+	spawned.cancel = spawnedCancel.bind(null, spawned, context);
 
 	setExitHandler(spawned, parsed.options, context);
 	setupTimeout(spawned, parsed.options, context);
@@ -400,7 +409,7 @@ const execa = (file, args, options) => {
 				command,
 				parsed,
 				timedOut: context.timedOut,
-				isCanceled,
+				isCanceled: context.isCanceled,
 				killed: spawned.killed
 			});
 
@@ -430,12 +439,6 @@ const execa = (file, args, options) => {
 	handleInput(spawned, parsed.options.input);
 
 	spawned.all = makeAllStream(spawned);
-
-	spawned.cancel = () => {
-		if (spawned.kill()) {
-			isCanceled = true;
-		}
-	};
 
 	return mergePromise(spawned, handlePromise);
 };

--- a/index.js
+++ b/index.js
@@ -303,11 +303,8 @@ const getForceKillAfterTimeout = ({forceKillAfterTimeout = true}) => {
 };
 
 const spawnedCancel = (spawned, context) => {
-	const killResult = spawned.kill();
-
-	if (killResult) {
-		context.isCanceled = true;
-	}
+	context.isCanceled = true;
+	spawned.kill();
 };
 
 const handleSpawned = (spawned, context) => {


### PR DESCRIPTION
This separates `cancel()` into its own function.

Also this makes `cancel()` return a `boolean` like `kill()` does. The fact that `kill()` returns a boolean is [not documented](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal) and is not part of [`@types/node`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/child_process.d.ts#L21) so I think we should do the same, and not document it nor type it. However it would not hurt to still forward `kill()` return value.