### PR TITLE
Upgrade `signal-exit` to v4

### DIFF
--- a/lib/kill.js
+++ b/lib/kill.js
@@ -1,5 +1,5 @@
 import os from 'node:os';
-import onExit from 'signal-exit';
+import {onExit} from 'signal-exit';
 
 const DEFAULT_FORCE_KILL_TIMEOUT = 1000 * 5;
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"merge-stream": "^2.0.0",
 		"npm-run-path": "^5.1.0",
 		"onetime": "^6.0.0",
-		"signal-exit": "^3.0.7",
+		"signal-exit": "^4.1.0",
 		"strip-final-newline": "^3.0.0"
 	},
 	"devDependencies": {

--- a/test/kill.js
+++ b/test/kill.js
@@ -177,17 +177,17 @@ test('spawnAndKill cleanup detached SIGKILL', spawnAndKill, ['SIGKILL', true, tr
 // See #128
 test('removes exit handler on exit', async t => {
 	// @todo this relies on `signal-exit` internals
-	const emitter = process.__signal_exit_emitter__;
+	const emitter = globalThis[Symbol.for('signal-exit emitter')];
 
 	const subprocess = execa('noop.js');
-	const listener = emitter.listeners('exit').pop();
+	const listener = emitter.listeners.exit.at(-1);
 
 	await new Promise((resolve, reject) => {
 		subprocess.on('error', reject);
 		subprocess.on('exit', resolve);
 	});
 
-	const included = emitter.listeners('exit').includes(listener);
+	const included = emitter.listeners.exit.includes(listener);
 	t.false(included);
 });
 


### PR DESCRIPTION
This upgrades `signal-exit` to a new major version.

---

Note: we should still wait until we upgrade `get-stream` before making a major release. That upgrade is currently being blocked by an issue in `get-stream` I have opened here: https://github.com/sindresorhus/get-stream/issues/56