### PR TITLE
Fix MarkDown in TSDoc comments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ export interface CommonOptions<EncodingType> {
 	/**
 	Prefer locally installed binaries when looking for a binary to execute.
 
-	If you `npm install foo`, you can then `execa('foo')`.
+	If you `$ npm install foo`, you can then `execa('foo')`.
 
 	@default false
 	*/
@@ -65,7 +65,7 @@ export interface CommonOptions<EncodingType> {
 
 	/**
 	Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-   *
+
 	@default 'pipe'
 	*/
 	readonly stdin?: StdioOption;
@@ -138,7 +138,7 @@ export interface CommonOptions<EncodingType> {
 
 	@default 'pipe'
 	*/
-	readonly stdio?: 'pipe' | 'ignore' | 'inherit' | readonly StdioOption[];
+	readonly stdio?: 'pipe' | 'overlapped' | 'ignore' | 'inherit' | readonly StdioOption[];
 
 	/**
 	Specify the kind of serialization used for sending messages between processes when using the `stdio: 'ipc'` option or `execaNode()`:
@@ -353,15 +353,15 @@ export interface ExecaSyncReturnValue<StdoutErrorType = string>
 
 /**
 Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
- *
+
 The child process fails when:
- *
+
 - its exit code is not `0`
 - it was killed with a signal
 - timing out
 - being canceled
 - there's not enough memory or there are already too many child processes
- */
+*/
 export interface ExecaReturnValue<StdoutErrorType = string>
 	extends ExecaSyncReturnValue<StdoutErrorType> {
 	/**
@@ -466,40 +466,40 @@ Promise<ExecaReturnValue<StdoutErrorType>>;
 
 /**
 Execute a file.
- *
+
 Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
- *
+
 @param file - The program/script to execute.
 @param arguments - Arguments to pass to `file` on execution.
 @returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
- *
+
 @example
 ```typescript
 import {execa} from 'execa';
- *
+
 const {stdout} = await execa('echo', ['unicorns']);
 console.log(stdout);
 //=> 'unicorns'
- *
+
 // Cancelling a spawned process
- *
+
 const subprocess = execa('node');
- *
+
 setTimeout(() => {
   subprocess.cancel()
 }, 1000);
- *
+
 try {
   await subprocess;
 } catch (error) {
   console.log(subprocess.killed); // true
   console.log(error.isCanceled); // true
 }
- *
+
 // Pipe the child process stdout to the current stdout
 execa('echo', ['unicorns']).stdout.pipe(process.stdout);
 ```
- */
+*/
 export function execa(
 	file: string,
 	arguments?: readonly string[],
@@ -515,13 +515,13 @@ export function execa(file: string, options?: Options<null>): ExecaChildProcess<
 
 /**
 Execute a file synchronously.
- *
+
 This method throws an `Error` if the command fails.
- *
+
 @param file - The program/script to execute.
 @param arguments - Arguments to pass to `file` on execution.
 @returns A result `Object` with `stdout` and `stderr` properties.
- */
+*/
 export function execaSync(
 	file: string,
 	arguments?: readonly string[],
@@ -540,48 +540,48 @@ export function execaSync(
 
 /**
 Same as `execa()` except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execaCommand('echo unicorns')`.
- *
+
 If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `__dirname` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
- *
+
 The `shell` option must be used if the `command` uses shell-specific features (for example, `&&` or `||`), as opposed to being a simple `file` followed by its `arguments`.
- *
+
 @param command - The program/script to execute and its arguments.
 @returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
- *
+
 @example
 ```typescript
 import {execaCommand} from 'execa';
- *
+
 const {stdout} = await execaCommand('echo unicorns');
 console.log(stdout);
 //=> 'unicorns'
 ```
- */
+*/
 export function execaCommand(command: string, options?: Options): ExecaChildProcess;
 export function execaCommand(command: string, options?: Options<null>): ExecaChildProcess<Buffer>;
 
 /**
 Same as `execaCommand()` but synchronous.
- *
+
 @param command - The program/script to execute and its arguments.
 @returns A result `Object` with `stdout` and `stderr` properties.
- */
+*/
 export function execaCommandSync(command: string, options?: SyncOptions): ExecaSyncReturnValue;
 export function execaCommandSync(command: string, options?: SyncOptions<null>): ExecaSyncReturnValue<Buffer>;
 
 /**
 Execute a Node.js script as a child process.
- *
+
 Same as `execa('node', [scriptPath, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
- *
+
 - the current Node version and options are used. This can be overridden using the `nodePath` and `nodeArguments` options.
 - the `shell` option cannot be used
 - an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)
- *
+
 @param scriptPath - Node.js script to execute.
 @param arguments - Arguments to pass to `scriptPath` on execution.
 @returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
- */
+*/
 export function execaNode(
 	scriptPath: string,
 	arguments?: readonly string[],

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,335 +14,335 @@ export type StdioOption =
 
 export interface CommonOptions<EncodingType> {
 	/**
-	 * Kill the spawned process when the parent process exits unless either:
-	 *
-	 * - the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
-	 * - the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
-	 *
-	 * @default true
-	 */
+	Kill the spawned process when the parent process exits unless either:
+
+	- the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
+	- the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
+
+	@default true
+	*/
 	readonly cleanup?: boolean;
 
 	/**
-	 * Prefer locally installed binaries when looking for a binary to execute.
-	 *
-	 * If you `npm install foo`, you can then `execa('foo')`.
-	 *
-	 * @default false
-	 */
+	Prefer locally installed binaries when looking for a binary to execute.
+
+	If you `npm install foo`, you can then `execa('foo')`.
+
+	@default false
+	*/
 	readonly preferLocal?: boolean;
 
 	/**
-	 * Preferred path to find locally installed binaries in (use with `preferLocal`).
-	 *
-	 * Using a `URL` is only supported in Node.js `14.18.0`, `16.14.0` or above.
-	 *
-	 * @default process.cwd()
-	 */
+	Preferred path to find locally installed binaries in (use with `preferLocal`).
+
+	Using a `URL` is only supported in Node.js `14.18.0`, `16.14.0` or above.
+
+	@default process.cwd()
+	*/
 	readonly localDir?: string | URL;
 
 	/**
-	 * Path to the Node.js executable to use in child processes.
-	 *
-	 * This can be either an absolute path or a path relative to the `cwd` option.
-	 *
-	 * Requires `preferLocal` to be `true`.
-	 *
-	 * For example, this can be used together with [`get-node`](https://github.com/ehmicky/get-node) to run a specific Node.js version in a child process.
-	 *
-	 * @default process.execPath
-	 */
+	Path to the Node.js executable to use in child processes.
+
+	This can be either an absolute path or a path relative to the `cwd` option.
+
+	Requires `preferLocal` to be `true`.
+
+	For example, this can be used together with [`get-node`](https://github.com/ehmicky/get-node) to run a specific Node.js version in a child process.
+
+	@default process.execPath
+	*/
 	readonly execPath?: string;
 
 	/**
-	 * Buffer the output from the spawned process. When set to `false`, you must read the output of `stdout` and `stderr` (or `all` if the `all` option is `true`). Otherwise the returned promise will not be resolved/rejected.
-	 *
-	 * If the spawned process fails, `error.stdout`, `error.stderr`, and `error.all` will contain the buffered data.
-	 *
-	 * @default true
-	 */
+	Buffer the output from the spawned process. When set to `false`, you must read the output of `stdout` and `stderr` (or `all` if the `all` option is `true`). Otherwise the returned promise will not be resolved/rejected.
+
+	If the spawned process fails, `error.stdout`, `error.stderr`, and `error.all` will contain the buffered data.
+
+	@default true
+	*/
 	readonly buffer?: boolean;
 
 	/**
-	 * Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+	Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
    *
-	 * @default 'pipe'
-	 */
+	@default 'pipe'
+	*/
 	readonly stdin?: StdioOption;
 
 	/**
-	 * Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-	 *
-	 * @default 'pipe'
-	 */
+	Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+
+	@default 'pipe'
+	*/
 	readonly stdout?: StdioOption;
 
 	/**
-	 * Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-	 *
-	 * @default 'pipe'
-	 */
+	Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+
+	@default 'pipe'
+	*/
 	readonly stderr?: StdioOption;
 
 	/**
-	 * Setting this to `false` resolves the promise with the error instead of rejecting it.
-	 *
-	 * @default true
-	 */
+	Setting this to `false` resolves the promise with the error instead of rejecting it.
+
+	@default true
+	*/
 	readonly reject?: boolean;
 
 	/**
-	 * Add an `.all` property on the promise and the resolved value. The property contains the output of the process with `stdout` and `stderr` interleaved.
-	 *
-	 * @default false
-	 */
+	Add an `.all` property on the promise and the resolved value. The property contains the output of the process with `stdout` and `stderr` interleaved.
+
+	@default false
+	*/
 	readonly all?: boolean;
 
 	/**
-	 * Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
-	 *
-	 * @default true
-	 */
+	Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
+
+	@default true
+	*/
 	readonly stripFinalNewline?: boolean;
 
 	/**
-	 * Set to `false` if you don't want to extend the environment variables when providing the `env` property.
-	 *
-	 * @default true
-	 */
+	Set to `false` if you don't want to extend the environment variables when providing the `env` property.
+
+	@default true
+	*/
 	readonly extendEnv?: boolean;
 
 	/**
-	 * Current working directory of the child process.
-	 *
-	 * Using a `URL` is only supported in Node.js `14.18.0`, `16.14.0` or above.
-	 *
-	 * @default process.cwd()
-	 */
+	Current working directory of the child process.
+
+	Using a `URL` is only supported in Node.js `14.18.0`, `16.14.0` or above.
+
+	@default process.cwd()
+	*/
 	readonly cwd?: string | URL;
 
 	/**
-	 * Environment key-value pairs. Extends automatically from `process.env`. Set `extendEnv` to `false` if you don't want this.
-	 *
-	 * @default process.env
-	 */
+	Environment key-value pairs. Extends automatically from `process.env`. Set `extendEnv` to `false` if you don't want this.
+
+	@default process.env
+	*/
 	readonly env?: NodeJS.ProcessEnv;
 
 	/**
-	 * Explicitly set the value of `argv[0]` sent to the child process. This will be set to `command` or `file` if not specified.
-	 */
+	Explicitly set the value of `argv[0]` sent to the child process. This will be set to `command` or `file` if not specified.
+	*/
 	readonly argv0?: string;
 
 	/**
-	 * Child's [stdio](https://nodejs.org/api/child_process.html#child_process_options_stdio) configuration.
-	 *
-	 * @default 'pipe'
-	 */
+	Child's [stdio](https://nodejs.org/api/child_process.html#child_process_options_stdio) configuration.
+
+	@default 'pipe'
+	*/
 	readonly stdio?: 'pipe' | 'ignore' | 'inherit' | readonly StdioOption[];
 
 	/**
-	 * Specify the kind of serialization used for sending messages between processes when using the `stdio: 'ipc'` option or `execaNode()`:
-	 *
-	 * - `json`: Uses `JSON.stringify()` and `JSON.parse()`.
-	 * - `advanced`: Uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
-	 *
-	 * Requires Node.js `13.2.0` or later.
-	 *
-	 * [More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization)
-	 *
-	 * @default 'json'
-	 */
+	Specify the kind of serialization used for sending messages between processes when using the `stdio: 'ipc'` option or `execaNode()`:
+
+	- `json`: Uses `JSON.stringify()` and `JSON.parse()`.
+	- `advanced`: Uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
+
+	Requires Node.js `13.2.0` or later.
+
+	[More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization)
+
+	@default 'json'
+	*/
 	readonly serialization?: 'json' | 'advanced';
 
 	/**
-	 * Prepare child to run independently of its parent process. Specific behavior [depends on the platform](https://nodejs.org/api/child_process.html#child_process_options_detached).
-	 *
-	 * @default false
-	 */
+	Prepare child to run independently of its parent process. Specific behavior [depends on the platform](https://nodejs.org/api/child_process.html#child_process_options_detached).
+
+	@default false
+	*/
 	readonly detached?: boolean;
 
 	/**
-	 * Sets the user identity of the process.
-	 */
+	Sets the user identity of the process.
+	*/
 	readonly uid?: number;
 
 	/**
-	 * Sets the group identity of the process.
-	 */
+	Sets the group identity of the process.
+	*/
 	readonly gid?: number;
 
 	/**
-	 * If `true`, runs `command` inside of a shell. Uses `/bin/sh` on UNIX and `cmd.exe` on Windows. A different shell can be specified as a string. The shell should understand the `-c` switch on UNIX or `/d /s /c` on Windows.
-	 *
-	 * We recommend against using this option since it is:
-	 *
-	 * - not cross-platform, encouraging shell-specific syntax.
-	 * - slower, because of the additional shell interpretation.
-	 * - unsafe, potentially allowing command injection.
-	 *
-	 * @default false
-	 */
+	If `true`, runs `command` inside of a shell. Uses `/bin/sh` on UNIX and `cmd.exe` on Windows. A different shell can be specified as a string. The shell should understand the `-c` switch on UNIX or `/d /s /c` on Windows.
+
+	We recommend against using this option since it is:
+
+	- not cross-platform, encouraging shell-specific syntax.
+	- slower, because of the additional shell interpretation.
+	- unsafe, potentially allowing command injection.
+
+	@default false
+	*/
 	readonly shell?: boolean | string;
 
 	/**
-	 * Specify the character encoding used to decode the `stdout` and `stderr` output. If set to `null`, then `stdout` and `stderr` will be a `Buffer` instead of a string.
-	 *
-	 * @default 'utf8'
-	 */
+	Specify the character encoding used to decode the `stdout` and `stderr` output. If set to `null`, then `stdout` and `stderr` will be a `Buffer` instead of a string.
+
+	@default 'utf8'
+	*/
 	readonly encoding?: EncodingType;
 
 	/**
-	 * If `timeout` is greater than `0`, the parent will send the signal identified by the `killSignal` property (the default is `SIGTERM`) if the child runs longer than `timeout` milliseconds.
-	 *
-	 * @default 0
-	 */
+	If `timeout` is greater than `0`, the parent will send the signal identified by the `killSignal` property (the default is `SIGTERM`) if the child runs longer than `timeout` milliseconds.
+
+	@default 0
+	*/
 	readonly timeout?: number;
 
 	/**
-	 * Largest amount of data in bytes allowed on `stdout` or `stderr`. Default: 100 MB.
-	 *
-	 * @default 100_000_000
-	 */
+	Largest amount of data in bytes allowed on `stdout` or `stderr`. Default: 100 MB.
+
+	@default 100_000_000
+	*/
 	readonly maxBuffer?: number;
 
 	/**
-	 * Signal value to be used when the spawned process will be killed.
-	 *
-	 * @default 'SIGTERM'
-	 */
+	Signal value to be used when the spawned process will be killed.
+
+	@default 'SIGTERM'
+	*/
 	readonly killSignal?: string | number;
 
 	/**
-	 * You can abort the spawned process using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-	 *
-	 * When `AbortController.abort()` is called, [`.isCanceled`](https://github.com/sindresorhus/execa#iscanceled) becomes `false`.
-	 *
-	 * *Requires Node.js 16 or later.*
-	 *
-	 * @example
-	 * ```typescript
-	 * import {execa} from 'execa';
-	 *
-	 * const abortController = new AbortController();
-	 * const subprocess = execa('node', [], {signal: abortController.signal});
-	 *
-	 * setTimeout(() => {
-	 * 	abortController.abort();
-	 * }, 1000);
-	 *
-	 * try {
-	 * 	await subprocess;
-	 * } catch (error) {
-	 * 	console.log(subprocess.killed); // true
-	 * 	console.log(error.isCanceled); // true
-	 * }
-	 * ```
-	 */
+	You can abort the spawned process using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+
+	When `AbortController.abort()` is called, [`.isCanceled`](https://github.com/sindresorhus/execa#iscanceled) becomes `false`.
+
+	*Requires Node.js 16 or later.*
+
+	@example
+	```typescript
+	import {execa} from 'execa';
+
+	const abortController = new AbortController();
+	const subprocess = execa('node', [], {signal: abortController.signal});
+
+	setTimeout(() => {
+		abortController.abort();
+	}, 1000);
+
+	try {
+		await subprocess;
+	} catch (error) {
+		console.log(subprocess.killed); // true
+		console.log(error.isCanceled); // true
+	}
+	```
+	*/
 	readonly signal?: AbortSignal;
 
 	/**
-	 * If `true`, no quoting or escaping of arguments is done on Windows. Ignored on other platforms. This is set to `true` automatically when the `shell` option is `true`.
-	 *
-	 * @default false
-	 */
+	If `true`, no quoting or escaping of arguments is done on Windows. Ignored on other platforms. This is set to `true` automatically when the `shell` option is `true`.
+
+	@default false
+	*/
 	readonly windowsVerbatimArguments?: boolean;
 
 	/**
-	 * On Windows, do not create a new console window. Please note this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
-	 *
-	 * @default true
-	 */
+	On Windows, do not create a new console window. Please note this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
+
+	@default true
+	*/
 	readonly windowsHide?: boolean;
 }
 
 export interface Options<EncodingType = string> extends CommonOptions<EncodingType> {
 	/**
-	 * Write some input to the `stdin` of your binary.
-	 */
+	Write some input to the `stdin` of your binary.
+	*/
 	readonly input?: string | Buffer | ReadableStream;
 }
 
 export interface SyncOptions<EncodingType = string> extends CommonOptions<EncodingType> {
 	/**
-	 * Write some input to the `stdin` of your binary.
-	 */
+	Write some input to the `stdin` of your binary.
+	*/
 	readonly input?: string | Buffer;
 }
 
 export interface NodeOptions<EncodingType = string> extends Options<EncodingType> {
 	/**
-	 * The Node.js executable to use.
-	 *
-	 * @default process.execPath
-	 */
+	The Node.js executable to use.
+
+	@default process.execPath
+	*/
 	readonly nodePath?: string;
 
 	/**
-	 * List of [CLI options](https://nodejs.org/api/cli.html#cli_options) passed to the Node.js executable.
-	 *
-	 * @default process.execArgv
-	 */
+	List of [CLI options](https://nodejs.org/api/cli.html#cli_options) passed to the Node.js executable.
+
+	@default process.execArgv
+	*/
 	readonly nodeOptions?: string[];
 }
 
 export interface ExecaReturnBase<StdoutStderrType> {
 	/**
-	 * The file and arguments that were run, for logging purposes.
-	 *
-	 * This is not escaped and should not be executed directly as a process, including using `execa()` or `execaCommand()`.
-	 */
+	The file and arguments that were run, for logging purposes.
+
+	This is not escaped and should not be executed directly as a process, including using `execa()` or `execaCommand()`.
+	*/
 	command: string;
 
 	/**
-	 * Same as `command` but escaped.
-	 *
-	 * This is meant to be copy and pasted into a shell, for debugging purposes.
-	 *
-	 * Since the escaping is fairly basic, this should not be executed directly as a process, including using `execa()` or `execaCommand()`.
-	 */
+	Same as `command` but escaped.
+
+	This is meant to be copy and pasted into a shell, for debugging purposes.
+
+	Since the escaping is fairly basic, this should not be executed directly as a process, including using `execa()` or `execaCommand()`.
+	*/
 	escapedCommand: string;
 
 	/**
-	 * The numeric exit code of the process that was run.
-	 */
+	The numeric exit code of the process that was run.
+	*/
 	exitCode: number;
 
 	/**
-	 * The output of the process on stdout.
-	 */
+	The output of the process on stdout.
+	*/
 	stdout: StdoutStderrType;
 
 	/**
-	 * The output of the process on stderr.
-	 */
+	The output of the process on stderr.
+	*/
 	stderr: StdoutStderrType;
 
 	/**
-	 * Whether the process failed to run.
-	 */
+	Whether the process failed to run.
+	*/
 	failed: boolean;
 
 	/**
-	 * Whether the process timed out.
-	 */
+	Whether the process timed out.
+	*/
 	timedOut: boolean;
 
 	/**
-	 * Whether the process was killed.
-	 */
+	Whether the process was killed.
+	*/
 	killed: boolean;
 
 	/**
-	 * The name of the signal that was used to terminate the process. For example, `SIGFPE`.
-	 *
-	 * If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
-	 */
+	The name of the signal that was used to terminate the process. For example, `SIGFPE`.
+
+	If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
+	*/
 	signal?: string;
 
 	/**
-	 * A human-friendly description of the signal that was used to terminate the process. For example, `Floating point arithmetic error`.
-	 *
-	 * If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`. It is also `undefined` when the signal is very uncommon which should seldomly happen.
+	A human-friendly description of the signal that was used to terminate the process. For example, `Floating point arithmetic error`.
+
+	If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`. It is also `undefined` when the signal is very uncommon which should seldomly happen.
 	*/
 	signalDescription?: string;
 }
@@ -352,33 +352,33 @@ export interface ExecaSyncReturnValue<StdoutErrorType = string>
 }
 
 /**
- * Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
+Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
  *
- * The child process fails when:
+The child process fails when:
  *
- * - its exit code is not `0`
- * - it was killed with a signal
- * - timing out
- * - being canceled
- * - there's not enough memory or there are already too many child processes
+- its exit code is not `0`
+- it was killed with a signal
+- timing out
+- being canceled
+- there's not enough memory or there are already too many child processes
  */
 export interface ExecaReturnValue<StdoutErrorType = string>
 	extends ExecaSyncReturnValue<StdoutErrorType> {
 	/**
-	 * The output of the process with `stdout` and `stderr` interleaved.
-	 *
-	 * This is `undefined` if either:
-	 *
-	 * - the `all` option is `false` (default value)
-	 * - `execaSync()` was used
-	 */
+	The output of the process with `stdout` and `stderr` interleaved.
+
+	This is `undefined` if either:
+
+	- the `all` option is `false` (default value)
+	- `execaSync()` was used
+	*/
 	all?: StdoutErrorType;
 
 	/**
-	 * Whether the process was canceled.
-	 *
-	 * You can cancel the spawned process using the [`signal`](https://github.com/sindresorhus/execa#signal-1) option.
-	 */
+	Whether the process was canceled.
+
+	You can cancel the spawned process using the [`signal`](https://github.com/sindresorhus/execa#signal-1) option.
+	*/
 	isCanceled: boolean;
 }
 
@@ -386,63 +386,63 @@ export interface ExecaSyncError<StdoutErrorType = string>
 	extends Error,
 	ExecaReturnBase<StdoutErrorType> {
 	/**
-	 * Error message when the child process failed to run. In addition to the underlying error message, it also contains some information related to why the child process errored.
-	 *
-	 * The child process stderr then stdout are appended to the end, separated with newlines and not interleaved.
-	 */
+	Error message when the child process failed to run. In addition to the underlying error message, it also contains some information related to why the child process errored.
+
+	The child process stderr then stdout are appended to the end, separated with newlines and not interleaved.
+	*/
 	message: string;
 
 	/**
-	 * This is the same as the `message` property except it does not include the child process stdout/stderr.
-	 */
+	This is the same as the `message` property except it does not include the child process stdout/stderr.
+	*/
 	shortMessage: string;
 
 	/**
-	 * Original error message. This is the same as the `message` property except it includes neither the child process stdout/stderr nor some additional information added by Execa.
-	 *
-	 * This is `undefined` unless the child process exited due to an `error` event or a timeout.
-	 */
+	Original error message. This is the same as the `message` property except it includes neither the child process stdout/stderr nor some additional information added by Execa.
+
+	This is `undefined` unless the child process exited due to an `error` event or a timeout.
+	*/
 	originalMessage?: string;
 }
 
 export interface ExecaError<StdoutErrorType = string>
 	extends ExecaSyncError<StdoutErrorType> {
 	/**
-	 * The output of the process with `stdout` and `stderr` interleaved.
-	 *
-	 * This is `undefined` if either:
-	 *
-	 * - the `all` option is `false` (default value)
-	 * - `execaSync()` was used
-	 */
+	The output of the process with `stdout` and `stderr` interleaved.
+
+	This is `undefined` if either:
+
+	- the `all` option is `false` (default value)
+	- `execaSync()` was used
+	*/
 	all?: StdoutErrorType;
 
 	/**
-	 * Whether the process was canceled.
-	 */
+	Whether the process was canceled.
+	*/
 	isCanceled: boolean;
 }
 
 export interface KillOptions {
 	/**
-	 * Milliseconds to wait for the child process to terminate before sending `SIGKILL`.
-	 *
-	 * Can be disabled with `false`.
-	 *
-	 * @default 5000
-	 */
+	Milliseconds to wait for the child process to terminate before sending `SIGKILL`.
+
+	Can be disabled with `false`.
+
+	@default 5000
+	*/
 	forceKillAfterTimeout?: number | false;
 }
 
 export interface ExecaChildPromise<StdoutErrorType> {
 	/**
-	 * Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
-	 *
-	 * This is `undefined` if either:
-	 *
-	 * - the `all` option is `false` (the default value)
-	 * - both `stdout` and `stderr` options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio)
-	 */
+	Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
+
+	This is `undefined` if either:
+
+	- the `all` option is `false` (the default value)
+	- both `stdout` and `stderr` options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio)
+	*/
 	all?: ReadableStream;
 
 	catch<ResultType = never>(
@@ -450,13 +450,13 @@ export interface ExecaChildPromise<StdoutErrorType> {
 	): Promise<ExecaReturnValue<StdoutErrorType> | ResultType>;
 
 	/**
-	 * Same as the original [`child_process#kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal), except if `signal` is `SIGTERM` (the default value) and the child process is not terminated after 5 seconds, force it by sending `SIGKILL`.
-	 */
+	Same as the original [`child_process#kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal), except if `signal` is `SIGTERM` (the default value) and the child process is not terminated after 5 seconds, force it by sending `SIGKILL`.
+	*/
 	kill(signal?: string, options?: KillOptions): void;
 
 	/**
-	 * Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal). This is preferred when cancelling the child process execution as the error is more descriptive and [`childProcessResult.isCanceled`](#iscanceled) is set to `true`.
-	 */
+	Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal). This is preferred when cancelling the child process execution as the error is more descriptive and [`childProcessResult.isCanceled`](#iscanceled) is set to `true`.
+	*/
 	cancel(): void;
 }
 
@@ -465,40 +465,40 @@ ExecaChildPromise<StdoutErrorType> &
 Promise<ExecaReturnValue<StdoutErrorType>>;
 
 /**
- * Execute a file.
+Execute a file.
  *
- * Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
+Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
  *
- * @param file - The program/script to execute.
- * @param arguments - Arguments to pass to `file` on execution.
- * @returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
+@param file - The program/script to execute.
+@param arguments - Arguments to pass to `file` on execution.
+@returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
  *
- * @example
- * ```typescript
- * import {execa} from 'execa';
+@example
+```typescript
+import {execa} from 'execa';
  *
- * const {stdout} = await execa('echo', ['unicorns']);
- * console.log(stdout);
- * //=> 'unicorns'
+const {stdout} = await execa('echo', ['unicorns']);
+console.log(stdout);
+//=> 'unicorns'
  *
- * // Cancelling a spawned process
+// Cancelling a spawned process
  *
- * const subprocess = execa('node');
+const subprocess = execa('node');
  *
- * setTimeout(() => {
- *   subprocess.cancel()
- * }, 1000);
+setTimeout(() => {
+  subprocess.cancel()
+}, 1000);
  *
- * try {
- *   await subprocess;
- * } catch (error) {
- *   console.log(subprocess.killed); // true
- *   console.log(error.isCanceled); // true
- * }
+try {
+  await subprocess;
+} catch (error) {
+  console.log(subprocess.killed); // true
+  console.log(error.isCanceled); // true
+}
  *
- * // Pipe the child process stdout to the current stdout
- * execa('echo', ['unicorns']).stdout.pipe(process.stdout);
- * ```
+// Pipe the child process stdout to the current stdout
+execa('echo', ['unicorns']).stdout.pipe(process.stdout);
+```
  */
 export function execa(
 	file: string,
@@ -514,13 +514,13 @@ export function execa(file: string, options?: Options): ExecaChildProcess;
 export function execa(file: string, options?: Options<null>): ExecaChildProcess<Buffer>;
 
 /**
- * Execute a file synchronously.
+Execute a file synchronously.
  *
- * This method throws an `Error` if the command fails.
+This method throws an `Error` if the command fails.
  *
- * @param file - The program/script to execute.
- * @param arguments - Arguments to pass to `file` on execution.
- * @returns A result `Object` with `stdout` and `stderr` properties.
+@param file - The program/script to execute.
+@param arguments - Arguments to pass to `file` on execution.
+@returns A result `Object` with `stdout` and `stderr` properties.
  */
 export function execaSync(
 	file: string,
@@ -539,48 +539,48 @@ export function execaSync(
 ): ExecaSyncReturnValue<Buffer>;
 
 /**
- * Same as `execa()` except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execaCommand('echo unicorns')`.
+Same as `execa()` except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execaCommand('echo unicorns')`.
  *
- * If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `__dirname` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
+If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `__dirname` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
  *
- * The `shell` option must be used if the `command` uses shell-specific features (for example, `&&` or `||`), as opposed to being a simple `file` followed by its `arguments`.
+The `shell` option must be used if the `command` uses shell-specific features (for example, `&&` or `||`), as opposed to being a simple `file` followed by its `arguments`.
  *
- * @param command - The program/script to execute and its arguments.
- * @returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
+@param command - The program/script to execute and its arguments.
+@returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
  *
- * @example
- * ```typescript
- * import {execaCommand} from 'execa';
+@example
+```typescript
+import {execaCommand} from 'execa';
  *
- * const {stdout} = await execaCommand('echo unicorns');
- * console.log(stdout);
- * //=> 'unicorns'
- * ```
+const {stdout} = await execaCommand('echo unicorns');
+console.log(stdout);
+//=> 'unicorns'
+```
  */
 export function execaCommand(command: string, options?: Options): ExecaChildProcess;
 export function execaCommand(command: string, options?: Options<null>): ExecaChildProcess<Buffer>;
 
 /**
- * Same as `execaCommand()` but synchronous.
+Same as `execaCommand()` but synchronous.
  *
- * @param command - The program/script to execute and its arguments.
- * @returns A result `Object` with `stdout` and `stderr` properties.
+@param command - The program/script to execute and its arguments.
+@returns A result `Object` with `stdout` and `stderr` properties.
  */
 export function execaCommandSync(command: string, options?: SyncOptions): ExecaSyncReturnValue;
 export function execaCommandSync(command: string, options?: SyncOptions<null>): ExecaSyncReturnValue<Buffer>;
 
 /**
- * Execute a Node.js script as a child process.
+Execute a Node.js script as a child process.
  *
- * Same as `execa('node', [scriptPath, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
+Same as `execa('node', [scriptPath, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
  *
- * - the current Node version and options are used. This can be overridden using the `nodePath` and `nodeArguments` options.
- * - the `shell` option cannot be used
- * - an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)
+- the current Node version and options are used. This can be overridden using the `nodePath` and `nodeArguments` options.
+- the `shell` option cannot be used
+- an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)
  *
- * @param scriptPath - Node.js script to execute.
- * @param arguments - Arguments to pass to `scriptPath` on execution.
- * @returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
+@param scriptPath - Node.js script to execute.
+@param arguments - Arguments to pass to `scriptPath` on execution.
+@returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
  */
 export function execaNode(
 	scriptPath: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,8 +35,6 @@ export interface CommonOptions<EncodingType> {
 	/**
 	Preferred path to find locally installed binaries in (use with `preferLocal`).
 
-	Using a `URL` is only supported in Node.js `14.18.0`, `16.14.0` or above.
-
 	@default process.cwd()
 	*/
 	readonly localDir?: string | URL;
@@ -115,8 +113,6 @@ export interface CommonOptions<EncodingType> {
 	/**
 	Current working directory of the child process.
 
-	Using a `URL` is only supported in Node.js `14.18.0`, `16.14.0` or above.
-
 	@default process.cwd()
 	*/
 	readonly cwd?: string | URL;
@@ -145,8 +141,6 @@ export interface CommonOptions<EncodingType> {
 
 	- `json`: Uses `JSON.stringify()` and `JSON.parse()`.
 	- `advanced`: Uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
-
-	Requires Node.js `13.2.0` or later.
 
 	[More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization)
 
@@ -486,14 +480,14 @@ console.log(stdout);
 const subprocess = execa('node');
 
 setTimeout(() => {
-  subprocess.cancel()
+	subprocess.cancel()
 }, 1000);
 
 try {
-  await subprocess;
+	await subprocess;
 } catch (error) {
-  console.log(subprocess.killed); // true
-  console.log(error.isCanceled); // true
+	console.log(subprocess.killed); // true
+	console.log(error.isCanceled); // true
 }
 
 // Pipe the child process stdout to the current stdout

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,325 +14,335 @@ export type StdioOption =
 
 export interface CommonOptions<EncodingType> {
 	/**
-	Kill the spawned process when the parent process exits unless either:
-		- the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
-		- the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
-
-	@default true
-	*/
+	 * Kill the spawned process when the parent process exits unless either:
+	 *
+	 * - the spawned process is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
+	 * - the parent process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
+	 *
+	 * @default true
+	 */
 	readonly cleanup?: boolean;
 
 	/**
-	Prefer locally installed binaries when looking for a binary to execute.
-
-	If you `$ npm install foo`, you can then `execa('foo')`.
-
-	@default false
-	*/
+	 * Prefer locally installed binaries when looking for a binary to execute.
+	 *
+	 * If you `npm install foo`, you can then `execa('foo')`.
+	 *
+	 * @default false
+	 */
 	readonly preferLocal?: boolean;
 
 	/**
-	Preferred path to find locally installed binaries in (use with `preferLocal`).
-
-	@default process.cwd()
-	*/
+	 * Preferred path to find locally installed binaries in (use with `preferLocal`).
+	 *
+	 * Using a `URL` is only supported in Node.js `14.18.0`, `16.14.0` or above.
+	 *
+	 * @default process.cwd()
+	 */
 	readonly localDir?: string | URL;
 
 	/**
-	Path to the Node.js executable to use in child processes.
-
-	This can be either an absolute path or a path relative to the `cwd` option.
-
-	Requires `preferLocal` to be `true`.
-
-	For example, this can be used together with [`get-node`](https://github.com/ehmicky/get-node) to run a specific Node.js version in a child process.
-
-	@default process.execPath
-	*/
+	 * Path to the Node.js executable to use in child processes.
+	 *
+	 * This can be either an absolute path or a path relative to the `cwd` option.
+	 *
+	 * Requires `preferLocal` to be `true`.
+	 *
+	 * For example, this can be used together with [`get-node`](https://github.com/ehmicky/get-node) to run a specific Node.js version in a child process.
+	 *
+	 * @default process.execPath
+	 */
 	readonly execPath?: string;
 
 	/**
-	Buffer the output from the spawned process. When set to `false`, you must read the output of `stdout` and `stderr` (or `all` if the `all` option is `true`). Otherwise the returned promise will not be resolved/rejected.
-
-	If the spawned process fails, `error.stdout`, `error.stderr`, and `error.all` will contain the buffered data.
-
-	@default true
-	*/
+	 * Buffer the output from the spawned process. When set to `false`, you must read the output of `stdout` and `stderr` (or `all` if the `all` option is `true`). Otherwise the returned promise will not be resolved/rejected.
+	 *
+	 * If the spawned process fails, `error.stdout`, `error.stderr`, and `error.all` will contain the buffered data.
+	 *
+	 * @default true
+	 */
 	readonly buffer?: boolean;
 
 	/**
-	Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-
-	@default 'pipe'
-	*/
+	 * Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+   *
+	 * @default 'pipe'
+	 */
 	readonly stdin?: StdioOption;
 
 	/**
-	Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-
-	@default 'pipe'
-	*/
+	 * Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+	 *
+	 * @default 'pipe'
+	 */
 	readonly stdout?: StdioOption;
 
 	/**
-	Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
-
-	@default 'pipe'
-	*/
+	 * Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
+	 *
+	 * @default 'pipe'
+	 */
 	readonly stderr?: StdioOption;
 
 	/**
-	Setting this to `false` resolves the promise with the error instead of rejecting it.
-
-	@default true
-	*/
+	 * Setting this to `false` resolves the promise with the error instead of rejecting it.
+	 *
+	 * @default true
+	 */
 	readonly reject?: boolean;
 
 	/**
-	Add an `.all` property on the promise and the resolved value. The property contains the output of the process with `stdout` and `stderr` interleaved.
-
-	@default false
-	*/
+	 * Add an `.all` property on the promise and the resolved value. The property contains the output of the process with `stdout` and `stderr` interleaved.
+	 *
+	 * @default false
+	 */
 	readonly all?: boolean;
 
 	/**
-	Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
-
-	@default true
-	*/
+	 * Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
+	 *
+	 * @default true
+	 */
 	readonly stripFinalNewline?: boolean;
 
 	/**
-	Set to `false` if you don't want to extend the environment variables when providing the `env` property.
-
-	@default true
-	*/
+	 * Set to `false` if you don't want to extend the environment variables when providing the `env` property.
+	 *
+	 * @default true
+	 */
 	readonly extendEnv?: boolean;
 
 	/**
-	Current working directory of the child process.
-
-	@default process.cwd()
-	*/
+	 * Current working directory of the child process.
+	 *
+	 * Using a `URL` is only supported in Node.js `14.18.0`, `16.14.0` or above.
+	 *
+	 * @default process.cwd()
+	 */
 	readonly cwd?: string | URL;
 
 	/**
-	Environment key-value pairs. Extends automatically from `process.env`. Set `extendEnv` to `false` if you don't want this.
-
-	@default process.env
-	*/
+	 * Environment key-value pairs. Extends automatically from `process.env`. Set `extendEnv` to `false` if you don't want this.
+	 *
+	 * @default process.env
+	 */
 	readonly env?: NodeJS.ProcessEnv;
 
 	/**
-	Explicitly set the value of `argv[0]` sent to the child process. This will be set to `command` or `file` if not specified.
-	*/
+	 * Explicitly set the value of `argv[0]` sent to the child process. This will be set to `command` or `file` if not specified.
+	 */
 	readonly argv0?: string;
 
 	/**
-	Child's [stdio](https://nodejs.org/api/child_process.html#child_process_options_stdio) configuration.
-
-	@default 'pipe'
-	*/
-	readonly stdio?: 'pipe' | 'overlapped' | 'ignore' | 'inherit' | readonly StdioOption[];
+	 * Child's [stdio](https://nodejs.org/api/child_process.html#child_process_options_stdio) configuration.
+	 *
+	 * @default 'pipe'
+	 */
+	readonly stdio?: 'pipe' | 'ignore' | 'inherit' | readonly StdioOption[];
 
 	/**
-	Specify the kind of serialization used for sending messages between processes when using the `stdio: 'ipc'` option or `execaNode()`:
-		- `json`: Uses `JSON.stringify()` and `JSON.parse()`.
-		- `advanced`: Uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
-
-	[More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization)
-
-	@default 'json'
-	*/
+	 * Specify the kind of serialization used for sending messages between processes when using the `stdio: 'ipc'` option or `execaNode()`:
+	 *
+	 * - `json`: Uses `JSON.stringify()` and `JSON.parse()`.
+	 * - `advanced`: Uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
+	 *
+	 * Requires Node.js `13.2.0` or later.
+	 *
+	 * [More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization)
+	 *
+	 * @default 'json'
+	 */
 	readonly serialization?: 'json' | 'advanced';
 
 	/**
-	Prepare child to run independently of its parent process. Specific behavior [depends on the platform](https://nodejs.org/api/child_process.html#child_process_options_detached).
-
-	@default false
-	*/
+	 * Prepare child to run independently of its parent process. Specific behavior [depends on the platform](https://nodejs.org/api/child_process.html#child_process_options_detached).
+	 *
+	 * @default false
+	 */
 	readonly detached?: boolean;
 
 	/**
-	Sets the user identity of the process.
-	*/
+	 * Sets the user identity of the process.
+	 */
 	readonly uid?: number;
 
 	/**
-	Sets the group identity of the process.
-	*/
+	 * Sets the group identity of the process.
+	 */
 	readonly gid?: number;
 
 	/**
-	If `true`, runs `command` inside of a shell. Uses `/bin/sh` on UNIX and `cmd.exe` on Windows. A different shell can be specified as a string. The shell should understand the `-c` switch on UNIX or `/d /s /c` on Windows.
-
-	We recommend against using this option since it is:
-	- not cross-platform, encouraging shell-specific syntax.
-	- slower, because of the additional shell interpretation.
-	- unsafe, potentially allowing command injection.
-
-	@default false
-	*/
+	 * If `true`, runs `command` inside of a shell. Uses `/bin/sh` on UNIX and `cmd.exe` on Windows. A different shell can be specified as a string. The shell should understand the `-c` switch on UNIX or `/d /s /c` on Windows.
+	 *
+	 * We recommend against using this option since it is:
+	 *
+	 * - not cross-platform, encouraging shell-specific syntax.
+	 * - slower, because of the additional shell interpretation.
+	 * - unsafe, potentially allowing command injection.
+	 *
+	 * @default false
+	 */
 	readonly shell?: boolean | string;
 
 	/**
-	Specify the character encoding used to decode the `stdout` and `stderr` output. If set to `null`, then `stdout` and `stderr` will be a `Buffer` instead of a string.
-
-	@default 'utf8'
-	*/
+	 * Specify the character encoding used to decode the `stdout` and `stderr` output. If set to `null`, then `stdout` and `stderr` will be a `Buffer` instead of a string.
+	 *
+	 * @default 'utf8'
+	 */
 	readonly encoding?: EncodingType;
 
 	/**
-	If `timeout` is greater than `0`, the parent will send the signal identified by the `killSignal` property (the default is `SIGTERM`) if the child runs longer than `timeout` milliseconds.
-
-	@default 0
-	*/
+	 * If `timeout` is greater than `0`, the parent will send the signal identified by the `killSignal` property (the default is `SIGTERM`) if the child runs longer than `timeout` milliseconds.
+	 *
+	 * @default 0
+	 */
 	readonly timeout?: number;
 
 	/**
-	Largest amount of data in bytes allowed on `stdout` or `stderr`. Default: 100 MB.
-
-	@default 100_000_000
-	*/
+	 * Largest amount of data in bytes allowed on `stdout` or `stderr`. Default: 100 MB.
+	 *
+	 * @default 100_000_000
+	 */
 	readonly maxBuffer?: number;
 
 	/**
-	Signal value to be used when the spawned process will be killed.
-
-	@default 'SIGTERM'
-	*/
+	 * Signal value to be used when the spawned process will be killed.
+	 *
+	 * @default 'SIGTERM'
+	 */
 	readonly killSignal?: string | number;
 
 	/**
-	You can abort the spawned process using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
-
-	When `AbortController.abort()` is called, [`.isCanceled`](https://github.com/sindresorhus/execa#iscanceled) becomes `false`.
-
-	*Requires Node.js 16 or later.*
-
-	@example
-	```js
-	import {execa} from 'execa';
-
-	const abortController = new AbortController();
-	const subprocess = execa('node', [], {signal: abortController.signal});
-
-	setTimeout(() => {
-		abortController.abort();
-	}, 1000);
-
-	try {
-		await subprocess;
-	} catch (error) {
-		console.log(subprocess.killed); // true
-		console.log(error.isCanceled); // true
-	}
-	```
-	*/
+	 * You can abort the spawned process using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
+	 *
+	 * When `AbortController.abort()` is called, [`.isCanceled`](https://github.com/sindresorhus/execa#iscanceled) becomes `false`.
+	 *
+	 * *Requires Node.js 16 or later.*
+	 *
+	 * @example
+	 * ```typescript
+	 * import {execa} from 'execa';
+	 *
+	 * const abortController = new AbortController();
+	 * const subprocess = execa('node', [], {signal: abortController.signal});
+	 *
+	 * setTimeout(() => {
+	 * 	abortController.abort();
+	 * }, 1000);
+	 *
+	 * try {
+	 * 	await subprocess;
+	 * } catch (error) {
+	 * 	console.log(subprocess.killed); // true
+	 * 	console.log(error.isCanceled); // true
+	 * }
+	 * ```
+	 */
 	readonly signal?: AbortSignal;
 
 	/**
-	If `true`, no quoting or escaping of arguments is done on Windows. Ignored on other platforms. This is set to `true` automatically when the `shell` option is `true`.
-
-	@default false
-	*/
+	 * If `true`, no quoting or escaping of arguments is done on Windows. Ignored on other platforms. This is set to `true` automatically when the `shell` option is `true`.
+	 *
+	 * @default false
+	 */
 	readonly windowsVerbatimArguments?: boolean;
 
 	/**
-	On Windows, do not create a new console window. Please note this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
-
-	@default true
-	*/
+	 * On Windows, do not create a new console window. Please note this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
+	 *
+	 * @default true
+	 */
 	readonly windowsHide?: boolean;
 }
 
 export interface Options<EncodingType = string> extends CommonOptions<EncodingType> {
 	/**
-	Write some input to the `stdin` of your binary.
-	*/
+	 * Write some input to the `stdin` of your binary.
+	 */
 	readonly input?: string | Buffer | ReadableStream;
 }
 
 export interface SyncOptions<EncodingType = string> extends CommonOptions<EncodingType> {
 	/**
-	Write some input to the `stdin` of your binary.
-	*/
+	 * Write some input to the `stdin` of your binary.
+	 */
 	readonly input?: string | Buffer;
 }
 
 export interface NodeOptions<EncodingType = string> extends Options<EncodingType> {
 	/**
-	The Node.js executable to use.
-
-	@default process.execPath
-	*/
+	 * The Node.js executable to use.
+	 *
+	 * @default process.execPath
+	 */
 	readonly nodePath?: string;
 
 	/**
-	List of [CLI options](https://nodejs.org/api/cli.html#cli_options) passed to the Node.js executable.
-
-	@default process.execArgv
-	*/
+	 * List of [CLI options](https://nodejs.org/api/cli.html#cli_options) passed to the Node.js executable.
+	 *
+	 * @default process.execArgv
+	 */
 	readonly nodeOptions?: string[];
 }
 
 export interface ExecaReturnBase<StdoutStderrType> {
 	/**
-	The file and arguments that were run, for logging purposes.
-
-	This is not escaped and should not be executed directly as a process, including using `execa()` or `execaCommand()`.
-	*/
+	 * The file and arguments that were run, for logging purposes.
+	 *
+	 * This is not escaped and should not be executed directly as a process, including using `execa()` or `execaCommand()`.
+	 */
 	command: string;
 
 	/**
-	Same as `command` but escaped.
-
-	This is meant to be copy and pasted into a shell, for debugging purposes.
-	Since the escaping is fairly basic, this should not be executed directly as a process, including using `execa()` or `execaCommand()`.
-	*/
+	 * Same as `command` but escaped.
+	 *
+	 * This is meant to be copy and pasted into a shell, for debugging purposes.
+	 *
+	 * Since the escaping is fairly basic, this should not be executed directly as a process, including using `execa()` or `execaCommand()`.
+	 */
 	escapedCommand: string;
 
 	/**
-	The numeric exit code of the process that was run.
-	*/
+	 * The numeric exit code of the process that was run.
+	 */
 	exitCode: number;
 
 	/**
-	The output of the process on stdout.
-	*/
+	 * The output of the process on stdout.
+	 */
 	stdout: StdoutStderrType;
 
 	/**
-	The output of the process on stderr.
-	*/
+	 * The output of the process on stderr.
+	 */
 	stderr: StdoutStderrType;
 
 	/**
-	Whether the process failed to run.
-	*/
+	 * Whether the process failed to run.
+	 */
 	failed: boolean;
 
 	/**
-	Whether the process timed out.
-	*/
+	 * Whether the process timed out.
+	 */
 	timedOut: boolean;
 
 	/**
-	Whether the process was killed.
-	*/
+	 * Whether the process was killed.
+	 */
 	killed: boolean;
 
 	/**
-	The name of the signal that was used to terminate the process. For example, `SIGFPE`.
-
-	If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
-	*/
+	 * The name of the signal that was used to terminate the process. For example, `SIGFPE`.
+	 *
+	 * If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`.
+	 */
 	signal?: string;
 
 	/**
-	A human-friendly description of the signal that was used to terminate the process. For example, `Floating point arithmetic error`.
-
-	If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`. It is also `undefined` when the signal is very uncommon which should seldomly happen.
+	 * A human-friendly description of the signal that was used to terminate the process. For example, `Floating point arithmetic error`.
+	 *
+	 * If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`. It is also `undefined` when the signal is very uncommon which should seldomly happen.
 	*/
 	signalDescription?: string;
 }
@@ -342,31 +352,33 @@ export interface ExecaSyncReturnValue<StdoutErrorType = string>
 }
 
 /**
-Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
-
-The child process fails when:
-- its exit code is not `0`
-- it was killed with a signal
-- timing out
-- being canceled
-- there's not enough memory or there are already too many child processes
-*/
+ * Result of a child process execution. On success this is a plain object. On failure this is also an `Error` instance.
+ *
+ * The child process fails when:
+ *
+ * - its exit code is not `0`
+ * - it was killed with a signal
+ * - timing out
+ * - being canceled
+ * - there's not enough memory or there are already too many child processes
+ */
 export interface ExecaReturnValue<StdoutErrorType = string>
 	extends ExecaSyncReturnValue<StdoutErrorType> {
 	/**
-	The output of the process with `stdout` and `stderr` interleaved.
-
-	This is `undefined` if either:
-	- the `all` option is `false` (default value)
-	- `execaSync()` was used
-	*/
+	 * The output of the process with `stdout` and `stderr` interleaved.
+	 *
+	 * This is `undefined` if either:
+	 *
+	 * - the `all` option is `false` (default value)
+	 * - `execaSync()` was used
+	 */
 	all?: StdoutErrorType;
 
 	/**
-	Whether the process was canceled.
-
-	You can cancel the spawned process using the [`signal`](https://github.com/sindresorhus/execa#signal-1) option.
-	*/
+	 * Whether the process was canceled.
+	 *
+	 * You can cancel the spawned process using the [`signal`](https://github.com/sindresorhus/execa#signal-1) option.
+	 */
 	isCanceled: boolean;
 }
 
@@ -374,61 +386,63 @@ export interface ExecaSyncError<StdoutErrorType = string>
 	extends Error,
 	ExecaReturnBase<StdoutErrorType> {
 	/**
-	Error message when the child process failed to run. In addition to the underlying error message, it also contains some information related to why the child process errored.
-
-	The child process stderr then stdout are appended to the end, separated with newlines and not interleaved.
-	*/
+	 * Error message when the child process failed to run. In addition to the underlying error message, it also contains some information related to why the child process errored.
+	 *
+	 * The child process stderr then stdout are appended to the end, separated with newlines and not interleaved.
+	 */
 	message: string;
 
 	/**
-	This is the same as the `message` property except it does not include the child process stdout/stderr.
-	*/
+	 * This is the same as the `message` property except it does not include the child process stdout/stderr.
+	 */
 	shortMessage: string;
 
 	/**
-	Original error message. This is the same as the `message` property except it includes neither the child process stdout/stderr nor some additional information added by Execa.
-
-	This is `undefined` unless the child process exited due to an `error` event or a timeout.
-	*/
+	 * Original error message. This is the same as the `message` property except it includes neither the child process stdout/stderr nor some additional information added by Execa.
+	 *
+	 * This is `undefined` unless the child process exited due to an `error` event or a timeout.
+	 */
 	originalMessage?: string;
 }
 
 export interface ExecaError<StdoutErrorType = string>
 	extends ExecaSyncError<StdoutErrorType> {
 	/**
-	The output of the process with `stdout` and `stderr` interleaved.
-
-	This is `undefined` if either:
-	- the `all` option is `false` (default value)
-	- `execaSync()` was used
-	*/
+	 * The output of the process with `stdout` and `stderr` interleaved.
+	 *
+	 * This is `undefined` if either:
+	 *
+	 * - the `all` option is `false` (default value)
+	 * - `execaSync()` was used
+	 */
 	all?: StdoutErrorType;
 
 	/**
-	Whether the process was canceled.
-	*/
+	 * Whether the process was canceled.
+	 */
 	isCanceled: boolean;
 }
 
 export interface KillOptions {
 	/**
-	Milliseconds to wait for the child process to terminate before sending `SIGKILL`.
-
-	Can be disabled with `false`.
-
-	@default 5000
-	*/
+	 * Milliseconds to wait for the child process to terminate before sending `SIGKILL`.
+	 *
+	 * Can be disabled with `false`.
+	 *
+	 * @default 5000
+	 */
 	forceKillAfterTimeout?: number | false;
 }
 
 export interface ExecaChildPromise<StdoutErrorType> {
 	/**
-	Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
-
-	This is `undefined` if either:
-		- the `all` option is `false` (the default value)
-		- both `stdout` and `stderr` options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio)
-	*/
+	 * Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
+	 *
+	 * This is `undefined` if either:
+	 *
+	 * - the `all` option is `false` (the default value)
+	 * - both `stdout` and `stderr` options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio)
+	 */
 	all?: ReadableStream;
 
 	catch<ResultType = never>(
@@ -436,13 +450,13 @@ export interface ExecaChildPromise<StdoutErrorType> {
 	): Promise<ExecaReturnValue<StdoutErrorType> | ResultType>;
 
 	/**
-	Same as the original [`child_process#kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal), except if `signal` is `SIGTERM` (the default value) and the child process is not terminated after 5 seconds, force it by sending `SIGKILL`.
-	*/
+	 * Same as the original [`child_process#kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal), except if `signal` is `SIGTERM` (the default value) and the child process is not terminated after 5 seconds, force it by sending `SIGKILL`.
+	 */
 	kill(signal?: string, options?: KillOptions): void;
 
 	/**
-	Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal). This is preferred when cancelling the child process execution as the error is more descriptive and [`childProcessResult.isCanceled`](#iscanceled) is set to `true`.
-	*/
+	 * Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal). This is preferred when cancelling the child process execution as the error is more descriptive and [`childProcessResult.isCanceled`](#iscanceled) is set to `true`.
+	 */
 	cancel(): void;
 }
 
@@ -451,41 +465,41 @@ ExecaChildPromise<StdoutErrorType> &
 Promise<ExecaReturnValue<StdoutErrorType>>;
 
 /**
-Execute a file.
-
-Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
-
-@param file - The program/script to execute.
-@param arguments - Arguments to pass to `file` on execution.
-@returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
-
-@example
-```
-import {execa} from 'execa';
-
-const {stdout} = await execa('echo', ['unicorns']);
-console.log(stdout);
-//=> 'unicorns'
-
-// Cancelling a spawned process
-
-const subprocess = execa('node');
-
-setTimeout(() => {
-	subprocess.cancel()
-}, 1000);
-
-try {
-	await subprocess;
-} catch (error) {
-	console.log(subprocess.killed); // true
-	console.log(error.isCanceled); // true
-}
-
-// Pipe the child process stdout to the current stdout
-execa('echo', ['unicorns']).stdout.pipe(process.stdout);
-```
-*/
+ * Execute a file.
+ *
+ * Think of this as a mix of `child_process.execFile` and `child_process.spawn`.
+ *
+ * @param file - The program/script to execute.
+ * @param arguments - Arguments to pass to `file` on execution.
+ * @returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
+ *
+ * @example
+ * ```typescript
+ * import {execa} from 'execa';
+ *
+ * const {stdout} = await execa('echo', ['unicorns']);
+ * console.log(stdout);
+ * //=> 'unicorns'
+ *
+ * // Cancelling a spawned process
+ *
+ * const subprocess = execa('node');
+ *
+ * setTimeout(() => {
+ *   subprocess.cancel()
+ * }, 1000);
+ *
+ * try {
+ *   await subprocess;
+ * } catch (error) {
+ *   console.log(subprocess.killed); // true
+ *   console.log(error.isCanceled); // true
+ * }
+ *
+ * // Pipe the child process stdout to the current stdout
+ * execa('echo', ['unicorns']).stdout.pipe(process.stdout);
+ * ```
+ */
 export function execa(
 	file: string,
 	arguments?: readonly string[],
@@ -500,14 +514,14 @@ export function execa(file: string, options?: Options): ExecaChildProcess;
 export function execa(file: string, options?: Options<null>): ExecaChildProcess<Buffer>;
 
 /**
-Execute a file synchronously.
-
-This method throws an `Error` if the command fails.
-
-@param file - The program/script to execute.
-@param arguments - Arguments to pass to `file` on execution.
-@returns A result `Object` with `stdout` and `stderr` properties.
-*/
+ * Execute a file synchronously.
+ *
+ * This method throws an `Error` if the command fails.
+ *
+ * @param file - The program/script to execute.
+ * @param arguments - Arguments to pass to `file` on execution.
+ * @returns A result `Object` with `stdout` and `stderr` properties.
+ */
 export function execaSync(
 	file: string,
 	arguments?: readonly string[],
@@ -525,48 +539,49 @@ export function execaSync(
 ): ExecaSyncReturnValue<Buffer>;
 
 /**
-Same as `execa()` except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execaCommand('echo unicorns')`.
-
-If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `__dirname` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
-
-The `shell` option must be used if the `command` uses shell-specific features (for example, `&&` or `||`), as opposed to being a simple `file` followed by its `arguments`.
-
-@param command - The program/script to execute and its arguments.
-@returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
-
-@example
-```
-import {execaCommand} from 'execa';
-
-const {stdout} = await execaCommand('echo unicorns');
-console.log(stdout);
-//=> 'unicorns'
-```
-*/
+ * Same as `execa()` except both file and arguments are specified in a single `command` string. For example, `execa('echo', ['unicorns'])` is the same as `execaCommand('echo unicorns')`.
+ *
+ * If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `__dirname` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
+ *
+ * The `shell` option must be used if the `command` uses shell-specific features (for example, `&&` or `||`), as opposed to being a simple `file` followed by its `arguments`.
+ *
+ * @param command - The program/script to execute and its arguments.
+ * @returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
+ *
+ * @example
+ * ```typescript
+ * import {execaCommand} from 'execa';
+ *
+ * const {stdout} = await execaCommand('echo unicorns');
+ * console.log(stdout);
+ * //=> 'unicorns'
+ * ```
+ */
 export function execaCommand(command: string, options?: Options): ExecaChildProcess;
 export function execaCommand(command: string, options?: Options<null>): ExecaChildProcess<Buffer>;
 
 /**
-Same as `execaCommand()` but synchronous.
-
-@param command - The program/script to execute and its arguments.
-@returns A result `Object` with `stdout` and `stderr` properties.
-*/
+ * Same as `execaCommand()` but synchronous.
+ *
+ * @param command - The program/script to execute and its arguments.
+ * @returns A result `Object` with `stdout` and `stderr` properties.
+ */
 export function execaCommandSync(command: string, options?: SyncOptions): ExecaSyncReturnValue;
 export function execaCommandSync(command: string, options?: SyncOptions<null>): ExecaSyncReturnValue<Buffer>;
 
 /**
-Execute a Node.js script as a child process.
-
-Same as `execa('node', [scriptPath, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
-	- the current Node version and options are used. This can be overridden using the `nodePath` and `nodeArguments` options.
-	- the `shell` option cannot be used
-	- an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)
-
-@param scriptPath - Node.js script to execute.
-@param arguments - Arguments to pass to `scriptPath` on execution.
-@returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
-*/
+ * Execute a Node.js script as a child process.
+ *
+ * Same as `execa('node', [scriptPath, ...arguments], options)` except (like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)):
+ *
+ * - the current Node version and options are used. This can be overridden using the `nodePath` and `nodeArguments` options.
+ * - the `shell` option cannot be used
+ * - an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to [`stdio`](#stdio)
+ *
+ * @param scriptPath - Node.js script to execute.
+ * @param arguments - Arguments to pass to `scriptPath` on execution.
+ * @returns A [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess), which is enhanced to also be a `Promise` for a result `Object` with `stdout` and `stderr` properties.
+ */
 export function execaNode(
 	scriptPath: string,
 	arguments?: readonly string[],


### PR DESCRIPTION
Changes:

- add blank line:
   - before lists;
   - between two lines of text which seem to be two separate paragraph (e.g. [`index.d.ts` (L290-291)](https://github.com/sindresorhus/execa/blob/main/index.d.ts#L290-L291));
- remove indentation before first-level in lists;
- specify syntax highlighting language as `typescript` for code blocks when missing or when `js` was used.