### PR TITLE
Do not read streams more than once

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const childProcess = require('child_process');
 const crossSpawn = require('cross-spawn');
 const stripFinalNewline = require('strip-final-newline');
 const npmRunPath = require('npm-run-path');
+const onetime = require('onetime');
 const makeError = require('./lib/error');
 const normalizeStdio = require('./lib/stdio');
 const {spawnedKill, spawnedCancel, setupTimeout, setExitHandler} = require('./lib/kill');
@@ -144,13 +145,15 @@ const execa = (file, args, options) => {
 		};
 	};
 
+	const handlePromiseOnce = onetime(handlePromise);
+
 	crossSpawn._enoent.hookChildProcess(spawned, parsed.parsed);
 
 	handleInput(spawned, parsed.options.input);
 
 	spawned.all = makeAllStream(spawned);
 
-	return mergePromise(spawned, handlePromise);
+	return mergePromise(spawned, handlePromiseOnce);
 };
 
 module.exports = execa;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"is-stream": "^2.0.0",
 		"merge-stream": "^2.0.0",
 		"npm-run-path": "^3.0.0",
+		"onetime": "^5.1.0",
 		"p-finally": "^2.0.0",
 		"signal-exit": "^3.0.2",
 		"strip-final-newline": "^2.0.0"

--- a/test/test.js
+++ b/test/test.js
@@ -138,6 +138,12 @@ test('child_process.spawnSync() errors are propagated with a correct shape', t =
 	t.true(failed);
 });
 
+test('do not try to consume streams twice', async t => {
+	const cp = execa('noop', ['foo']);
+	t.is((await cp).stdout, 'foo');
+	t.is((await cp).stdout, 'foo');
+});
+
 test('use relative path with \'..\' chars', async t => {
 	const pathViaParentDir = path.join('..', path.basename(path.dirname(__dirname)), 'test', 'fixtures', 'noop');
 	const {stdout} = await execa(pathViaParentDir, ['foo']);


### PR DESCRIPTION
Fixes #327 
Fixes #321

We read the `stdout`, `stderr` and `all` streams to make them available as a string/buffer to users. We defer it (we wait for `execaResult.then()` to be called) in case users prefer consuming those streams themselves.

However if `execaResult.then()` is called twice: 
  - the second result will fail, as a stream cannot be consumed twice. I.e. the second call will show the stream as empty. 
  - the repeated computation is unnecessary as all `execaResult.then()` should just follow the same promise.
  - this repeated computation creates issues as consuming streams sets [event listeners](https://github.com/mafintosh/pump/blob/master/index.js#L30) which are not cleared up because of a [bug in `pump`](https://github.com/sindresorhus/execa/issues/321#issuecomment-505866238), which leads to a memory leak and warnings in the console.

Arguably users should not call `execaResult.then()` several times. However this might happen when `execaResult` is passed from consumer to consumer, with each consumer doing its own (possibly delayed) logic with it.

This PR fixes this problem by ensuring the streams consumption function is only called once, using the small utility [`onetime`](https://github.com/sindresorhus/onetime).