### PR TITLE
Fix use of floating number for the `timeout` and `forceKillAfterTimeout` options

### DIFF
--- a/lib/kill.js
+++ b/lib/kill.js
@@ -71,7 +71,7 @@ const setupTimeout = (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise
 		return spawnedPromise;
 	}
 
-	if (Number.isFinite(number) || timeout < 0) {
+	if (!Number.isFinite(number) || timeout < 0) {
 		throw new TypeError(`Expected the \`timeout\` option to be a non-negative integer, got \`${timeout}\` (${typeof timeout})`);
 	}
 

--- a/lib/kill.js
+++ b/lib/kill.js
@@ -44,7 +44,7 @@ const getForceKillAfterTimeout = ({forceKillAfterTimeout = true}) => {
 		return DEFAULT_FORCE_KILL_TIMEOUT;
 	}
 
-	if (typeof forceKillAfterTimeout !== 'number' || forceKillAfterTimeout < 0) {
+	if (Number.isFinite(forceKillAfterTimeout) || forceKillAfterTimeout < 0) {
 		throw new TypeError(`Expected the \`forceKillAfterTimeout\` option to be a non-negative integer, got \`${forceKillAfterTimeout}\` (${typeof forceKillAfterTimeout})`);
 	}
 
@@ -71,7 +71,7 @@ const setupTimeout = (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise
 		return spawnedPromise;
 	}
 
-	if (typeof timeout !== 'number' || timeout < 0) {
+	if (Number.isFinite(number) || timeout < 0) {
 		throw new TypeError(`Expected the \`timeout\` option to be a non-negative integer, got \`${timeout}\` (${typeof timeout})`);
 	}
 

--- a/lib/kill.js
+++ b/lib/kill.js
@@ -44,7 +44,7 @@ const getForceKillAfterTimeout = ({forceKillAfterTimeout = true}) => {
 		return DEFAULT_FORCE_KILL_TIMEOUT;
 	}
 
-	if (Number.isFinite(forceKillAfterTimeout) || forceKillAfterTimeout < 0) {
+	if (!Number.isFinite(forceKillAfterTimeout) || forceKillAfterTimeout < 0) {
 		throw new TypeError(`Expected the \`forceKillAfterTimeout\` option to be a non-negative integer, got \`${forceKillAfterTimeout}\` (${typeof forceKillAfterTimeout})`);
 	}
 

--- a/lib/kill.js
+++ b/lib/kill.js
@@ -44,7 +44,7 @@ const getForceKillAfterTimeout = ({forceKillAfterTimeout = true}) => {
 		return DEFAULT_FORCE_KILL_TIMEOUT;
 	}
 
-	if (!Number.isInteger(forceKillAfterTimeout) || forceKillAfterTimeout < 0) {
+	if (typeof forceKillAfterTimeout !== 'number' || forceKillAfterTimeout < 0) {
 		throw new TypeError(`Expected the \`forceKillAfterTimeout\` option to be a non-negative integer, got \`${forceKillAfterTimeout}\` (${typeof forceKillAfterTimeout})`);
 	}
 
@@ -71,7 +71,7 @@ const setupTimeout = (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise
 		return spawnedPromise;
 	}
 
-	if (!Number.isInteger(timeout) || timeout < 0) {
+	if (typeof timeout !== 'number' || timeout < 0) {
 		throw new TypeError(`Expected the \`timeout\` option to be a non-negative integer, got \`${timeout}\` (${typeof timeout})`);
 	}
 

--- a/lib/kill.js
+++ b/lib/kill.js
@@ -71,7 +71,7 @@ const setupTimeout = (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise
 		return spawnedPromise;
 	}
 
-	if (!Number.isFinite(number) || timeout < 0) {
+	if (!Number.isFinite(timeout) || timeout < 0) {
 		throw new TypeError(`Expected the \`timeout\` option to be a non-negative integer, got \`${timeout}\` (${typeof timeout})`);
 	}
 

--- a/test/kill.js
+++ b/test/kill.js
@@ -66,6 +66,12 @@ if (process.platform !== 'win32') {
 			execa('noop').kill('SIGTERM', {forceKillAfterTimeout: NaN});
 		}, {instanceOf: TypeError, message: /non-negative integer/});
 	});
+
+	test('`forceKillAfterTimeout` should not be negative', t => {
+		t.throws(() => {
+			execa('noop').kill('SIGTERM', {forceKillAfterTimeout: -1});
+		}, {instanceOf: TypeError, message: /non-negative integer/});
+	});
 }
 
 test('execa() returns a promise with kill()', t => {

--- a/test/kill.js
+++ b/test/kill.js
@@ -61,15 +61,9 @@ if (process.platform !== 'win32') {
 		t.is(signal, 'SIGKILL');
 	});
 
-	test('`forceKillAfterTimeout` should not be a float', t => {
+	test('`forceKillAfterTimeout` should not be NaN', t => {
 		t.throws(() => {
-			execa('noop').kill('SIGTERM', {forceKillAfterTimeout: 0.5});
-		}, {instanceOf: TypeError, message: /non-negative integer/});
-	});
-
-	test('`forceKillAfterTimeout` should not be negative', t => {
-		t.throws(() => {
-			execa('noop').kill('SIGTERM', {forceKillAfterTimeout: -1});
+			execa('noop').kill('SIGTERM', {forceKillAfterTimeout: NaN});
 		}, {instanceOf: TypeError, message: /non-negative integer/});
 	});
 }


### PR DESCRIPTION
When the `timeout` or `forceKillAfterTimeout` a float number is causes an error that can be avoided