### PR TITLE
Improve the `execa.command()` documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -407,6 +407,8 @@ declare const execa: {
 
 	If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `__dirname` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
 
+	The `shell` option must be used if the `command` uses shell-specific features, as opposed to being a simple `file` followed by its `arguments`.
+
 	@param command - The program/script to execute and its arguments.
 	@returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
 

--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,8 @@ Same as [`execa()`](#execafile-arguments-options) except both file and arguments
 
 If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `__dirname` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
 
+The [`shell` option](#shell) must be used if the `command` uses shell-specific features, as opposed to being a simple `file` followed by its `arguments`.
+
 ### execa.commandSync(command, [options])
 
 Same as [`execa.command()`](#execacommand-command-options) but synchronous.


### PR DESCRIPTION
Fixes #316. Some users are thinking `execa.command()` implies a shell is being used (like `execa.shell()`). This PR updates the documentation to make the goal of this method clearer.