### PR TITLE
Cleanup child processes created during tests

### DIFF
--- a/test/error.js
+++ b/test/error.js
@@ -58,7 +58,7 @@ test('execa() returns code and failed properties', async t => {
 });
 
 test('error.killed is true if process was killed directly', async t => {
-	const cp = execa('forever');
+	const cp = execa('noop');
 
 	cp.kill();
 
@@ -67,7 +67,7 @@ test('error.killed is true if process was killed directly', async t => {
 });
 
 test('error.killed is false if process was killed indirectly', async t => {
-	const cp = execa('forever');
+	const cp = execa('noop');
 
 	process.kill(cp.pid, 'SIGINT');
 
@@ -101,7 +101,7 @@ test('result.killed is false on process error, in sync mode', t => {
 
 if (process.platform === 'darwin') {
 	test.cb('sanity check: child_process.exec also has killed.false if killed indirectly', t => {
-		const {pid} = childProcess.exec('forever', error => {
+		const {pid} = childProcess.exec('noop', error => {
 			t.truthy(error);
 			t.false(error.killed);
 			t.end();
@@ -113,7 +113,7 @@ if (process.platform === 'darwin') {
 
 if (process.platform !== 'win32') {
 	test('error.signal is SIGINT', async t => {
-		const cp = execa('forever');
+		const cp = execa('noop');
 
 		process.kill(cp.pid, 'SIGINT');
 
@@ -122,7 +122,7 @@ if (process.platform !== 'win32') {
 	});
 
 	test('error.signal is SIGTERM', async t => {
-		const cp = execa('forever');
+		const cp = execa('noop');
 
 		process.kill(cp.pid, 'SIGTERM');
 
@@ -131,7 +131,7 @@ if (process.platform !== 'win32') {
 	});
 
 	test('custom error.signal', async t => {
-		const {signal} = await t.throwsAsync(execa('forever', {killSignal: 'SIGHUP', timeout: 1, message: TIMEOUT_REGEXP}));
+		const {signal} = await t.throwsAsync(execa('noop', {killSignal: 'SIGHUP', timeout: 1, message: TIMEOUT_REGEXP}));
 		t.is(signal, 'SIGHUP');
 	});
 }

--- a/test/fixtures/detach
+++ b/test/fixtures/detach
@@ -3,6 +3,6 @@
 
 const execa = require('../..');
 
-const subprocess = execa('node', ['./test/fixtures/forever'], {detached: true});
+const subprocess = execa('node', ['./test/fixtures/noop'], {detached: true});
 console.log(subprocess.pid);
 process.exit();

--- a/test/kill.js
+++ b/test/kill.js
@@ -80,14 +80,14 @@ test('execa() returns a promise with kill()', t => {
 });
 
 test('timeout kills the process if it times out', async t => {
-	const {killed, timedOut} = await t.throwsAsync(execa('forever', {timeout: 1}), TIMEOUT_REGEXP);
+	const {killed, timedOut} = await t.throwsAsync(execa('noop', {timeout: 1}), TIMEOUT_REGEXP);
 	t.false(killed);
 	t.true(timedOut);
 });
 
 test('timeout kills the process if it times out, in sync mode', async t => {
 	const {killed, timedOut} = await t.throws(() => {
-		execa.sync('forever', {timeout: 1, message: TIMEOUT_REGEXP});
+		execa.sync('noop', {timeout: 1, message: TIMEOUT_REGEXP});
 	});
 	t.false(killed);
 	t.true(timedOut);

--- a/test/kill.js
+++ b/test/kill.js
@@ -152,7 +152,7 @@ const spawnAndKill = async (t, signal, cleanup, detached, isKilled) => {
 	t.false(isRunning(subprocess.pid));
 	t.is(isRunning(pid), !isKilled);
 
-	if (!isKilled) {
+	if (isRunning(pid)) {
 		process.kill(pid, 'SIGKILL');
 	}
 };

--- a/test/test.js
+++ b/test/test.js
@@ -107,7 +107,7 @@ test('child process errors are handled', async t => {
 });
 
 test('child process errors rejects promise right away', async t => {
-	const child = execa('forever');
+	const child = execa('noop');
 	child.emit('error', new Error('test'));
 	await t.throwsAsync(child, /test/);
 });


### PR DESCRIPTION
Some tests are spawning child processes that never end. Few tests were not properly killing those child processes, which meant running tests was creating zombie processes on the host machine.

Almost all of those tests do not need to use child processes that never end, so this PR fixes that.