### PR TITLE
Improve validation of `$.sync` options binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,15 +234,19 @@ export function execaSync(file, args, options) {
 
 function create$(options) {
 	function $(templatesOrOptions, ...expressions) {
-		if (Array.isArray(templatesOrOptions)) {
-			const [file, ...args] = parseTemplates(templatesOrOptions, expressions);
-			return execa(file, args, options);
+		if (!Array.isArray(templatesOrOptions)) {
+			return create$({...options, ...templatesOrOptions});
 		}
 
-		return create$({...options, ...templatesOrOptions});
+		const [file, ...args] = parseTemplates(templatesOrOptions, expressions);
+		return execa(file, args, options);
 	}
 
 	$.sync = (templates, ...expressions) => {
+		if (!Array.isArray(templates)) {
+			throw new TypeError('Please use $(options).sync`command` instead of $.sync(options)`command`.');
+		}
+
 		const [file, ...args] = parseTemplates(templates, expressions);
 		return execaSync(file, args, options);
 	};

--- a/test/command.js
+++ b/test/command.js
@@ -196,6 +196,10 @@ test('$.sync accepts options', t => {
 	t.is(stdout, 'foo');
 });
 
+test('$.sync must be used after options binding, not before', t => {
+	t.throws(() => $.sync({})`noop.js`, {message: /Please use/});
+});
+
 test('$.sync allows execa return value interpolation', t => {
 	const foo = $.sync`node test/fixtures/echo.js foo`;
 	const {stdout} = $.sync`node test/fixtures/echo.js ${foo} bar`;


### PR DESCRIPTION
To bind options with the synchronous `$` API, one must do:

```js
$(options).sync`command`
```

However, users are likely to do the following instead:

```js
$.sync(options)`command`
```

We could fix this either:
  - By supporting that second syntax.
  - By making it fail with a better error message.

This PR implements the second solution. However, I am happy to implement the first solution if you'd prefer it instead, just let me know!