### PR TITLE
Add `all` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ declare namespace execa {
 		readonly localDir?: string;
 
 		/**
-		Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
+		Buffer the output from the spawned process. When set to `false`, you must read the output of `stdout` and `stderr` (or `all` if the `all` option is `true`). Otherwise the returned promise will not be resolved/rejected.
 
 		If the spawned process fails, `error.stdout`, `error.stderr`, and `error.all` will contain the buffered data.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -270,7 +270,7 @@ declare namespace execa {
 	interface ExecaReturnValue<StdoutErrorType = string>
 		extends ExecaSyncReturnValue<StdoutErrorType> {
 		/**
-		The output of the process with stdout and stderr interleaved.
+		The output of the process with `stdout` and `stderr` interleaved.
 
 		This is `undefined` if:
 		- the `all` option is `false` (default value).
@@ -296,7 +296,7 @@ declare namespace execa {
 	interface ExecaError<StdoutErrorType = string>
 		extends ExecaSyncError<StdoutErrorType> {
 		/**
-		The output of the process with stdout and stderr interleaved.
+		The output of the process with `stdout` and `stderr` interleaved.
 
 		This is `undefined` if:
 		- the `all` option is `false` (default value).

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@ declare namespace execa {
 		readonly reject?: boolean;
 
 		/**
-		Add `all` properties on the promise and the resolved value containing the output of the process on both `stdout` and `stderr`.
+		Add `all` properties on the promise and the resolved value. Those properties contain the output of the process on both `stdout` and `stderr`.
 		@default false
 		*/
 		readonly all?: boolean;
@@ -272,9 +272,9 @@ declare namespace execa {
 		/**
 		The output of the process on both stdout and stderr.
 
-		This is `undefined`:
-		- unless the `all` option is `true`.
-		- if `execa.sync()` was used.
+		This is `undefined` if:
+		- the `all` option is `false` (default value).
+		- `execa.sync()` was used.
 		*/
 		all?: StdoutErrorType;
 
@@ -298,9 +298,9 @@ declare namespace execa {
 		/**
 		The output of the process on both stdout and stderr.
 
-		This is `undefined`:
-		- unless the `all` option is `true`.
-		- if `execa.sync()` was used.
+		This is `undefined` if:
+		- the `all` option is `false` (default value).
+		- `execa.sync()` was used.
 		*/
 		all?: StdoutErrorType;
 
@@ -339,9 +339,9 @@ declare namespace execa {
 		/**
 		Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
-		This is `undefined`:
-			- unless the `all` option is `true`
-			- when both `stdout` and `stderr` options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+		This is `undefined` if:
+			- the `all` option is `false` (the default value)
+			- both `stdout` and `stderr` options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 		*/
 		all?: ReadableStream;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -273,8 +273,8 @@ declare namespace execa {
 		The output of the process with `stdout` and `stderr` interleaved.
 
 		This is `undefined` if either:
-		- the `all` option is `false` (default value).
-		- `execa.sync()` was used.
+		- the `all` option is `false` (default value)
+		- `execa.sync()` was used
 		*/
 		all?: StdoutErrorType;
 
@@ -299,8 +299,8 @@ declare namespace execa {
 		The output of the process with `stdout` and `stderr` interleaved.
 
 		This is `undefined` if either:
-		- the `all` option is `false` (default value).
-		- `execa.sync()` was used.
+		- the `all` option is `false` (default value)
+		- `execa.sync()` was used
 		*/
 		all?: StdoutErrorType;
 
@@ -341,7 +341,7 @@ declare namespace execa {
 
 		This is `undefined` if either:
 			- the `all` option is `false` (the default value)
-			- both `stdout` and `stderr` options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+			- both `stdout` and `stderr` options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio)
 		*/
 		all?: ReadableStream;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,6 +76,12 @@ declare namespace execa {
 		readonly reject?: boolean;
 
 		/**
+		Add `all` properties on the promise and the resolved value containing the output of the process on both `stdout` and `stderr`.
+		@default false
+		*/
+		readonly all?: boolean;
+
+		/**
 		Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
 
 		@default true
@@ -264,9 +270,13 @@ declare namespace execa {
 	interface ExecaReturnValue<StdoutErrorType = string>
 		extends ExecaSyncReturnValue<StdoutErrorType> {
 		/**
-		The output of the process with `stdout` and `stderr` interleaved.
+		The output of the process on both stdout and stderr.
+
+		This is `undefined`:
+		- unless the `all` option is `true`.
+		- if `execa.sync()` was used.
 		*/
-		all: StdoutErrorType;
+		all?: StdoutErrorType;
 
 		/**
 		Whether the process was canceled.
@@ -286,9 +296,13 @@ declare namespace execa {
 	interface ExecaError<StdoutErrorType = string>
 		extends ExecaSyncError<StdoutErrorType> {
 		/**
-		The output of the process with `stdout` and `stderr` interleaved.
+		The output of the process on both stdout and stderr.
+
+		This is `undefined`:
+		- unless the `all` option is `true`.
+		- if `execa.sync()` was used.
 		*/
-		all: StdoutErrorType;
+		all?: StdoutErrorType;
 
 		/**
 		Whether the process was canceled.
@@ -325,7 +339,9 @@ declare namespace execa {
 		/**
 		Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
-		This is `undefined` when both `stdout` and `stderr` options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+		This is `undefined`:
+			- unless the `all` option is `true`
+			- when both `stdout` and `stderr` options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 		*/
 		all?: ReadableStream;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,8 @@ declare namespace execa {
 		readonly reject?: boolean;
 
 		/**
-		Add `all` properties on the promise and the resolved value. Those properties contain the output of the process with `stdout` and `stderr` interleaved.
+		Add an `.all` property on the promise and the resolved value. The property contains the output of the process with `stdout` and `stderr` interleaved.
+
 		@default false
 		*/
 		readonly all?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,7 +76,7 @@ declare namespace execa {
 		readonly reject?: boolean;
 
 		/**
-		Add `all` properties on the promise and the resolved value. Those properties contain the output of the process on both `stdout` and `stderr`.
+		Add `all` properties on the promise and the resolved value. Those properties contain the output of the process with `stdout` and `stderr` interleaved.
 		@default false
 		*/
 		readonly all?: boolean;
@@ -270,7 +270,7 @@ declare namespace execa {
 	interface ExecaReturnValue<StdoutErrorType = string>
 		extends ExecaSyncReturnValue<StdoutErrorType> {
 		/**
-		The output of the process on both stdout and stderr.
+		The output of the process with stdout and stderr interleaved.
 
 		This is `undefined` if:
 		- the `all` option is `false` (default value).
@@ -296,7 +296,7 @@ declare namespace execa {
 	interface ExecaError<StdoutErrorType = string>
 		extends ExecaSyncError<StdoutErrorType> {
 		/**
-		The output of the process on both stdout and stderr.
+		The output of the process with stdout and stderr interleaved.
 
 		This is `undefined` if:
 		- the `all` option is `false` (default value).
@@ -341,7 +341,7 @@ declare namespace execa {
 
 		This is `undefined` if:
 			- the `all` option is `false` (the default value)
-			- both `stdout` and `stderr` options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+			- both `stdout` and `stderr` options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 		*/
 		all?: ReadableStream;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -272,7 +272,7 @@ declare namespace execa {
 		/**
 		The output of the process with `stdout` and `stderr` interleaved.
 
-		This is `undefined` if:
+		This is `undefined` if either:
 		- the `all` option is `false` (default value).
 		- `execa.sync()` was used.
 		*/
@@ -298,7 +298,7 @@ declare namespace execa {
 		/**
 		The output of the process with `stdout` and `stderr` interleaved.
 
-		This is `undefined` if:
+		This is `undefined` if either:
 		- the `all` option is `false` (default value).
 		- `execa.sync()` was used.
 		*/
@@ -339,7 +339,7 @@ declare namespace execa {
 		/**
 		Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
-		This is `undefined` if:
+		This is `undefined` if either:
 			- the `all` option is `false` (the default value)
 			- both `stdout` and `stderr` options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 		*/

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ const handleArgs = (file, args, options = {}) => {
 		encoding: 'utf8',
 		reject: true,
 		cleanup: true,
+		all: false,
 		...options,
 		windowsHide: true
 	};
@@ -150,7 +151,7 @@ const execa = (file, args, options) => {
 
 	handleInput(spawned, parsed.options.input);
 
-	spawned.all = makeAllStream(spawned);
+	spawned.all = makeAllStream(spawned, parsed.options);
 
 	return mergePromise(spawned, handlePromiseOnce);
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -20,7 +20,7 @@ try {
 	expectType<string>(unicornsResult.exitCodeName);
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.stderr);
-	expectType<string>(unicornsResult.all);
+	expectType<string | undefined>(unicornsResult.all);
 	expectType<boolean>(unicornsResult.failed);
 	expectType<boolean>(unicornsResult.timedOut);
 	expectType<boolean>(unicornsResult.isCanceled);
@@ -34,7 +34,7 @@ try {
 	expectType<string>(execaError.exitCodeName);
 	expectType<string>(execaError.stdout);
 	expectType<string>(execaError.stderr);
-	expectType<string>(execaError.all);
+	expectType<string | undefined>(execaError.all);
 	expectType<boolean>(execaError.failed);
 	expectType<boolean>(execaError.timedOut);
 	expectType<boolean>(execaError.isCanceled);
@@ -99,6 +99,7 @@ execa('unicorns', {stderr: 'inherit'});
 execa('unicorns', {stderr: process.stderr});
 execa('unicorns', {stderr: 1});
 execa('unicorns', {stderr: undefined});
+execa('unicorns', {all: true});
 execa('unicorns', {reject: false});
 execa('unicorns', {stripFinalNewline: false});
 execa('unicorns', {extendEnv: false});

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -19,7 +19,11 @@ const handleInput = (spawned, input) => {
 };
 
 // `all` interleaves `stdout` and `stderr`
-const makeAllStream = spawned => {
+const makeAllStream = (spawned, {all}) => {
+	if (!all) {
+		return;
+	}
+
 	if (!spawned.stdout && !spawned.stderr) {
 		return;
 	}
@@ -53,17 +57,8 @@ const getBufferedData = async (stream, streamPromise) => {
 };
 
 const getStreamPromise = (stream, {encoding, buffer, maxBuffer}) => {
-	if (!stream) {
+	if (!stream || !buffer) {
 		return;
-	}
-
-	if (!buffer) {
-		// TODO: Use `ret = util.promisify(stream.finished)(stream);` when targeting Node.js 10
-		return new Promise((resolve, reject) => {
-			stream
-				.once('end', resolve)
-				.once('error', reject);
-		});
 	}
 
 	if (encoding) {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -20,11 +20,7 @@ const handleInput = (spawned, input) => {
 
 // `all` interleaves `stdout` and `stderr`
 const makeAllStream = (spawned, {all}) => {
-	if (!all) {
-		return;
-	}
-
-	if (!spawned.stdout && !spawned.stderr) {
+	if (!all || (!spawned.stdout && !spawned.stderr)) {
 		return;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -168,7 +168,9 @@ Type: `ReadableStream | undefined`
 
 Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
-This is `undefined` when both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+This is `undefined`:
+  - unless the [`all` option](#all-2) is `true`
+  - when both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 
 ### execa.sync(file, [arguments], [options])
 
@@ -237,9 +239,13 @@ The output of the process on stderr.
 
 #### all
 
-Type: `string | Buffer`
+Type: `string | Buffer | undefined`
 
-The output of the process on both stdout and stderr. `undefined` if `execa.sync()` was used.
+The output of the process on both stdout and stderr.
+
+This is `undefined`:
+  - unless the [`all` option](#all-2) is `true`.
+  - if `execa.sync()` was used.
 
 #### failed
 
@@ -335,6 +341,13 @@ Type: `string | number | Stream | undefined`<br>
 Default: `pipe`
 
 Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+
+#### all
+
+Type: `boolean`<br>
+Default: `false`
+
+Add `all` properties on the [promise](#all) and the [resolved value](#all-1) containing the output of the process on both `stdout` and `stderr`.
 
 #### reject
 

--- a/readme.md
+++ b/readme.md
@@ -241,7 +241,7 @@ The output of the process on stderr.
 
 Type: `string | Buffer | undefined`
 
-The output of the process with stdout and stderr interleaved.
+The output of the process with `stdout` and `stderr` interleaved.
 
 This is `undefined` if:
   - the [`all` option](#all-2) is `false` (the default value).

--- a/readme.md
+++ b/readme.md
@@ -168,9 +168,9 @@ Type: `ReadableStream | undefined`
 
 Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
-This is `undefined`:
-  - unless the [`all` option](#all-2) is `true`
-  - when both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+This is `undefined` if:
+  - the [`all` option](#all-2) is `false` (the default value)
+  - both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 
 ### execa.sync(file, [arguments], [options])
 
@@ -243,9 +243,9 @@ Type: `string | Buffer | undefined`
 
 The output of the process on both stdout and stderr.
 
-This is `undefined`:
-  - unless the [`all` option](#all-2) is `true`.
-  - if `execa.sync()` was used.
+This is `undefined` if:
+  - the [`all` option](#all-2) is `false` (the default value).
+  - `execa.sync()` was used.
 
 #### failed
 
@@ -347,7 +347,7 @@ Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_pro
 Type: `boolean`<br>
 Default: `false`
 
-Add `all` properties on the [promise](#all) and the [resolved value](#all-1) containing the output of the process on both `stdout` and `stderr`.
+Add `all` properties on the [promise](#all) and the [resolved value](#all-1). Those properties contain the output of the process on both `stdout` and `stderr`.
 
 #### reject
 

--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,7 @@ Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.ht
 
 This is `undefined` if either:
   - the [`all` option](#all-2) is `false` (the default value)
-  - both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+  - both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio)
 
 ### execa.sync(file, [arguments], [options])
 
@@ -244,8 +244,8 @@ Type: `string | Buffer | undefined`
 The output of the process with `stdout` and `stderr` interleaved.
 
 This is `undefined` if either:
-  - the [`all` option](#all-2) is `false` (the default value).
-  - `execa.sync()` was used.
+  - the [`all` option](#all-2) is `false` (the default value)
+  - `execa.sync()` was used
 
 #### failed
 

--- a/readme.md
+++ b/readme.md
@@ -347,7 +347,7 @@ Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_pro
 Type: `boolean`<br>
 Default: `false`
 
-Add `all` properties on the [promise](#all) and the [resolved value](#all-1). Those properties contain the output of the process with `stdout` and `stderr` interleaved.
+Add an `.all` property on the [promise](#all) and the [resolved value](#all-1). The property contains the output of the process with `stdout` and `stderr` interleaved.
 
 #### reject
 

--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,7 @@ Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.ht
 
 This is `undefined` if:
   - the [`all` option](#all-2) is `false` (the default value)
-  - both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'pipe'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+  - both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 
 ### execa.sync(file, [arguments], [options])
 
@@ -241,7 +241,7 @@ The output of the process on stderr.
 
 Type: `string | Buffer | undefined`
 
-The output of the process on both stdout and stderr.
+The output of the process with stdout and stderr interleaved.
 
 This is `undefined` if:
   - the [`all` option](#all-2) is `false` (the default value).
@@ -347,7 +347,7 @@ Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_pro
 Type: `boolean`<br>
 Default: `false`
 
-Add `all` properties on the [promise](#all) and the [resolved value](#all-1). Those properties contain the output of the process on both `stdout` and `stderr`.
+Add `all` properties on the [promise](#all) and the [resolved value](#all-1). Those properties contain the output of the process with `stdout` and `stderr` interleaved.
 
 #### reject
 

--- a/readme.md
+++ b/readme.md
@@ -168,7 +168,7 @@ Type: `ReadableStream | undefined`
 
 Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
-This is `undefined` if:
+This is `undefined` if either:
   - the [`all` option](#all-2) is `false` (the default value)
   - both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 
@@ -243,7 +243,7 @@ Type: `string | Buffer | undefined`
 
 The output of the process with `stdout` and `stderr` interleaved.
 
-This is `undefined` if:
+This is `undefined` if either:
   - the [`all` option](#all-2) is `false` (the default value).
   - `execa.sync()` was used.
 

--- a/readme.md
+++ b/readme.md
@@ -310,7 +310,7 @@ Preferred path to find locally installed binaries in (use with `preferLocal`).
 Type: `boolean`<br>
 Default: `true`
 
-Buffer the output from the spawned process. When buffering is disabled you must consume the output of the `stdout` and `stderr` streams because the promise will not be resolved/rejected until they have completed.
+Buffer the output from the spawned process. When set to `false`, you must read the output of [`stdout`](#stdout-1) and [`stderr`](#stderr-1) (or [`all`](#all) if the [`all`](#all-2) option is `true`). Otherwise the returned promise will not be resolved/rejected.
 
 If the spawned process fails, [`error.stdout`](#stdout), [`error.stderr`](#stderr), and [`error.all`](#all) will contain the buffered data.
 

--- a/test/error.js
+++ b/test/error.js
@@ -10,7 +10,7 @@ const TIMEOUT_REGEXP = /timed out after/;
 const getExitRegExp = exitMessage => new RegExp(`failed with exit code ${exitMessage}`);
 
 test('stdout/stderr/all available on errors', async t => {
-	const {stdout, stderr, all} = await t.throwsAsync(execa('exit', ['2']), {message: getExitRegExp('2')});
+	const {stdout, stderr, all} = await t.throwsAsync(execa('exit', ['2'], {all: true}), {message: getExitRegExp('2')});
 	t.is(typeof stdout, 'string');
 	t.is(typeof stderr, 'string');
 	t.is(typeof all, 'string');
@@ -21,7 +21,7 @@ const WRONG_COMMAND = process.platform === 'win32' ?
 	'';
 
 test('stdout/stderr/all on process errors', async t => {
-	const {stdout, stderr, all} = await t.throwsAsync(execa('wrong command'));
+	const {stdout, stderr, all} = await t.throwsAsync(execa('wrong command', {all: true}));
 	t.is(stdout, '');
 	t.is(stderr, WRONG_COMMAND);
 	t.is(all, WRONG_COMMAND);

--- a/test/fixtures/max-buffer
+++ b/test/fixtures/max-buffer
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 'use strict';
-const output = process.argv[2];
-const bytes = Number(process.argv[3]);
+const output = process.argv[2] || 'stdout';
+const bytes = Number(process.argv[3] || 1e7);
 
 process[output].write('.'.repeat(bytes - 1) + '\n');

--- a/test/stream.js
+++ b/test/stream.js
@@ -37,14 +37,14 @@ test('result.all is undefined unless opts.all is true', async t => {
 });
 
 test('stdout/stderr/all are undefined if ignored', async t => {
-	const {stdout, stderr, all} = await execa('noop', {stdio: 'ignore'});
+	const {stdout, stderr, all} = await execa('noop', {stdio: 'ignore', all: true});
 	t.is(stdout, undefined);
 	t.is(stderr, undefined);
 	t.is(all, undefined);
 });
 
 test('stdout/stderr/all are undefined if ignored in sync mode', t => {
-	const {stdout, stderr, all} = execa.sync('noop', {stdio: 'ignore'});
+	const {stdout, stderr, all} = execa.sync('noop', {stdio: 'ignore', all: true});
 	t.is(stdout, undefined);
 	t.is(stderr, undefined);
 	t.is(all, undefined);

--- a/test/stream.js
+++ b/test/stream.js
@@ -156,8 +156,6 @@ test('buffer: false > promise resolves when output is big and is read', async t 
 
 test('buffer: false > promise resolves when output is big and "all" is used and is read', async t => {
 	const cp = execa('max-buffer', {buffer: false, all: true});
-	cp.stdout.resume();
-	cp.stderr.resume();
 	cp.all.resume();
 	await t.notThrowsAsync(cp);
 });

--- a/test/stream.js
+++ b/test/stream.js
@@ -147,6 +147,10 @@ test('buffer: false > promise resolves', async t => {
 	await t.notThrowsAsync(execa('noop', {buffer: false}));
 });
 
+test('buffer: false > promise resolves when output is big but is not pipable', async t => {
+	await t.notThrowsAsync(execa('max-buffer', {buffer: false, stdout: 'ignore'}));
+});
+
 test('buffer: false > promise resolves when output is big and is read', async t => {
 	const cp = execa('max-buffer', {buffer: false});
 	cp.stdout.resume();
@@ -158,10 +162,6 @@ test('buffer: false > promise resolves when output is big and "all" is used and 
 	const cp = execa('max-buffer', {buffer: false, all: true});
 	cp.all.resume();
 	await t.notThrowsAsync(cp);
-});
-
-test('buffer: false > promise resolves when output is big but is not pipable', async t => {
-	await t.notThrowsAsync(execa('max-buffer', {buffer: false, stdout: 'ignore'}));
 });
 
 const BUFFER_TIMEOUT = 1e3;

--- a/test/stream.js
+++ b/test/stream.js
@@ -147,26 +147,11 @@ test('buffer: false > promise resolves', async t => {
 	await t.notThrowsAsync(execa('noop', {buffer: false}));
 });
 
-const BUFFER_TIMEOUT = 1e3;
-
-test.serial('buffer: false > promise does not resolve when output is big and is not read', async t => {
-	const {timedOut} = await t.throwsAsync(execa('max-buffer', {buffer: false, timeout: BUFFER_TIMEOUT}));
-	t.true(timedOut);
-});
-
 test('buffer: false > promise resolves when output is big and is read', async t => {
 	const cp = execa('max-buffer', {buffer: false});
 	cp.stdout.resume();
 	cp.stderr.resume();
 	await t.notThrowsAsync(cp);
-});
-
-test.serial('buffer: false > promise does not resolve when output is big and "all" is used but not read', async t => {
-	const cp = execa('max-buffer', {buffer: false, all: true, timeout: BUFFER_TIMEOUT});
-	cp.stdout.resume();
-	cp.stderr.resume();
-	const {timedOut} = await t.throwsAsync(cp);
-	t.true(timedOut);
 });
 
 test('buffer: false > promise resolves when output is big and "all" is used and is read', async t => {
@@ -179,4 +164,19 @@ test('buffer: false > promise resolves when output is big and "all" is used and 
 
 test('buffer: false > promise resolves when output is big but is not pipable', async t => {
 	await t.notThrowsAsync(execa('max-buffer', {buffer: false, stdout: 'ignore'}));
+});
+
+const BUFFER_TIMEOUT = 1e3;
+
+test.serial('buffer: false > promise does not resolve when output is big and is not read', async t => {
+	const {timedOut} = await t.throwsAsync(execa('max-buffer', {buffer: false, timeout: BUFFER_TIMEOUT}));
+	t.true(timedOut);
+});
+
+test.serial('buffer: false > promise does not resolve when output is big and "all" is used but not read', async t => {
+	const cp = execa('max-buffer', {buffer: false, all: true, timeout: BUFFER_TIMEOUT});
+	cp.stdout.resume();
+	cp.stderr.resume();
+	const {timedOut} = await t.throwsAsync(cp);
+	t.true(timedOut);
 });

--- a/test/stream.js
+++ b/test/stream.js
@@ -31,6 +31,11 @@ test.serial('result.all shows both `stdout` and `stderr` intermixed', async t =>
 	t.is(all, '132');
 });
 
+test('result.all is undefined unless opts.all is true', async t => {
+	const {all} = await execa('noop');
+	t.is(all, undefined);
+});
+
 test('stdout/stderr/all are undefined if ignored', async t => {
 	const {stdout, stderr, all} = await execa('noop', {stdio: 'ignore'});
 	t.is(stdout, undefined);
@@ -142,7 +147,7 @@ test('buffer: false > promise resolves', async t => {
 	await t.notThrowsAsync(execa('echo', ['hello'], {buffer: false}));
 });
 
-test('buffer: false > promise does not resolve when output is big and is not read', async t => {
+test.serial('buffer: false > promise does not resolve when output is big and is not read', async t => {
 	const {timedOut} = await t.throwsAsync(execa('max-buffer', ['stdout', '3000000'], {buffer: false, timeout: 1e3}));
 	t.true(timedOut);
 });
@@ -154,7 +159,7 @@ test('buffer: false > promise resolves when output is big and is read', async t 
 	await t.notThrowsAsync(cp);
 });
 
-test('buffer: false > promise does not resolve when output is big and "all" is used but not read', async t => {
+test.serial('buffer: false > promise does not resolve when output is big and "all" is used but not read', async t => {
 	const cp = execa('max-buffer', ['stdout', '3000000'], {buffer: false, all: true, timeout: 1e3});
 	cp.stdout.resume();
 	cp.stderr.resume();

--- a/test/stream.js
+++ b/test/stream.js
@@ -144,7 +144,7 @@ test('do not buffer when streaming', async t => {
 });
 
 test('buffer: false > promise resolves', async t => {
-	await t.notThrowsAsync(execa('echo', ['hello'], {buffer: false}));
+	await t.notThrowsAsync(execa('noop', {buffer: false}));
 });
 
 test.serial('buffer: false > promise does not resolve when output is big and is not read', async t => {

--- a/test/stream.js
+++ b/test/stream.js
@@ -147,8 +147,10 @@ test('buffer: false > promise resolves', async t => {
 	await t.notThrowsAsync(execa('noop', {buffer: false}));
 });
 
+const BUFFER_TIMEOUT = 1e3;
+
 test.serial('buffer: false > promise does not resolve when output is big and is not read', async t => {
-	const {timedOut} = await t.throwsAsync(execa('max-buffer', {buffer: false, timeout: 1e3}));
+	const {timedOut} = await t.throwsAsync(execa('max-buffer', {buffer: false, timeout: BUFFER_TIMEOUT}));
 	t.true(timedOut);
 });
 
@@ -160,7 +162,7 @@ test('buffer: false > promise resolves when output is big and is read', async t 
 });
 
 test.serial('buffer: false > promise does not resolve when output is big and "all" is used but not read', async t => {
-	const cp = execa('max-buffer', {buffer: false, all: true, timeout: 1e3});
+	const cp = execa('max-buffer', {buffer: false, all: true, timeout: BUFFER_TIMEOUT});
 	cp.stdout.resume();
 	cp.stderr.resume();
 	const {timedOut} = await t.throwsAsync(cp);

--- a/test/stream.js
+++ b/test/stream.js
@@ -164,6 +164,12 @@ test('buffer: false > promise resolves when output is big and "all" is used and 
 	await t.notThrowsAsync(cp);
 });
 
+test('buffer: false > promise rejects when process returns non-zero', async t => {
+	const cp = execa('fail', {buffer: false});
+	const {exitCode} = await t.throwsAsync(cp);
+	t.is(exitCode, 2);
+});
+
 const BUFFER_TIMEOUT = 1e3;
 
 test.serial('buffer: false > promise does not resolve when output is big and is not read', async t => {

--- a/test/stream.js
+++ b/test/stream.js
@@ -148,19 +148,19 @@ test('buffer: false > promise resolves', async t => {
 });
 
 test.serial('buffer: false > promise does not resolve when output is big and is not read', async t => {
-	const {timedOut} = await t.throwsAsync(execa('max-buffer', ['stdout', '3000000'], {buffer: false, timeout: 1e3}));
+	const {timedOut} = await t.throwsAsync(execa('max-buffer', {buffer: false, timeout: 1e3}));
 	t.true(timedOut);
 });
 
 test('buffer: false > promise resolves when output is big and is read', async t => {
-	const cp = execa('max-buffer', ['stdout', '3000000'], {buffer: false});
+	const cp = execa('max-buffer', {buffer: false});
 	cp.stdout.resume();
 	cp.stderr.resume();
 	await t.notThrowsAsync(cp);
 });
 
 test.serial('buffer: false > promise does not resolve when output is big and "all" is used but not read', async t => {
-	const cp = execa('max-buffer', ['stdout', '3000000'], {buffer: false, all: true, timeout: 1e3});
+	const cp = execa('max-buffer', {buffer: false, all: true, timeout: 1e3});
 	cp.stdout.resume();
 	cp.stderr.resume();
 	const {timedOut} = await t.throwsAsync(cp);
@@ -168,7 +168,7 @@ test.serial('buffer: false > promise does not resolve when output is big and "al
 });
 
 test('buffer: false > promise resolves when output is big and "all" is used and is read', async t => {
-	const cp = execa('max-buffer', ['stdout', '3000000'], {buffer: false, all: true});
+	const cp = execa('max-buffer', {buffer: false, all: true});
 	cp.stdout.resume();
 	cp.stderr.resume();
 	cp.all.resume();
@@ -176,5 +176,5 @@ test('buffer: false > promise resolves when output is big and "all" is used and 
 });
 
 test('buffer: false > promise resolves when output is big but is not pipable', async t => {
-	await t.notThrowsAsync(execa('max-buffer', ['stdout', '3000000'], {buffer: false, stdout: 'ignore'}));
+	await t.notThrowsAsync(execa('max-buffer', {buffer: false, stdout: 'ignore'}));
 });


### PR DESCRIPTION
## Description

Fixes #350 
Fixes #344

Currently, when `buffer` is set to `false`, `execa` wait for the process to finish, `stdout`, `stderr` and `all` streams to finish. However, in order for the process to certainly finish, the user will have to consume or just `resume` the `all` stream, because if `all` is not consumed and the process is output intensive, `all`, which is a `PassThrough` stream, will block the process output pipeline, preventing the process to close. So `all` stream has to be consumed or `resumed` and `stdout`,`stderr` can be optionally consumed. 

It does make more sense for the user, when `buffer=false`, to consume only `stderr` and `stdout`, optionally consuming `all`, but for this behavior, `all` should be opt-in (if `all` is present, the user will have to consume it, otherwise the process may not finish), which makes sense in general, not only when `buffer=false`: in case the user genuinely wants to use `all` stream, he/she will opt-in for it.

When `buffer=false` another change that makes more sense is just to wait for the process to finish and not wait for the output streams. The user will have to consume them anyway, otherwise the process may not finish, so why not mirror `child_process`'s behavior in this case and remove this complexity from `execa`? 

So this PR proposes to make `all` opt-in, which is a breaking change, and fixes bugs reported on #350 when `buffer=false`.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change required a documentation update

## Faulty behavior this PR solves

These bugs were detailed in #350, but this is a summary of them and the code below is the reason to 1 and 2 (and the fact that execa waits for `stdout`, `stderr` and `all` stream promises to finish):
https://github.com/sindresorhus/execa/blob/071a8154f882d13116a6a91d8691ea150de31753/lib/stream.js#L55-L74

1) A bug on `getStreamPromise` when `buffer=false`. Currently, waiting for the end of stream is faulty:  The `all` stream emits a `finish` event, instead an `end` event, because `all` is a `Duplex`, and its `Writable` part is in action (`stdout` and `stderr` are being piped into it), not its `Readable` part. If `all` is not consumed, `execa` never finishes because its waiting an `end` or `error` event from `all`. 

```js
const execa = require("execa");
(async () => {
  const proc = execa("echo", ["hello"], { buffer: false });
  proc.stdout.resume();
  proc.stderr.resume();
  const procRes = await proc;
  // This never gets printed
  console.log("done", procRes);
})();
```

2) Another bug similar to 1). This time is because the streams are destroyed on error. When a stream is destroyed it emits only a close event, so `stdio`, `stderr` and `all` stream promises never end.

```js
const execa = require("execa");
(async () => {
  // Intended mistake. The promise should reject with ENOENT
  const proc = execa("echo hello", { buffer: false });
  proc.stdout.resume();
  proc.stderr.resume();
  try {
    const procRes = await proc;
  } catch(err) {
    // This never gets printed
    console.log(err)
  }
  
})();
```
3) A complication on 1) and 2). The solution to the previous bugs was just fix `getStreamPromise` when `buffer=false`, meaning listen to the correct events for stream completion. The following bug _forces_ the user to consume `all`, because otherwise the process will never finish, since `all` blocks the output pipeline. This is the cause to make `all` opt-in. 

```js
const execa = require("execa");
(async () => {
  // With big output the process doesnt exit until all is resumed (all blocks the pipeline)
  const proc = execa('node', ['-e', 'console.log("a".repeat(3000000))'], {buffer: false});
  proc.stdout.resume();
  proc.stderr.resume();
  // proc.all.resume(); 
  const procRes = await proc;
  //if all is not resumed, this never gets printed
  console.log("done")
})();
```

