### PR TITLE
Make `preferLocal` default to `true` with `$`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export type CommonOptions<EncodingType> = {
 
 	If you `$ npm install foo`, you can then `execa('foo')`.
 
-	@default false
+	@default `true` with `$`/`$.sync`, `false` otherwise
 	*/
 	readonly preferLocal?: boolean;
 

--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ function create$(options) {
 	return $;
 }
 
-export const $ = create$();
+export const $ = create$({preferLocal: true});
 
 export function execaCommand(command, options) {
 	const [file, ...args] = parseCommand(command);

--- a/readme.md
+++ b/readme.md
@@ -425,7 +425,7 @@ Kill the spawned process when the parent process exits unless either:
 #### preferLocal
 
 Type: `boolean`\
-Default: `false`
+Default: `true` with [`$`](#command)/[`$.sync`](#synccommand), `false` otherwise
 
 Prefer locally installed binaries when looking for a binary to execute.\
 If you `$ npm install foo`, you can then `execa('foo')`.

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ import {fileURLToPath, pathToFileURL} from 'node:url';
 import test from 'ava';
 import isRunning from 'is-running';
 import getNode from 'get-node';
-import {execa, execaSync} from '../index.js';
+import {execa, execaSync, $} from '../index.js';
 import {setFixtureDir, PATH_KEY} from './helpers/fixtures-dir.js';
 
 setFixtureDir();
@@ -94,6 +94,10 @@ test('preferLocal: false', async t => {
 
 test('preferLocal: undefined', async t => {
 	await t.throwsAsync(execa('ava', ['--version'], {env: getPathWithoutLocalDir()}), {message: ENOENT_REGEXP});
+});
+
+test('preferLocal: undefined with $', async t => {
+	await t.notThrowsAsync($({env: getPathWithoutLocalDir()})`ava --version`);
 });
 
 test('localDir option', async t => {


### PR DESCRIPTION
Fixes #522.

This makes the `preferLocal` option default to `true` when using `$` or `$.sync`.

cc @aaronccasanova for code review too.