### PR TITLE
Add `serialization` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -140,7 +140,7 @@ declare namespace execa {
 			- `json`: uses `JSON.serialize()`
 			- `advanced`: uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
 
-		See more information [here](https://nodejs.org/api/child_process.html#child_process_advanced_serialization).
+		[More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization).
 
 		@default 'json'
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -138,7 +138,7 @@ declare namespace execa {
 		/**
 		When using the `stdio: 'ipc'` option or `execa.node()`, how messages passed to [`childProcess.send()`](https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback) are serialized:
 			- `json`: uses `JSON.serialize()`
-			- `advanced`: uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
+			- `advanced`: Uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
 
 		[More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization).
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,7 +137,7 @@ declare namespace execa {
 
 		/**
 		When using the `stdio: 'ipc'` option or `execa.node()`, how messages passed to [`childProcess.send()`](https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback) are serialized:
-			- `json`: uses `JSON.serialize()`
+			- `json`: Uses `JSON.stringify()` and `JSON.parse()`.
 			- `advanced`: Uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
 
 		[More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization).

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,6 +136,17 @@ declare namespace execa {
 		readonly stdio?: 'pipe' | 'ignore' | 'inherit' | readonly StdioOption[];
 
 		/**
+		When using the `stdio: 'ipc'` option or `execa.node()`, how messages passed to [`childProcess.send()`](https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback) are serialized:
+			- `json`: uses `JSON.serialize()`
+			- `advanced`: uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
+
+		See more information [here](https://nodejs.org/api/child_process.html#child_process_advanced_serialization).
+
+		@default 'json'
+		*/
+		readonly serialization?: 'json' | 'advanced';
+
+		/**
 		Prepare child to run independently of its parent process. Specific behavior [depends on the platform](https://nodejs.org/api/child_process.html#child_process_options_detached).
 
 		@default false

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,11 +136,13 @@ declare namespace execa {
 		readonly stdio?: 'pipe' | 'ignore' | 'inherit' | readonly StdioOption[];
 
 		/**
-		When using the `stdio: 'ipc'` option or `execa.node()`, how messages passed to [`childProcess.send()`](https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback) are serialized:
+		Specify the kind of serialization used for sending messages between processes when using the `stdio: 'ipc'` option or `execa.node()`:
 			- `json`: Uses `JSON.stringify()` and `JSON.parse()`.
 			- `advanced`: Uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
 
-		[More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization).
+		Requires Node.js `13.2.0` or later.
+
+		[More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization)
 
 		@default 'json'
 		*/

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -115,6 +115,7 @@ execa('unicorns', {stdio: 'inherit'});
 execa('unicorns', {
 	stdio: ['pipe', 'ipc', 'ignore', 'inherit', process.stdin, 1, undefined]
 });
+execa('unicorns', {serialization: 'advanced'});
 execa('unicorns', {detached: true});
 execa('unicorns', {uid: 0});
 execa('unicorns', {gid: 0});

--- a/readme.md
+++ b/readme.md
@@ -457,7 +457,7 @@ Type: `string`<br>
 Default: `'json'`
 
 When using the [`stdio: 'ipc'`](#stdio) option or [`execa.node()`](#execanodescriptpath-arguments-options), how messages passed to [`childProcess.send()`](https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback) are serialized:
-  - `json`: uses `JSON.serialize()`
+	- `json`: uses `JSON.serialize()`
 	- `advanced`: uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
 
 See more information [here](https://nodejs.org/api/child_process.html#child_process_advanced_serialization).

--- a/readme.md
+++ b/readme.md
@@ -456,11 +456,13 @@ Child's [stdio](https://nodejs.org/api/child_process.html#child_process_options_
 Type: `string`<br>
 Default: `'json'`
 
-When using the [`stdio: 'ipc'`](#stdio) option or [`execa.node()`](#execanodescriptpath-arguments-options), how messages passed to [`childProcess.send()`](https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback) are serialized:
-	- `json`: uses `JSON.serialize()`
-	- `advanced`: uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
+Specify the kind of serialization used for sending messages between processes when using the [`stdio: 'ipc'`](#stdio) option or [`execa.node()`](#execanodescriptpath-arguments-options):
+	- `json`: Uses `JSON.stringify()` and `JSON.parse()`.
+	- `advanced`: Uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
 
-See more information [here](https://nodejs.org/api/child_process.html#child_process_advanced_serialization).
+Requires Node.js `13.2.0` or later.
+
+[More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization)
 
 #### detached
 

--- a/readme.md
+++ b/readme.md
@@ -451,6 +451,17 @@ Default: `pipe`
 
 Child's [stdio](https://nodejs.org/api/child_process.html#child_process_options_stdio) configuration.
 
+#### serialization
+
+Type: `string`<br>
+Default: `json`
+
+When using the [`stdio: 'ipc'`](#stdio) option or [`execa.node()`](#execanodescriptpath-arguments-options), how messages passed to [`childProcess.send()`](https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback) are serialized:
+  - `json`: uses `JSON.serialize()`
+	- `advanced`: uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
+
+See more information [here](https://nodejs.org/api/child_process.html#child_process_advanced_serialization).
+
 #### detached
 
 Type: `boolean`

--- a/readme.md
+++ b/readme.md
@@ -454,7 +454,7 @@ Child's [stdio](https://nodejs.org/api/child_process.html#child_process_options_
 #### serialization
 
 Type: `string`<br>
-Default: `json`
+Default: `'json'`
 
 When using the [`stdio: 'ipc'`](#stdio) option or [`execa.node()`](#execanodescriptpath-arguments-options), how messages passed to [`childProcess.send()`](https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback) are serialized:
   - `json`: uses `JSON.serialize()`


### PR DESCRIPTION
Node `13.2.0` added support for [an additional option](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) in `child_process.spawn()` called `serialization`.

This PR adds TypeScript types and documentation for it.