### PR TITLE
Add `error.originalMessage` property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -262,6 +262,11 @@ declare namespace execa {
 		The signal that was used to terminate the process.
 		*/
 		signal?: string;
+
+		/**
+		Original error message when the child process exits due to an error or a timeout.
+		*/
+		originalMessage?: string;
 	}
 
 	interface ExecaSyncReturnValue<StdoutErrorType = string>

--- a/index.d.ts
+++ b/index.d.ts
@@ -262,11 +262,6 @@ declare namespace execa {
 		The signal that was used to terminate the process.
 		*/
 		signal?: string;
-
-		/**
-		Original error message when the child process exits due to an error or a timeout.
-		*/
-		originalMessage?: string;
 	}
 
 	interface ExecaSyncReturnValue<StdoutErrorType = string>
@@ -307,6 +302,11 @@ declare namespace execa {
 		The error message.
 		*/
 		message: string;
+
+		/**
+		Original error message when the child process exits due to an error or a timeout.
+		*/
+		originalMessage?: string;
 	}
 
 	interface ExecaError<StdoutErrorType = string>

--- a/index.d.ts
+++ b/index.d.ts
@@ -304,7 +304,9 @@ declare namespace execa {
 		message: string;
 
 		/**
-		Original error message when the child process exits due to an error or a timeout.
+		Original error message. This is `undefined` unless the child process exited due to an `error` event or a timeout.
+
+		The `message` property contains both the `originalMessage` and some additional information added by Execa.
 		*/
 		originalMessage?: string;
 	}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -26,7 +26,6 @@ try {
 	expectType<boolean>(unicornsResult.isCanceled);
 	expectType<boolean>(unicornsResult.killed);
 	expectType<string | undefined>(unicornsResult.signal);
-	expectType<string | undefined>(unicornsResult.originalMessage);
 } catch (error) {
 	const execaError: ExecaError = error;
 
@@ -57,7 +56,6 @@ try {
 	expectError(unicornsResult.isCanceled);
 	expectType<boolean>(unicornsResult.killed);
 	expectType<string | undefined>(unicornsResult.signal);
-	expectType<string | undefined>(unicornsResult.originalMessage);
 } catch (error) {
 	const execaError: ExecaSyncError = error;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -26,6 +26,7 @@ try {
 	expectType<boolean>(unicornsResult.isCanceled);
 	expectType<boolean>(unicornsResult.killed);
 	expectType<string | undefined>(unicornsResult.signal);
+	expectType<string | undefined>(unicornsResult.originalMessage);
 } catch (error) {
 	const execaError: ExecaError = error;
 
@@ -40,6 +41,7 @@ try {
 	expectType<boolean>(execaError.isCanceled);
 	expectType<boolean>(execaError.killed);
 	expectType<string | undefined>(execaError.signal);
+	expectType<string | undefined>(execaError.originalMessage);
 }
 
 try {
@@ -55,6 +57,7 @@ try {
 	expectError(unicornsResult.isCanceled);
 	expectType<boolean>(unicornsResult.killed);
 	expectType<string | undefined>(unicornsResult.signal);
+	expectType<string | undefined>(unicornsResult.originalMessage);
 } catch (error) {
 	const execaError: ExecaSyncError = error;
 
@@ -69,6 +72,7 @@ try {
 	expectError(execaError.isCanceled);
 	expectType<boolean>(execaError.killed);
 	expectType<string | undefined>(execaError.signal);
+	expectType<string | undefined>(execaError.originalMessage);
 }
 
 execa('unicorns', {cleanup: false});

--- a/lib/error.js
+++ b/lib/error.js
@@ -53,6 +53,7 @@ const makeError = ({
 	const message = `Command ${prefix}: ${command}`;
 
 	if (error instanceof Error) {
+		error.originalMessage = error.message;
 		error.message = `${message}\n${error.message}`;
 	} else {
 		error = new Error(message);

--- a/readme.md
+++ b/readme.md
@@ -281,7 +281,9 @@ The signal that was used to terminate the process.
 
 Type: `string | undefined`
 
-Original error message when the child process exits due to an error or a timeout.
+Original error message. This is `undefined` unless the child process exited due to an `error` event or a timeout.
+
+The `message` property contains both the `originalMessage` and some additional information added by Execa.
 
 ### options
 

--- a/readme.md
+++ b/readme.md
@@ -277,6 +277,12 @@ Type: `string | undefined`
 
 The signal that was used to terminate the process.
 
+#### originalMessage
+
+Type: `string | undefined`
+
+Original error message when the child process exits due to an error or a timeout.
+
 ### options
 
 Type: `object`

--- a/test/error.js
+++ b/test/error.js
@@ -163,3 +163,8 @@ errorMessage.title = (message, expected) => `error.message matches: ${expected}`
 
 test(errorMessage, /Command failed with exit code 2.*: exit 2 foo bar/, 2, 'foo', 'bar');
 test(errorMessage, /Command failed with exit code 3.*: exit 3 baz quz/, 3, 'baz', 'quz');
+
+test('Original error message is kept', async t => {
+	const {originalMessage} = await t.throwsAsync(execa('wrong command'));
+	t.is(originalMessage, 'spawn wrong command ENOENT');
+});


### PR DESCRIPTION
When an `error` event is thrown on the child process or when a timeout happens, we re-use the original `Error` instance instead of creating a new one. However we override the `error.message`.

This PR keep the original `error.message` as an additional property `error.originalMessage`.

I need this for one my projects using Execa. That project should proxy a user's command in such a way that users should not be aware of that proxy. In particular, the error messages produced by Execa should be not printed to the console. However the error messages coming from `error` events on the child process (such as `command not found`) should be printed. This PR allows for this to happen.