### PR TITLE
Fix test for Node `>= 12.6.0`

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -157,7 +157,9 @@ if (process.platform !== 'win32') {
 	});
 
 	test('execa() rejects with correct error and doesn\'t throw if running non-executable with input', async t => {
-		await t.throwsAsync(execa('non-executable', {input: 'Hey!'}), /EACCES/);
+		// On Node <12.6.0, `EACCESS` is emitted on `childProcess`.
+		// On Node >=12.6.0, `EPIPE` is emitted on `childProcess.stdin`.
+		await t.throwsAsync(execa('non-executable', {input: 'Hey!'}), /EACCES|EPIPE/);
 	});
 }
 


### PR DESCRIPTION
One test is failing with `12.6.0` but not `<=12.5.0`. 

The test is running a non-executable binary while passing some `stdin`. In Node `12.5.0` this emits an `EACCESS` on `childProcess`. In Node `12.6.0` this emits an `EPIPE` on `childProcess.stdin`. Both are caught by `execa` but the test needs to be updated.

The only commit was has changed streams in Node `12.6.0` seems to be [that one](https://github.com/nodejs/node/pull/28007) so that's probably the reason.