### PR TITLE
Add missing 'use strict'

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,3 +1,4 @@
+'use strict';
 const isStream = require('is-stream');
 const getStream = require('get-stream');
 const mergeStream = require('merge-stream');


### PR DESCRIPTION
A `use strict` was missing from #324.