### PR TITLE
Fix typescript compile errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -113,7 +113,7 @@ declare namespace execa {
 
 		@default 'pipe'
 		*/
-		readonly stdio?: 'pipe' | 'ignore' | 'inherit' | readonly StdioOption[];
+		readonly stdio?: 'pipe' | 'ignore' | 'inherit' | StdioOption[];
 
 		/**
 		Prepare child to run independently of its parent process. Specific behavior [depends on the platform](https://nodejs.org/api/child_process.html#child_process_options_detached).
@@ -364,12 +364,12 @@ declare const execa: {
 	*/
 	(
 		file: string,
-		arguments?: readonly string[],
+		arguments?: string[],
 		options?: execa.Options
 	): execa.ExecaChildProcess;
 	(
 		file: string,
-		arguments?: readonly string[],
+		arguments?: string[],
 		options?: execa.Options<null>
 	): execa.ExecaChildProcess<Buffer>;
 	(file: string, options?: execa.Options): execa.ExecaChildProcess;
@@ -388,12 +388,12 @@ declare const execa: {
 	*/
 	sync(
 		file: string,
-		arguments?: readonly string[],
+		arguments?: string[],
 		options?: execa.SyncOptions
 	): execa.ExecaSyncReturnValue;
 	sync(
 		file: string,
-		arguments?: readonly string[],
+		arguments?: string[],
 		options?: execa.SyncOptions<null>
 	): execa.ExecaSyncReturnValue<Buffer>;
 	sync(file: string, options?: execa.SyncOptions): execa.ExecaSyncReturnValue;
@@ -449,12 +449,12 @@ declare const execa: {
 	*/
 	node(
 		scriptPath: string,
-		arguments?: readonly string[],
+		arguments?: string[],
 		options?: execa.NodeOptions
 	): execa.ExecaChildProcess;
 	node(
 		scriptPath: string,
-		arguments?: readonly string[],
+		arguments?: string[],
 		options?: execa.Options<null>
 	): execa.ExecaChildProcess<Buffer>;
 	node(scriptPath: string, options?: execa.Options): execa.ExecaChildProcess;


### PR DESCRIPTION
After upgrading from v0.10.0 to v2.0.1 in a typescript project, `tsc` gives the following errors:

```
node_modules/execa/index.d.ts:116:61 - error TS1005: ';' expected.

116  	readonly stdio?: 'pipe' | 'ignore' | 'inherit' | readonly StdioOption[];
     	                                                          ~~~~~~~~~~~

node_modules/execa/index.d.ts:116:73 - error TS1011: An element access expression should take an argument.

116  	readonly stdio?: 'pipe' | 'ignore' | 'inherit' | readonly StdioOption[];
     	                                                                      

node_modules/execa/index.d.ts:123:3 - error TS1128: Declaration or statement expected.

123  	readonly detached?: boolean;
     	~~~~~~~~

node_modules/execa/index.d.ts:123:21 - error TS1109: Expression expected.

123  	readonly detached?: boolean;
     	                  ~

node_modules/execa/index.d.ts:128:3 - error TS1128: Declaration or statement expected.

128  	readonly uid?: number;
     	~~~~~~~~

node_modules/execa/index.d.ts:128:16 - error TS1109: Expression expected.

128  	readonly uid?: number;
     	             ~

node_modules/execa/index.d.ts:133:3 - error TS1128: Declaration or statement expected.

133  	readonly gid?: number;
     	~~~~~~~~

node_modules/execa/index.d.ts:133:16 - error TS1109: Expression expected.

133  	readonly gid?: number;
     	             ~

node_modules/execa/index.d.ts:145:3 - error TS1128: Declaration or statement expected.

145  	readonly shell?: boolean | string;
     	~~~~~~~~

node_modules/execa/index.d.ts:145:18 - error TS1109: Expression expected.

145  	readonly shell?: boolean | string;
     	               ~

node_modules/execa/index.d.ts:152:3 - error TS1128: Declaration or statement expected.

152  	readonly encoding?: EncodingType;
     	~~~~~~~~

node_modules/execa/index.d.ts:152:21 - error TS1109: Expression expected.

152  	readonly encoding?: EncodingType;
     	                  ~

node_modules/execa/index.d.ts:159:3 - error TS1128: Declaration or statement expected.

159  	readonly timeout?: number;
     	~~~~~~~~

node_modules/execa/index.d.ts:159:20 - error TS1109: Expression expected.

159  	readonly timeout?: number;
     	                 ~

node_modules/execa/index.d.ts:166:3 - error TS1128: Declaration or statement expected.

166  	readonly maxBuffer?: number;
     	~~~~~~~~

node_modules/execa/index.d.ts:166:22 - error TS1109: Expression expected.

166  	readonly maxBuffer?: number;
     	                   ~

node_modules/execa/index.d.ts:173:3 - error TS1128: Declaration or statement expected.

173  	readonly killSignal?: string | number;
     	~~~~~~~~

node_modules/execa/index.d.ts:173:23 - error TS1109: Expression expected.

173  	readonly killSignal?: string | number;
     	                    ~

node_modules/execa/index.d.ts:180:3 - error TS1128: Declaration or statement expected.

180  	readonly windowsVerbatimArguments?: boolean;
     	~~~~~~~~

node_modules/execa/index.d.ts:180:37 - error TS1109: Expression expected.

180  	readonly windowsVerbatimArguments?: boolean;
     	                                  ~

node_modules/execa/index.d.ts:329:1 - error TS1128: Declaration or statement expected.

329 }
    ~

node_modules/execa/index.d.ts:367:24 - error TS1005: ',' expected.

367  	arguments?: readonly string[],
     	                     ~~~~~~

node_modules/execa/index.d.ts:367:30 - error TS1005: ',' expected.

367  	arguments?: readonly string[],
     	                           ~

node_modules/execa/index.d.ts:372:24 - error TS1005: ',' expected.

372  	arguments?: readonly string[],
     	                     ~~~~~~

node_modules/execa/index.d.ts:372:30 - error TS1005: ',' expected.

372  	arguments?: readonly string[],
     	                           ~

node_modules/execa/index.d.ts:391:24 - error TS1005: ',' expected.

391  	arguments?: readonly string[],
     	                     ~~~~~~

node_modules/execa/index.d.ts:391:30 - error TS1005: ',' expected.

391  	arguments?: readonly string[],
     	                           ~

node_modules/execa/index.d.ts:396:24 - error TS1005: ',' expected.

396  	arguments?: readonly string[],
     	                     ~~~~~~

node_modules/execa/index.d.ts:396:30 - error TS1005: ',' expected.

396  	arguments?: readonly string[],
     	                           ~

node_modules/execa/index.d.ts:452:24 - error TS1005: ',' expected.

452  	arguments?: readonly string[],
     	                     ~~~~~~

node_modules/execa/index.d.ts:452:30 - error TS1005: ',' expected.

452  	arguments?: readonly string[],
     	                           ~

node_modules/execa/index.d.ts:457:24 - error TS1005: ',' expected.

457  	arguments?: readonly string[],
     	                     ~~~~~~

node_modules/execa/index.d.ts:457:30 - error TS1005: ',' expected.

457  	arguments?: readonly string[],
     	                           ~
Found 33 errors.
```

I tried moving the `readonly` modifiers to the start of those lines, but then got this (possibly helpful) error message from the linter:

```
index.d.ts:367:2
✖  367:2  A parameter property is only allowed in a constructor implementation.  
✖  372:2  A parameter property is only allowed in a constructor implementation.  
✖  391:2  A parameter property is only allowed in a constructor implementation.  
✖  396:2  A parameter property is only allowed in a constructor implementation.  
✖  452:2  A parameter property is only allowed in a constructor implementation.  
✖  457:2  A parameter property is only allowed in a constructor implementation.  
```