### PR TITLE
Update `engines` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": "^8.12.0 || ^9.7.0 || >=10"
 	},
 	"scripts": {
 		"test": "xo && nyc ava && tsd"


### PR DESCRIPTION
Fixes #318 (with some background in #221). 

We are using `util.getSystemErrorName()` which has been added to Node `9.7.0` then backported to `8.12.0`. At the moment users with let's say Node `8.10.0` are not warned during installation that we don't support them. They discover it when running `execa` and have to dig to understand what's wrong. Adding the proper semver in `engines` field would prevent some frustration for those users.