### PR TITLE
Add `pipeToStdinFrom()` method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -479,6 +479,13 @@ export type ExecaChildPromise<StdoutStderrType extends StdoutStderrAll> = {
 	*/
 	pipeAll?<Target extends ExecaChildPromise<StdoutStderrAll>>(target: Target): Target;
 	pipeAll?(target: WritableStream | string): ExecaChildProcess<StdoutStderrType>;
+
+	/**
+	Inverse of `pipeStdout()`: pipes the `source` to the current child process's `stdin`.
+
+	If the `source` is a child process, its `stdout` is used, not its `stderr`. The `source`'s `stdout` option must then be kept as `pipe`, its default value.
+	*/
+	pipeToStdinFrom?(source: ExecaChildProcess<StdoutStderrAll> | WritableStream | string): ExecaChildProcess<StdoutStderrType>;
 };
 
 export type ExecaChildProcess<StdoutStderrType extends StdoutStderrAll = string> = ChildProcess &

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -58,6 +58,16 @@ try {
 	expectType<ExecaChildProcess>(execaBufferPromise.pipeAll!(execaPromise));
 	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeAll!(execaBufferPromise));
 
+	expectAssignable<Function | undefined>(execaPromise.pipeToStdinFrom);
+	expectType<ExecaChildProcess>(execaPromise.pipeToStdinFrom!('file.txt'));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeToStdinFrom!('file.txt'));
+	expectType<ExecaChildProcess>(execaPromise.pipeToStdinFrom!(writeStream));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeToStdinFrom!(writeStream));
+	expectType<ExecaChildProcess>(execaPromise.pipeToStdinFrom!(execaPromise));
+	expectType<ExecaChildProcess>(execaPromise.pipeToStdinFrom!(execaBufferPromise));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeToStdinFrom!(execaPromise));
+	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeToStdinFrom!(execaBufferPromise));
+
 	const unicornsResult = await execaPromise;
 	expectType<string>(unicornsResult.command);
 	expectType<string>(unicornsResult.escapedCommand);

--- a/lib/pipe.js
+++ b/lib/pipe.js
@@ -1,6 +1,6 @@
-import {createWriteStream} from 'node:fs';
+import {createWriteStream, createReadStream} from 'node:fs';
 import {ChildProcess} from 'node:child_process';
-import {isWritableStream} from 'is-stream';
+import {isWritableStream, isReadableStream} from 'is-stream';
 
 const isExecaChildProcess = target => target instanceof ChildProcess && typeof target.then === 'function';
 
@@ -27,6 +27,29 @@ const pipeToTarget = (spawned, streamName, target) => {
 	return target;
 };
 
+const pipeFromSource = (spawned, source) => {
+	if (typeof source === 'string') {
+		createReadStream(source).pipe(spawned.stdin);
+		return spawned;
+	}
+
+	if (isReadableStream(source)) {
+		source.pipe(spawned.stdin);
+		return spawned;
+	}
+
+	if (!isExecaChildProcess(source)) {
+		throw new TypeError('The second argument must be a string, a stream or an Execa child process.');
+	}
+
+	if (!isReadableStream(source.stdout)) {
+		throw new TypeError('The source child process\'s stdout must be available.');
+	}
+
+	source.stdout.pipe(spawned.stdin);
+	return spawned;
+};
+
 export const addPipeMethods = spawned => {
 	if (spawned.stdout !== null) {
 		spawned.pipeStdout = pipeToTarget.bind(undefined, spawned, 'stdout');
@@ -38,5 +61,9 @@ export const addPipeMethods = spawned => {
 
 	if (spawned.all !== undefined) {
 		spawned.pipeAll = pipeToTarget.bind(undefined, spawned, 'all');
+	}
+
+	if (spawned.stdin !== null) {
+		spawned.pipeToStdinFrom = pipeFromSource.bind(undefined, spawned);
 	}
 };

--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,15 @@ await execa('echo', ['unicorns']).pipeStderr('stderr.txt')
 await execa('echo', ['unicorns'], {all:true}).pipeAll('all.txt')
 ```
 
+### Redirect input from a file
+
+```js
+import {execa} from 'execa';
+
+// Similar to `cat < stdin.txt` in Bash
+await execa('cat').pipeToStdinFrom('stdin.txt')
+```
+
 ### Save and pipe output from a child process
 
 ```js
@@ -316,6 +325,12 @@ The [`stderr` option](#stderr-1) must be kept as `pipe`, its default value.
 Combines both [`pipeStdout()`](#pipestdouttarget) and [`pipeStderr()`](#pipestderrtarget).
 
 Either the [`stdout` option](#stdout-1) or the [`stderr` option](#stderr-1) must be kept as `pipe`, their default value. Also, the [`all` option](#all-2) must be set to `true`.
+
+#### pipeToStdinFrom(source)
+
+Inverse of [`pipeStdout()`](#pipestdouttarget): pipes the `source` to the current child process's `stdin`.
+
+If the `source` is a child process, its `stdout` is used, not its `stderr`. The `source`'s [`stdout` option](#stdout-1) must then be kept as `pipe`, its default value.
 
 ### execaSync(file, arguments?, options?)
 
@@ -762,15 +777,6 @@ const run = async () => {
 };
 
 console.log(await pRetry(run, {retries: 5}));
-```
-
-### Redirect input from a file
-
-```js
-import {execa} from 'execa';
-
-const subprocess = execa('cat')
-fs.createReadStream('stdin.txt').pipe(subprocess.stdin)
 ```
 
 ### Execute the current package's binary


### PR DESCRIPTION
Fixes #534.

This adds the following shortcut method: `pipeToStdinFrom()`.

For Node.js shell-like scripts, this is the equivalent to the `|` and `<` shell characters.