### PR TITLE
Refactor the `timeout` option

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -74,7 +74,7 @@ const makeError = ({
 	}
 
 	error.failed = true;
-	error.timedOut = timedOut;
+	error.timedOut = Boolean(timedOut);
 	error.isCanceled = isCanceled;
 	error.killed = killed && !timedOut;
 	// `signal` emitted on `spawned.on('exit')` event can be `null`. We normalize

--- a/lib/kill.js
+++ b/lib/kill.js
@@ -1,6 +1,7 @@
 'use strict';
 const os = require('os');
 const onExit = require('signal-exit');
+const pFinally = require('p-finally');
 
 const DEFAULT_FORCE_KILL_TIMEOUT = 1000 * 5;
 
@@ -52,14 +53,33 @@ const spawnedCancel = (spawned, context) => {
 	}
 };
 
+const timeoutKill = (spawned, signal, reject) => {
+	spawned.kill(signal);
+	reject(Object.assign(new Error('Timed out'), {timedOut: true, signal}));
+};
+
 // `timeout` option handling
-const setupTimeout = (spawned, {timeout, killSignal}, context) => {
-	if (timeout > 0) {
-		return setTimeout(() => {
-			context.timedOut = true;
-			spawned.kill(killSignal);
-		}, timeout);
+const setupTimeout = (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise) => {
+	if (timeout === 0 || timeout === undefined) {
+		return spawnedPromise;
 	}
+
+	if (!Number.isInteger(timeout) || timeout < 0) {
+		throw new TypeError(`Expected the \`timeout\` option to be a non-negative integer, got \`${timeout}\` (${typeof timeout})`);
+	}
+
+	let timeoutId;
+	const timeoutPromise = new Promise((resolve, reject) => {
+		timeoutId = setTimeout(() => {
+			timeoutKill(spawned, killSignal, reject);
+		}, timeout);
+	});
+
+	const safeSpawnedPromise = pFinally(spawnedPromise, () => {
+		clearTimeout(timeoutId);
+	});
+
+	return Promise.race([timeoutPromise, safeSpawnedPromise]);
 };
 
 // `cleanup` option handling
@@ -73,11 +93,7 @@ const setExitHandler = (spawned, {cleanup, detached}) => {
 	});
 };
 
-const cleanup = (timeoutId, removeExitHandler) => {
-	if (timeoutId !== undefined) {
-		clearTimeout(timeoutId);
-	}
-
+const cleanup = removeExitHandler => {
 	if (removeExitHandler !== undefined) {
 		removeExitHandler();
 	}

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -27,14 +27,9 @@ const mergePromise = (spawned, promise) => {
 };
 
 // Use promises instead of `child_process` events
-const getSpawnedPromise = (spawned, context) => {
+const getSpawnedPromise = spawned => {
 	return new Promise((resolve, reject) => {
 		spawned.on('exit', (code, signal) => {
-			if (context.timedOut) {
-				reject(Object.assign(new Error('Timed out'), {code, signal}));
-				return;
-			}
-
 			resolve({code, signal});
 		});
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -83,7 +83,7 @@ const getSpawnedResult = async ({stdout, stderr, all}, {encoding, buffer, maxBuf
 		return await Promise.all([processDone, stdoutPromise, stderrPromise, allPromise]);
 	} catch (error) {
 		return Promise.all([
-			{error, code: error.code, signal: error.signal},
+			{error, code: error.code, signal: error.signal, timedOut: error.timedOut},
 			getBufferedData(stdout, stdoutPromise),
 			getBufferedData(stderr, stderrPromise),
 			getBufferedData(all, allPromise)

--- a/test/kill.js
+++ b/test/kill.js
@@ -98,6 +98,20 @@ test('timeout does not kill the process if it does not time out', async t => {
 	t.false(timedOut);
 });
 
+const INVALID_TIMEOUT_REGEXP = /`timeout` option to be a non-negative integer/;
+
+test('timeout must not be negative', async t => {
+	await t.throws(() => {
+		execa('noop', {timeout: -1});
+	}, INVALID_TIMEOUT_REGEXP);
+});
+
+test('timeout must be an integer', async t => {
+	await t.throws(() => {
+		execa('noop', {timeout: false});
+	}, INVALID_TIMEOUT_REGEXP);
+});
+
 test('timedOut is false if no timeout was set', async t => {
 	const {timedOut} = await execa('noop');
 	t.false(timedOut);


### PR DESCRIPTION
At the moment the `timeout` option works like this:
  - we share and mutate a `context.timedOut` variable around to several functions.
  - on timeout, we set `context.timedOut` to `true` and kill the child process.
  - we expect the child process to emit an `exit` event right after being killed. Inside the event handler, if `context.timedOut` is `true`, we reject the `spawnedPromise` instead of resolving it.

This PR takes a different approach:
  - on timeout, we reject a `timeoutPromise` and kill the child process. 
  - we await `Promise.race([timeoutPromise, spawnedPromise])` instead of `spawnedPromise` (providing a timeout is used)

Which means we are using promise races instead of passing information around with a mutable variable. Although it adds few extra lines of code, I think this is cleaner. It decouples the "childProcess events -> promise" logic and the timeout logic. By removing half of the `context` variable, it also allows further refactoring down the road. Let me know what you think about this.

This PR also validates that the `timeout` option is a non-negative integer.