### PR TITLE
Change documentation of `.cancel()` to mention that it’s deprecated

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -441,7 +441,7 @@ export interface ExecaChildPromise<StdoutErrorType> {
 	kill(signal?: string, options?: KillOptions): void;
 
 	/**
-	Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal). This is preferred when cancelling the child process execution as the error is more descriptive and [`childProcessResult.isCanceled`](#iscanceled) is set to `true`.
+	Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal). This used to be preferred when cancelling the child process execution as the error is more descriptive and [`childProcessResult.isCanceled`](#iscanceled) is set to `true`. But now this is deprecated and you should either use `.kill()` or the `signal` option when creating the child process.
 	*/
 	cancel(): void;
 }


### PR DESCRIPTION

See https://github.com/sindresorhus/execa/issues/511#issuecomment-1328047085