### PR TITLE
Do not mutate process promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,14 +162,19 @@ const execa = (file, args, options) => {
 	});
 
 	const handlePromise = async () => {
-		const [result, stdout, stderr, all] = await getSpawnedResult(spawned, parsed.options, processDone);
-		result.stdout = handleOutput(parsed.options, stdout);
-		result.stderr = handleOutput(parsed.options, stderr);
-		result.all = handleOutput(parsed.options, all);
+		const [{error, code, signal}, stdoutResult, stderrResult, allResult] = await getSpawnedResult(spawned, parsed.options, processDone);
+		const stdout = handleOutput(parsed.options, stdoutResult);
+		const stderr = handleOutput(parsed.options, stderrResult);
+		const all = handleOutput(parsed.options, allResult);
 
-		if (result.error || result.code !== 0 || result.signal !== null) {
-			const error = makeError({
-				...result,
+		if (error || code !== 0 || signal !== null) {
+			const returnedError = makeError({
+				error,
+				code,
+				signal,
+				stdout,
+				stderr,
+				all,
 				command,
 				parsed,
 				timedOut: context.timedOut,
@@ -178,19 +183,19 @@ const execa = (file, args, options) => {
 			});
 
 			if (!parsed.options.reject) {
-				return error;
+				return returnedError;
 			}
 
-			throw error;
+			throw returnedError;
 		}
 
 		return {
 			command,
 			exitCode: 0,
 			exitCodeName: 'SUCCESS',
-			stdout: result.stdout,
-			stderr: result.stderr,
-			all: result.all,
+			stdout,
+			stderr,
+			all,
 			failed: false,
 			timedOut: false,
 			isCanceled: false,


### PR DESCRIPTION
When a child process ends, we return [a promise](https://github.com/sindresorhus/execa/blob/master/index.js#L106). If that promise is awaited several times, each `await` will receive the same resolved|rejected object (which is normal). 

However that object is being [directly modified](https://github.com/sindresorhus/execa/blob/master/index.js#L166) (the `stdout`, `stderr` and `all` properties are added), which means the next `await` will re-use the modifications of the previous `await`. 

I could not find a precise bug this is creating, but this definitely might introduce problems. It also makes debugging a little trickier (which is how I encounter this issue first). I fixed it by avoiding those mutating assignments.