### PR TITLE
Remove `--inspect` & `--inspect-brk` from `execArgv`

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,20 +234,7 @@ module.exports.node = (scriptPath, args, options = {}) => {
 	}
 
 	const stdio = normalizeStdio.node(options);
-
-	// Filter out `--inspect` & `--inspect-brk` from default `execArgv`.
-	const defaultExecArgv = process.execArgv.filter(arg => {
-		if (
-			arg === '--inspect' ||
-			arg.startsWith('--inspect=') ||
-			arg === '--inspect-brk' ||
-			arg.startsWith('--inspect-brk=')
-		) {
-			return false;
-		}
-
-		return true;
-	});
+	const defaultExecArgv = process.execArgv.filter(arg => !arg.startsWith('--inspect'));
 
 	const {
 		nodePath = process.execPath,

--- a/index.js
+++ b/index.js
@@ -234,8 +234,24 @@ module.exports.node = (scriptPath, args, options = {}) => {
 	}
 
 	const stdio = normalizeStdio.node(options);
+	// Filter out --inspect & --inspect-brk from default execArgv
+	const defaultExecArgv = process.execArgv.filter(arg => {
+		if (
+			arg === '--inspect' ||
+			arg.startsWith('--inspect=') ||
+			arg === '--inspect-brk' ||
+			arg.startsWith('--inspect-brk=')
+		) {
+			return false;
+		}
 
-	const {nodePath = process.execPath, nodeOptions = process.execArgv} = options;
+		return true;
+	});
+
+	const {
+		nodePath = process.execPath,
+		nodeOptions = defaultExecArgv
+	} = options;
 
 	return execa(
 		nodePath,

--- a/index.js
+++ b/index.js
@@ -234,7 +234,8 @@ module.exports.node = (scriptPath, args, options = {}) => {
 	}
 
 	const stdio = normalizeStdio.node(options);
-	// Filter out --inspect & --inspect-brk from default execArgv
+
+	// Filter out `--inspect` & `--inspect-brk` from default `execArgv`.
 	const defaultExecArgv = process.execArgv.filter(arg => {
 		if (
 			arg === '--inspect' ||

--- a/test/node.js
+++ b/test/node.js
@@ -13,7 +13,7 @@ async function inspectMacro(t, input) {
 			reject: false
 		});
 
-		const {stdout, stderr} = await subprocess
+		const {stdout, stderr} = await subprocess;
 
 		t.is(stdout, 'foo');
 		t.is(stderr, '');
@@ -57,7 +57,7 @@ test('node pass on nodeOptions', async t => {
 test.serial(
 	'node removes --inspect from nodeOptions when defined by parent process',
 	inspectMacro,
-  `--inspect`
+	'--inspect'
 );
 
 test.serial(

--- a/test/node.js
+++ b/test/node.js
@@ -3,7 +3,8 @@ import test from 'ava';
 import pEvent from 'p-event';
 import execa from '..';
 
-process.env.PATH = path.join(__dirname, 'fixtures') + path.delimiter + process.env.PATH;
+process.env.PATH =
+	path.join(__dirname, 'fixtures') + path.delimiter + process.env.PATH;
 
 test('node()', async t => {
 	const {exitCode} = await execa.node('test/fixtures/noop');
@@ -19,11 +20,14 @@ test('node pipe stdout', async t => {
 });
 
 test('node correctly use nodePath', async t => {
-	const {stdout} = await execa.node(process.platform === 'win32' ? 'hello.cmd' : 'hello.sh', {
-		stdout: 'pipe',
-		nodePath: process.platform === 'win32' ? 'cmd.exe' : 'bash',
-		nodeOptions: process.platform === 'win32' ? ['/c'] : []
-	});
+	const {stdout} = await execa.node(
+		process.platform === 'win32' ? 'hello.cmd' : 'hello.sh',
+		{
+			stdout: 'pipe',
+			nodePath: process.platform === 'win32' ? 'cmd.exe' : 'bash',
+			nodeOptions: process.platform === 'win32' ? ['/c'] : []
+		}
+	);
 
 	t.is(stdout, 'Hello World');
 });
@@ -36,6 +40,94 @@ test('node pass on nodeOptions', async t => {
 
 	t.is(stdout, 'foo');
 });
+
+test.serial(
+	'node removes --inspect from nodeOptions when defined by parent process',
+	async t => {
+		const originalArgv = process.execArgv;
+		process.execArgv = ['--inspect', '-e'];
+		const {stdout, stderr} = await execa.node('console.log("foo")', {
+			stdout: 'pipe'
+		});
+		process.execArgv = originalArgv;
+
+		t.is(stdout, 'foo');
+		t.is(stderr, '');
+	}
+);
+
+test.serial(
+	'node removes --inspect=9222 from nodeOptions when defined by parent process',
+	async t => {
+		const originalArgv = process.execArgv;
+		process.execArgv = ['--inspect=9222', '-e'];
+		const {stdout, stderr} = await execa.node('console.log("foo")', {
+			stdout: 'pipe'
+		});
+		process.execArgv = originalArgv;
+
+		t.is(stdout, 'foo');
+		t.is(stderr, '');
+	}
+);
+
+test.serial(
+	'node removes --inspect-brk from nodeOptions when defined by parent process',
+	async t => {
+		const originalArgv = process.execArgv;
+		process.execArgv = ['--inspect-brk', '-e'];
+		const childProc = execa.node('console.log("foo")', {
+			stdout: 'pipe'
+		});
+		process.execArgv = originalArgv;
+
+		setTimeout(() => {
+			childProc.cancel();
+		}, 1000);
+
+		const {stdout, stderr} = await childProc.catch(error => error);
+
+		t.is(stdout, 'foo');
+		t.is(stderr, '');
+	}
+);
+
+test.serial(
+	'node removes --inspect-brk=9222 from nodeOptions when defined by parent process',
+	async t => {
+		const originalArgv = process.execArgv;
+		process.execArgv = ['--inspect-brk=9222', '-e'];
+		const childProc = execa.node('console.log("foo")', {
+			stdout: 'pipe'
+		});
+		process.execArgv = originalArgv;
+
+		setTimeout(() => {
+			childProc.cancel();
+		}, 1000);
+
+		const {stdout, stderr} = await childProc.catch(error => error);
+
+		t.is(stdout, 'foo');
+		t.is(stderr, '');
+	}
+);
+
+test.serial(
+	'node should not remove --inspect when passed through nodeOptions',
+	async t => {
+		const {stdout, stderr} = await execa.node('console.log("foo")', {
+			stdout: 'pipe',
+			nodeOptions: ['--inspect', '-e']
+		});
+
+		t.is(stdout, 'foo');
+		t.regex(
+			stderr,
+			/^Debugger listening on ws:\/\/127.0.0.1:9229\/.*[\r\n]+For help, see: https:\/\/nodejs.org\/en\/docs\/inspector$/
+		);
+	}
+);
 
 test('node\'s forked script has a communication channel', async t => {
 	const subprocess = execa.node('test/fixtures/send');


### PR DESCRIPTION
When using `execa.node` and the parent process has --inspect or --inspect-brk defined, it will run the child process with those options as well. It will throw an error that the inspector already is running on port 9229.

I've added a filter for those options on the default execArgv value. I tried to test it but I'm not sure this is the correct way to do so.