### PR TITLE
Add "verbose" option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -244,6 +244,15 @@ export type CommonOptions<EncodingType> = {
 	@default true
 	*/
 	readonly windowsHide?: boolean;
+
+	/**
+	Print each command on `stderr` before executing it.
+
+  This can also be enabled by setting the `NODE_DEBUG=execa` environment variable in the current process.
+
+	@default false
+	*/
+	readonly verbose?: boolean;
 };
 
 export type Options<EncodingType = string> = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -248,7 +248,7 @@ export type CommonOptions<EncodingType> = {
 	/**
 	Print each command on `stderr` before executing it.
 
-  This can also be enabled by setting the `NODE_DEBUG=execa` environment variable in the current process.
+	This can also be enabled by setting the `NODE_DEBUG=execa` environment variable in the current process.
 
 	@default false
 	*/

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import {spawnedKill, spawnedCancel, setupTimeout, validateTimeout, setExitHandle
 import {handleInput, getSpawnedResult, makeAllStream, validateInputSync} from './lib/stream.js';
 import {mergePromise, getSpawnedPromise} from './lib/promise.js';
 import {joinCommand, parseCommand, parseTemplates, getEscapedCommand} from './lib/command.js';
+import {logCommand, verboseDefault} from './lib/verbose.js';
 
 const DEFAULT_MAX_BUFFER = 1000 * 1000 * 100;
 
@@ -44,6 +45,7 @@ const handleArguments = (file, args, options = {}) => {
 		cleanup: true,
 		all: false,
 		windowsHide: true,
+		verbose: verboseDefault,
 		...options,
 	};
 
@@ -76,6 +78,7 @@ export function execa(file, args, options) {
 	const parsed = handleArguments(file, args, options);
 	const command = joinCommand(file, args);
 	const escapedCommand = getEscapedCommand(file, args);
+	logCommand(escapedCommand, parsed.options);
 
 	validateTimeout(parsed.options);
 
@@ -165,6 +168,7 @@ export function execaSync(file, args, options) {
 	const parsed = handleArguments(file, args, options);
 	const command = joinCommand(file, args);
 	const escapedCommand = getEscapedCommand(file, args);
+	logCommand(escapedCommand, parsed.options);
 
 	validateInputSync(parsed.options);
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -150,6 +150,7 @@ execa('unicorns', {killSignal: 9});
 execa('unicorns', {signal: new AbortController().signal});
 execa('unicorns', {windowsVerbatimArguments: true});
 execa('unicorns', {windowsHide: false});
+execa('unicorns', {verbose: false});
 /* eslint-enable @typescript-eslint/no-floating-promises */
 execa('unicorns').kill();
 execa('unicorns').kill('SIGKILL');

--- a/lib/verbose.js
+++ b/lib/verbose.js
@@ -1,0 +1,19 @@
+import {debuglog} from 'node:util';
+import process from 'node:process';
+
+export const verboseDefault = debuglog('execa').enabled;
+
+const padField = (field, padding) => String(field).padStart(padding, '0');
+
+const getTimestamp = () => {
+	const date = new Date();
+	return `${padField(date.getHours(), 2)}:${padField(date.getMinutes(), 2)}:${padField(date.getSeconds(), 2)}.${padField(date.getMilliseconds(), 3)}`;
+};
+
+export const logCommand = (escapedCommand, {verbose}) => {
+	if (!verbose) {
+		return;
+	}
+
+	process.stderr.write(`[${getTimestamp()}] ${escapedCommand}\n`);
+};

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,20 @@ $({stdio: 'inherit'}).sync`echo ${unicorns} rainbows`;
 //=> 'unicorns rainbows'
 ```
 
+#### Verbose mode
+
+```sh
+$ node file.js
+unicorns
+rainbows
+
+$ NODE_DEBUG=execa node file.js
+[16:50:03.305] echo unicorns
+unicorns
+[16:50:03.308] echo rainbows
+rainbows
+```
+
 ### Pipe the child process stdout to the parent
 
 ```js
@@ -651,6 +665,15 @@ Type: `boolean`\
 Default: `true`
 
 On Windows, do not create a new console window. Please note this also prevents `CTRL-C` [from working](https://github.com/nodejs/node/issues/29837) on Windows.
+
+#### verbose
+
+Type: `boolean`\
+Default: `false`
+
+[Print each command](#verbose-mode) on `stderr` before executing it.
+
+This can also be enabled by setting the `NODE_DEBUG=execa` environment variable in the current process.
 
 #### nodePath *(For `.node()` only)*
 

--- a/readme.md
+++ b/readme.md
@@ -104,11 +104,11 @@ $({stdio: 'inherit'}).sync`echo ${unicorns} rainbows`;
 #### Verbose mode
 
 ```sh
-$ node file.js
+> node file.js
 unicorns
 rainbows
 
-$ NODE_DEBUG=execa node file.js
+> NODE_DEBUG=execa node file.js
 [16:50:03.305] echo unicorns
 unicorns
 [16:50:03.308] echo rainbows

--- a/test/fixtures/nested.js
+++ b/test/fixtures/nested.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {execa} from '../../index.js';
+
+const [options, file, ...args] = process.argv.slice(2);
+const nestedOptions = {stdio: 'inherit', ...JSON.parse(options)};
+await execa(file, args, nestedOptions);

--- a/test/fixtures/verbose-script.js
+++ b/test/fixtures/verbose-script.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import {$} from '../../index.js';
+
+const $$ = $({stdio: 'inherit'});
+await $$`node -p "one"`;
+await $$`node -p "two"`;

--- a/test/verbose.js
+++ b/test/verbose.js
@@ -1,0 +1,35 @@
+import test from 'ava';
+import {execa} from '../index.js';
+import {setFixtureDir} from './helpers/fixtures-dir.js';
+
+setFixtureDir();
+
+const normalizeTimestamp = output => output.replace(/\d/g, '0');
+const testTimestamp = '[00:00:00.000]';
+
+test('Prints command when "verbose" is true', async t => {
+	const {stdout, stderr, all} = await execa('nested.js', [JSON.stringify({verbose: true}), 'noop.js', 'test'], {all: true});
+	t.is(stdout, 'test');
+	t.is(normalizeTimestamp(stderr), `${testTimestamp} noop.js test`);
+	t.is(normalizeTimestamp(all), `${testTimestamp} noop.js test\ntest`);
+});
+
+test('Prints command with NODE_DEBUG=execa', async t => {
+	const {stdout, stderr, all} = await execa('nested.js', [JSON.stringify({}), 'noop.js', 'test'], {all: true, env: {NODE_DEBUG: 'execa'}});
+	t.is(stdout, 'test');
+	t.is(normalizeTimestamp(stderr), `${testTimestamp} noop.js test`);
+	t.is(normalizeTimestamp(all), `${testTimestamp} noop.js test\ntest`);
+});
+
+test('Escape verbose command', async t => {
+	const {stderr} = await execa('nested.js', [JSON.stringify({verbose: true}), 'noop.js', 'one two', '"'], {all: true});
+	t.true(stderr.endsWith('"one two" "\\""'));
+});
+
+test('Verbose option works with inherit', async t => {
+	const {all} = await execa('verbose-script.js', {all: true, env: {NODE_DEBUG: 'execa'}});
+	t.is(normalizeTimestamp(all), `${testTimestamp} node -p "\\"one\\""
+one
+${testTimestamp} node -p "\\"two\\""
+two`);
+});


### PR DESCRIPTION
Fixes #524.

This adds a `verbose` boolean option. It defaults to `false`, unless the [`NODE_DEBUG=execa` environment variable](https://nodejs.org/api/util.html#debuglogenabled) is set. When enabled, it prints any command before executing it. It also prints a timestamp.

The "problem" and "prior art" sections in #524 give some background on why this feature might be a good addition.

For example, the following script:

```js
import {$} from 'execa'

await $`echo one`
await $`echo two`
```

Would print:

```
$ node example.js

$ NODE_DEBUG=execa node example.js
[22:44:57.723] echo one
[22:44:57.731] echo two
```

While the following:

```js
import {$} from 'execa'

const $$ = $({ stdio: 'inherit' })

await $$`echo one`
await $$`echo two`
```

Would print:

```
$ node example.js
one
two

$ NODE_DEBUG=execa node example.js
[22:47:52.056] echo one
one
[22:47:52.060] echo two
two
```

This can also be enabled for individual commands with:

```js
await $({ verbose: true })`echo one`
```

This feature works with any other Execa method too.

```js
await execa('echo', ['one'], { verbose: true })
```

The PR's code and tests are done, but I haven't added the types, type tests nor readme documentation. I'd like to first confirm the overall idea and design make sense to you @sindresorhus. :)