### PR TITLE
Fix randomly failing test

### DIFF
--- a/test/fixtures/detach
+++ b/test/fixtures/detach
@@ -3,6 +3,6 @@
 
 const execa = require('../..');
 
-const subprocess = execa('node', ['./test/fixtures/noop'], {detached: true});
+const subprocess = execa('node', ['./test/fixtures/forever'], {detached: true});
 console.log(subprocess.pid);
 process.exit();


### PR DESCRIPTION
One of the tests is randomly failing due to a race condition.

The test checks that if a process spawns a `detached` process, the `detached` process outlives its parent. However, the current `detached` process is short-lived, therefore it might have exited or not depending on timing. This results in this test failing randomly in CI.

CI Tests on Node 16 are failing due to #463.