### PR TITLE
Upgrade `npm-run-path` from `3.0.0` to `4.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"get-stream": "^5.0.0",
 		"is-stream": "^2.0.0",
 		"merge-stream": "^2.0.0",
-		"npm-run-path": "^3.0.0",
+		"npm-run-path": "^4.0.0",
 		"onetime": "^5.1.0",
 		"p-finally": "^2.0.0",
 		"signal-exit": "^3.0.2",


### PR DESCRIPTION
This upgrades the `npm-run-path` dependency to its [latest major version](https://github.com/sindresorhus/npm-run-path/releases/tag/v4.0.0).