### PR TITLE
Rename internal variables

### DIFF
--- a/test/error.js
+++ b/test/error.js
@@ -70,22 +70,22 @@ test('failed is true on failure', async t => {
 });
 
 test('error.killed is true if process was killed directly', async t => {
-	const cp = execa('noop');
+	const subprocess = execa('noop');
 
-	cp.kill();
+	subprocess.kill();
 
-	const {killed} = await t.throwsAsync(cp, {message: /was killed with SIGTERM/});
+	const {killed} = await t.throwsAsync(subprocess, {message: /was killed with SIGTERM/});
 	t.true(killed);
 });
 
 test('error.killed is false if process was killed indirectly', async t => {
-	const cp = execa('noop');
+	const subprocess = execa('noop');
 
-	process.kill(cp.pid, 'SIGINT');
+	process.kill(subprocess.pid, 'SIGINT');
 
 	// `process.kill()` is emulated by Node.js on Windows
 	const message = process.platform === 'win32' ? /failed with exit code 1/ : /was killed with SIGINT/;
-	const {killed} = await t.throwsAsync(cp, {message});
+	const {killed} = await t.throwsAsync(subprocess, {message});
 	t.false(killed);
 });
 
@@ -125,20 +125,20 @@ if (process.platform === 'darwin') {
 
 if (process.platform !== 'win32') {
 	test('error.signal is SIGINT', async t => {
-		const cp = execa('noop');
+		const subprocess = execa('noop');
 
-		process.kill(cp.pid, 'SIGINT');
+		process.kill(subprocess.pid, 'SIGINT');
 
-		const {signal} = await t.throwsAsync(cp, {message: /was killed with SIGINT/});
+		const {signal} = await t.throwsAsync(subprocess, {message: /was killed with SIGINT/});
 		t.is(signal, 'SIGINT');
 	});
 
 	test('error.signal is SIGTERM', async t => {
-		const cp = execa('noop');
+		const subprocess = execa('noop');
 
-		process.kill(cp.pid, 'SIGTERM');
+		process.kill(subprocess.pid, 'SIGTERM');
 
-		const {signal} = await t.throwsAsync(cp, {message: /was killed with SIGTERM/});
+		const {signal} = await t.throwsAsync(subprocess, {message: /was killed with SIGTERM/});
 		t.is(signal, 'SIGTERM');
 	});
 
@@ -148,11 +148,11 @@ if (process.platform !== 'win32') {
 	});
 
 	test('exitCode is undefined on signal termination', async t => {
-		const cp = execa('noop');
+		const subprocess = execa('noop');
 
-		process.kill(cp.pid);
+		process.kill(subprocess.pid);
 
-		const {exitCode} = await t.throwsAsync(cp);
+		const {exitCode} = await t.throwsAsync(subprocess);
 		t.is(exitCode, undefined);
 	});
 }

--- a/test/kill.js
+++ b/test/kill.js
@@ -176,17 +176,17 @@ test('spawnAndKill cleanup detached SIGKILL', spawnAndKill, 'SIGKILL', true, tru
 // See #128
 test('removes exit handler on exit', async t => {
 	// FIXME: This relies on `signal-exit` internals
-	const ee = process.__signal_exit_emitter__;
+	const emitter = process.__signal_exit_emitter__;
 
-	const child = execa('noop');
-	const listener = ee.listeners('exit').pop();
+	const subprocess = execa('noop');
+	const listener = emitter.listeners('exit').pop();
 
 	await new Promise((resolve, reject) => {
-		child.on('error', reject);
-		child.on('exit', resolve);
+		subprocess.on('error', reject);
+		subprocess.on('exit', resolve);
 	});
 
-	const included = ee.listeners('exit').includes(listener);
+	const included = emitter.listeners('exit').includes(listener);
 	t.false(included);
 });
 

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import stream from 'stream';
+import Stream from 'stream';
 import test from 'ava';
 import getStream from 'get-stream';
 import tempfile from 'tempfile';
@@ -61,17 +61,17 @@ test('input option can be a Buffer', async t => {
 });
 
 test('input can be a Stream', async t => {
-	const s = new stream.PassThrough();
-	s.write('howdy');
-	s.end();
-	const {stdout} = await execa('stdin', {input: s});
+	const stream = new Stream.PassThrough();
+	stream.write('howdy');
+	stream.end();
+	const {stdout} = await execa('stdin', {input: stream});
 	t.is(stdout, 'howdy');
 });
 
 test('you can write to child.stdin', async t => {
-	const child = execa('stdin');
-	child.stdin.end('unicorns');
-	t.is((await child).stdout, 'unicorns');
+	const subprocess = execa('stdin');
+	subprocess.stdin.end('unicorns');
+	t.is((await subprocess).stdout, 'unicorns');
 });
 
 test('input option can be a String - sync', t => {
@@ -95,7 +95,7 @@ test('opts.stdout:ignore - stdout will not collect data', async t => {
 test('helpful error trying to provide an input stream in sync mode', t => {
 	t.throws(
 		() => {
-			execa.sync('stdin', {input: new stream.PassThrough()});
+			execa.sync('stdin', {input: new Stream.PassThrough()});
 		},
 		/The `input` option cannot be a stream in sync mode/
 	);
@@ -152,21 +152,21 @@ test('buffer: false > promise resolves when output is big but is not pipable', a
 });
 
 test('buffer: false > promise resolves when output is big and is read', async t => {
-	const cp = execa('max-buffer', {buffer: false});
-	cp.stdout.resume();
-	cp.stderr.resume();
-	await t.notThrowsAsync(cp);
+	const subprocess = execa('max-buffer', {buffer: false});
+	subprocess.stdout.resume();
+	subprocess.stderr.resume();
+	await t.notThrowsAsync(subprocess);
 });
 
 test('buffer: false > promise resolves when output is big and "all" is used and is read', async t => {
-	const cp = execa('max-buffer', {buffer: false, all: true});
-	cp.all.resume();
-	await t.notThrowsAsync(cp);
+	const subprocess = execa('max-buffer', {buffer: false, all: true});
+	subprocess.all.resume();
+	await t.notThrowsAsync(subprocess);
 });
 
 test('buffer: false > promise rejects when process returns non-zero', async t => {
-	const cp = execa('fail', {buffer: false});
-	const {exitCode} = await t.throwsAsync(cp);
+	const subprocess = execa('fail', {buffer: false});
+	const {exitCode} = await t.throwsAsync(subprocess);
 	t.is(exitCode, 2);
 });
 
@@ -180,10 +180,10 @@ if (process.platform !== 'win32') {
 	});
 
 	test.serial('buffer: false > promise does not resolve when output is big and "all" is used but not read', async t => {
-		const cp = execa('max-buffer', {buffer: false, all: true, timeout: BUFFER_TIMEOUT});
-		cp.stdout.resume();
-		cp.stderr.resume();
-		const {timedOut} = await t.throwsAsync(cp);
+		const subprocess = execa('max-buffer', {buffer: false, all: true, timeout: BUFFER_TIMEOUT});
+		subprocess.stdout.resume();
+		subprocess.stderr.resume();
+		const {timedOut} = await t.throwsAsync(subprocess);
 		t.true(timedOut);
 	});
 }

--- a/test/test.js
+++ b/test/test.js
@@ -100,21 +100,21 @@ test('execPath option', async t => {
 });
 
 test('stdin errors are handled', async t => {
-	const child = execa('noop');
-	child.stdin.emit('error', new Error('test'));
-	await t.throwsAsync(child, /test/);
+	const subprocess = execa('noop');
+	subprocess.stdin.emit('error', new Error('test'));
+	await t.throwsAsync(subprocess, /test/);
 });
 
 test('child process errors are handled', async t => {
-	const child = execa('noop');
-	child.emit('error', new Error('test'));
-	await t.throwsAsync(child, /test/);
+	const subprocess = execa('noop');
+	subprocess.emit('error', new Error('test'));
+	await t.throwsAsync(subprocess, /test/);
 });
 
 test('child process errors rejects promise right away', async t => {
-	const child = execa('noop');
-	child.emit('error', new Error('test'));
-	await t.throwsAsync(child, /test/);
+	const subprocess = execa('noop');
+	subprocess.emit('error', new Error('test'));
+	await t.throwsAsync(subprocess, /test/);
 });
 
 test('execa() returns a promise with pid', t => {
@@ -123,11 +123,11 @@ test('execa() returns a promise with pid', t => {
 });
 
 test('child_process.spawn() propagated errors have correct shape', t => {
-	const cp = execa('noop', {uid: -1});
+	const subprocess = execa('noop', {uid: -1});
 	t.notThrows(() => {
-		cp.catch(() => {});
-		cp.unref();
-		cp.on('error', () => {});
+		subprocess.catch(() => {});
+		subprocess.unref();
+		subprocess.on('error', () => {});
 	});
 });
 
@@ -144,9 +144,9 @@ test('child_process.spawnSync() errors are propagated with a correct shape', t =
 });
 
 test('do not try to consume streams twice', async t => {
-	const cp = execa('noop', ['foo']);
-	t.is((await cp).stdout, 'foo');
-	t.is((await cp).stdout, 'foo');
+	const subprocess = execa('noop', ['foo']);
+	t.is((await subprocess).stdout, 'foo');
+	t.is((await subprocess).stdout, 'foo');
 });
 
 test('use relative path with \'..\' chars', async t => {
@@ -157,8 +157,8 @@ test('use relative path with \'..\' chars', async t => {
 
 if (process.platform !== 'win32') {
 	test('execa() rejects if running non-executable', async t => {
-		const cp = execa('non-executable');
-		await t.throwsAsync(cp);
+		const subprocess = execa('non-executable');
+		await t.throwsAsync(subprocess);
 	});
 
 	test('execa() rejects with correct error and doesn\'t throw if running non-executable with input', async t => {


### PR DESCRIPTION
This renames internal variables used in tests to make them more consistent and avoid abbreviations:
  - `child`, `cp` -> `subprocess`
  - `s` -> `stream`
  - `ee` -> `emitter`