### PR TITLE
Add `.escapedCommand` property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -259,7 +259,7 @@ declare namespace execa {
 		/**
 		Same as `command` but quoted so it can be run in most shells.
 		*/
-		debugString: string;
+		escapedCommand: string;
 
 		/**
 		The numeric exit code of the process that was run.

--- a/index.d.ts
+++ b/index.d.ts
@@ -261,7 +261,7 @@ declare namespace execa {
 		/**
 		Same as `command` but escaped.
 
-		This is meant to be copy/pasted in a shell, for debugging purpose.
+		This is meant to be copy and pasted into a shell, for debugging purposes.
 		Since the escaping is fairly basic, this should be passed to neither `execa()` nor `execa.command()`
 		*/
 		escapedCommand: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -254,7 +254,7 @@ declare namespace execa {
 		/**
 		The file and arguments that were run, for logging purposes.
 
-		This is not escaped and should be passed to neither `execa()` nor `execa.command()`
+		This is not escaped and should not be executed directly as a process, including using `execa()` or `execa.command()`.
 		*/
 		command: string;
 
@@ -262,7 +262,7 @@ declare namespace execa {
 		Same as `command` but escaped.
 
 		This is meant to be copy and pasted into a shell, for debugging purposes.
-		Since the escaping is fairly basic, this should be passed to neither `execa()` nor `execa.command()`
+		Since the escaping is fairly basic, this should not be executed directly as a process, including using `execa()` or `execa.command()`.
 		*/
 		escapedCommand: string;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -252,7 +252,7 @@ declare namespace execa {
 
 	interface ExecaReturnBase<StdoutStderrType> {
 		/**
-		The file and arguments that were run, for logging purpose.
+		The file and arguments that were run, for logging purposes.
 
 		This is not escaped and should be passed to neither `execa()` nor `execa.command()`
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -257,6 +257,11 @@ declare namespace execa {
 		command: string;
 
 		/**
+		Same as `command` but quoted so it can be run in most shells.
+		*/
+		debugString: string;
+
+		/**
 		The numeric exit code of the process that was run.
 		*/
 		exitCode: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -252,12 +252,17 @@ declare namespace execa {
 
 	interface ExecaReturnBase<StdoutStderrType> {
 		/**
-		The file and arguments that were run.
+		The file and arguments that were run, for logging purpose.
+
+		This is not escaped and should be passed to neither `execa()` nor `execa.command()`
 		*/
 		command: string;
 
 		/**
-		Same as `command` but quoted so it can be run in most shells.
+		Same as `command` but escaped.
+
+		This is meant to be copy/pasted in a shell, for debugging purpose.
+		Since the escaping is fairly basic, this should be passed to neither `execa()` nor `execa.command()`
 		*/
 		escapedCommand: string;
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const normalizeStdio = require('./lib/stdio');
 const {spawnedKill, spawnedCancel, setupTimeout, validateTimeout, setExitHandler} = require('./lib/kill');
 const {handleInput, getSpawnedResult, makeAllStream, validateInputSync} = require('./lib/stream');
 const {mergePromise, getSpawnedPromise} = require('./lib/promise');
-const {joinCommand, parseCommand} = require('./lib/command');
+const {joinCommand, parseCommand, getDebugString} = require('./lib/command');
 
 const DEFAULT_MAX_BUFFER = 1000 * 1000 * 100;
 
@@ -74,6 +74,7 @@ const handleOutput = (options, value, error) => {
 const execa = (file, args, options) => {
 	const parsed = handleArguments(file, args, options);
 	const command = joinCommand(file, args);
+	const debugString = getDebugString(file, args);
 
 	validateTimeout(parsed.options);
 
@@ -89,6 +90,7 @@ const execa = (file, args, options) => {
 			stderr: '',
 			all: '',
 			command,
+			debugString,
 			parsed,
 			timedOut: false,
 			isCanceled: false,
@@ -121,6 +123,7 @@ const execa = (file, args, options) => {
 				stderr,
 				all,
 				command,
+				debugString,
 				parsed,
 				timedOut,
 				isCanceled: context.isCanceled,
@@ -136,6 +139,7 @@ const execa = (file, args, options) => {
 
 		return {
 			command,
+			debugString,
 			exitCode: 0,
 			stdout,
 			stderr,
@@ -161,6 +165,7 @@ module.exports = execa;
 module.exports.sync = (file, args, options) => {
 	const parsed = handleArguments(file, args, options);
 	const command = joinCommand(file, args);
+	const debugString = getDebugString(file, args);
 
 	validateInputSync(parsed.options);
 
@@ -174,6 +179,7 @@ module.exports.sync = (file, args, options) => {
 			stderr: '',
 			all: '',
 			command,
+			debugString,
 			parsed,
 			timedOut: false,
 			isCanceled: false,
@@ -192,6 +198,7 @@ module.exports.sync = (file, args, options) => {
 			signal: result.signal,
 			exitCode: result.status,
 			command,
+			debugString,
 			parsed,
 			timedOut: result.error && result.error.code === 'ETIMEDOUT',
 			isCanceled: false,
@@ -207,6 +214,7 @@ module.exports.sync = (file, args, options) => {
 
 	return {
 		command,
+		debugString,
 		exitCode: 0,
 		stdout,
 		stderr,

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const normalizeStdio = require('./lib/stdio');
 const {spawnedKill, spawnedCancel, setupTimeout, validateTimeout, setExitHandler} = require('./lib/kill');
 const {handleInput, getSpawnedResult, makeAllStream, validateInputSync} = require('./lib/stream');
 const {mergePromise, getSpawnedPromise} = require('./lib/promise');
-const {joinCommand, parseCommand, getDebugString} = require('./lib/command');
+const {joinCommand, parseCommand, getEscapedCommand} = require('./lib/command');
 
 const DEFAULT_MAX_BUFFER = 1000 * 1000 * 100;
 
@@ -74,7 +74,7 @@ const handleOutput = (options, value, error) => {
 const execa = (file, args, options) => {
 	const parsed = handleArguments(file, args, options);
 	const command = joinCommand(file, args);
-	const debugString = getDebugString(file, args);
+	const escapedCommand = getEscapedCommand(file, args);
 
 	validateTimeout(parsed.options);
 
@@ -90,7 +90,7 @@ const execa = (file, args, options) => {
 			stderr: '',
 			all: '',
 			command,
-			debugString,
+			escapedCommand,
 			parsed,
 			timedOut: false,
 			isCanceled: false,
@@ -123,7 +123,7 @@ const execa = (file, args, options) => {
 				stderr,
 				all,
 				command,
-				debugString,
+				escapedCommand,
 				parsed,
 				timedOut,
 				isCanceled: context.isCanceled,
@@ -139,7 +139,7 @@ const execa = (file, args, options) => {
 
 		return {
 			command,
-			debugString,
+			escapedCommand,
 			exitCode: 0,
 			stdout,
 			stderr,
@@ -165,7 +165,7 @@ module.exports = execa;
 module.exports.sync = (file, args, options) => {
 	const parsed = handleArguments(file, args, options);
 	const command = joinCommand(file, args);
-	const debugString = getDebugString(file, args);
+	const escapedCommand = getEscapedCommand(file, args);
 
 	validateInputSync(parsed.options);
 
@@ -179,7 +179,7 @@ module.exports.sync = (file, args, options) => {
 			stderr: '',
 			all: '',
 			command,
-			debugString,
+			escapedCommand,
 			parsed,
 			timedOut: false,
 			isCanceled: false,
@@ -198,7 +198,7 @@ module.exports.sync = (file, args, options) => {
 			signal: result.signal,
 			exitCode: result.status,
 			command,
-			debugString,
+			escapedCommand,
 			parsed,
 			timedOut: result.error && result.error.code === 'ETIMEDOUT',
 			isCanceled: false,
@@ -214,7 +214,7 @@ module.exports.sync = (file, args, options) => {
 
 	return {
 		command,
-		debugString,
+		escapedCommand,
 		exitCode: 0,
 		stdout,
 		stderr,

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,6 +16,7 @@ try {
 
 	const unicornsResult = await execaPromise;
 	expectType<string>(unicornsResult.command);
+	expectType<string>(unicornsResult.debugString);
 	expectType<number>(unicornsResult.exitCode);
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.stderr);
@@ -47,6 +48,7 @@ try {
 try {
 	const unicornsResult = execa.sync('unicorns');
 	expectType<string>(unicornsResult.command);
+	expectType<string>(unicornsResult.debugString);
 	expectType<number>(unicornsResult.exitCode);
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.stderr);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,7 +16,7 @@ try {
 
 	const unicornsResult = await execaPromise;
 	expectType<string>(unicornsResult.command);
-	expectType<string>(unicornsResult.debugString);
+	expectType<string>(unicornsResult.escapedCommand);
 	expectType<number>(unicornsResult.exitCode);
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.stderr);
@@ -48,7 +48,7 @@ try {
 try {
 	const unicornsResult = execa.sync('unicorns');
 	expectType<string>(unicornsResult.command);
-	expectType<string>(unicornsResult.debugString);
+	expectType<string>(unicornsResult.escapedCommand);
 	expectType<number>(unicornsResult.exitCode);
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.stderr);

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,13 +1,32 @@
 'use strict';
-const SPACES_REGEXP = / +/g;
-
-const joinCommand = (file, args = []) => {
+const normalizeArgs = (file, args = []) => {
 	if (!Array.isArray(args)) {
-		return file;
+		return [file];
 	}
 
-	return [file, ...args].join(' ');
+	return [file, ...args];
 };
+
+const NO_ESCAPE_REGEXP = /^[\w.-]+$/;
+const DOUBLE_QUOTES_REGEXP = /"/g;
+
+const escapeArg = arg => {
+	if (NO_ESCAPE_REGEXP.test(arg)) {
+		return arg;
+	}
+
+	return `"${arg.replace(DOUBLE_QUOTES_REGEXP, '\\"')}"`;
+};
+
+const joinCommand = (file, args) => {
+	return normalizeArgs(file, args).join(' ');
+};
+
+const getDebugString = (file, args) => {
+	return normalizeArgs(file, args).map(arg => escapeArg(arg)).join(' ');
+};
+
+const SPACES_REGEXP = / +/g;
 
 // Handle `execa.command()`
 const parseCommand = command => {
@@ -28,5 +47,6 @@ const parseCommand = command => {
 
 module.exports = {
 	joinCommand,
+	getDebugString,
 	parseCommand
 };

--- a/lib/command.js
+++ b/lib/command.js
@@ -22,7 +22,7 @@ const joinCommand = (file, args) => {
 	return normalizeArgs(file, args).join(' ');
 };
 
-const getDebugString = (file, args) => {
+const getEscapedCommand = (file, args) => {
 	return normalizeArgs(file, args).map(arg => escapeArg(arg)).join(' ');
 };
 
@@ -47,6 +47,6 @@ const parseCommand = command => {
 
 module.exports = {
 	joinCommand,
-	getDebugString,
+	getEscapedCommand,
 	parseCommand
 };

--- a/lib/error.js
+++ b/lib/error.js
@@ -33,6 +33,7 @@ const makeError = ({
 	signal,
 	exitCode,
 	command,
+	debugString,
 	timedOut,
 	isCanceled,
 	killed,
@@ -61,6 +62,7 @@ const makeError = ({
 
 	error.shortMessage = shortMessage;
 	error.command = command;
+	error.debugString = debugString;
 	error.exitCode = exitCode;
 	error.signal = signal;
 	error.signalDescription = signalDescription;

--- a/lib/error.js
+++ b/lib/error.js
@@ -33,7 +33,7 @@ const makeError = ({
 	signal,
 	exitCode,
 	command,
-	debugString,
+	escapedCommand,
 	timedOut,
 	isCanceled,
 	killed,
@@ -62,7 +62,7 @@ const makeError = ({
 
 	error.shortMessage = shortMessage;
 	error.command = command;
-	error.debugString = debugString;
+	error.escapedCommand = escapedCommand;
 	error.exitCode = exitCode;
 	error.signal = signal;
 	error.signalDescription = signalDescription;

--- a/readme.md
+++ b/readme.md
@@ -236,7 +236,7 @@ The child process [fails](#failed) when:
 
 Type: `string`
 
-The file and arguments that were run, for logging purpose.
+The file and arguments that were run, for logging purposes.
 
 This is not escaped and should be passed to neither [`execa()`](#execafile-arguments-options) nor [`execa.command()`](#execacommandcommand-options).
 
@@ -246,7 +246,7 @@ Type: `string`
 
 Same as [`command`](#command) but escaped.
 
-This is meant to be copy/pasted in a shell, for debugging purpose.
+This is meant to be copy and pasted into a shell, for debugging purposes.
 Since the escaping is fairly basic, this should be passed to neither [`execa()`](#execafile-arguments-options) nor [`execa.command()`](#execacommandcommand-options).
 
 #### exitCode

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ const execa = require('execa');
 			originalMessage: 'spawn unknown ENOENT',
 			shortMessage: 'Command failed with ENOENT: unknown command spawn unknown ENOENT',
 			command: 'unknown command',
+			debugString: 'unknown command',
 			stdout: '',
 			stderr: '',
 			all: '',
@@ -121,6 +122,7 @@ try {
 		originalMessage: 'spawnSync unknown ENOENT',
 		shortMessage: 'Command failed with ENOENT: unknown command spawnSync unknown ENOENT',
 		command: 'unknown command',
+		debugString: 'unknown command',
 		stdout: '',
 		stderr: '',
 		all: '',
@@ -235,6 +237,12 @@ The child process [fails](#failed) when:
 Type: `string`
 
 The file and arguments that were run.
+
+#### debugString
+
+Type: `string`
+
+Same as [`command`](#command) but quoted so it can be run in most shells.
 
 #### exitCode
 

--- a/readme.md
+++ b/readme.md
@@ -236,13 +236,18 @@ The child process [fails](#failed) when:
 
 Type: `string`
 
-The file and arguments that were run.
+The file and arguments that were run, for logging purpose.
+
+This is not escaped and should be passed to neither [`execa()`](#execafile-arguments-options) nor [`execa.command()`](#execacommandcommand-options).
 
 #### escapedCommand
 
 Type: `string`
 
-Same as [`command`](#command) but quoted so it can be run in most shells.
+Same as [`command`](#command) but escaped.
+
+This is meant to be copy/pasted in a shell, for debugging purpose.
+Since the escaping is fairly basic, this should be passed to neither [`execa()`](#execafile-arguments-options) nor [`execa.command()`](#execacommandcommand-options).
 
 #### exitCode
 

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ const execa = require('execa');
 			originalMessage: 'spawn unknown ENOENT',
 			shortMessage: 'Command failed with ENOENT: unknown command spawn unknown ENOENT',
 			command: 'unknown command',
-			debugString: 'unknown command',
+			escapedCommand: 'unknown command',
 			stdout: '',
 			stderr: '',
 			all: '',
@@ -122,7 +122,7 @@ try {
 		originalMessage: 'spawnSync unknown ENOENT',
 		shortMessage: 'Command failed with ENOENT: unknown command spawnSync unknown ENOENT',
 		command: 'unknown command',
-		debugString: 'unknown command',
+		escapedCommand: 'unknown command',
 		stdout: '',
 		stderr: '',
 		all: '',
@@ -238,7 +238,7 @@ Type: `string`
 
 The file and arguments that were run.
 
-#### debugString
+#### escapedCommand
 
 Type: `string`
 

--- a/readme.md
+++ b/readme.md
@@ -238,7 +238,7 @@ Type: `string`
 
 The file and arguments that were run, for logging purposes.
 
-This is not escaped and should be passed to neither [`execa()`](#execafile-arguments-options) nor [`execa.command()`](#execacommandcommand-options).
+This is not escaped and should not be executed directly as a process, including using [`execa()`](#execafile-arguments-options) or [`execa.command()`](#execacommandcommand-options).
 
 #### escapedCommand
 
@@ -247,7 +247,7 @@ Type: `string`
 Same as [`command`](#command) but escaped.
 
 This is meant to be copy and pasted into a shell, for debugging purposes.
-Since the escaping is fairly basic, this should be passed to neither [`execa()`](#execafile-arguments-options) nor [`execa.command()`](#execacommandcommand-options).
+Since the escaping is fairly basic, this should not be executed directly as a process, including using [`execa()`](#execafile-arguments-options) or [`execa.command()`](#execacommandcommand-options).
 
 #### exitCode
 

--- a/test/command.js
+++ b/test/command.js
@@ -18,28 +18,28 @@ test(command, ' foo bar', 'foo', 'bar');
 test(command, ' baz quz', 'baz', 'quz');
 test(command, '');
 
-const testDebugString = async (t, expected, args) => {
-	const {debugString: failDebugString} = await t.throwsAsync(execa('fail', args));
-	t.is(failDebugString, `fail ${expected}`);
+const testEscapedCommand = async (t, expected, args) => {
+	const {escapedCommand: failEscapedCommand} = await t.throwsAsync(execa('fail', args));
+	t.is(failEscapedCommand, `fail ${expected}`);
 
-	const {debugString: failDebugStringSync} = t.throws(() => {
+	const {escapedCommand: failEscapedCommandSync} = t.throws(() => {
 		execa.sync('fail', args);
 	});
-	t.is(failDebugStringSync, `fail ${expected}`);
+	t.is(failEscapedCommandSync, `fail ${expected}`);
 
-	const {debugString} = await execa('noop', args);
-	t.is(debugString, `noop ${expected}`);
+	const {escapedCommand} = await execa('noop', args);
+	t.is(escapedCommand, `noop ${expected}`);
 
-	const {debugString: debugStringSync} = execa.sync('noop', args);
-	t.is(debugStringSync, `noop ${expected}`);
+	const {escapedCommand: escapedCommandSync} = execa.sync('noop', args);
+	t.is(escapedCommandSync, `noop ${expected}`);
 };
 
-testDebugString.title = (message, expected) => `debugString is: ${JSON.stringify(expected)}`;
+testEscapedCommand.title = (message, expected) => `escapedCommand is: ${JSON.stringify(expected)}`;
 
-test(testDebugString, 'foo bar', ['foo', 'bar']);
-test(testDebugString, '"foo bar"', ['foo bar']);
-test(testDebugString, '"\\"foo\\""', ['"foo"']);
-test(testDebugString, '"*"', ['*']);
+test(testEscapedCommand, 'foo bar', ['foo', 'bar']);
+test(testEscapedCommand, '"foo bar"', ['foo bar']);
+test(testEscapedCommand, '"\\"foo\\""', ['"foo"']);
+test(testEscapedCommand, '"*"', ['*']);
 
 test('allow commands with spaces and no array arguments', async t => {
 	const {stdout} = await execa('command with space');

--- a/test/command.js
+++ b/test/command.js
@@ -18,6 +18,29 @@ test(command, ' foo bar', 'foo', 'bar');
 test(command, ' baz quz', 'baz', 'quz');
 test(command, '');
 
+const testDebugString = async (t, expected, args) => {
+	const {debugString: failDebugString} = await t.throwsAsync(execa('fail', args));
+	t.is(failDebugString, `fail ${expected}`);
+
+	const {debugString: failDebugStringSync} = t.throws(() => {
+		execa.sync('fail', args);
+	});
+	t.is(failDebugStringSync, `fail ${expected}`);
+
+	const {debugString} = await execa('noop', args);
+	t.is(debugString, `noop ${expected}`);
+
+	const {debugString: debugStringSync} = execa.sync('noop', args);
+	t.is(debugStringSync, `noop ${expected}`);
+};
+
+testDebugString.title = (message, expected) => `debugString is: ${JSON.stringify(expected)}`;
+
+test(testDebugString, 'foo bar', ['foo', 'bar']);
+test(testDebugString, '"foo bar"', ['foo bar']);
+test(testDebugString, '"\\"foo\\""', ['"foo"']);
+test(testDebugString, '"*"', ['*']);
+
 test('allow commands with spaces and no array arguments', async t => {
 	const {stdout} = await execa('command with space');
 	t.is(stdout, '');


### PR DESCRIPTION
Closes #455.

This adds a `debugString` property to the return value and error instances, as described in the above issue.

As I implemented this, I realized that this property is very similar to the existing `command` property. What are your thoughts on either of the following options?
  1. Rename `debugString` to `escapedCommand` or `quotedCommand` to reflect this.
  2. Add escaping to the `command` property instead. This would be a breaking change.