### PR TITLE
Allow `cwd` and `localDir` options to be URLs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -113,7 +113,7 @@ export interface CommonOptions<EncodingType> {
 
 	@default process.cwd()
 	*/
-	readonly cwd?: string;
+	readonly cwd?: string | URL;
 
 	/**
 	Environment key-value pairs. Extends automatically from `process.env`. Set `extendEnv` to `false` if you don't want this.

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ export interface CommonOptions<EncodingType> {
 
 	@default process.cwd()
 	*/
-	readonly localDir?: string;
+	readonly localDir?: string | URL;
 
 	/**
 	Path to the Node.js executable to use in child processes.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -90,6 +90,7 @@ try {
 execa('unicorns', {cleanup: false});
 execa('unicorns', {preferLocal: false});
 execa('unicorns', {localDir: '.'});
+execa('unicorns', {localDir: new URL('file:///test')});
 execa('unicorns', {execPath: '/path'});
 execa('unicorns', {buffer: false});
 execa('unicorns', {input: ''});
@@ -121,7 +122,7 @@ execa('unicorns', {reject: false});
 execa('unicorns', {stripFinalNewline: false});
 execa('unicorns', {extendEnv: false});
 execa('unicorns', {cwd: '.'});
-execa('unicorns', {cwd: new URL('.')});
+execa('unicorns', {cwd: new URL('file:///test')});
 // eslint-disable-next-line @typescript-eslint/naming-convention
 execa('unicorns', {env: {PATH: ''}});
 execa('unicorns', {argv0: ''});

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -121,6 +121,7 @@ execa('unicorns', {reject: false});
 execa('unicorns', {stripFinalNewline: false});
 execa('unicorns', {extendEnv: false});
 execa('unicorns', {cwd: '.'});
+execa('unicorns', {cwd: new URL('.')});
 // eslint-disable-next-line @typescript-eslint/naming-convention
 execa('unicorns', {env: {PATH: ''}});
 execa('unicorns', {argv0: ''});

--- a/readme.md
+++ b/readme.md
@@ -357,7 +357,7 @@ If you `$ npm install foo`, you can then `execa('foo')`.
 
 #### localDir
 
-Type: `string`\
+Type: `string | URL`\
 Default: `process.cwd()`
 
 Preferred path to find locally installed binaries in (use with `preferLocal`).

--- a/readme.md
+++ b/readme.md
@@ -446,7 +446,7 @@ Execa also accepts the below options which are the same as the options for [`chi
 
 #### cwd
 
-Type: `string`\
+Type: `string | URL`\
 Default: `process.cwd()`
 
 Current working directory of the child process.

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import process from 'node:process';
-import {fileURLToPath} from 'node:url';
+import {fileURLToPath, pathToFileURL} from 'node:url';
 import test from 'ava';
 import isRunning from 'is-running';
 import getNode from 'get-node';
@@ -196,6 +196,19 @@ test('extend environment variables by default', async t => {
 test('do not extend environment with `extendEnv: false`', async t => {
 	const {stdout} = await execa('environment.js', [], {env: {BAR: 'bar', PATH: process.env.PATH}, extendEnv: false});
 	t.deepEqual(stdout.split('\n'), ['undefined', 'bar']);
+});
+
+test('can use `options.cwd` as a string', async t => {
+	const cwd = '/';
+	const {stdout} = await execa('node', ['-p', 'process.cwd()'], {cwd});
+	t.is(stdout, cwd);
+});
+
+test('can use `options.cwd` as a URL', async t => {
+	const cwd = '/';
+	const cwdUrl = pathToFileURL(cwd);
+	const {stdout} = await execa('node', ['-p', 'process.cwd()'], {cwd: cwdUrl});
+	t.is(stdout, cwd);
 });
 
 test('can use `options.shell: true`', async t => {

--- a/test/test.js
+++ b/test/test.js
@@ -95,6 +95,13 @@ test('localDir option', async t => {
 	t.true(envPaths.some(envPath => envPath.endsWith('.bin')));
 });
 
+test('localDir option can be a URL', async t => {
+	const command = process.platform === 'win32' ? 'echo %PATH%' : 'echo $PATH';
+	const {stdout} = await execa(command, {shell: true, preferLocal: true, localDir: pathToFileURL('/test')});
+	const envPaths = stdout.split(path.delimiter);
+	t.true(envPaths.some(envPath => envPath.endsWith('.bin')));
+});
+
 test('execPath option', async t => {
 	const {path: execPath} = await getNode('6.0.0');
 	const {stdout} = await execa('node', ['-p', 'process.env.Path || process.env.PATH'], {preferLocal: true, execPath});


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/execa/issues/491

This allows the `cwd` and `localDir` options to be URLs with the `file:` scheme.