### PR TITLE
Make execa compatible with Node.js 13.0.0-pre

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,7 +190,7 @@ module.exports.sync = (file, args, options) => {
 			code: result.status,
 			command,
 			parsed,
-			timedOut: result.error && result.error.errno === 'ETIMEDOUT',
+			timedOut: result.error && result.error.code === 'ETIMEDOUT',
 			isCanceled: false,
 			killed: result.signal !== null
 		});

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ const execa = require('execa');
 		/*
 		{
 			message: 'Command failed with exit code 2 (ENOENT): wrong command spawn wrong ENOENT',
-			errno: 'ENOENT',
+			errno: -2,
 			syscall: 'spawn wrong',
 			path: 'wrong',
 			spawnargs: ['command'],
@@ -98,7 +98,7 @@ try {
 	/*
 	{
 		message: 'Command failed with exit code 2 (ENOENT): wrong command spawnSync wrong ENOENT',
-		errno: 'ENOENT',
+		errno: -2,
 		syscall: 'spawnSync wrong',
 		path: 'wrong',
 		spawnargs: ['command'],


### PR DESCRIPTION
Use `error.code` instead of `error.errno` when expecting a string error
code. `errno` is always numeric in Node.js 13.0.0-pre.

Node.js 13.0.0 comes out later this month (October 2019) so implementing
and publishing this change will hopefully smooth the upgrade path for
execa users.