### PR TITLE
Add `result.all` TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -324,6 +324,8 @@ declare namespace execa {
 
 		/**
 		Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
+
+		This is `undefined` when both `stdout` and `stderr` options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 		*/
 		all?: ReadableStream;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -321,6 +321,11 @@ declare namespace execa {
 		Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal). This is preferred when cancelling the child process execution as the error is more descriptive and [`childProcessResult.isCanceled`](#iscanceled) is set to `true`.
 		*/
 		cancel(): void;
+
+		/**
+		Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
+		*/
+		all?: ReadableStream;
 	}
 
 	type ExecaChildProcess<StdoutErrorType = string> = ChildProcess &

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,5 @@
 import {expectType, expectError} from 'tsd';
+import {Readable as ReadableStream} from 'stream'
 import execa = require('.');
 import {
 	ExecaReturnValue,
@@ -11,6 +12,7 @@ import {
 try {
 	const execaPromise = execa('unicorns');
 	execaPromise.cancel();
+	expectType<ReadableStream | undefined>(execaPromise.all)
 
 	const unicornsResult = await execaPromise;
 	expectType<string>(unicornsResult.command);

--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,8 @@ Type: `ReadableStream | undefined`
 
 Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
+This is `undefined` when both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+
 ### execa.sync(file, [arguments], [options])
 
 Execute a file synchronously.

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,8 @@ Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#chi
 
 #### all
 
+Type: `ReadableStream | undefined`
+
 Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
 ### execa.sync(file, [arguments], [options])


### PR DESCRIPTION
Fixes #342

While the `all` property is defined on the resolved value or rejected error (where it's a string or buffer), we forgot it on the return value (where it's a stream).

@tomsotte 	