### PR TITLE
Fix mixing stream and promise consumption

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,8 @@ declare namespace execa {
 		/**
 		Buffer the output from the spawned process. When set to `false`, you must read the output of `stdout` and `stderr` (or `all` if the `all` option is `true`). Otherwise the returned promise will not be resolved/rejected.
 
+		Should be set to `false` when the returned promise is not used.
+
 		If the spawned process fails, `error.stdout`, `error.stderr`, and `error.all` will contain the buffered data.
 
 		@default true

--- a/readme.md
+++ b/readme.md
@@ -305,6 +305,8 @@ Default: `true`
 
 Buffer the output from the spawned process. When set to `false`, you must read the output of [`stdout`](#stdout-1) and [`stderr`](#stderr-1) (or [`all`](#all) if the [`all`](#all-2) option is `true`). Otherwise the returned promise will not be resolved/rejected.
 
+Should be set to `false` when the returned promise is not used.
+
 If the spawned process fails, [`error.stdout`](#stdout), [`error.stderr`](#stderr), and [`error.all`](#all) will contain the buffered data.
 
 #### input

--- a/test/stream.js
+++ b/test/stream.js
@@ -187,7 +187,7 @@ test.serial('buffer: false > promise does not resolve when output is big and "al
 });
 
 test('can mix promise and streams', async t => {
-	const promise = execa('noop', ['test']);
+	const promise = execa('noop', ['test'], {all: true});
 	await pEvent(promise, 'exit');
 	const {stdout, all} = await promise;
 	t.is(stdout, 'test');

--- a/test/stream.js
+++ b/test/stream.js
@@ -4,6 +4,7 @@ import stream from 'stream';
 import test from 'ava';
 import getStream from 'get-stream';
 import tempfile from 'tempfile';
+import pEvent from 'p-event';
 import execa from '..';
 
 process.env.PATH = path.join(__dirname, 'fixtures') + path.delimiter + process.env.PATH;
@@ -138,7 +139,7 @@ test('do not buffer stderr when `buffer` set to `false`', async t => {
 });
 
 test('do not buffer when streaming', async t => {
-	const {stdout} = execa('max-buffer', ['stdout', '21'], {maxBuffer: 10});
+	const {stdout} = execa('max-buffer', ['stdout', '21'], {maxBuffer: 10, buffer: false});
 	const result = await getStream(stdout);
 	t.is(result, '....................\n');
 });
@@ -183,4 +184,12 @@ test.serial('buffer: false > promise does not resolve when output is big and "al
 	cp.stderr.resume();
 	const {timedOut} = await t.throwsAsync(cp);
 	t.true(timedOut);
+});
+
+test('can mix promise and streams', async t => {
+	const promise = execa('noop', ['test']);
+	await pEvent(promise, 'exit');
+	const {stdout, all} = await promise;
+	t.is(stdout, 'test');
+	t.is(all, 'test');
 });


### PR DESCRIPTION
Fixes #322 

At the moment, we delay child process streams being consumed by `get-stream` until `execaPromise.then()` is called. However this does not work for the following reason: 
  - if the child process exits before `execaPromise.then()` is called, its streams will be closed when `get-stream` starts reading them. 
  - which means `execaResult.stdout` and `execaResult.stderr` will be empty. 

This PR solves this problem by not delaying `get-stream` consumption. 

The drawback (and breaking change) is that users would now need to pass the `buffer: false` option when not consuming `execaPromise` as a promise. Otherwise:
  1) `get-stream` would buffer streams into memory
  2) `execaPromise.stdout|stderr.pipe()` will only work if done in the same tick as `execa()`

The core issue is that we are consuming child process streams in two ways: 
  a. with `get-stream` (promise consumption)
  b. we let users consume it themselves

Mixing those two creates several issues since streams can be piped to several streams at once, but not consumed twice. 

Some refactoring can be done and some dependencies can be removed following this PR, but we can do this in a separate PR.

@tiagonapoli @sindresorhus do you have some feedback on this?