### PR TITLE
Improve documentation of the usage section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,13 +68,21 @@ console.log(stdout);
 ```js
 import {$} from 'execa';
 
+await $({stdio: 'inherit'})`echo unicorns`;
+//=> 'unicorns'
+```
+
+#### Shared options
+
+```js
+import {$} from 'execa';
+
 const $$ = $({stdio: 'inherit'});
 
 await $$`echo unicorns`;
 //=> 'unicorns'
 
-await $$({shell: true})`echo unicorns && echo rainbows`;
-//=> 'unicorns'
+await $$`echo rainbows`;
 //=> 'rainbows'
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -53,14 +53,19 @@ For more information about Execa scripts, please see [this page](docs/scripts.md
 ```js
 import {$} from 'execa';
 
-const unicorns = await $`echo unicorns`;
-const {stdout} = await $`echo ${unicorns}${'!'}}`;
-console.log(stdout);
-//=> 'unicorns!'
+const branch = await $`git branch --show-current`
+await $`dep deploy --branch=${branch}`
+```
 
-const {stdout} = await $`echo ${['unicorns', 'rainbows']}`;
+#### Multiple arguments
+
+```js
+import {$} from 'execa';
+
+const args = ['unicorns', '&', 'rainbows!']
+const {stdout} = await $`echo ${args}`;
 console.log(stdout);
-//=> 'unicorns rainbows'
+//=> 'unicorns & rainbows!'
 ```
 
 #### With options

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,8 @@ npm install execa
 
 ## Usage
 
+### Promise interface
+
 ```js
 import {execa} from 'execa';
 
@@ -44,31 +46,24 @@ console.log(stdout);
 
 ### Scripts interface
 
-For more information, please see [this page](docs/scripts.md).
+For more information about Execa scripts, please see [this page](docs/scripts.md).
 
 #### Basic
 
 ```js
 import {$} from 'execa';
 
-const {stdout} = await $`echo unicorns`;
-// const {stdout} = await $`echo ${'unicorns'}`;
-// const {stdout} = await $`echo ${['unicorns', 'rainbows']}`;
-
+const unicorns = await $`echo unicorns`;
+const {stdout} = await $`echo ${unicorns}${'!'}}`;
 console.log(stdout);
-//=> 'unicorns'
+//=> 'unicorns!'
+
+const {stdout} = await $`echo ${['unicorns', 'rainbows']}`;
+console.log(stdout);
+//=> 'unicorns rainbows'
 ```
 
 #### With options
-
-```js
-import {$} from 'execa';
-
-await $({stdio: 'inherit'})`echo unicorns`;
-//=> 'unicorns'
-```
-
-#### With pre-defined options
 
 ```js
 import {$} from 'execa';
@@ -77,33 +72,10 @@ const $$ = $({stdio: 'inherit'});
 
 await $$`echo unicorns`;
 //=> 'unicorns'
+
 await $$({shell: true})`echo unicorns && echo rainbows`;
 //=> 'unicorns'
 //=> 'rainbows'
-```
-
-#### Synchronous
-
-```js
-import {$} from 'execa';
-
-const {stdout} = $.sync`echo unicorns`;
-console.log(stdout);
-//=> 'unicorns'
-
-$({stdio: 'inherit'}).sync`echo rainbows`;
-//=> 'rainbows'
-```
-
-#### With results from `$` or `$.sync`
-
-```js
-import {$} from 'execa';
-
-const unicorns = await $`echo unicorns`;
-
-$({stdio: 'inherit'}).sync`echo ${unicorns} rainbows`;
-//=> 'unicorns rainbows'
 ```
 
 #### Verbose mode
@@ -120,7 +92,9 @@ unicorns
 rainbows
 ```
 
-### Redirect output to a file
+### Input/output
+
+#### Redirect output to a file
 
 ```js
 import {execa} from 'execa';
@@ -135,7 +109,7 @@ await execa('echo', ['unicorns']).pipeStderr('stderr.txt');
 await execa('echo', ['unicorns'], {all:true}).pipeAll('all.txt');
 ```
 
-### Redirect input from a file
+#### Redirect input from a file
 
 ```js
 import {execa} from 'execa';
@@ -146,7 +120,7 @@ console.log(stdout);
 //=> 'unicorns'
 ```
 
-### Save and pipe output from a child process
+#### Save and pipe output from a child process
 
 ```js
 import {execa} from 'execa';
@@ -157,7 +131,7 @@ console.log(stdout);
 // Also returns 'unicorns'
 ```
 
-### Pipe multiple processes
+#### Pipe multiple processes
 
 ```js
 import {execa} from 'execa';
@@ -202,60 +176,7 @@ try {
 }
 ```
 
-### Cancelling a spawned process
-
-```js
-import {execa} from 'execa';
-
-const abortController = new AbortController();
-const subprocess = execa('node', [], {signal: abortController.signal});
-
-setTimeout(() => {
-	abortController.abort();
-}, 1000);
-
-try {
-	await subprocess;
-} catch (error) {
-	console.log(subprocess.killed); // true
-	console.log(error.isCanceled); // true
-}
-```
-
-### Catching an error with the sync method
-
-```js
-import {execaSync} from 'execa';
-
-try {
-	execaSync('unknown', ['command']);
-} catch (error) {
-	console.log(error);
-	/*
-	{
-		message: 'Command failed with ENOENT: unknown command spawnSync unknown ENOENT',
-		errno: -2,
-		code: 'ENOENT',
-		syscall: 'spawnSync unknown',
-		path: 'unknown',
-		spawnargs: ['command'],
-		originalMessage: 'spawnSync unknown ENOENT',
-		shortMessage: 'Command failed with ENOENT: unknown command spawnSync unknown ENOENT',
-		command: 'unknown command',
-		escapedCommand: 'unknown command',
-		stdout: '',
-		stderr: '',
-		all: '',
-		failed: true,
-		timedOut: false,
-		isCanceled: false,
-		killed: false
-	}
-	*/
-}
-```
-
-### Kill a process
+### Graceful termination
 
 Using SIGTERM, and after 2 seconds, kill it with SIGKILL.
 
@@ -776,13 +697,33 @@ const run = async () => {
 console.log(await pRetry(run, {retries: 5}));
 ```
 
+### Cancelling a spawned process
+
+```js
+import {execa} from 'execa';
+
+const abortController = new AbortController();
+const subprocess = execa('node', [], {signal: abortController.signal});
+
+setTimeout(() => {
+	abortController.abort();
+}, 1000);
+
+try {
+	await subprocess;
+} catch (error) {
+	console.log(subprocess.killed); // true
+	console.log(error.isCanceled); // true
+}
+```
+
 ### Execute the current package's binary
 
 ```js
-import {getBinPathSync} from 'get-bin-path';
+import {getBinPath} from 'get-bin-path';
 
-const binPath = getBinPathSync();
-const subprocess = execa(binPath);
+const binPath = await getBinPath();
+await execa(binPath);
 ```
 
 `execa` can be combined with [`get-bin-path`](https://github.com/ehmicky/get-bin-path) to test the current package's binary. As opposed to hard-coding the path to the binary, this validates that the `package.json` `bin` field is correctly set up.


### PR DESCRIPTION
This improves the Usage section of the documentation. That section has been augmented ad-hoc incrementally over time and could use some small improvement. It also removes some information that is not strictly worth documenting, as it helps highlighting the features that are more interesting. 
  - Some of the scripting interface examples are slightly redundant, so I combined them into fewer examples, while keeping the same information.
  - Move the `signal` option's example to the Tips sections, since it is not really a feature anymore now that the option is supported by the `child_process` core module.
  - Remove examples of the synchronous methods, as the async version should usually (although not always) be preferred. The synchronous methods are documented in the API, and are pretty straightforward once you know the related async method.
  - Small description changes

I am hoping those changes help the Usage section to better focus and highlight the major features that Execa does bring.