### PR TITLE
Fix incorrect execaNode signature in `index.d.ts`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -575,7 +575,7 @@ export function execaNode(
 export function execaNode(
 	scriptPath: string,
 	arguments?: readonly string[],
-	options?: Options<null>
+	options?: NodeOptions<null>
 ): ExecaChildProcess<Buffer>;
-export function execaNode(scriptPath: string, options?: Options): ExecaChildProcess;
-export function execaNode(scriptPath: string, options?: Options<null>): ExecaChildProcess<Buffer>;
+export function execaNode(scriptPath: string, options?: NodeOptions): ExecaChildProcess;
+export function execaNode(scriptPath: string, options?: NodeOptions<null>): ExecaChildProcess<Buffer>;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -210,7 +210,12 @@ expectType<ExecaReturnValue>(
 expectType<ExecaReturnValue<Buffer>>(
 	await execaNode('unicorns', ['foo'], {encoding: null}),
 );
-execaNode('unicorns', {nodeOptions: ['--async-stack-traces']})
-execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces']})
-execaNode('unicorns', {nodeOptions: ['--async-stack-traces'], encoding: null})
-execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces'], encoding: null})
+
+expectType<ExecaChildProcess>(execaNode('unicorns', {nodeOptions: ['--async-stack-traces']}));
+expectType<ExecaChildProcess>(execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces']}));
+expectType<ExecaChildProcess<Buffer>>(
+	execaNode('unicorns', {nodeOptions: ['--async-stack-traces'], encoding: null}),
+);
+expectType<ExecaChildProcess<Buffer>>(
+	execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces'], encoding: null}),
+);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -210,3 +210,7 @@ expectType<ExecaReturnValue>(
 expectType<ExecaReturnValue<Buffer>>(
 	await execaNode('unicorns', ['foo'], {encoding: null}),
 );
+execaNode('unicorns', {nodeOptions: ['--async-stack-traces']})
+execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces']})
+execaNode('unicorns', {nodeOptions: ['--async-stack-traces'], encoding: null})
+execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces'], encoding: null})


### PR DESCRIPTION
All signatures of `execaNode` support `nodeOptions` (and `nodePath`)