### PR TITLE
Fix `timeout` option validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const npmRunPath = require('npm-run-path');
 const onetime = require('onetime');
 const makeError = require('./lib/error');
 const normalizeStdio = require('./lib/stdio');
-const {spawnedKill, spawnedCancel, setupTimeout, setExitHandler} = require('./lib/kill');
+const {spawnedKill, spawnedCancel, setupTimeout, validateTimeout, setExitHandler} = require('./lib/kill');
 const {handleInput, getSpawnedResult, makeAllStream, validateInputSync} = require('./lib/stream');
 const {mergePromise, getSpawnedPromise} = require('./lib/promise');
 const {joinCommand, parseCommand} = require('./lib/command');
@@ -74,6 +74,8 @@ const handleOutput = (options, value, error) => {
 const execa = (file, args, options) => {
 	const parsed = handleArguments(file, args, options);
 	const command = joinCommand(file, args);
+
+	validateTimeout(parsed.options);
 
 	let spawned;
 	try {

--- a/lib/kill.js
+++ b/lib/kill.js
@@ -71,10 +71,6 @@ const setupTimeout = (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise
 		return spawnedPromise;
 	}
 
-	if (!Number.isFinite(timeout) || timeout < 0) {
-		throw new TypeError(`Expected the \`timeout\` option to be a non-negative integer, got \`${timeout}\` (${typeof timeout})`);
-	}
-
 	let timeoutId;
 	const timeoutPromise = new Promise((resolve, reject) => {
 		timeoutId = setTimeout(() => {
@@ -87,6 +83,12 @@ const setupTimeout = (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise
 	});
 
 	return Promise.race([timeoutPromise, safeSpawnedPromise]);
+};
+
+const validateTimeout = ({timeout}) => {
+	if (timeout !== undefined && (!Number.isFinite(timeout) || timeout < 0)) {
+		throw new TypeError(`Expected the \`timeout\` option to be a non-negative integer, got \`${timeout}\` (${typeof timeout})`);
+	}
 };
 
 // `cleanup` option handling
@@ -108,5 +110,6 @@ module.exports = {
 	spawnedKill,
 	spawnedCancel,
 	setupTimeout,
+	validateTimeout,
 	setExitHandler
 };


### PR DESCRIPTION
Before Node `15.13.0` ([link to PR](https://github.com/nodejs/node/pull/37256)), the `timeout` was only available in `execFile()` and `exec()` but not in `spawn()`, which is used by Execa.

Execa implemented its own `timeout` option to fix this. That option probably won't be needed after support for Node `15.13.0` is dropped.

In the meantime, the `timeout` option added to `child_process.spawn()` introduces the following inconsistent behavior in Execa depending on the Node.js version:
  - In Node `<15.13.0`, using an invalid `timeout` (such as a negative integer) will throw an exception, using Execa's validation logic
  - In Node `>=15.13.0`, it will return a rejected promise instead, using `child_process.spawn()` validation logic

This PR fixes this inconsistency by moving Execa's validation logic earlier, before `child_process.spawn()` is called.

CI tests are failing due to #462.