### PR TITLE
Emit `end` event on streams when process fails

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -36,7 +36,7 @@ export const makeAllStream = (spawned, {all}) => {
 
 // On failure, `result.stdout|stderr|all` should contain the currently buffered stream
 const getBufferedData = async (stream, streamPromise) => {
-	if (!stream) {
+	if (!stream || streamPromise === undefined) {
 		return;
 	}
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -36,6 +36,7 @@ export const makeAllStream = (spawned, {all}) => {
 
 // On failure, `result.stdout|stderr|all` should contain the currently buffered stream
 const getBufferedData = async (stream, streamPromise) => {
+	// When `buffer` is `false`, `streamPromise` is `undefined` and there is no buffered data to retrieve
 	if (!stream || streamPromise === undefined) {
 		return;
 	}

--- a/test/stream.js
+++ b/test/stream.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import Stream from 'node:stream';
 import test from 'ava';
 import getStream from 'get-stream';
+import {pEvent} from 'p-event';
 import tempfile from 'tempfile';
 import {execa, execaSync} from '../index.js';
 import {setFixtureDir} from './helpers/fixtures-dir.js';
@@ -171,6 +172,11 @@ test('buffer: false > promise rejects when process returns non-zero', async t =>
 	const subprocess = execa('fail.js', {buffer: false});
 	const {exitCode} = await t.throwsAsync(subprocess);
 	t.is(exitCode, 2);
+});
+
+test('buffer: false > emits end event when promise is rejected', async t => {
+	const subprocess = execa('wrong command', {buffer: false, reject: false});
+	await t.notThrowsAsync(Promise.all([subprocess, pEvent(subprocess.stdout, 'end')]));
 });
 
 test('can use all: true with stdout: ignore', async t => {


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/execa/issues/517

When a process (or one of its standard streams) errors, we return what could have been buffered so far from stdout/stderr as `error.stdout` and `error.stderr` (which are also appended to `error.message`). To do this, we first `destroy()` those streams, then retrieve the buffered value from `get-stream`.

However, calling `destroy()` prevents the `end` event from being emitted on those streams. This behavior differs from how `child_process.spawn()` and might be unexpected.

This PR fixes this for the case where the `buffer` option is `false`. When that's the case, there is no need to destroy the streams since we do not need to do anything with them anymore. We can just let Node.js destroy them naturally as part of the child process exit.