### PR TITLE
Remove faulty emulated ENOENT error on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,8 +147,6 @@ const execa = (file, args, options) => {
 
 	const handlePromiseOnce = onetime(handlePromise);
 
-	crossSpawn._enoent.hookChildProcess(spawned, parsed.parsed);
-
 	handleInput(spawned, parsed.options.input);
 
 	spawned.all = makeAllStream(spawned, parsed.options);

--- a/test/error.js
+++ b/test/error.js
@@ -73,8 +73,8 @@ test('error.shortMessage does not contain stdout/stderr', async t => {
 });
 
 test('Original error.message is kept', async t => {
-	const {originalMessage} = await t.throwsAsync(execa('wrong command'));
-	t.is(originalMessage, 'spawn wrong command ENOENT');
+	const {originalMessage} = await t.throwsAsync(execa('noop', {cwd: 1}));
+	t.true(originalMessage.startsWith('The "options.cwd" property must be of type string. Received type number'));
 });
 
 test('failed is false on success', async t => {
@@ -205,6 +205,6 @@ test('error.code is undefined on success', async t => {
 });
 
 test('error.code is defined on failure if applicable', async t => {
-	const {code} = await t.throwsAsync(execa('invalid'));
-	t.is(code, 'ENOENT');
+	const {code} = await t.throwsAsync(execa('noop', {cwd: 1}));
+	t.is(code, 'ERR_INVALID_ARG_TYPE');
 });


### PR DESCRIPTION
## Old behavior

Prior to this PR, `execa` on Windows would emulate behavior seen on POSIX platforms where attempting to run a non-existent command would throw an error that had `code` set to `ENOENT`. However, this emulation worked incorrectly for many common cases (fixes #446 and moxystudio/node-cross-spawn#104), especially when the `shell` option is set to a truthy value.

## New behavior

There is no obvious way to fix the emulation of `ENOENT` on Windows in a reasonable way, so this PR removes it. That means that `execa` will no longer throw `ENOENT` on Windows, but still will on POSIX platforms.
After this PR is merged, when `execa` is given a non-existent command to run on Windows, `execa` will have the default Node.js `spawn` behavior of throwing an error that has `exitCode` set to `1` and any error message given by Windows will appear in the `stderr` output/stream.

## Detecting "command not found" on Windows

On English versions of Windows, the error message given by the OS looks similar to this:

```
'somebadcommand' is not recognized as an internal or external command,
operable program or batch file.
```

However, this message will likely be translated on non-English versions of Windows.

## Additional info

Prior to this PR, there were two failing test cases on Windows. Removing the faulty `ENOENT` emulation actually fixed those two test cases, but caused two new ones to break. I fixed both by inducing a different error.
