### PR TITLE
Fix error properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -229,11 +229,6 @@ declare namespace execa {
 		exitCode: number;
 
 		/**
-		The textual exit code of the process that was run.
-		*/
-		exitCodeName: string;
-
-		/**
 		The output of the process on stdout.
 		*/
 		stdout: StdoutStderrType;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -17,7 +17,6 @@ try {
 	const unicornsResult = await execaPromise;
 	expectType<string>(unicornsResult.command);
 	expectType<number>(unicornsResult.exitCode);
-	expectType<string>(unicornsResult.exitCodeName);
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.stderr);
 	expectType<string | undefined>(unicornsResult.all);
@@ -31,7 +30,6 @@ try {
 
 	expectType<string>(execaError.message);
 	expectType<number>(execaError.exitCode);
-	expectType<string>(execaError.exitCodeName);
 	expectType<string>(execaError.stdout);
 	expectType<string>(execaError.stderr);
 	expectType<string | undefined>(execaError.all);
@@ -47,7 +45,6 @@ try {
 	const unicornsResult = execa.sync('unicorns');
 	expectType<string>(unicornsResult.command);
 	expectType<number>(unicornsResult.exitCode);
-	expectType<string>(unicornsResult.exitCodeName);
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.stderr);
 	expectError(unicornsResult.all);
@@ -61,7 +58,6 @@ try {
 
 	expectType<string>(execaError.message);
 	expectType<number>(execaError.exitCode);
-	expectType<string>(execaError.exitCodeName);
 	expectType<string>(execaError.stdout);
 	expectType<string>(execaError.stderr);
 	expectError(execaError.all);

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,20 +1,5 @@
 'use strict';
-const os = require('os');
-const util = require('util');
-
-const getCode = (error, code) => {
-	if (error && error.code) {
-		return [error.code, os.constants.errno[error.code]];
-	}
-
-	if (Number.isInteger(code)) {
-		return [util.getSystemErrorName(-code), code];
-	}
-
-	return [];
-};
-
-const getErrorPrefix = ({timedOut, timeout, signal, exitCodeName, exitCode, isCanceled}) => {
+const getErrorPrefix = ({timedOut, timeout, errorCode, signal, exitCode, isCanceled}) => {
 	if (timedOut) {
 		return `timed out after ${timeout} milliseconds`;
 	}
@@ -23,12 +8,16 @@ const getErrorPrefix = ({timedOut, timeout, signal, exitCodeName, exitCode, isCa
 		return 'was canceled';
 	}
 
-	if (signal) {
+	if (errorCode !== undefined) {
+		return `failed with ${errorCode}`;
+	}
+
+	if (signal !== undefined) {
 		return `was killed with ${signal}`;
 	}
 
 	if (exitCode !== undefined) {
-		return `failed with exit code ${exitCode} (${exitCodeName})`;
+		return `failed with exit code ${exitCode}`;
 	}
 
 	return 'failed';
@@ -40,16 +29,21 @@ const makeError = ({
 	all,
 	error,
 	signal,
-	code,
+	exitCode,
 	command,
 	timedOut,
 	isCanceled,
 	killed,
 	parsed: {options: {timeout}}
 }) => {
-	const [exitCodeName, exitCode] = getCode(error, code);
+	// `signal` and `exitCode` emitted on `spawned.on('exit')` event can be `null`.
+	// We normalize them to `undefined`
+	exitCode = exitCode === null ? undefined : exitCode;
+	signal = signal === null ? undefined : signal;
 
-	const prefix = getErrorPrefix({timedOut, timeout, signal, exitCodeName, exitCode, isCanceled});
+	const errorCode = error && error.code;
+
+	const prefix = getErrorPrefix({timedOut, timeout, errorCode, signal, exitCode, isCanceled});
 	const message = `Command ${prefix}: ${command}`;
 
 	if (error instanceof Error) {
@@ -60,9 +54,8 @@ const makeError = ({
 	}
 
 	error.command = command;
-	delete error.code;
 	error.exitCode = exitCode;
-	error.exitCodeName = exitCodeName;
+	error.signal = signal;
 	error.stdout = stdout;
 	error.stderr = stderr;
 
@@ -78,9 +71,6 @@ const makeError = ({
 	error.timedOut = Boolean(timedOut);
 	error.isCanceled = isCanceled;
 	error.killed = killed && !timedOut;
-	// `signal` emitted on `spawned.on('exit')` event can be `null`. We normalize
-	// it to `undefined`
-	error.signal = signal || undefined;
 
 	return error;
 };

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -29,8 +29,8 @@ const mergePromise = (spawned, promise) => {
 // Use promises instead of `child_process` events
 const getSpawnedPromise = spawned => {
 	return new Promise((resolve, reject) => {
-		spawned.on('exit', (code, signal) => {
-			resolve({code, signal});
+		spawned.on('exit', (exitCode, signal) => {
+			resolve({exitCode, signal});
 		});
 
 		spawned.on('error', error => {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -74,7 +74,7 @@ const getSpawnedResult = async ({stdout, stderr, all}, {encoding, buffer, maxBuf
 		return await Promise.all([processDone, stdoutPromise, stderrPromise, allPromise]);
 	} catch (error) {
 		return Promise.all([
-			{error, code: error.code, signal: error.signal, timedOut: error.timedOut},
+			{error, signal: error.signal, timedOut: error.timedOut},
 			getBufferedData(stdout, stdoutPromise),
 			getBufferedData(stderr, stderrPromise),
 			getBufferedData(all, allPromise)

--- a/readme.md
+++ b/readme.md
@@ -53,19 +53,19 @@ const execa = require('execa');
 
 	// Catching an error
 	try {
-		await execa('wrong', ['command']);
+		await execa('unknown', ['command']);
 	} catch (error) {
 		console.log(error);
 		/*
 		{
-			message: 'Command failed with exit code 2 (ENOENT): wrong command spawn wrong ENOENT',
-			errno: -2,
-			syscall: 'spawn wrong',
-			path: 'wrong',
+			message: 'Command failed with ENOENT: unknown command spawn unknown ENOENT',
+			errno: 'ENOENT',
+			code: 'ENOENT',
+			syscall: 'spawn unknown',
+			path: 'unknown',
 			spawnargs: ['command'],
-			command: 'wrong command',
-			exitCode: 2,
-			exitCodeName: 'ENOENT',
+			originalMessage: 'spawn unknown ENOENT',
+			command: 'unknown command',
 			stdout: '',
 			stderr: '',
 			all: '',
@@ -92,21 +92,22 @@ const execa = require('execa');
 
 // Catching an error with a sync method
 try {
-	execa.sync('wrong', ['command']);
+	execa.sync('unknown', ['command']);
 } catch (error) {
 	console.log(error);
 	/*
 	{
-		message: 'Command failed with exit code 2 (ENOENT): wrong command spawnSync wrong ENOENT',
-		errno: -2,
-		syscall: 'spawnSync wrong',
-		path: 'wrong',
+		message: 'Command failed with ENOENT: unknown command spawnSync unknown ENOENT',
+		errno: 'ENOENT',
+		code: 'ENOENT',
+		syscall: 'spawnSync unknown',
+		path: 'unknown',
 		spawnargs: ['command'],
-		command: 'wrong command',
-		exitCode: 2,
-		exitCodeName: 'ENOENT',
+		originalMessage: 'spawnSync unknown ENOENT',
+		command: 'unknown command',
 		stdout: '',
 		stderr: '',
+		all: '',
 		failed: true,
 		timedOut: false,
 		isCanceled: false,
@@ -218,12 +219,6 @@ The file and arguments that were run.
 Type: `number`
 
 The numeric exit code of the process that was run.
-
-#### exitCodeName
-
-Type: `string`
-
-The textual exit code of the process that was run.
 
 #### stdout
 

--- a/test/test.js
+++ b/test/test.js
@@ -169,7 +169,7 @@ if (process.platform !== 'win32') {
 			await execa(`fast-exit-${process.platform}`, [], {input: 'data'});
 			t.pass();
 		} catch (error) {
-			t.is(error.exitCode, 32);
+			t.is(error.code, 'EPIPE');
 		}
 	});
 }


### PR DESCRIPTION
The `exitCode` and `exitCodeName` are currently wrong. 

[We use `error.code` as the base](https://github.com/sindresorhus/execa/blob/07d2b76a32566d147c5ee44fd617e68a0e4f231e/lib/error.js#L5) for `exitCode` and `exitCodeName`. [We also use `util.getSystemErrorName()`](https://github.com/sindresorhus/execa/blob/07d2b76a32566d147c5ee44fd617e68a0e4f231e/lib/error.js#L10) on an exit code. Both are erroneous as they are mixing exit codes and `error.code`/`error.errno`, which are different things. `error.code` and `error.errno` are based on [OS-specific system calls](https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno-base.h). Those are sometimes used as exit codes, but an exit code does not always translate to an `error.errno`.

Assigning a name or description to exit codes is tricky. That's because exit codes meaning is both application-specific and OS-specific. For example, the exit code `2` means "Command line usage error" [if the command is `bash`](https://www.tldp.org/LDP/abs/html/exitcodes.html#EXITCODESREF). But it means "ENOENT - No such file or directory" if the error was due to [a Linux system call error](https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/errno-base.h).

This PR fixes this by:
  - removing `error.exitCodeName` (breaking change). 
  - not making `exitCode` use `error.code` anymore
  - keeping `error.code` when defined instead of deleting it
  - adding the error message `Command failed with ${error.code}` when `error.code` is defined
  - improving error-related tests
  - renaming the internal variable `code` to `exitCode` for clarity