### PR TITLE
Is it not possible to kill shelled process?

### DIFF
--- a/test/kill.js
+++ b/test/kill.js
@@ -19,6 +19,27 @@ test('kill("SIGKILL") should terminate cleanly', async t => {
 	t.false(isRunning(subprocess.pid));
 });
 
+// `sleep` is a Linux command so these tests do not make sense on Windows.
+if (process.platform !== 'win32') {
+	test('`kill` should kill a process cleanly', async t => {
+		const subprocess = execa('sleep', ['200'], { stdio: ['ipc'] });
+
+		subprocess.kill('SIGTERM', { forceKillAfterTimeout: 2000 });
+
+		await t.throwsAsync(subprocess);
+		t.false(isRunning(subprocess.pid));
+	});
+
+	test('`kill` should kill a shell process cleanly', async t => {
+		const subprocess = execa('sleep', ['200'], { shell: true, stdio: ['ipc'] });
+
+		subprocess.kill('SIGTERM', { forceKillAfterTimeout: 2000 });
+
+		await t.throwsAsync(subprocess);
+		t.false(isRunning(subprocess.pid));
+	})
+}
+
 // `SIGTERM` cannot be caught on Windows, and it always aborts the process (like `SIGKILL` on Unix).
 // Therefore, this feature and those tests do not make sense on Windows.
 if (process.platform !== 'win32') {

--- a/test/kill.js
+++ b/test/kill.js
@@ -16,6 +16,7 @@ test('kill("SIGKILL") should terminate cleanly', async t => {
 
 	const {signal} = await t.throwsAsync(subprocess);
 	t.is(signal, 'SIGKILL');
+	t.false(isRunning(subprocess.pid));
 });
 
 // `SIGTERM` cannot be caught on Windows, and it always aborts the process (like `SIGKILL` on Unix).


### PR DESCRIPTION
It seems to me that a process started with `shell:true` don't always get killed properly.

Here I've added tests that uses Linux's sleep, and killing the non-shell version works fine but the shelled version hangs the test-suite for the 200 seconds. The sleep sits in the process list, unkilled.

Is this expected behaviour? To my understanding a shelled process should receive signals just as well as any other process, but happy to learn otherwise.