### PR TITLE
Fix checking for `Error` instances

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -48,10 +48,11 @@ const makeError = ({
 
 	const prefix = getErrorPrefix({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled});
 	const execaMessage = `Command ${prefix}: ${command}`;
-	const shortMessage = error instanceof Error ? `${execaMessage}\n${error.message}` : execaMessage;
+	const isError = Object.prototype.toString.call(error) === '[object Error]';
+	const shortMessage = isError ? `${execaMessage}\n${error.message}` : execaMessage;
 	const message = [shortMessage, stderr, stdout].filter(Boolean).join('\n');
 
-	if (error instanceof Error) {
+	if (isError) {
 		error.originalMessage = error.message;
 		error.message = message;
 	} else {


### PR DESCRIPTION
Fixes #422.

`value instanceof Error` does not work across realms.