### PR TITLE
Add `pipeStdout()`-related methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -453,29 +453,29 @@ export type ExecaChildPromise<StdoutStderrType extends StdoutStderrAll> = {
 
 	/**
 	[Pipe](https://nodejs.org/api/stream.html#readablepipedestination-options) the child process's `stdout` to `target`, which can be:
-    - Another `execa()` return value
-    - A writable stream
-    - A file path string
+	- Another `execa()` return value
+	- A writable stream
+	- A file path string
 
-  If the `target` is another `execa()` return value, it is returned. Otherwise, the original `execa()` return value is returned. This allows chaining `pipeStdout()` then `await`ing the final result.
+	If the `target` is another `execa()` return value, it is returned. Otherwise, the original `execa()` return value is returned. This allows chaining `pipeStdout()` then `await`ing the final result.
 
-  The `stdout` option] must be kept as `pipe`, its default value.
+	The `stdout` option] must be kept as `pipe`, its default value.
 	*/
 	pipeStdout?<Target extends ExecaChildPromise<StdoutStderrAll>>(target: Target): Target;
 	pipeStdout?(target: WritableStream | string): ExecaChildProcess<StdoutStderrType>;
 
 	/**
-  Like `pipeStdout()` but piping the child process's `stderr` instead.
+	Like `pipeStdout()` but piping the child process's `stderr` instead.
 
-  The `stderr` option must be kept as `pipe`, its default value.
+	The `stderr` option must be kept as `pipe`, its default value.
 	*/
 	pipeStderr?<Target extends ExecaChildPromise<StdoutStderrAll>>(target: Target): Target;
 	pipeStderr?(target: WritableStream | string): ExecaChildProcess<StdoutStderrType>;
 
 	/**
-  Combines both `pipeStdout()` and `pipeStderr()`.
+	Combines both `pipeStdout()` and `pipeStderr()`.
 
-  Either the `stdout` option or the `stderr` option must be kept as `pipe`, their default value. Also, the `all` option must be set to `true`.
+	Either the `stdout` option or the `stderr` option must be kept as `pipe`, their default value. Also, the `all` option must be set to `true`.
 	*/
 	pipeAll?<Target extends ExecaChildPromise<StdoutStderrAll>>(target: Target): Target;
 	pipeAll?(target: WritableStream | string): ExecaChildProcess<StdoutStderrType>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -452,20 +452,31 @@ export type ExecaChildPromise<StdoutStderrType extends StdoutStderrAll> = {
 	cancel(): void;
 
 	/**
+	[Pipe](https://nodejs.org/api/stream.html#readablepipedestination-options) the child process's `stdout` to `target`, which can be:
+    - Another `execa()` return value
+    - A writable stream
+    - A file path string
 
-	 */
+  If the `target` is another `execa()` return value, it is returned. Otherwise, the original `execa()` return value is returned. This allows chaining `pipeStdout()` then `await`ing the final result.
+
+  The `stdout` option] must be kept as `pipe`, its default value.
+	*/
 	pipeStdout?<Target extends ExecaChildPromise<StdoutStderrAll>>(target: Target): Target;
 	pipeStdout?(target: WritableStream | string): ExecaChildProcess<StdoutStderrType>;
 
 	/**
+  Like `pipeStdout()` but piping the child process's `stderr` instead.
 
-	 */
+  The `stderr` option must be kept as `pipe`, its default value.
+	*/
 	pipeStderr?<Target extends ExecaChildPromise<StdoutStderrAll>>(target: Target): Target;
 	pipeStderr?(target: WritableStream | string): ExecaChildProcess<StdoutStderrType>;
 
 	/**
+  Combines both `pipeStdout()` and `pipeStderr()`.
 
-	 */
+  Either the `stdout` option or the `stderr` option must be kept as `pipe`, their default value. Also, the `all` option must be set to `true`.
+	*/
 	pipeAll?<Target extends ExecaChildPromise<StdoutStderrAll>>(target: Target): Target;
 	pipeAll?(target: WritableStream | string): ExecaChildProcess<StdoutStderrType>;
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import {type Buffer} from 'node:buffer';
 import {type ChildProcess} from 'node:child_process';
-import {type Stream, type Readable as ReadableStream} from 'node:stream';
+import {type Stream, type Readable as ReadableStream, type Writable as WritableStream} from 'node:stream';
 
 export type StdioOption =
 	| 'pipe'
@@ -285,7 +285,9 @@ export type NodeOptions<EncodingType = string> = {
 	readonly nodeOptions?: string[];
 } & Options<EncodingType>;
 
-export type ExecaReturnBase<StdoutStderrType> = {
+type StdoutStderrAll = string | Buffer | undefined;
+
+export type ExecaReturnBase<StdoutStderrType extends StdoutStderrAll> = {
 	/**
 	The file and arguments that were run, for logging purposes.
 
@@ -346,7 +348,7 @@ export type ExecaReturnBase<StdoutStderrType> = {
 	signalDescription?: string;
 };
 
-export type ExecaSyncReturnValue<StdoutStderrType = string> = {
+export type ExecaSyncReturnValue<StdoutStderrType extends StdoutStderrAll = string> = {
 } & ExecaReturnBase<StdoutStderrType>;
 
 /**
@@ -359,7 +361,7 @@ The child process fails when:
 - being canceled
 - there's not enough memory or there are already too many child processes
 */
-export type ExecaReturnValue<StdoutStderrType = string> = {
+export type ExecaReturnValue<StdoutStderrType extends StdoutStderrAll = string> = {
 	/**
 	The output of the process with `stdout` and `stderr` interleaved.
 
@@ -377,7 +379,7 @@ export type ExecaReturnValue<StdoutStderrType = string> = {
 	isCanceled: boolean;
 } & ExecaSyncReturnValue<StdoutStderrType>;
 
-export type ExecaSyncError<StdoutStderrType = string> = {
+export type ExecaSyncError<StdoutStderrType extends StdoutStderrAll = string> = {
 	/**
 	Error message when the child process failed to run. In addition to the underlying error message, it also contains some information related to why the child process errored.
 
@@ -398,7 +400,7 @@ export type ExecaSyncError<StdoutStderrType = string> = {
 	originalMessage?: string;
 } & Error & ExecaReturnBase<StdoutStderrType>;
 
-export type ExecaError<StdoutStderrType = string> = {
+export type ExecaError<StdoutStderrType extends StdoutStderrAll = string> = {
 	/**
 	The output of the process with `stdout` and `stderr` interleaved.
 
@@ -425,7 +427,7 @@ export type KillOptions = {
 	forceKillAfterTimeout?: number | false;
 };
 
-export type ExecaChildPromise<StdoutStderrType> = {
+export type ExecaChildPromise<StdoutStderrType extends StdoutStderrAll> = {
 	/**
 	Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
@@ -448,9 +450,27 @@ export type ExecaChildPromise<StdoutStderrType> = {
 	Similar to [`childProcess.kill()`](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal). This used to be preferred when cancelling the child process execution as the error is more descriptive and [`childProcessResult.isCanceled`](#iscanceled) is set to `true`. But now this is deprecated and you should either use `.kill()` or the `signal` option when creating the child process.
 	*/
 	cancel(): void;
+
+	/**
+
+	 */
+	pipeStdout?<Target extends ExecaChildPromise<StdoutStderrAll>>(target: Target): Target;
+	pipeStdout?(target: WritableStream | string): ExecaChildProcess<StdoutStderrType>;
+
+	/**
+
+	 */
+	pipeStderr?<Target extends ExecaChildPromise<StdoutStderrAll>>(target: Target): Target;
+	pipeStderr?(target: WritableStream | string): ExecaChildProcess<StdoutStderrType>;
+
+	/**
+
+	 */
+	pipeAll?<Target extends ExecaChildPromise<StdoutStderrAll>>(target: Target): Target;
+	pipeAll?(target: WritableStream | string): ExecaChildProcess<StdoutStderrType>;
 };
 
-export type ExecaChildProcess<StdoutStderrType = string> = ChildProcess &
+export type ExecaChildProcess<StdoutStderrType extends StdoutStderrAll = string> = ChildProcess &
 ExecaChildPromise<StdoutStderrType> &
 Promise<ExecaReturnValue<StdoutStderrType>>;
 
@@ -557,7 +577,7 @@ type TemplateExpression =
 	| ExecaSyncReturnValue<string | Buffer>
 	| Array<string | number | ExecaReturnValue<string | Buffer> | ExecaSyncReturnValue<string | Buffer>>;
 
-type Execa$<StdoutStderrType = string> = {
+type Execa$<StdoutStderrType extends StdoutStderrAll = string> = {
 	/**
 	Same as `execa()` except both file and arguments are specified in a single tagged template string. For example, `` $`echo unicorns` `` is the same as `execa('echo', ['unicorns'])`.
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ import onetime from 'onetime';
 import {makeError} from './lib/error.js';
 import {normalizeStdio, normalizeStdioNode} from './lib/stdio.js';
 import {spawnedKill, spawnedCancel, setupTimeout, validateTimeout, setExitHandler} from './lib/kill.js';
+import {addPipeMethods} from './lib/pipe.js';
 import {handleInput, getSpawnedResult, makeAllStream, validateInputSync} from './lib/stream.js';
 import {mergePromise, getSpawnedPromise} from './lib/promise.js';
 import {joinCommand, parseCommand, parseTemplates, getEscapedCommand} from './lib/command.js';
@@ -100,7 +101,8 @@ export function execa(file, args, options) {
 			isCanceled: false,
 			killed: false,
 		}));
-		return mergePromise(dummySpawned, errorPromise);
+		mergePromise(dummySpawned, errorPromise);
+		return dummySpawned;
 	}
 
 	const spawnedPromise = getSpawnedPromise(spawned);
@@ -161,7 +163,9 @@ export function execa(file, args, options) {
 
 	spawned.all = makeAllStream(spawned, parsed.options);
 
-	return mergePromise(spawned, handlePromiseOnce);
+	addPipeMethods(spawned);
+	mergePromise(spawned, handlePromiseOnce);
+	return spawned;
 }
 
 export function execaSync(file, args, options) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,7 +4,8 @@ import {Buffer} from 'node:buffer';
 // to get treated as `any` by `@typescript-eslint/no-unsafe-assignment`.
 import * as process from 'node:process';
 import {type Readable as ReadableStream} from 'node:stream';
-import {expectType, expectError} from 'tsd';
+import {createWriteStream} from 'node:fs';
+import {expectType, expectError, expectAssignable} from 'tsd';
 import {
 	$,
 	execa,
@@ -23,6 +24,39 @@ try {
 	const execaPromise = execa('unicorns');
 	execaPromise.cancel();
 	expectType<ReadableStream | undefined>(execaPromise.all);
+
+	const execaBufferPromise = execa('unicorns', {encoding: null});
+	const writeStream = createWriteStream('output.txt');
+
+	expectAssignable<Function | undefined>(execaPromise.pipeStdout);
+	expectType<ExecaChildProcess>(execaPromise.pipeStdout!('file.txt'));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStdout!('file.txt'));
+	expectType<ExecaChildProcess>(execaPromise.pipeStdout!(writeStream));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStdout!(writeStream));
+	expectType<ExecaChildProcess>(execaPromise.pipeStdout!(execaPromise));
+	expectType<ExecaChildProcess<Buffer>>(execaPromise.pipeStdout!(execaBufferPromise));
+	expectType<ExecaChildProcess>(execaBufferPromise.pipeStdout!(execaPromise));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStdout!(execaBufferPromise));
+
+	expectAssignable<Function | undefined>(execaPromise.pipeStderr);
+	expectType<ExecaChildProcess>(execaPromise.pipeStderr!('file.txt'));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStderr!('file.txt'));
+	expectType<ExecaChildProcess>(execaPromise.pipeStderr!(writeStream));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStderr!(writeStream));
+	expectType<ExecaChildProcess>(execaPromise.pipeStderr!(execaPromise));
+	expectType<ExecaChildProcess<Buffer>>(execaPromise.pipeStderr!(execaBufferPromise));
+	expectType<ExecaChildProcess>(execaBufferPromise.pipeStderr!(execaPromise));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStderr!(execaBufferPromise));
+
+	expectAssignable<Function | undefined>(execaPromise.pipeAll);
+	expectType<ExecaChildProcess>(execaPromise.pipeAll!('file.txt'));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeAll!('file.txt'));
+	expectType<ExecaChildProcess>(execaPromise.pipeAll!(writeStream));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeAll!(writeStream));
+	expectType<ExecaChildProcess>(execaPromise.pipeAll!(execaPromise));
+	expectType<ExecaChildProcess<Buffer>>(execaPromise.pipeAll!(execaBufferPromise));
+	expectType<ExecaChildProcess>(execaBufferPromise.pipeAll!(execaPromise));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeAll!(execaBufferPromise));
 
 	const unicornsResult = await execaPromise;
 	expectType<string>(unicornsResult.command);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -97,6 +97,9 @@ try {
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.stderr);
 	expectError(unicornsResult.all);
+	expectError(unicornsResult.pipeStdout);
+	expectError(unicornsResult.pipeStderr);
+	expectError(unicornsResult.pipeAll);
 	expectType<boolean>(unicornsResult.failed);
 	expectType<boolean>(unicornsResult.timedOut);
 	expectError(unicornsResult.isCanceled);

--- a/lib/pipe.js
+++ b/lib/pipe.js
@@ -25,7 +25,7 @@ const pipeToTarget = (spawned, streamName, target) => {
 
 export const addPipeMethods = spawned => {
 	if (spawned.stdout !== null) {
-		spawned.pipeStdout = pipeToTarget.bind(null, spawned, 'stdout');
+		spawned.pipeStdout = pipeToTarget.bind(undefined, spawned, 'stdout');
 	}
 
 	if (spawned.stderr !== null) {

--- a/lib/pipe.js
+++ b/lib/pipe.js
@@ -1,0 +1,38 @@
+import {createWriteStream} from 'node:fs';
+import {ChildProcess} from 'node:child_process';
+import {isWritableStream} from 'is-stream';
+
+const isExecaChildProcess = target => target instanceof ChildProcess && isWritableStream(target.stdin) && typeof target.then === 'function';
+
+const pipeToTarget = (spawned, streamName, target) => {
+	if (typeof target === 'string') {
+		spawned[streamName].pipe(createWriteStream(target));
+		return spawned;
+	}
+
+	if (isWritableStream(target)) {
+		spawned[streamName].pipe(target);
+		return spawned;
+	}
+
+	if (isExecaChildProcess(target)) {
+		spawned[streamName].pipe(target.stdin);
+		return target;
+	}
+
+	throw new TypeError('The second argument must be a string, a stream or an Execa child process.');
+};
+
+export const addPipeMethods = spawned => {
+	if (spawned.stdout !== null) {
+		spawned.pipeStdout = pipeToTarget.bind(null, spawned, 'stdout');
+	}
+
+	if (spawned.stderr !== null) {
+		spawned.pipeStderr = pipeToTarget.bind(null, spawned, 'stderr');
+	}
+
+	if (spawned.all !== undefined) {
+		spawned.pipeAll = pipeToTarget.bind(null, spawned, 'all');
+	}
+};

--- a/lib/pipe.js
+++ b/lib/pipe.js
@@ -29,10 +29,10 @@ export const addPipeMethods = spawned => {
 	}
 
 	if (spawned.stderr !== null) {
-		spawned.pipeStderr = pipeToTarget.bind(null, spawned, 'stderr');
+		spawned.pipeStderr = pipeToTarget.bind(undefined, spawned, 'stderr');
 	}
 
 	if (spawned.all !== undefined) {
-		spawned.pipeAll = pipeToTarget.bind(null, spawned, 'all');
+		spawned.pipeAll = pipeToTarget.bind(undefined, spawned, 'all');
 	}
 };

--- a/lib/pipe.js
+++ b/lib/pipe.js
@@ -2,7 +2,7 @@ import {createWriteStream} from 'node:fs';
 import {ChildProcess} from 'node:child_process';
 import {isWritableStream} from 'is-stream';
 
-const isExecaChildProcess = target => target instanceof ChildProcess && isWritableStream(target.stdin) && typeof target.then === 'function';
+const isExecaChildProcess = target => target instanceof ChildProcess && typeof target.then === 'function';
 
 const pipeToTarget = (spawned, streamName, target) => {
 	if (typeof target === 'string') {
@@ -15,12 +15,16 @@ const pipeToTarget = (spawned, streamName, target) => {
 		return spawned;
 	}
 
-	if (isExecaChildProcess(target)) {
-		spawned[streamName].pipe(target.stdin);
-		return target;
+	if (!isExecaChildProcess(target)) {
+		throw new TypeError('The second argument must be a string, a stream or an Execa child process.');
 	}
 
-	throw new TypeError('The second argument must be a string, a stream or an Execa child process.');
+	if (!isWritableStream(target.stdin)) {
+		throw new TypeError('The target child process\'s stdin must be available.');
+	}
+
+	spawned[streamName].pipe(target.stdin);
+	return target;
 };
 
 export const addPipeMethods = spawned => {

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -16,8 +16,6 @@ export const mergePromise = (spawned, promise) => {
 
 		Reflect.defineProperty(spawned, property, {...descriptor, value});
 	}
-
-	return spawned;
 };
 
 // Use promises instead of `child_process` events

--- a/readme.md
+++ b/readme.md
@@ -713,10 +713,7 @@ Let's say you want to show the output of a child process in real-time while also
 ```js
 import {execa} from 'execa';
 
-const subprocess = execa('echo', ['foo']);
-subprocess.stdout.pipe(process.stdout);
-
-const {stdout} = await subprocess;
+const {stdout} = await execa('echo', ['foo']).pipeStdout(process.stdout);
 console.log('child output:', stdout);
 ```
 
@@ -725,8 +722,7 @@ console.log('child output:', stdout);
 ```js
 import {execa} from 'execa';
 
-const subprocess = execa('echo', ['foo'])
-subprocess.stdout.pipe(fs.createWriteStream('stdout.txt'))
+await execa('echo', ['foo']).pipeStdout('stdout.txt')
 ```
 
 ### Redirect input from a file

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ This package improves [`child_process`](https://nodejs.org/api/child_process.htm
 - [Executes locally installed binaries by name.](#preferlocal)
 - [Cleans up spawned processes when the parent process dies.](#cleanup)
 - [Get interleaved output](#all) from `stdout` and `stderr` similar to what is printed on the terminal. [*(Async only)*](#execasyncfile-arguments-options)
+- Convenience methods to [pipe processes' output](#redirect-output-to-a-file)
 - [Can specify file and arguments as a single string without a shell](#execacommandcommand-options)
 - More descriptive errors.
 
@@ -115,12 +116,41 @@ unicorns
 rainbows
 ```
 
-### Pipe the child process stdout to the parent
+### Redirect output to a file
 
 ```js
 import {execa} from 'execa';
 
-execa('echo', ['unicorns']).stdout.pipe(process.stdout);
+// Similar to `echo unicorns > stdout.txt` in Bash
+await execa('echo', ['unicorns']).pipeStdout('stdout.txt')
+
+// Similar to `echo unicorns 2> stdout.txt` in Bash
+await execa('echo', ['unicorns']).pipeStderr('stderr.txt')
+
+// Similar to `echo unicorns &> stdout.txt` in Bash
+await execa('echo', ['unicorns'], {all:true}).pipeAll('all.txt')
+```
+
+### Save and pipe output from a child process
+
+```js
+import {execa} from 'execa';
+
+const {stdout} = await execa('echo', ['unicorns']).pipeStdout(process.stdout);
+// Prints `unicorns`
+console.log(stdout);
+// Also returns 'unicorns'
+```
+
+### Pipe multiple processes
+
+```js
+import {execa} from 'execa';
+
+// Similar to `echo unicorns | cat` in Bash
+const {stdout} = await execa('echo', ['unicorns']).pipeStdout(execa('cat'));
+console.log(stdout);
+//=> 'unicorns'
 ```
 
 ### Handling Errors
@@ -260,6 +290,29 @@ Stream combining/interleaving [`stdout`](https://nodejs.org/api/child_process.ht
 This is `undefined` if either:
   - the [`all` option](#all-2) is `false` (the default value)
   - both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'inherit'`, `'ipc'`, `Stream` or `integer`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio)
+
+#### pipeStdout(target)
+
+[Pipe](https://nodejs.org/api/stream.html#readablepipedestination-options) the child process's `stdout` to `target`, which can be:
+  - Another [`execa()` return value](#pipe-multiple-processes)
+  - A [writable stream](#save-and-pipe-output-from-a-child-process)
+  - A [file path string](#redirect-output-to-a-file)
+
+If the `target` is another [`execa()` return value](#execacommandcommand-options), it is returned. Otherwise, the original `execa()` return value is returned.
+
+This requires the [`stdout` option](#stdout-1) to be kept as `pipe`, its default value.
+
+#### pipeStderr(target)
+
+Like [`pipeStdout()`](#pipestdouttarget) but piping the child process's `stderr` instead.
+
+This requires the [`stderr` option](#stderr-1) to be kept as `pipe`, its default value.
+
+#### pipeAll(target)
+
+Combines both [`pipeStdout()`](#pipestdouttarget) and [`pipeStderr()`](#pipestderrtarget).
+
+This requires either the [`stdout` option](#stdout-1) or the [`stderr` option](#stderr-1) to be kept as `pipe`, their default value. Also, the [`all` option](#all-2) must be set to `true`.
 
 ### execaSync(file, arguments?, options?)
 
@@ -704,25 +757,6 @@ const run = async () => {
 };
 
 console.log(await pRetry(run, {retries: 5}));
-```
-
-### Save and pipe output from a child process
-
-Let's say you want to show the output of a child process in real-time while also saving it to a variable.
-
-```js
-import {execa} from 'execa';
-
-const {stdout} = await execa('echo', ['foo']).pipeStdout(process.stdout);
-console.log('child output:', stdout);
-```
-
-### Redirect output to a file
-
-```js
-import {execa} from 'execa';
-
-await execa('echo', ['foo']).pipeStdout('stdout.txt')
 ```
 
 ### Redirect input from a file

--- a/readme.md
+++ b/readme.md
@@ -298,21 +298,21 @@ This is `undefined` if either:
   - A [writable stream](#save-and-pipe-output-from-a-child-process)
   - A [file path string](#redirect-output-to-a-file)
 
-If the `target` is another [`execa()` return value](#execacommandcommand-options), it is returned. Otherwise, the original `execa()` return value is returned.
+If the `target` is another [`execa()` return value](#execacommandcommand-options), it is returned. Otherwise, the original `execa()` return value is returned. This allows chaining `pipeStdout()` then `await`ing the [final result](#childprocessresult).
 
-This requires the [`stdout` option](#stdout-1) to be kept as `pipe`, its default value.
+The [`stdout` option](#stdout-1) must be kept as `pipe`, its default value.
 
 #### pipeStderr(target)
 
 Like [`pipeStdout()`](#pipestdouttarget) but piping the child process's `stderr` instead.
 
-This requires the [`stderr` option](#stderr-1) to be kept as `pipe`, its default value.
+The [`stderr` option](#stderr-1) must be kept as `pipe`, its default value.
 
 #### pipeAll(target)
 
 Combines both [`pipeStdout()`](#pipestdouttarget) and [`pipeStderr()`](#pipestderrtarget).
 
-This requires either the [`stdout` option](#stdout-1) or the [`stderr` option](#stderr-1) to be kept as `pipe`, their default value. Also, the [`all` option](#all-2) must be set to `true`.
+Either the [`stdout` option](#stdout-1) or the [`stderr` option](#stderr-1) must be kept as `pipe`, their default value. Also, the [`all` option](#all-2) must be set to `true`.
 
 ### execaSync(file, arguments?, options?)
 

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,0 +1,71 @@
+import {PassThrough, Readable} from 'node:stream';
+import {spawn} from 'node:child_process';
+import {readFile} from 'node:fs/promises';
+import tempfile from 'tempfile';
+import test from 'ava';
+import getStream from 'get-stream';
+import {execa} from '../index.js';
+import {setFixtureDir} from './helpers/fixtures-dir.js';
+
+setFixtureDir();
+
+const pipeToProcess = async (t, fixtureName, funcName) => {
+	const {stdout} = await execa(fixtureName, ['test'], {all: true})[funcName](execa('stdin.js'));
+	t.is(stdout, 'test');
+};
+
+test('pipeStdout() can pipe to Execa child processes', pipeToProcess, 'noop.js', 'pipeStdout');
+test('pipeStderr() can pipe to Execa child processes', pipeToProcess, 'noop-err.js', 'pipeStderr');
+test('pipeAll() can pipe stdout to Execa child processes', pipeToProcess, 'noop.js', 'pipeAll');
+test('pipeAll() can pipe stderr to Execa child processes', pipeToProcess, 'noop-err.js', 'pipeAll');
+
+const pipeToStream = async (t, fixtureName, funcName, streamName) => {
+	const stream = new PassThrough();
+	const result = await execa(fixtureName, ['test'], {all: true})[funcName](stream);
+	t.is(result[streamName], 'test');
+	t.is(await getStream(stream), 'test\n');
+};
+
+test('pipeStdout() can pipe to streams', pipeToStream, 'noop.js', 'pipeStdout', 'stdout');
+test('pipeStderr() can pipe to streams', pipeToStream, 'noop-err.js', 'pipeStderr', 'stderr');
+test('pipeAll() can pipe stdout to streams', pipeToStream, 'noop.js', 'pipeAll', 'stdout');
+test('pipeAll() can pipe stderr to streams', pipeToStream, 'noop-err.js', 'pipeAll', 'stderr');
+
+const pipeToFile = async (t, fixtureName, funcName, streamName) => {
+	const file = tempfile('.txt');
+	const result = await execa(fixtureName, ['test'], {all: true})[funcName](file);
+	t.is(result[streamName], 'test');
+	t.is(await readFile(file, 'utf8'), 'test\n');
+};
+
+test('pipeStdout() can pipe to files', pipeToFile, 'noop.js', 'pipeStdout', 'stdout');
+test('pipeStderr() can pipe to files', pipeToFile, 'noop-err.js', 'pipeStderr', 'stderr');
+test('pipeAll() can pipe stdout to files', pipeToFile, 'noop.js', 'pipeAll', 'stdout');
+test('pipeAll() can pipe stderr to files', pipeToFile, 'noop-err.js', 'pipeAll', 'stderr');
+
+const invalidTargetMacro = (t, funcName, getTarget) => {
+	t.throws(() => execa('noop.js', {all: true})[funcName](getTarget()), {
+		message: /a stream or an Execa child process/,
+	});
+};
+
+test('pipeStdout() can only pipe to writable streams', invalidTargetMacro, 'pipeStdout', () => new Readable());
+test('pipeStderr() can only pipe to writable streams', invalidTargetMacro, 'pipeStderr', () => new Readable());
+test('pipeAll() can only pipe to writable streams', invalidTargetMacro, 'pipeAll', () => new Readable());
+test('pipeStdout() cannot pipe to processes with inherited stdin', invalidTargetMacro, 'pipeStdout', () => execa('stdin.js', {stdin: 'inherit'}));
+test('pipeStderr() cannot pipe to processes with inherited stdin', invalidTargetMacro, 'pipeStderr', () => execa('stdin.js', {stdin: 'inherit'}));
+test('pipeAll() cannot pipe to processes with inherited stdin', invalidTargetMacro, 'pipeStderr', () => execa('stdin.js', {stdin: 'inherit'}));
+test('pipeStdout() cannot pipe to non-processes', invalidTargetMacro, 'pipeStdout', () => ({stdin: new PassThrough()}));
+test('pipeStderr() cannot pipe to non-processes', invalidTargetMacro, 'pipeStderr', () => ({stdin: new PassThrough()}));
+test('pipeAll() cannot pipe to non-processes', invalidTargetMacro, 'pipeStderr', () => ({stdin: new PassThrough()}));
+test('pipeStdout() cannot pipe to non-Execa processes', invalidTargetMacro, 'pipeStdout', () => spawn('node', ['--version']));
+test('pipeStderr() cannot pipe to non-Execa processes', invalidTargetMacro, 'pipeStderr', () => spawn('node', ['--version']));
+test('pipeAll() cannot pipe to non-Execa processes', invalidTargetMacro, 'pipeStderr', () => spawn('node', ['--version']));
+
+const invalidSourceMacro = (t, funcName) => {
+	t.false(funcName in execa('noop.js', {stdout: 'ignore', stderr: 'ignore'}));
+};
+
+test('Must set "stdout" option to "pipe" use pipeStdout()', invalidSourceMacro, 'pipeStdout');
+test('Must set "stderr" option to "pipe" use pipeStderr()', invalidSourceMacro, 'pipeStderr');
+test('Must set "stdout" or "stderr" option to "pipe" use pipeAll()', invalidSourceMacro, 'pipeAll');

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -43,29 +43,36 @@ test('pipeStderr() can pipe to files', pipeToFile, 'noop-err.js', 'pipeStderr', 
 test('pipeAll() can pipe stdout to files', pipeToFile, 'noop.js', 'pipeAll', 'stdout');
 test('pipeAll() can pipe stderr to files', pipeToFile, 'noop-err.js', 'pipeAll', 'stderr');
 
-const invalidTargetMacro = (t, funcName, getTarget) => {
+const invalidTarget = (t, funcName, getTarget) => {
 	t.throws(() => execa('noop.js', {all: true})[funcName](getTarget()), {
 		message: /a stream or an Execa child process/,
 	});
 };
 
-test('pipeStdout() can only pipe to writable streams', invalidTargetMacro, 'pipeStdout', () => new Readable());
-test('pipeStderr() can only pipe to writable streams', invalidTargetMacro, 'pipeStderr', () => new Readable());
-test('pipeAll() can only pipe to writable streams', invalidTargetMacro, 'pipeAll', () => new Readable());
-test('pipeStdout() cannot pipe to processes with inherited stdin', invalidTargetMacro, 'pipeStdout', () => execa('stdin.js', {stdin: 'inherit'}));
-test('pipeStderr() cannot pipe to processes with inherited stdin', invalidTargetMacro, 'pipeStderr', () => execa('stdin.js', {stdin: 'inherit'}));
-test('pipeAll() cannot pipe to processes with inherited stdin', invalidTargetMacro, 'pipeStderr', () => execa('stdin.js', {stdin: 'inherit'}));
-test('pipeStdout() cannot pipe to non-processes', invalidTargetMacro, 'pipeStdout', () => ({stdin: new PassThrough()}));
-test('pipeStderr() cannot pipe to non-processes', invalidTargetMacro, 'pipeStderr', () => ({stdin: new PassThrough()}));
-test('pipeAll() cannot pipe to non-processes', invalidTargetMacro, 'pipeStderr', () => ({stdin: new PassThrough()}));
-test('pipeStdout() cannot pipe to non-Execa processes', invalidTargetMacro, 'pipeStdout', () => spawn('node', ['--version']));
-test('pipeStderr() cannot pipe to non-Execa processes', invalidTargetMacro, 'pipeStderr', () => spawn('node', ['--version']));
-test('pipeAll() cannot pipe to non-Execa processes', invalidTargetMacro, 'pipeStderr', () => spawn('node', ['--version']));
+test('pipeStdout() can only pipe to writable streams', invalidTarget, 'pipeStdout', () => new Readable());
+test('pipeStderr() can only pipe to writable streams', invalidTarget, 'pipeStderr', () => new Readable());
+test('pipeAll() can only pipe to writable streams', invalidTarget, 'pipeAll', () => new Readable());
+test('pipeStdout() cannot pipe to non-processes', invalidTarget, 'pipeStdout', () => ({stdin: new PassThrough()}));
+test('pipeStderr() cannot pipe to non-processes', invalidTarget, 'pipeStderr', () => ({stdin: new PassThrough()}));
+test('pipeAll() cannot pipe to non-processes', invalidTarget, 'pipeStderr', () => ({stdin: new PassThrough()}));
+test('pipeStdout() cannot pipe to non-Execa processes', invalidTarget, 'pipeStdout', () => spawn('node', ['--version']));
+test('pipeStderr() cannot pipe to non-Execa processes', invalidTarget, 'pipeStderr', () => spawn('node', ['--version']));
+test('pipeAll() cannot pipe to non-Execa processes', invalidTarget, 'pipeStderr', () => spawn('node', ['--version']));
 
-const invalidSourceMacro = (t, funcName) => {
+const invalidSource = (t, funcName) => {
 	t.false(funcName in execa('noop.js', {stdout: 'ignore', stderr: 'ignore'}));
 };
 
-test('Must set "stdout" option to "pipe" use pipeStdout()', invalidSourceMacro, 'pipeStdout');
-test('Must set "stderr" option to "pipe" use pipeStderr()', invalidSourceMacro, 'pipeStderr');
-test('Must set "stdout" or "stderr" option to "pipe" use pipeAll()', invalidSourceMacro, 'pipeAll');
+test('Must set "stdout" option to "pipe" to use pipeStdout()', invalidSource, 'pipeStdout');
+test('Must set "stderr" option to "pipe" to use pipeStderr()', invalidSource, 'pipeStderr');
+test('Must set "stdout" or "stderr" option to "pipe" to use pipeAll()', invalidSource, 'pipeAll');
+
+const invalidPipeToProcess = async (t, fixtureName, funcName) => {
+	t.throws(() => execa(fixtureName, ['test'], {all: true})[funcName](execa('stdin.js', {stdin: 'ignore'})), {
+		message: /stdin must be available/,
+	});
+};
+
+test('Must set target "stdin" option to "pipe" to use pipeStdout()', invalidPipeToProcess, 'noop.js', 'pipeStdout');
+test('Must set target "stdin" option to "pipe" to use pipeStderr()', invalidPipeToProcess, 'noop-err.js', 'pipeStderr');
+test('Must set target "stdin" option to "pipe" to use pipeAll()', invalidPipeToProcess, 'noop.js', 'pipeAll');


### PR DESCRIPTION
Fixes #525.

This adds the following shortcut methods: `pipeStdout()`, `pipeStderr()` and `pipeAll()`.

For Node.js shell-like scripts, this is the equivalent to the `|`, `|&`, `>`, `&>`, or `2>&1` shell characters.

Pipe to stream, before:

```js
const subprocess = $`echo foo`;
subprocess.stdout.pipe(process.stdout);
const {stdout} = await subprocess;
```

After:

```js
const {stdout} = await $`echo foo`.pipeStdout(process.stdout);
```

Pipe to file, before:

```js
const subprocess = $`echo foo`;
subprocess.stdout.pipe(fs.createWriteStream('stdout.txt'))
const {stdout} = await subprocess;
```

After:

```js
const {stdout} = await $`echo foo`.pipeStdout('stdout.txt');
```

Pipe to another process, before:

```js
const ffmpegProcess = $`ffmpeg -ss 5 -i input.mp4 -t 1 -vf cropdetect -f null -`
const awkProcess = $`awk ${'/crop/ {print $NF}'}`
const tailProcess = $`tail -1`

ffmpegProcess.stderr.pipe(awkProcess.stdin)
awkProcess.stdout.pipe(tailProcess.stdin)

const { stdout } = await tailProcess
```

After:

```js
const {stdout} = await $`ffmpeg -ss 5 -i input.mp4 -t 1 -vf cropdetect -f null -`
  .pipeStderr($`awk ${'/crop/ {print $NF}'}`)
  .pipeStdout($`tail -1`)
```

The PR's code and tests are done, but I haven't added the types, type tests nor readme documentation. I'd like to first confirm the overall idea and design make sense to you @sindresorhus. :)