### PR TITLE
Fix anchor in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -312,7 +312,7 @@ This is not escaped and should not be executed directly as a process, including 
 
 Type: `string`
 
-Same as [`command`](#command) but escaped.
+Same as [`command`](#command-1) but escaped.
 
 This is meant to be copy and pasted into a shell, for debugging purposes.
 Since the escaping is fairly basic, this should not be executed directly as a process, including using [`execa()`](#execafile-arguments-options) or [`execaCommand()`](#execacommandcommand-options).


### PR DESCRIPTION
This fixes an anchor in `readme.md` currently pointing at the wrong section.