### PR TITLE
Add documentation link to nvexeca

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -617,6 +617,7 @@ const subprocess = execa(binPath);
 ## Related
 
 - [gulp-execa](https://github.com/ehmicky/gulp-execa) - Gulp plugin for `execa`
+- [nvexeca](https://github.com/ehmicky/nvexeca) - Run `execa` using any Node.js version
 
 
 ## Maintainers


### PR DESCRIPTION
This adds a link to nvexeca in the `Related` section.

[nvexeca](https://github.com/ehmicky/nvexeca) is a thin wrapper around Execa which adds the possibility to choose a Node.js version to run the command.

In a nutshell it simply: 
  - downloads the Node.js binary from https://nodejs.org (unless already cached)
  - then calls `execa(command, args, { execPath: nodeBinaryPath })`

Instead of:

```js
const execa = require('execa')
execa(command, args, options)
```

One would do (to run Node 10):

```js
const nvexeca = require('nvexeca')
nvexeca('10', command, args, options)
```