### PR TITLE
Add tip on how to execute the current package's binary

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -508,7 +508,8 @@ const binPath = getBinPathSync();
 const subprocess = execa(binPath);
 ```
 
-This is useful when testing the current package's binary. As opposed to hard-coding the path to the binary, this validates that the `package.json` `bin` field is correctly setup.
+This is useful when testing the current package's binary. As opposed to hard-coding the path to the binary, this validates that the `package.json` `bin` field is correctly set up.
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -502,10 +502,10 @@ fs.createReadStream('stdin.txt').pipe(subprocess.stdin)
 ### Execute the current package's binary
 
 ```js
-const { getBinPathSync } = require('get-bin-path')
+const {getBinPathSync} = require('get-bin-path');
 
-const binPath = getBinPathSync()
-const subprocess = execa(binPath)
+const binPath = getBinPathSync();
+const subprocess = execa(binPath);
 ```
 
 This is useful when testing the current package's binary. As opposed to hard-coding the path to the binary, this validates that the `package.json` `bin` field is correctly setup.

--- a/readme.md
+++ b/readme.md
@@ -499,6 +499,16 @@ const subprocess = execa('cat')
 fs.createReadStream('stdin.txt').pipe(subprocess.stdin)
 ```
 
+### Execute the current package's binary
+
+```js
+const { getBinPathSync } = require('get-bin-path')
+
+const binPath = getBinPathSync()
+const subprocess = execa(binPath)
+```
+
+This is useful when testing the current package's binary. As opposed to hard-coding the path to the binary, this validates that the `package.json` `bin` field is correctly setup.
 
 ## Related
 


### PR DESCRIPTION
Fixes #281.

This gives a tip on executing the current package's binary, for example during testing. 

This is based on the [`get-bin-path`](https://github.com/ehmicky/get-bin-path) library that I just created.