### PR TITLE
Make the synchronous errors code clearer

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,19 +78,20 @@ const execa = (file, args, options) => {
 	try {
 		spawned = childProcess.spawn(parsed.file, parsed.args, parsed.options);
 	} catch (error) {
-		return mergePromise(new childProcess.ChildProcess(), () =>
-			Promise.reject(makeError({
-				error,
-				stdout: '',
-				stderr: '',
-				all: '',
-				command,
-				parsed,
-				timedOut: false,
-				isCanceled: false,
-				killed: false
-			}))
-		);
+		// Ensure the returned error is always both a promise and a child process
+		const dummyChildProcess = new childProcess.ChildProcess();
+		const errorPromise = Promise.reject(makeError({
+			error,
+			stdout: '',
+			stderr: '',
+			all: '',
+			command,
+			parsed,
+			timedOut: false,
+			isCanceled: false,
+			killed: false
+		}));
+		return mergePromise(dummyChildProcess, errorPromise);
 	}
 
 	const context = {timedOut: false, isCanceled: false};

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ const execa = (file, args, options) => {
 		spawned = childProcess.spawn(parsed.file, parsed.args, parsed.options);
 	} catch (error) {
 		// Ensure the returned error is always both a promise and a child process
-		const dummyChildProcess = new childProcess.ChildProcess();
+		const dummySpawned = new childProcess.ChildProcess();
 		const errorPromise = Promise.reject(makeError({
 			error,
 			stdout: '',
@@ -91,7 +91,7 @@ const execa = (file, args, options) => {
 			isCanceled: false,
 			killed: false
 		}));
-		return mergePromise(dummyChildProcess, errorPromise);
+		return mergePromise(dummySpawned, errorPromise);
 	}
 
 	const context = {timedOut: false, isCanceled: false};

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,9 +1,12 @@
 'use strict';
-const mergePromiseProperty = (spawned, getPromise, property) => {
+const mergePromiseProperty = (spawned, promise, property) => {
+	// Starting the main `promise` is deferred to avoid consuming streams
+	const value = typeof promise === 'function' ?
+		(...args) => promise()[property](...args) :
+		promise[property].bind(promise);
+
 	Object.defineProperty(spawned, property, {
-		value(...args) {
-			return getPromise()[property](...args);
-		},
+		value,
 		writable: true,
 		enumerable: false,
 		configurable: true
@@ -11,13 +14,13 @@ const mergePromiseProperty = (spawned, getPromise, property) => {
 };
 
 // The return value is a mixin of `childProcess` and `Promise`
-const mergePromise = (spawned, getPromise) => {
-	mergePromiseProperty(spawned, getPromise, 'then');
-	mergePromiseProperty(spawned, getPromise, 'catch');
+const mergePromise = (spawned, promise) => {
+	mergePromiseProperty(spawned, promise, 'then');
+	mergePromiseProperty(spawned, promise, 'catch');
 
 	// TODO: Remove the `if`-guard when targeting Node.js 10
 	if (Promise.prototype.finally) {
-		mergePromiseProperty(spawned, getPromise, 'finally');
+		mergePromiseProperty(spawned, promise, 'finally');
 	}
 
 	return spawned;


### PR DESCRIPTION
When a synchronous error is thrown with `child_process.spawn()`, we wrap the error into both a promise and a child process. 

This PR refactors the code a little to clarify the intent. 

Also it creates the rejected promise right away, as opposed to deferring it when the user calls `then()` or `catch()`. This ensures that Node.js emits an [`unhandledRejection` event](https://nodejs.org/api/process.html#process_event_unhandledrejection) if those methods haven't been called.