### PR TITLE
Add `error.signalDescription`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -267,12 +267,16 @@ declare namespace execa {
 		killed: boolean;
 
 		/**
-		The name of the signal that was used to terminate the process.
+		The name of the signal that was used to terminate the process. For example `"SIGFPE"`.
+
+		If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
 		*/
 		signal?: string;
 
 		/**
-		A human-friendly description of the signal that was used to terminate the process.
+		A human-friendly description of the signal that was used to terminate the process. For example `"Floating point arithmetic error"`.
+
+		If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
 		*/
 		signalDescription?: string;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -276,7 +276,7 @@ declare namespace execa {
 		/**
 		A human-friendly description of the signal that was used to terminate the process. For example, `Floating point arithmetic error`.
 
-		If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
+		If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`. It is also `undefined` when the signal is very uncommon which should seldomly happen.
 		*/
 		signalDescription?: string;
 	}

--- a/index.d.ts
+++ b/index.d.ts
@@ -267,14 +267,14 @@ declare namespace execa {
 		killed: boolean;
 
 		/**
-		The name of the signal that was used to terminate the process. For example `"SIGFPE"`.
+		The name of the signal that was used to terminate the process. For example, `SIGFPE`.
 
 		If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
 		*/
 		signal?: string;
 
 		/**
-		A human-friendly description of the signal that was used to terminate the process. For example `"Floating point arithmetic error"`.
+		A human-friendly description of the signal that was used to terminate the process. For example, `Floating point arithmetic error`.
 
 		If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -267,9 +267,14 @@ declare namespace execa {
 		killed: boolean;
 
 		/**
-		The signal that was used to terminate the process.
+		The name of the signal that was used to terminate the process.
 		*/
 		signal?: string;
+
+		/**
+		A human-friendly description of the signal that was used to terminate the process.
+		*/
+		signalDescription?: string;
 	}
 
 	interface ExecaSyncReturnValue<StdoutErrorType = string>

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -25,6 +25,7 @@ try {
 	expectType<boolean>(unicornsResult.isCanceled);
 	expectType<boolean>(unicornsResult.killed);
 	expectType<string | undefined>(unicornsResult.signal);
+	expectType<string | undefined>(unicornsResult.signalDescription);
 } catch (error) {
 	const execaError: ExecaError = error;
 
@@ -38,6 +39,7 @@ try {
 	expectType<boolean>(execaError.isCanceled);
 	expectType<boolean>(execaError.killed);
 	expectType<string | undefined>(execaError.signal);
+	expectType<string | undefined>(execaError.signalDescription);
 	expectType<string | undefined>(execaError.originalMessage);
 }
 
@@ -53,6 +55,7 @@ try {
 	expectError(unicornsResult.isCanceled);
 	expectType<boolean>(unicornsResult.killed);
 	expectType<string | undefined>(unicornsResult.signal);
+	expectType<string | undefined>(unicornsResult.signalDescription);
 } catch (error) {
 	const execaError: ExecaSyncError = error;
 
@@ -66,6 +69,7 @@ try {
 	expectError(execaError.isCanceled);
 	expectType<boolean>(execaError.killed);
 	expectType<string | undefined>(execaError.signal);
+	expectType<string | undefined>(execaError.signalDescription);
 	expectType<string | undefined>(execaError.originalMessage);
 }
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,5 +1,7 @@
 'use strict';
-const getErrorPrefix = ({timedOut, timeout, errorCode, signal, exitCode, isCanceled}) => {
+const {signalsByName} = require('human-signals');
+
+const getErrorPrefix = ({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled}) => {
 	if (timedOut) {
 		return `timed out after ${timeout} milliseconds`;
 	}
@@ -13,7 +15,7 @@ const getErrorPrefix = ({timedOut, timeout, errorCode, signal, exitCode, isCance
 	}
 
 	if (signal !== undefined) {
-		return `was killed with ${signal}`;
+		return `was killed with ${signal} (${signalDescription})`;
 	}
 
 	if (exitCode !== undefined) {
@@ -40,10 +42,11 @@ const makeError = ({
 	// We normalize them to `undefined`
 	exitCode = exitCode === null ? undefined : exitCode;
 	signal = signal === null ? undefined : signal;
+	const signalDescription = signal === undefined ? undefined : signalsByName[signal].description;
 
 	const errorCode = error && error.code;
 
-	const prefix = getErrorPrefix({timedOut, timeout, errorCode, signal, exitCode, isCanceled});
+	const prefix = getErrorPrefix({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled});
 	const message = `Command ${prefix}: ${command}`;
 
 	if (error instanceof Error) {
@@ -56,6 +59,7 @@ const makeError = ({
 	error.command = command;
 	error.exitCode = exitCode;
 	error.signal = signal;
+	error.signalDescription = signalDescription;
 	error.stdout = stdout;
 	error.stderr = stderr;
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	"dependencies": {
 		"cross-spawn": "^7.0.0",
 		"get-stream": "^5.0.0",
-		"human-signals": "^1.1.0",
+		"human-signals": "^1.1.1",
 		"is-stream": "^2.0.0",
 		"merge-stream": "^2.0.0",
 		"npm-run-path": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 	"dependencies": {
 		"cross-spawn": "^7.0.0",
 		"get-stream": "^5.0.0",
+		"human-signals": "^1.1.0",
 		"is-stream": "^2.0.0",
 		"merge-stream": "^2.0.0",
 		"npm-run-path": "^4.0.0",

--- a/readme.md
+++ b/readme.md
@@ -270,13 +270,17 @@ Whether the process was killed.
 
 Type: `string | undefined`
 
-The name of the signal that was used to terminate the process.
+The name of the signal that was used to terminate the process. For example `"SIGFPE"`.
+
+If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
 
 #### signalDescription
 
 Type: `string | undefined`
 
-A human-friendly description of the signal that was used to terminate the process.
+A human-friendly description of the signal that was used to terminate the process. For example `"Floating point arithmetic error"`.
+
+If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
 
 #### originalMessage
 

--- a/readme.md
+++ b/readme.md
@@ -280,7 +280,7 @@ Type: `string | undefined`
 
 A human-friendly description of the signal that was used to terminate the process. For example, `Floating point arithmetic error`.
 
-If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
+If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`. It is also `undefined` when the signal is very uncommon which should seldomly happen.
 
 #### originalMessage
 

--- a/readme.md
+++ b/readme.md
@@ -270,7 +270,13 @@ Whether the process was killed.
 
 Type: `string | undefined`
 
-The signal that was used to terminate the process.
+The name of the signal that was used to terminate the process.
+
+#### signalDescription
+
+Type: `string | undefined`
+
+A human-friendly description of the signal that was used to terminate the process.
 
 #### originalMessage
 

--- a/readme.md
+++ b/readme.md
@@ -270,7 +270,7 @@ Whether the process was killed.
 
 Type: `string | undefined`
 
-The name of the signal that was used to terminate the process. For example `"SIGFPE"`.
+The name of the signal that was used to terminate the process. For example, `SIGFPE`.
 
 If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
 
@@ -278,7 +278,7 @@ If a signal terminated the process, this property is defined and included in the
 
 Type: `string | undefined`
 
-A human-friendly description of the signal that was used to terminate the process. For example `"Floating point arithmetic error"`.
+A human-friendly description of the signal that was used to terminate the process. For example, `Floating point arithmetic error`.
 
 If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
 

--- a/test/error.js
+++ b/test/error.js
@@ -133,6 +133,15 @@ if (process.platform !== 'win32') {
 		t.is(signal, 'SIGINT');
 	});
 
+	test('error.signalDescription is defined', async t => {
+		const cp = execa('noop');
+
+		process.kill(cp.pid, 'SIGINT');
+
+		const {signalDescription} = await t.throwsAsync(cp, {message: /User interruption with CTRL-C/});
+		t.is(signalDescription, 'User interruption with CTRL-C');
+	});
+
 	test('error.signal is SIGTERM', async t => {
 		const subprocess = execa('noop');
 
@@ -165,6 +174,11 @@ test('result.signal is undefined for successful execution', async t => {
 test('result.signal is undefined if process failed, but was not killed', async t => {
 	const {signal} = await t.throwsAsync(execa('exit', [2]), {message: getExitRegExp('2')});
 	t.is(signal, undefined);
+});
+
+test('result.signalDescription is undefined for successful execution', async t => {
+	const {signalDescription} = await execa('noop');
+	t.is(signalDescription, undefined);
 });
 
 test('error.code is undefined on success', async t => {

--- a/test/error.js
+++ b/test/error.js
@@ -134,11 +134,11 @@ if (process.platform !== 'win32') {
 	});
 
 	test('error.signalDescription is defined', async t => {
-		const cp = execa('noop');
+		const subprocess = execa('noop');
 
-		process.kill(cp.pid, 'SIGINT');
+		process.kill(subprocess.pid, 'SIGINT');
 
-		const {signalDescription} = await t.throwsAsync(cp, {message: /User interruption with CTRL-C/});
+		const {signalDescription} = await t.throwsAsync(subprocess, {message: /User interruption with CTRL-C/});
 		t.is(signalDescription, 'User interruption with CTRL-C');
 	});
 


### PR DESCRIPTION
At the moment we set `error.signal` to either `undefined` or the signal that terminated a process such as `"SIGFPE"`. This PR adds `error.signalDescription` which is a human-friendly description of that signal such as `"Floating point arithmetic error"`.

This also enhances error messages accordingly such as:

```
Command was killed with SIGFPE (Floating point arithmetic error)
```

instead of:

```
Command was killed with SIGFPE
```

This uses [`human-signals`](https://github.com/ehmicky/human-signals), a library I wrote which exports a simple plain object where the key is the signal name and the value the signal description. This works cross-platform.