### PR TITLE
Upgrade `human-signals`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 	"dependencies": {
 		"cross-spawn": "^7.0.3",
 		"get-stream": "^6.0.1",
-		"human-signals": "^3.0.1",
+		"human-signals": "^4.1.0",
 		"is-stream": "^3.0.0",
 		"merge-stream": "^2.0.0",
 		"npm-run-path": "^5.1.0",


### PR DESCRIPTION
This upgrades the `human-signals` dependency.
The new major release [only drops support for Node 12](https://github.com/ehmicky/human-signals/releases/tag/4.0.0), so no code changes is needed.