### PR TITLE
Move `onExit()` cleanup code next to `onExit()`

### DIFF
--- a/lib/kill.js
+++ b/lib/kill.js
@@ -83,26 +83,22 @@ const setupTimeout = (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise
 };
 
 // `cleanup` option handling
-const setExitHandler = (spawned, {cleanup, detached}) => {
+const setExitHandler = (spawned, {cleanup, detached}, timedPromise) => {
 	if (!cleanup || detached) {
 		return;
 	}
 
-	return onExit(() => {
+	const removeExitHandler = onExit(() => {
 		spawned.kill();
 	});
-};
 
-const cleanup = removeExitHandler => {
-	if (removeExitHandler !== undefined) {
-		removeExitHandler();
-	}
+	// TODO: Use native "finally" syntax when targeting Node.js 10
+	return pFinally(timedPromise, removeExitHandler);
 };
 
 module.exports = {
 	spawnedKill,
 	spawnedCancel,
 	setupTimeout,
-	setExitHandler,
-	cleanup
+	setExitHandler
 };


### PR DESCRIPTION
`onExit()` returns a cleanup function. We call that function in a different file.

This PR refactors this by putting the cleanup function and the setup function together.