### PR TITLE
Add `execPath` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,8 @@ declare namespace execa {
 		/**
 		Path to the Node.js executable to use in child processes.
 
+		For example this can be used together with `get-node` to run a specific Node.js version in a child process.
+
 		This can be either an absolute path or a path relative to the `cwd` option.
 
 		Requires `preferLocal` to be `true`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,17 @@ declare namespace execa {
 		readonly localDir?: string;
 
 		/**
+		Path to the Node.js executable to use in child processes.
+
+		This can be either an absolute path or a path relative to the `cwd` option.
+
+		Requires `preferLocal` to be `true`.
+
+		@default process.execPath
+		*/
+		readonly execPath?: string;
+
+		/**
 		Buffer the output from the spawned process. When set to `false`, you must read the output of `stdout` and `stderr` (or `all` if the `all` option is `true`). Otherwise the returned promise will not be resolved/rejected.
 
 		If the spawned process fails, `error.stdout`, `error.stderr`, and `error.all` will contain the buffered data.

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,11 +41,11 @@ declare namespace execa {
 		/**
 		Path to the Node.js executable to use in child processes.
 
-		For example this can be used together with `get-node` to run a specific Node.js version in a child process.
-
 		This can be either an absolute path or a path relative to the `cwd` option.
 
 		Requires `preferLocal` to be `true`.
+		
+		For example, this can be used together with [`get-node`](https://github.com/ehmicky/get-node) to run a specific Node.js version in a child process.
 
 		@default process.execPath
 		*/

--- a/index.js
+++ b/index.js
@@ -14,11 +14,11 @@ const {joinCommand, parseCommand} = require('./lib/command.js');
 
 const DEFAULT_MAX_BUFFER = 1000 * 1000 * 100;
 
-const getEnv = ({env: envOption, extendEnv, preferLocal, localDir}) => {
+const getEnv = ({env: envOption, extendEnv, preferLocal, localDir, execPath}) => {
 	const env = extendEnv ? {...process.env, ...envOption} : envOption;
 
 	if (preferLocal) {
-		return npmRunPath.env({env, cwd: localDir});
+		return npmRunPath.env({env, cwd: localDir, execPath});
 	}
 
 	return env;
@@ -37,6 +37,7 @@ const handleArgs = (file, args, options = {}) => {
 		extendEnv: true,
 		preferLocal: false,
 		localDir: options.cwd || process.cwd(),
+		execPath: process.execPath,
 		encoding: 'utf8',
 		reject: true,
 		cleanup: true,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -72,6 +72,7 @@ try {
 execa('unicorns', {cleanup: false});
 execa('unicorns', {preferLocal: false});
 execa('unicorns', {localDir: '.'});
+execa('unicorns', {execPath: '/path'});
 execa('unicorns', {buffer: false});
 execa('unicorns', {input: ''});
 execa('unicorns', {input: Buffer.from('')});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"@types/node": "^12.0.7",
 		"ava": "^2.1.0",
 		"coveralls": "^3.0.4",
+		"get-node": "^5.0.0",
 		"is-running": "^2.1.0",
 		"nyc": "^14.1.1",
 		"p-event": "^4.1.0",

--- a/readme.md
+++ b/readme.md
@@ -308,6 +308,17 @@ Default: `process.cwd()`
 
 Preferred path to find locally installed binaries in (use with `preferLocal`).
 
+#### execPath
+
+Type: `string`<br>
+Default: `process.execPath` (current Node.js executable)
+
+Path to the Node.js executable to use in child processes.
+
+This can be either an absolute path or a path relative to the [`cwd` option](#cwd).
+
+Requires [`preferLocal`](#preferlocal) to be `true`.
+
 #### buffer
 
 Type: `boolean`<br>

--- a/readme.md
+++ b/readme.md
@@ -315,6 +315,8 @@ Default: `process.execPath` (current Node.js executable)
 
 Path to the Node.js executable to use in child processes.
 
+For example this can be used together with [`get-node`](https://github.com/ehmicky/get-node) to run a specific Node.js version in a child process.
+
 This can be either an absolute path or a path relative to the [`cwd` option](#cwd).
 
 Requires [`preferLocal`](#preferlocal) to be `true`.

--- a/readme.md
+++ b/readme.md
@@ -315,11 +315,11 @@ Default: `process.execPath` (current Node.js executable)
 
 Path to the Node.js executable to use in child processes.
 
-For example this can be used together with [`get-node`](https://github.com/ehmicky/get-node) to run a specific Node.js version in a child process.
-
 This can be either an absolute path or a path relative to the [`cwd` option](#cwd).
 
 Requires [`preferLocal`](#preferlocal) to be `true`.
+
+For example, this can be used together with [`get-node`](https://github.com/ehmicky/get-node) to run a specific Node.js version in a child process.
 
 #### buffer
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import test from 'ava';
 import isRunning from 'is-running';
+import getNode from 'get-node';
 import execa from '..';
 
 process.env.PATH = path.join(__dirname, 'fixtures') + path.delimiter + process.env.PATH;
@@ -90,6 +91,12 @@ test('localDir option', async t => {
 	const {stdout} = await execa(command, {shell: true, preferLocal: true, localDir: '/test'});
 	const envPaths = stdout.split(path.delimiter);
 	t.true(envPaths.some(envPath => envPath.endsWith('.bin')));
+});
+
+test('execPath option', async t => {
+	const {path: execPath} = await getNode('6.0.0');
+	const {stdout} = await execa('node', ['-p', 'process.env.Path || process.env.PATH'], {preferLocal: true, execPath});
+	t.true(stdout.includes('6.0.0'));
 });
 
 test('stdin errors are handled', async t => {


### PR DESCRIPTION
Fixes #153 
Fixes #196

This adds an `execPath` option to modify which Node.js executable to use in child processes.

See [here](https://github.com/sindresorhus/npm-run-path/pull/9#issuecomment-541437833) for some use cases.