### PR TITLE
Document the reasons why the returned promise might fail

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -272,11 +272,11 @@ declare namespace execa {
 	Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
 
 	The child process fails when:
-		- its exit code is not `0`
-		- it was killed with a signal
-		- timing out
-		- being canceled
-		- there's not enough memory or there are already too many child processes
+	- its exit code is not `0`
+	- it was killed with a signal
+	- timing out
+	- being canceled
+	- there's not enough memory or there are already too many child processes
 	*/
 	interface ExecaReturnValue<StdoutErrorType = string>
 		extends ExecaSyncReturnValue<StdoutErrorType> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -268,6 +268,16 @@ declare namespace execa {
 		extends ExecaReturnBase<StdoutErrorType> {
 	}
 
+	/**
+	Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
+
+	The child process fails when:
+		- its exit code is not `0`
+		- it was killed with a signal
+		- timing out
+		- being canceled
+		- there's not enough memory or there are already too many child processes
+	*/
 	interface ExecaReturnValue<StdoutErrorType = string>
 		extends ExecaSyncReturnValue<StdoutErrorType> {
 		/**

--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,13 @@ Type: `object`
 
 Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
 
+The child process [fails](#failed) when:
+  - its [exit code](#exitcode) is not `0`
+	- it was [killed](#killed) with a [signal](#signal)
+	- [timing out](#timedout)
+	- [being canceled](#iscanceled)
+  - there's not enough memory or there are already too many child processes
+
 #### command
 
 Type: `string`

--- a/readme.md
+++ b/readme.md
@@ -201,11 +201,11 @@ Type: `object`
 Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
 
 The child process [fails](#failed) when:
-  - its [exit code](#exitcode) is not `0`
-  - it was [killed](#killed) with a [signal](#signal)
-  - [timing out](#timedout)
-  - [being canceled](#iscanceled)
-  - there's not enough memory or there are already too many child processes
+- its [exit code](#exitcode) is not `0`
+- it was [killed](#killed) with a [signal](#signal)
+- [timing out](#timedout)
+- [being canceled](#iscanceled)
+- there's not enough memory or there are already too many child processes
 
 #### command
 

--- a/readme.md
+++ b/readme.md
@@ -202,9 +202,9 @@ Result of a child process execution. On success this is a plain object. On failu
 
 The child process [fails](#failed) when:
   - its [exit code](#exitcode) is not `0`
-	- it was [killed](#killed) with a [signal](#signal)
-	- [timing out](#timedout)
-	- [being canceled](#iscanceled)
+  - it was [killed](#killed) with a [signal](#signal)
+  - [timing out](#timedout)
+  - [being canceled](#iscanceled)
   - there's not enough memory or there are already too many child processes
 
 #### command


### PR DESCRIPTION
Fixes #361. 

This adds documentation on why the returned promise might fail.

CI is failing on Windows with Node 12, but this is unrelated to this PR.