### PR TITLE
Separate promise-related logic into their own files

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,0 +1,54 @@
+'use strict';
+const mergePromiseProperty = (spawned, getPromise, property) => {
+	Object.defineProperty(spawned, property, {
+		value(...args) {
+			return getPromise()[property](...args);
+		},
+		writable: true,
+		enumerable: false,
+		configurable: true
+	});
+};
+
+// The return value is a mixin of `childProcess` and `Promise`
+const mergePromise = (spawned, getPromise) => {
+	mergePromiseProperty(spawned, getPromise, 'then');
+	mergePromiseProperty(spawned, getPromise, 'catch');
+
+	// TODO: Remove the `if`-guard when targeting Node.js 10
+	if (Promise.prototype.finally) {
+		mergePromiseProperty(spawned, getPromise, 'finally');
+	}
+
+	return spawned;
+};
+
+// Use promises instead of `child_process` events
+const getSpawnedPromise = (spawned, context) => {
+	return new Promise((resolve, reject) => {
+		spawned.on('exit', (code, signal) => {
+			if (context.timedOut) {
+				reject(Object.assign(new Error('Timed out'), {code, signal}));
+				return;
+			}
+
+			resolve({code, signal});
+		});
+
+		spawned.on('error', error => {
+			reject(error);
+		});
+
+		if (spawned.stdin) {
+			spawned.stdin.on('error', error => {
+				reject(error);
+			});
+		}
+	});
+};
+
+module.exports = {
+	mergePromise,
+	getSpawnedPromise
+};
+

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,52 @@
+import path from 'path';
+import test from 'ava';
+import execa from '..';
+
+process.env.PATH = path.join(__dirname, 'fixtures') + path.delimiter + process.env.PATH;
+
+test('promise methods are not enumerable', t => {
+	const descriptors = Object.getOwnPropertyDescriptors(execa('noop'));
+	// eslint-disable-next-line promise/prefer-await-to-then
+	t.false(descriptors.then.enumerable);
+	t.false(descriptors.catch.enumerable);
+	// TOOD: Remove the `if`-guard when targeting Node.js 10
+	if (Promise.prototype.finally) {
+		t.false(descriptors.finally.enumerable);
+	}
+});
+
+// TOOD: Remove the `if`-guard when targeting Node.js 10
+if (Promise.prototype.finally) {
+	test('finally function is executed on success', async t => {
+		let isCalled = false;
+		const {stdout} = await execa('noop', ['foo']).finally(() => {
+			isCalled = true;
+		});
+		t.is(isCalled, true);
+		t.is(stdout, 'foo');
+	});
+
+	test('finally function is executed on failure', async t => {
+		let isError = false;
+		const {stdout, stderr} = await t.throwsAsync(execa('exit', ['2']).finally(() => {
+			isError = true;
+		}));
+		t.is(isError, true);
+		t.is(typeof stdout, 'string');
+		t.is(typeof stderr, 'string');
+	});
+
+	test('throw in finally function bubbles up on success', async t => {
+		const {message} = await t.throwsAsync(execa('noop', ['foo']).finally(() => {
+			throw new Error('called');
+		}));
+		t.is(message, 'called');
+	});
+
+	test('throw in finally bubbles up on error', async t => {
+		const {message} = await t.throwsAsync(execa('exit', ['2']).finally(() => {
+			throw new Error('called');
+		}));
+		t.is(message, 'called');
+	});
+}

--- a/test/test.js
+++ b/test/test.js
@@ -225,53 +225,6 @@ test('detach child process', async t => {
 	process.kill(pid, 'SIGKILL');
 });
 
-test('promise methods are not enumerable', t => {
-	const descriptors = Object.getOwnPropertyDescriptors(execa('noop'));
-	// eslint-disable-next-line promise/prefer-await-to-then
-	t.false(descriptors.then.enumerable);
-	t.false(descriptors.catch.enumerable);
-	// TOOD: Remove the `if`-guard when targeting Node.js 10
-	if (Promise.prototype.finally) {
-		t.false(descriptors.finally.enumerable);
-	}
-});
-
-// TOOD: Remove the `if`-guard when targeting Node.js 10
-if (Promise.prototype.finally) {
-	test('finally function is executed on success', async t => {
-		let isCalled = false;
-		const {stdout} = await execa('noop', ['foo']).finally(() => {
-			isCalled = true;
-		});
-		t.is(isCalled, true);
-		t.is(stdout, 'foo');
-	});
-
-	test('finally function is executed on failure', async t => {
-		let isError = false;
-		const {stdout, stderr} = await t.throwsAsync(execa('exit', ['2']).finally(() => {
-			isError = true;
-		}));
-		t.is(isError, true);
-		t.is(typeof stdout, 'string');
-		t.is(typeof stderr, 'string');
-	});
-
-	test('throw in finally function bubbles up on success', async t => {
-		const {message} = await t.throwsAsync(execa('noop', ['foo']).finally(() => {
-			throw new Error('called');
-		}));
-		t.is(message, 'called');
-	});
-
-	test('throw in finally bubbles up on error', async t => {
-		const {message} = await t.throwsAsync(execa('exit', ['2']).finally(() => {
-			throw new Error('called');
-		}));
-		t.is(message, 'called');
-	});
-}
-
 test('allow commands with spaces and no array arguments', async t => {
 	const {stdout} = await execa('command with space');
 	t.is(stdout, '');


### PR DESCRIPTION
This separates all promise-related logic into their own file: merging promise with child process, using a promise instead of `child_process` events, `Promise.finally` support. No behavior is changed, lines of code are just moved around.

The related tests are also separated into their own file.