### PR TITLE
Separate command-related logic into its own file

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,9 @@ const normalizeStdio = require('./lib/stdio');
 const {spawnedKill, spawnedCancel, setupTimeout, setExitHandler, cleanup} = require('./lib/kill');
 const {handleInput, getSpawnedResult, makeAllStream, validateInputSync} = require('./lib/stream.js');
 const {mergePromise, getSpawnedPromise} = require('./lib/promise.js');
+const {joinCommand, parseCommand} = require('./lib/command.js');
 
 const DEFAULT_MAX_BUFFER = 1000 * 1000 * 100;
-
-const SPACES_REGEXP = / +/g;
 
 const handleArgs = (file, args, options = {}) => {
 	const parsed = crossSpawn._parse(file, args, options);
@@ -69,14 +68,6 @@ const handleOutput = (options, value, error) => {
 	}
 
 	return value;
-};
-
-const joinCommand = (file, args = []) => {
-	if (!Array.isArray(args)) {
-		return file;
-	}
-
-	return [file, ...args].join(' ');
 };
 
 const execa = (file, args, options) => {
@@ -218,28 +209,6 @@ module.exports.sync = (file, args, options) => {
 		isCanceled: false,
 		killed: false
 	};
-};
-
-// Allow spaces to be escaped by a backslash if not meant as a delimiter
-const handleEscaping = (tokens, token, index) => {
-	if (index === 0) {
-		return [token];
-	}
-
-	const previousToken = tokens[tokens.length - 1];
-
-	if (previousToken.endsWith('\\')) {
-		return [...tokens.slice(0, -1), `${previousToken.slice(0, -1)} ${token}`];
-	}
-
-	return [...tokens, token];
-};
-
-const parseCommand = command => {
-	return command
-		.trim()
-		.split(SPACES_REGEXP)
-		.reduce(handleEscaping, []);
 };
 
 module.exports.command = (command, options) => {

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,0 +1,39 @@
+'use strict';
+const SPACES_REGEXP = / +/g;
+
+const joinCommand = (file, args = []) => {
+	if (!Array.isArray(args)) {
+		return file;
+	}
+
+	return [file, ...args].join(' ');
+};
+
+// Allow spaces to be escaped by a backslash if not meant as a delimiter
+const handleEscaping = (tokens, token, index) => {
+	if (index === 0) {
+		return [token];
+	}
+
+	const previousToken = tokens[tokens.length - 1];
+
+	if (previousToken.endsWith('\\')) {
+		return [...tokens.slice(0, -1), `${previousToken.slice(0, -1)} ${token}`];
+	}
+
+	return [...tokens, token];
+};
+
+// Handle `execa.command()`
+const parseCommand = command => {
+	return command
+		.trim()
+		.split(SPACES_REGEXP)
+		.reduce(handleEscaping, []);
+};
+
+module.exports = {
+	joinCommand,
+	parseCommand
+};
+

--- a/lib/command.js
+++ b/lib/command.js
@@ -36,4 +36,3 @@ module.exports = {
 	joinCommand,
 	parseCommand
 };
-

--- a/test/command.js
+++ b/test/command.js
@@ -1,0 +1,64 @@
+import path from 'path';
+import test from 'ava';
+import execa from '..';
+
+process.env.PATH = path.join(__dirname, 'fixtures') + path.delimiter + process.env.PATH;
+
+const command = async (t, expected, ...args) => {
+	const {command: failCommand} = await t.throwsAsync(execa('fail', args));
+	t.is(failCommand, `fail${expected}`);
+
+	const {command} = await execa('noop', args);
+	t.is(command, `noop${expected}`);
+};
+
+command.title = (message, expected) => `command is: ${JSON.stringify(expected)}`;
+
+test(command, ' foo bar', 'foo', 'bar');
+test(command, ' baz quz', 'baz', 'quz');
+test(command, '');
+
+test('allow commands with spaces and no array arguments', async t => {
+	const {stdout} = await execa('command with space');
+	t.is(stdout, '');
+});
+
+test('allow commands with spaces and array arguments', async t => {
+	const {stdout} = await execa('command with space', ['foo', 'bar']);
+	t.is(stdout, 'foo\nbar');
+});
+
+test('execa.command()', async t => {
+	const {stdout} = await execa.command('node test/fixtures/echo foo bar');
+	t.is(stdout, 'foo\nbar');
+});
+
+test('execa.command() ignores consecutive spaces', async t => {
+	const {stdout} = await execa.command('node test/fixtures/echo foo    bar');
+	t.is(stdout, 'foo\nbar');
+});
+
+test('execa.command() allows escaping spaces in commands', async t => {
+	const {stdout} = await execa.command('command\\ with\\ space foo bar');
+	t.is(stdout, 'foo\nbar');
+});
+
+test('execa.command() allows escaping spaces in arguments', async t => {
+	const {stdout} = await execa.command('node test/fixtures/echo foo\\ bar');
+	t.is(stdout, 'foo bar');
+});
+
+test('execa.command() escapes other whitespaces', async t => {
+	const {stdout} = await execa.command('node test/fixtures/echo foo\tbar');
+	t.is(stdout, 'foo\tbar');
+});
+
+test('execa.command() trims', async t => {
+	const {stdout} = await execa.command('  node test/fixtures/echo foo bar  ');
+	t.is(stdout, 'foo\nbar');
+});
+
+test('execa.command.sync()', t => {
+	const {stdout} = execa.commandSync('node test/fixtures/echo foo bar');
+	t.is(stdout, 'foo\nbar');
+});

--- a/test/test.js
+++ b/test/test.js
@@ -155,20 +155,6 @@ if (process.platform !== 'win32') {
 	});
 }
 
-const command = async (t, expected, ...args) => {
-	const {command: failCommand} = await t.throwsAsync(execa('fail', args));
-	t.is(failCommand, `fail${expected}`);
-
-	const {command} = await execa('noop', args);
-	t.is(command, `noop${expected}`);
-};
-
-command.title = (message, expected) => `command is: ${JSON.stringify(expected)}`;
-
-test(command, ' foo bar', 'foo', 'bar');
-test(command, ' baz quz', 'baz', 'quz');
-test(command, '');
-
 if (process.platform !== 'win32') {
 	test('write to fast-exit process', async t => {
 		// Try-catch here is necessary, because this test is not 100% accurate
@@ -223,49 +209,4 @@ test('detach child process', async t => {
 	t.true(isRunning(pid));
 
 	process.kill(pid, 'SIGKILL');
-});
-
-test('allow commands with spaces and no array arguments', async t => {
-	const {stdout} = await execa('command with space');
-	t.is(stdout, '');
-});
-
-test('allow commands with spaces and array arguments', async t => {
-	const {stdout} = await execa('command with space', ['foo', 'bar']);
-	t.is(stdout, 'foo\nbar');
-});
-
-test('execa.command()', async t => {
-	const {stdout} = await execa.command('node test/fixtures/echo foo bar');
-	t.is(stdout, 'foo\nbar');
-});
-
-test('execa.command() ignores consecutive spaces', async t => {
-	const {stdout} = await execa.command('node test/fixtures/echo foo    bar');
-	t.is(stdout, 'foo\nbar');
-});
-
-test('execa.command() allows escaping spaces in commands', async t => {
-	const {stdout} = await execa.command('command\\ with\\ space foo bar');
-	t.is(stdout, 'foo\nbar');
-});
-
-test('execa.command() allows escaping spaces in arguments', async t => {
-	const {stdout} = await execa.command('node test/fixtures/echo foo\\ bar');
-	t.is(stdout, 'foo bar');
-});
-
-test('execa.command() escapes other whitespaces', async t => {
-	const {stdout} = await execa.command('node test/fixtures/echo foo\tbar');
-	t.is(stdout, 'foo\tbar');
-});
-
-test('execa.command() trims', async t => {
-	const {stdout} = await execa.command('  node test/fixtures/echo foo bar  ');
-	t.is(stdout, 'foo\nbar');
-});
-
-test('execa.command.sync()', t => {
-	const {stdout} = execa.commandSync('node test/fixtures/echo foo bar');
-	t.is(stdout, 'foo\nbar');
 });


### PR DESCRIPTION
This separates all command-related logic into their own file: `execa.command()` parsing, `result.command`, `error.command`. No behavior is changed, lines of code are just moved around.

The related tests are also separated into their own file.