### PR TITLE
Make `@types/node` a production `dependency` instead of a `devDependency`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"local"
 	],
 	"dependencies": {
+		"@types/node": "^12.0.7",
 		"cross-spawn": "^6.0.5",
 		"get-stream": "^5.0.0",
 		"is-stream": "^2.0.0",
@@ -48,7 +49,6 @@
 		"strip-final-newline": "^2.0.0"
 	},
 	"devDependencies": {
-		"@types/node": "^12.0.7",
 		"ava": "^2.1.0",
 		"coveralls": "^3.0.4",
 		"is-running": "^2.1.0",


### PR DESCRIPTION
I think TypeScript types dependencies should be production dependencies not development dependencies. 
Please correct me if I'm wrong. Otherwise TypeScript users would need to manually install `@types/node` themselves to properly use `execa` types.

This also seems to be what the [official documentation says](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies) and what one of the TypeScript guys is [saying here](https://github.com/microsoft/types-publisher/issues/81#issuecomment-234051338).

@BendingBender and @sindresorhus what do you think?