### PR TITLE
Fix default value of `stdin` with `$`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export type CommonOptions<EncodingType> = {
 
 	If you `$ npm install foo`, you can then `execa('foo')`.
 
-	@default `true` with `$`/`$.sync`, `false` otherwise
+	@default `true` with `$`, `false` otherwise
 	*/
 	readonly preferLocal?: boolean;
 
@@ -63,7 +63,7 @@ export type CommonOptions<EncodingType> = {
 	/**
 	Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 
-	@default 'pipe'
+	@default `inherit` with `$`, `pipe` otherwise
 	*/
 	readonly stdin?: StdioOption;
 

--- a/index.js
+++ b/index.js
@@ -232,6 +232,16 @@ export function execaSync(file, args, options) {
 	};
 }
 
+const normalizeScriptStdin = ({input, inputFile, stdio}) => input === undefined && inputFile === undefined && stdio === undefined
+	? {stdin: 'inherit'}
+	: {};
+
+const normalizeScriptOptions = (options = {}) => ({
+	preferLocal: true,
+	...normalizeScriptStdin(options),
+	...options,
+});
+
 function create$(options) {
 	function $(templatesOrOptions, ...expressions) {
 		if (!Array.isArray(templatesOrOptions)) {
@@ -239,7 +249,7 @@ function create$(options) {
 		}
 
 		const [file, ...args] = parseTemplates(templatesOrOptions, expressions);
-		return execa(file, args, options);
+		return execa(file, args, normalizeScriptOptions(options));
 	}
 
 	$.sync = (templates, ...expressions) => {
@@ -248,13 +258,13 @@ function create$(options) {
 		}
 
 		const [file, ...args] = parseTemplates(templates, expressions);
-		return execaSync(file, args, options);
+		return execaSync(file, args, normalizeScriptOptions(options));
 	};
 
 	return $;
 }
 
-export const $ = create$({preferLocal: true});
+export const $ = create$();
 
 export function execaCommand(command, options) {
 	const [file, ...args] = parseCommand(command);

--- a/readme.md
+++ b/readme.md
@@ -467,7 +467,7 @@ Kill the spawned process when the parent process exits unless either:
 #### preferLocal
 
 Type: `boolean`\
-Default: `true` with [`$`](#command)/[`$.sync`](#synccommand), `false` otherwise
+Default: `true` with [`$`](#command), `false` otherwise
 
 Prefer locally installed binaries when looking for a binary to execute.\
 If you `$ npm install foo`, you can then `execa('foo')`.
@@ -521,7 +521,7 @@ If the input is not a file, use the [`input` option](#input) instead.
 #### stdin
 
 Type: `string | number | Stream | undefined`\
-Default: `pipe`
+Default: `inherit` with [`$`](#command), `pipe` otherwise
 
 Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 

--- a/test/command.js
+++ b/test/command.js
@@ -1,5 +1,6 @@
 import {inspect} from 'node:util';
 import test from 'ava';
+import {isStream} from 'is-stream';
 import {execa, execaSync, execaCommand, execaCommandSync, $} from '../index.js';
 import {setFixtureDir} from './helpers/fixtures-dir.js';
 
@@ -273,3 +274,17 @@ test('[ $`noop.js` ]', invalidExpression, [$`noop.js`], 'Unexpected "object" in 
 
 test('$({stdio: \'inherit\'}).sync`noop.js`', invalidExpression, $({stdio: 'inherit'}).sync`noop.js`, 'Unexpected "undefined" stdout in template expression');
 test('[ $({stdio: \'inherit\'}).sync`noop.js` ]', invalidExpression, [$({stdio: 'inherit'}).sync`noop.js`], 'Unexpected "undefined" stdout in template expression');
+
+test('$ stdin defaults to "inherit"', async t => {
+	const {stdout} = await $({input: 'foo'})`stdin-script.js`;
+	t.is(stdout, 'foo');
+});
+
+test('$.sync stdin defaults to "inherit"', t => {
+	const {stdout} = $({input: 'foo'}).sync`stdin-script.js`;
+	t.is(stdout, 'foo');
+});
+
+test('$ stdin has no default value when stdio is set', t => {
+	t.true(isStream($({stdio: 'pipe'})`noop.js`.stdin));
+});

--- a/test/fixtures/stdin-script.js
+++ b/test/fixtures/stdin-script.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import {$} from '../../index.js';
+import {FIXTURES_DIR} from '../helpers/fixtures-dir.js';
+
+await $({stdout: 'inherit'})`node ${`${FIXTURES_DIR}/stdin.js`}`;

--- a/test/helpers/fixtures-dir.js
+++ b/test/helpers/fixtures-dir.js
@@ -4,7 +4,7 @@ import {fileURLToPath} from 'node:url';
 import pathKey from 'path-key';
 
 export const PATH_KEY = pathKey();
-const FIXTURES_DIR = fileURLToPath(new URL('../fixtures', import.meta.url));
+export const FIXTURES_DIR = fileURLToPath(new URL('../fixtures', import.meta.url));
 
 // Add the fixtures directory to PATH so fixtures can be executed without adding
 // `node`. This is only meant to make writing tests simpler.

--- a/test/stream.js
+++ b/test/stream.js
@@ -6,7 +6,7 @@ import test from 'ava';
 import getStream from 'get-stream';
 import {pEvent} from 'p-event';
 import tempfile from 'tempfile';
-import {execa, execaSync} from '../index.js';
+import {execa, execaSync, $} from '../index.js';
 import {setFixtureDir} from './helpers/fixtures-dir.js';
 
 setFixtureDir();
@@ -71,10 +71,22 @@ test('input can be a Stream', async t => {
 	t.is(stdout, 'howdy');
 });
 
+test('input option can be used with $', async t => {
+	const {stdout} = await $({input: 'foobar'})`stdin.js`;
+	t.is(stdout, 'foobar');
+});
+
 test('inputFile can be set', async t => {
 	const inputFile = tempfile();
 	fs.writeFileSync(inputFile, 'howdy');
 	const {stdout} = await execa('stdin.js', {inputFile});
+	t.is(stdout, 'howdy');
+});
+
+test('inputFile can be set with $', async t => {
+	const inputFile = tempfile();
+	fs.writeFileSync(inputFile, 'howdy');
+	const {stdout} = await $({inputFile})`stdin.js`;
 	t.is(stdout, 'howdy');
 });
 
@@ -93,6 +105,11 @@ test('you can write to child.stdin', async t => {
 
 test('input option can be a String - sync', t => {
 	const {stdout} = execaSync('stdin.js', {input: 'foobar'});
+	t.is(stdout, 'foobar');
+});
+
+test('input option can be used with $.sync', t => {
+	const {stdout} = $({input: 'foobar'}).sync`stdin.js`;
 	t.is(stdout, 'foobar');
 });
 
@@ -122,6 +139,13 @@ test('inputFile can be set - sync', t => {
 	const inputFile = tempfile();
 	fs.writeFileSync(inputFile, 'howdy');
 	const {stdout} = execaSync('stdin.js', {inputFile});
+	t.is(stdout, 'howdy');
+});
+
+test('inputFile option can be used with $.sync', t => {
+	const inputFile = tempfile();
+	fs.writeFileSync(inputFile, 'howdy');
+	const {stdout} = $({inputFile}).sync`stdin.js`;
 	t.is(stdout, 'howdy');
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -100,6 +100,10 @@ test('preferLocal: undefined with $', async t => {
 	await t.notThrowsAsync($({env: getPathWithoutLocalDir()})`ava --version`);
 });
 
+test('preferLocal: undefined with $.sync', t => {
+	t.notThrows(() => $({env: getPathWithoutLocalDir()}).sync`ava --version`);
+});
+
 test('localDir option', async t => {
 	const command = process.platform === 'win32' ? 'echo %PATH%' : 'echo $PATH';
 	const {stdout} = await execa(command, {shell: true, preferLocal: true, localDir: '/test'});


### PR DESCRIPTION
Fixes #549 

This makes `stdin` of processes created with `$` default to `inherit` instead of `pipe`, as this is most likely the intended behavior of users in that case.

This is technically a breaking change from `7.1.0`. However, considering this is a very recent release and this is correcting the intended behavior, I am not sure whether we can consider `7.1.0`'s behavior a bug, i.e. this would be a bug fix instead? :thinking: 