### PR TITLE
Fix argument concatenation with `$`

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -140,6 +140,26 @@ const example = await $`echo example`;
 await $`echo ${example}`;
 ```
 
+### Concatenation
+
+```sh
+# Bash
+tmpDir="/tmp"
+mkdir "$tmpDir/filename"
+```
+
+```js
+// zx
+const tmpDir = '/tmp'
+await $`mkdir ${tmpDir}/filename`;
+```
+
+```js
+// Execa
+const tmpDir = '/tmp'
+await $`mkdir ${tmpDir}/filename`;
+```
+
 ### Parallel commands
 
 ```sh

--- a/lib/command.js
+++ b/lib/command.js
@@ -76,21 +76,41 @@ const parseExpression = expression => {
 	throw new TypeError(`Unexpected "${typeOfExpression}" in template expression`);
 };
 
-const parseTemplate = (template, index, templates, expressions) => {
-	const templateString = template ?? templates.raw[index];
-	const templateTokens = templateString.split(SPACES_REGEXP).filter(Boolean);
+const concatTokens = (tokens, nextTokens, isNew) => isNew || tokens.length === 0 || nextTokens.length === 0
+	? [...tokens, ...nextTokens]
+	: [
+		...tokens.slice(0, -1),
+		`${tokens[tokens.length - 1]}${nextTokens[0]}`,
+		...nextTokens.slice(1),
+	];
 
-	if (index === expressions.length) {
-		return templateTokens;
+export const parseTemplates = (templates, expressions) => {
+	let tokens = [];
+
+	for (const [index, template] of templates.entries()) {
+		const templateString = template ?? templates.raw[index];
+		const templateTokens = templateString.split(SPACES_REGEXP).filter(Boolean);
+		tokens = concatTokens(
+			tokens,
+			templateTokens,
+			templateString.startsWith(' '),
+		);
+
+		if (index === expressions.length) {
+			break;
+		}
+
+		const expression = expressions[index];
+		const expressionTokens = Array.isArray(expression)
+			? expression.map(expression => parseExpression(expression))
+			: [parseExpression(expression)];
+		tokens = concatTokens(
+			tokens,
+			expressionTokens,
+			templateString.endsWith(' '),
+		);
 	}
 
-	const expression = expressions[index];
-
-	return Array.isArray(expression)
-		? [...templateTokens, ...expression.map(expression => parseExpression(expression))]
-		: [...templateTokens, parseExpression(expression)];
+	return tokens;
 };
 
-export const parseTemplates = (templates, expressions) => templates.flatMap(
-	(template, index) => parseTemplate(template, index, templates, expressions),
-);

--- a/lib/command.js
+++ b/lib/command.js
@@ -84,31 +84,35 @@ const concatTokens = (tokens, nextTokens, isNew) => isNew || tokens.length === 0
 		...nextTokens.slice(1),
 	];
 
+const parseTemplate = ({templates, expressions, tokens, index, template}) => {
+	const templateString = template ?? templates.raw[index];
+	const templateTokens = templateString.split(SPACES_REGEXP).filter(Boolean);
+	const newTokens = concatTokens(
+		tokens,
+		templateTokens,
+		templateString.startsWith(' '),
+	);
+
+	if (index === expressions.length) {
+		return newTokens;
+	}
+
+	const expression = expressions[index];
+	const expressionTokens = Array.isArray(expression)
+		? expression.map(expression => parseExpression(expression))
+		: [parseExpression(expression)];
+	return concatTokens(
+		newTokens,
+		expressionTokens,
+		templateString.endsWith(' '),
+	);
+};
+
 export const parseTemplates = (templates, expressions) => {
 	let tokens = [];
 
 	for (const [index, template] of templates.entries()) {
-		const templateString = template ?? templates.raw[index];
-		const templateTokens = templateString.split(SPACES_REGEXP).filter(Boolean);
-		tokens = concatTokens(
-			tokens,
-			templateTokens,
-			templateString.startsWith(' '),
-		);
-
-		if (index === expressions.length) {
-			break;
-		}
-
-		const expression = expressions[index];
-		const expressionTokens = Array.isArray(expression)
-			? expression.map(expression => parseExpression(expression))
-			: [parseExpression(expression)];
-		tokens = concatTokens(
-			tokens,
-			expressionTokens,
-			templateString.endsWith(' '),
-		);
+		tokens = parseTemplate({templates, expressions, tokens, index, template});
 	}
 
 	return tokens;

--- a/test/command.js
+++ b/test/command.js
@@ -112,6 +112,11 @@ test('$ allows array interpolation', async t => {
 	t.is(stdout, 'foo\nbar');
 });
 
+test('$ allows empty array interpolation', async t => {
+	const {stdout} = await $`echo.js foo ${[]} bar`;
+	t.is(stdout, 'foo\nbar');
+});
+
 test('$ allows execa return value interpolation', async t => {
 	const foo = await $`echo.js foo`;
 	const {stdout} = await $`echo.js ${foo} bar`;
@@ -169,6 +174,41 @@ test('$ passes newline escape sequence in interpolation as one argument', async 
 test('$ handles invalid escape sequence', async t => {
 	const {stdout} = await $`echo.js \u`;
 	t.is(stdout, '\\u');
+});
+
+test('$ can concatenate at the end of tokens', async t => {
+	const {stdout} = await $`echo.js foo${'bar'}`;
+	t.is(stdout, 'foobar');
+});
+
+test('$ does not concatenate at the end of tokens with a space', async t => {
+	const {stdout} = await $`echo.js foo ${'bar'}`;
+	t.is(stdout, 'foo\nbar');
+});
+
+test('$ can concatenate at the end of tokens followed by an array', async t => {
+	const {stdout} = await $`echo.js foo${['bar', 'foo']}`;
+	t.is(stdout, 'foobar\nfoo');
+});
+
+test('$ can concatenate at the start of tokens', async t => {
+	const {stdout} = await $`echo.js ${'foo'}bar`;
+	t.is(stdout, 'foobar');
+});
+
+test('$ does not concatenate at the start of tokens with a space', async t => {
+	const {stdout} = await $`echo.js ${'foo'} bar`;
+	t.is(stdout, 'foo\nbar');
+});
+
+test('$ can concatenate at the start of tokens followed by an array', async t => {
+	const {stdout} = await $`echo.js ${['foo', 'bar']}foo`;
+	t.is(stdout, 'foo\nbarfoo');
+});
+
+test('$ can concatenate multiple tokens', async t => {
+	const {stdout} = await $`echo.js ${'foo'}bar${'foo'}`;
+	t.is(stdout, 'foobarfoo');
 });
 
 test('$ allows escaping spaces in commands with interpolation', async t => {

--- a/test/command.js
+++ b/test/command.js
@@ -206,6 +206,11 @@ test('$ can concatenate at the start of tokens followed by an array', async t =>
 	t.is(stdout, 'foo\nbarfoo');
 });
 
+test('$ can concatenate at the start and end of tokens followed by an array', async t => {
+	const {stdout} = await $`echo.js foo${['bar', 'foo']}bar`;
+	t.is(stdout, 'foobar\nfoobar');
+});
+
 test('$ can concatenate multiple tokens', async t => {
 	const {stdout} = await $`echo.js ${'foo'}bar${'foo'}`;
 	t.is(stdout, 'foobarfoo');


### PR DESCRIPTION
The `$` method concatenates arguments incorrectly currently. For example:

```js
const bar = '/bar'
$`mkdir /foo${bar}`
```

Currently behaves the same way as:

```js
const bar = '/bar'
$`mkdir /foo ${bar}`
```

I.e. it evaluates to `mkdir /foo /bar`. Instead, it should result in `mkdir /foo/bar`. Concatenation is a very common use case, especially (but not limited to) file paths.

This PR fixes this problem.