### PR TITLE
Fix error message when user passes a single array argument

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -11,7 +11,7 @@ const NO_ESCAPE_REGEXP = /^[\w.-]+$/;
 const DOUBLE_QUOTES_REGEXP = /"/g;
 
 const escapeArg = arg => {
-	if (NO_ESCAPE_REGEXP.test(arg)) {
+	if (typeof arg !== 'string' || NO_ESCAPE_REGEXP.test(arg)) {
 		return arg;
 	}
 


### PR DESCRIPTION
When the user passes a single array argument, the error message used to be `The "file" argument must be of type string. Received an instance of Array`. With #466, it is now much less clear:

```
TypeError: arg.replace is not a function
at escapeArg (/var/www/html/node_modules/execa/lib/command.js:18:17)
```

This PR fixes this.