### PR TITLE
Allow setting the `windowsHide` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -198,6 +198,13 @@ declare namespace execa {
 		@default false
 		*/
 		readonly windowsVerbatimArguments?: boolean;
+
+		/**
+		On Windows, do not create a new console window. However this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
+
+		@default true
+		*/
+		readonly windowsHide?: boolean;
 	}
 
 	interface Options<EncodingType = string> extends CommonOptions<EncodingType> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -200,7 +200,7 @@ declare namespace execa {
 		readonly windowsVerbatimArguments?: boolean;
 
 		/**
-		On Windows, do not create a new console window. However this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
+		On Windows, do not create a new console window. Please note this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
 
 		@default true
 		*/

--- a/index.js
+++ b/index.js
@@ -42,8 +42,8 @@ const handleArgs = (file, args, options = {}) => {
 		reject: true,
 		cleanup: true,
 		all: false,
-		...options,
-		windowsHide: true
+		windowsHide: true,
+		...options
 	};
 
 	options.env = getEnv(options);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -125,6 +125,7 @@ execa('unicorns', {maxBuffer: 1000});
 execa('unicorns', {killSignal: 'SIGTERM'});
 execa('unicorns', {killSignal: 9});
 execa('unicorns', {windowsVerbatimArguments: true});
+execa('unicorns', {windowsHide: false});
 execa('unicorns').kill();
 execa('unicorns').kill('SIGKILL');
 execa('unicorns').kill(undefined);

--- a/readme.md
+++ b/readme.md
@@ -497,7 +497,7 @@ If `true`, no quoting or escaping of arguments is done on Windows. Ignored on ot
 Type: `boolean`<br>
 Default: `true`
 
-On Windows, do not create a new console window. However this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
+On Windows, do not create a new console window. Please note this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
 
 #### nodePath *(for `.node()` only)*
 

--- a/readme.md
+++ b/readme.md
@@ -492,6 +492,13 @@ Default: `false`
 
 If `true`, no quoting or escaping of arguments is done on Windows. Ignored on other platforms. This is set to `true` automatically when the `shell` option is `true`.
 
+#### windowsHide
+
+Type: `boolean`<br>
+Default: `true`
+
+On Windows, do not create a new console window. However this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
+
 #### nodePath *(for `.node()` only)*
 
 Type: `string`<br>


### PR DESCRIPTION
Fixes #371. 

At the moment, we force the `windowsHide` option to be `true`. However this prevents `CTRL-C` from working on Windows. 

This PR allows `windowsHide` to be set to `false`. It keeps the default value as `true`.