### PR TITLE
Run CI tests on Node 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 15
+          - 16
           - 14
           - 12
           - 10


### PR DESCRIPTION
This runs the CI tests on Node 16 instead of Node 15.

CI test are currently failing due to #462 and #463.