### PR TITLE
Upgrade cross-spawn to `7.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"local"
 	],
 	"dependencies": {
-		"cross-spawn": "^6.0.5",
+		"cross-spawn": "^7.0.0",
 		"get-stream": "^5.0.0",
 		"is-stream": "^2.0.0",
 		"merge-stream": "^2.0.0",


### PR DESCRIPTION
The new major release of `cross-spawn` drops support for Node `<8`. This allowed `cross-spawn` to remove two dependencies: `nice-try` and `semver`.