### PR TITLE
`buffer` encoding option now returns `Uint8Array` instead of `Buffer`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,10 +41,9 @@ type EncodingOption =
   | 'base64'
   | 'base64url'
   | 'buffer'
-  | null
   | undefined;
 type DefaultEncodingOption = 'utf8';
-type BufferEncodingOption = 'buffer' | null;
+type BufferEncodingOption = 'buffer';
 
 type GetStdoutStderrType<EncodingType extends EncodingOption> =
   EncodingType extends DefaultEncodingOption ? string : Buffer;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-import {type Buffer} from 'node:buffer';
 import {type ChildProcess} from 'node:child_process';
 import {type Stream, type Readable, type Writable} from 'node:stream';
 
@@ -46,7 +45,7 @@ type DefaultEncodingOption = 'utf8';
 type BufferEncodingOption = 'buffer';
 
 type GetStdoutStderrType<EncodingType extends EncodingOption> =
-  EncodingType extends DefaultEncodingOption ? string : Buffer;
+  EncodingType extends DefaultEncodingOption ? string : Uint8Array;
 
 export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingOption> = {
 	/**
@@ -218,7 +217,7 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	readonly shell?: boolean | string;
 
 	/**
-	Specify the character encoding used to decode the `stdout` and `stderr` output. If set to `'buffer'` or `null`, then `stdout` and `stderr` will be a `Buffer` instead of a string.
+	Specify the character encoding used to decode the `stdout` and `stderr` output. If set to `'buffer'`, then `stdout` and `stderr` will be a `Uint8Array` instead of a string.
 
 	@default 'utf8'
 	*/
@@ -343,7 +342,7 @@ export type NodeOptions<EncodingType extends EncodingOption = DefaultEncodingOpt
 	readonly nodeOptions?: string[];
 } & Options<EncodingType>;
 
-type StdoutStderrAll = string | Buffer | undefined;
+type StdoutStderrAll = string | Uint8Array | undefined;
 
 export type ExecaReturnBase<StdoutStderrType extends StdoutStderrAll> = {
 	/**
@@ -790,9 +789,9 @@ export function execaCommandSync<EncodingType extends EncodingOption = DefaultEn
 type TemplateExpression =
 	| string
 	| number
-	| ExecaReturnValue<string | Buffer>
-	| ExecaSyncReturnValue<string | Buffer>
-	| Array<string | number | ExecaReturnValue<string | Buffer> | ExecaSyncReturnValue<string | Buffer>>;
+	| ExecaReturnValue<string | Uint8Array>
+	| ExecaSyncReturnValue<string | Uint8Array>
+	| Array<string | number | ExecaReturnValue<string | Uint8Array> | ExecaSyncReturnValue<string | Uint8Array>>;
 
 type Execa$<StdoutStderrType extends StdoutStderrAll = string> = {
 	/**
@@ -820,7 +819,7 @@ type Execa$<StdoutStderrType extends StdoutStderrAll = string> = {
 	*/
 	(options: Options<undefined>): Execa$<StdoutStderrType>;
 	(options: Options): Execa$;
-	(options: Options<BufferEncodingOption>): Execa$<Buffer>;
+	(options: Options<BufferEncodingOption>): Execa$<Uint8Array>;
 	(
 		templates: TemplateStringsArray,
 		...expressions: TemplateExpression[]

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import {Buffer} from 'node:buffer';
 import path from 'node:path';
 import childProcess from 'node:child_process';
 import process from 'node:process';
@@ -59,6 +60,14 @@ const handleArguments = (file, args, options = {}) => {
 	}
 
 	return {file, args, options};
+};
+
+const handleOutputSync = (options, value, error) => {
+	if (options.encoding === 'buffer' && Buffer.isBuffer(value)) {
+		value = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+	}
+
+	return handleOutput(options, value, error);
 };
 
 const handleOutput = (options, value, error) => {
@@ -192,8 +201,8 @@ export function execaSync(file, args, options) {
 	}
 
 	pipeOutputSync(stdioStreams, result);
-	const stdout = handleOutput(parsed.options, result.stdout, result.error);
-	const stderr = handleOutput(parsed.options, result.stderr, result.error);
+	const stdout = handleOutputSync(parsed.options, result.stdout, result.error);
+	const stderr = handleOutputSync(parsed.options, result.stderr, result.error);
 
 	if (result.error || result.status !== 0 || result.signal !== null) {
 		const error = makeError({

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ const handleArguments = (file, args, options = {}) => {
 };
 
 const handleOutputSync = (options, value, error) => {
-	if (options.encoding === 'buffer' && Buffer.isBuffer(value)) {
+	if (Buffer.isBuffer(value)) {
 		value = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
 	}
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-import {Buffer} from 'node:buffer';
 import path from 'node:path';
 import childProcess from 'node:child_process';
 import process from 'node:process';
@@ -63,7 +62,7 @@ const handleArguments = (file, args, options = {}) => {
 };
 
 const handleOutput = (options, value, error) => {
-	if (typeof value !== 'string' && !Buffer.isBuffer(value)) {
+	if (typeof value !== 'string' && !ArrayBuffer.isView(value)) {
 		// When `execaSync()` errors, we normalize it to '' to mimic `execa()`
 		return error === undefined ? undefined : '';
 	}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,3 @@
-import {Buffer} from 'node:buffer';
 // For some reason a default import of `process` causes
 // `process.stdin`, `process.stderr`, and `process.stdout`
 // to get treated as `any` by `@typescript-eslint/no-unsafe-assignment`.
@@ -30,33 +29,33 @@ try {
 
 	expectAssignable<Function | undefined>(execaPromise.pipeStdout);
 	expectType<ExecaChildProcess>(execaPromise.pipeStdout!('file.txt'));
-	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStdout!('file.txt'));
+	expectType<ExecaChildProcess<Uint8Array>>(execaBufferPromise.pipeStdout!('file.txt'));
 	expectType<ExecaChildProcess>(execaPromise.pipeStdout!(writeStream));
-	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStdout!(writeStream));
+	expectType<ExecaChildProcess<Uint8Array>>(execaBufferPromise.pipeStdout!(writeStream));
 	expectType<ExecaChildProcess>(execaPromise.pipeStdout!(execaPromise));
-	expectType<ExecaChildProcess<Buffer>>(execaPromise.pipeStdout!(execaBufferPromise));
+	expectType<ExecaChildProcess<Uint8Array>>(execaPromise.pipeStdout!(execaBufferPromise));
 	expectType<ExecaChildProcess>(execaBufferPromise.pipeStdout!(execaPromise));
-	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStdout!(execaBufferPromise));
+	expectType<ExecaChildProcess<Uint8Array>>(execaBufferPromise.pipeStdout!(execaBufferPromise));
 
 	expectAssignable<Function | undefined>(execaPromise.pipeStderr);
 	expectType<ExecaChildProcess>(execaPromise.pipeStderr!('file.txt'));
-	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStderr!('file.txt'));
+	expectType<ExecaChildProcess<Uint8Array>>(execaBufferPromise.pipeStderr!('file.txt'));
 	expectType<ExecaChildProcess>(execaPromise.pipeStderr!(writeStream));
-	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStderr!(writeStream));
+	expectType<ExecaChildProcess<Uint8Array>>(execaBufferPromise.pipeStderr!(writeStream));
 	expectType<ExecaChildProcess>(execaPromise.pipeStderr!(execaPromise));
-	expectType<ExecaChildProcess<Buffer>>(execaPromise.pipeStderr!(execaBufferPromise));
+	expectType<ExecaChildProcess<Uint8Array>>(execaPromise.pipeStderr!(execaBufferPromise));
 	expectType<ExecaChildProcess>(execaBufferPromise.pipeStderr!(execaPromise));
-	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeStderr!(execaBufferPromise));
+	expectType<ExecaChildProcess<Uint8Array>>(execaBufferPromise.pipeStderr!(execaBufferPromise));
 
 	expectAssignable<Function | undefined>(execaPromise.pipeAll);
 	expectType<ExecaChildProcess>(execaPromise.pipeAll!('file.txt'));
-	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeAll!('file.txt'));
+	expectType<ExecaChildProcess<Uint8Array>>(execaBufferPromise.pipeAll!('file.txt'));
 	expectType<ExecaChildProcess>(execaPromise.pipeAll!(writeStream));
-	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeAll!(writeStream));
+	expectType<ExecaChildProcess<Uint8Array>>(execaBufferPromise.pipeAll!(writeStream));
 	expectType<ExecaChildProcess>(execaPromise.pipeAll!(execaPromise));
-	expectType<ExecaChildProcess<Buffer>>(execaPromise.pipeAll!(execaBufferPromise));
+	expectType<ExecaChildProcess<Uint8Array>>(execaPromise.pipeAll!(execaBufferPromise));
 	expectType<ExecaChildProcess>(execaBufferPromise.pipeAll!(execaPromise));
-	expectType<ExecaChildProcess<Buffer>>(execaBufferPromise.pipeAll!(execaBufferPromise));
+	expectType<ExecaChildProcess<Uint8Array>>(execaBufferPromise.pipeAll!(execaBufferPromise));
 
 	const unicornsResult = await execaPromise;
 	expectType<string>(unicornsResult.command);
@@ -149,7 +148,6 @@ expectError(execa('unicorns', {encoding: 'unknownEncoding'}));
 execa('unicorns', {execPath: '/path'});
 execa('unicorns', {buffer: false});
 execa('unicorns', {input: ''});
-execa('unicorns', {input: Buffer.from('')});
 execa('unicorns', {input: process.stdin});
 execa('unicorns', {inputFile: ''});
 execa('unicorns', {stdin: 'pipe'});
@@ -235,85 +233,61 @@ expectType<ExecaReturnValue>(await execa('unicorns'));
 expectType<ExecaReturnValue>(
 	await execa('unicorns', {encoding: 'utf8'}),
 );
-expectType<ExecaReturnValue<Buffer>>(await execa('unicorns', {encoding: 'buffer'}));
-expectType<ExecaReturnValue<Buffer>>(await execa('unicorns', {encoding: null}));
+expectType<ExecaReturnValue<Uint8Array>>(await execa('unicorns', {encoding: 'buffer'}));
 expectType<ExecaReturnValue>(
 	await execa('unicorns', ['foo'], {encoding: 'utf8'}),
 );
-expectType<ExecaReturnValue<Buffer>>(
+expectType<ExecaReturnValue<Uint8Array>>(
 	await execa('unicorns', ['foo'], {encoding: 'buffer'}),
-);
-expectType<ExecaReturnValue<Buffer>>(
-	await execa('unicorns', ['foo'], {encoding: null}),
 );
 
 expectType<ExecaSyncReturnValue>(execaSync('unicorns'));
 expectType<ExecaSyncReturnValue>(
 	execaSync('unicorns', {encoding: 'utf8'}),
 );
-expectType<ExecaSyncReturnValue<Buffer>>(
+expectType<ExecaSyncReturnValue<Uint8Array>>(
 	execaSync('unicorns', {encoding: 'buffer'}),
-);
-expectType<ExecaSyncReturnValue<Buffer>>(
-	execaSync('unicorns', {encoding: null}),
 );
 expectType<ExecaSyncReturnValue>(
 	execaSync('unicorns', ['foo'], {encoding: 'utf8'}),
 );
-expectType<ExecaSyncReturnValue<Buffer>>(
+expectType<ExecaSyncReturnValue<Uint8Array>>(
 	execaSync('unicorns', ['foo'], {encoding: 'buffer'}),
-);
-expectType<ExecaSyncReturnValue<Buffer>>(
-	execaSync('unicorns', ['foo'], {encoding: null}),
 );
 
 expectType<ExecaChildProcess>(execaCommand('unicorns'));
 expectType<ExecaReturnValue>(await execaCommand('unicorns'));
 expectType<ExecaReturnValue>(await execaCommand('unicorns', {encoding: 'utf8'}));
-expectType<ExecaReturnValue<Buffer>>(await execaCommand('unicorns', {encoding: 'buffer'}));
-expectType<ExecaReturnValue<Buffer>>(await execaCommand('unicorns', {encoding: null}));
+expectType<ExecaReturnValue<Uint8Array>>(await execaCommand('unicorns', {encoding: 'buffer'}));
 expectType<ExecaReturnValue>(await execaCommand('unicorns foo', {encoding: 'utf8'}));
-expectType<ExecaReturnValue<Buffer>>(await execaCommand('unicorns foo', {encoding: 'buffer'}));
-expectType<ExecaReturnValue<Buffer>>(await execaCommand('unicorns foo', {encoding: null}));
+expectType<ExecaReturnValue<Uint8Array>>(await execaCommand('unicorns foo', {encoding: 'buffer'}));
 
 expectType<ExecaSyncReturnValue>(execaCommandSync('unicorns'));
 expectType<ExecaSyncReturnValue>(execaCommandSync('unicorns', {encoding: 'utf8'}));
-expectType<ExecaSyncReturnValue<Buffer>>(execaCommandSync('unicorns', {encoding: 'buffer'}));
-expectType<ExecaSyncReturnValue<Buffer>>(execaCommandSync('unicorns', {encoding: null}));
+expectType<ExecaSyncReturnValue<Uint8Array>>(execaCommandSync('unicorns', {encoding: 'buffer'}));
 expectType<ExecaSyncReturnValue>(execaCommandSync('unicorns foo', {encoding: 'utf8'}));
-expectType<ExecaSyncReturnValue<Buffer>>(execaCommandSync('unicorns foo', {encoding: 'buffer'}));
-expectType<ExecaSyncReturnValue<Buffer>>(execaCommandSync('unicorns foo', {encoding: null}));
+expectType<ExecaSyncReturnValue<Uint8Array>>(execaCommandSync('unicorns foo', {encoding: 'buffer'}));
 
 expectType<ExecaChildProcess>(execaNode('unicorns'));
 expectType<ExecaReturnValue>(await execaNode('unicorns'));
 expectType<ExecaReturnValue>(
 	await execaNode('unicorns', {encoding: 'utf8'}),
 );
-expectType<ExecaReturnValue<Buffer>>(await execaNode('unicorns', {encoding: 'buffer'}));
-expectType<ExecaReturnValue<Buffer>>(await execaNode('unicorns', {encoding: null}));
+expectType<ExecaReturnValue<Uint8Array>>(await execaNode('unicorns', {encoding: 'buffer'}));
 expectType<ExecaReturnValue>(
 	await execaNode('unicorns', ['foo'], {encoding: 'utf8'}),
 );
-expectType<ExecaReturnValue<Buffer>>(
+expectType<ExecaReturnValue<Uint8Array>>(
 	await execaNode('unicorns', ['foo'], {encoding: 'buffer'}),
-);
-expectType<ExecaReturnValue<Buffer>>(
-	await execaNode('unicorns', ['foo'], {encoding: null}),
 );
 
 expectType<ExecaChildProcess>(execaNode('unicorns', {nodeOptions: ['--async-stack-traces']}));
 expectType<ExecaChildProcess>(execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces']}));
-expectType<ExecaChildProcess<Buffer>>(
+expectType<ExecaChildProcess<Uint8Array>>(
 	execaNode('unicorns', {nodeOptions: ['--async-stack-traces'], encoding: 'buffer'}),
 );
-expectType<ExecaChildProcess<Buffer>>(
-	execaNode('unicorns', {nodeOptions: ['--async-stack-traces'], encoding: null}),
-);
-expectType<ExecaChildProcess<Buffer>>(
+expectType<ExecaChildProcess<Uint8Array>>(
 	execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces'], encoding: 'buffer'}),
-);
-expectType<ExecaChildProcess<Buffer>>(
-	execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces'], encoding: null}),
 );
 
 expectType<ExecaChildProcess>($`unicorns`);
@@ -329,14 +303,13 @@ expectType<ExecaChildProcess>($({encoding: 'utf8'})`unicorns foo`);
 expectType<ExecaReturnValue>(await $({encoding: 'utf8'})`unicorns foo`);
 expectType<ExecaSyncReturnValue>($({encoding: 'utf8'}).sync`unicorns foo`);
 
-expectType<ExecaChildProcess<Buffer>>($({encoding: null})`unicorns`);
-expectType<ExecaChildProcess<Buffer>>($({encoding: 'buffer'})`unicorns`);
-expectType<ExecaReturnValue<Buffer>>(await $({encoding: 'buffer'})`unicorns`);
-expectType<ExecaSyncReturnValue<Buffer>>($({encoding: 'buffer'}).sync`unicorns`);
+expectType<ExecaChildProcess<Uint8Array>>($({encoding: 'buffer'})`unicorns`);
+expectType<ExecaReturnValue<Uint8Array>>(await $({encoding: 'buffer'})`unicorns`);
+expectType<ExecaSyncReturnValue<Uint8Array>>($({encoding: 'buffer'}).sync`unicorns`);
 
-expectType<ExecaChildProcess<Buffer>>($({encoding: 'buffer'})`unicorns foo`);
-expectType<ExecaReturnValue<Buffer>>(await $({encoding: 'buffer'})`unicorns foo`);
-expectType<ExecaSyncReturnValue<Buffer>>($({encoding: 'buffer'}).sync`unicorns foo`);
+expectType<ExecaChildProcess<Uint8Array>>($({encoding: 'buffer'})`unicorns foo`);
+expectType<ExecaReturnValue<Uint8Array>>(await $({encoding: 'buffer'})`unicorns foo`);
+expectType<ExecaSyncReturnValue<Uint8Array>>($({encoding: 'buffer'}).sync`unicorns foo`);
 
 expectType<ExecaChildProcess>($({encoding: 'buffer'})({encoding: 'utf8'})`unicorns`);
 expectType<ExecaReturnValue>(await $({encoding: 'buffer'})({encoding: 'utf8'})`unicorns`);
@@ -346,13 +319,13 @@ expectType<ExecaChildProcess>($({encoding: 'buffer'})({encoding: 'utf8'})`unicor
 expectType<ExecaReturnValue>(await $({encoding: 'buffer'})({encoding: 'utf8'})`unicorns foo`);
 expectType<ExecaSyncReturnValue>($({encoding: 'buffer'})({encoding: 'utf8'}).sync`unicorns foo`);
 
-expectType<ExecaChildProcess<Buffer>>($({encoding: 'buffer'})({})`unicorns`);
-expectType<ExecaReturnValue<Buffer>>(await $({encoding: 'buffer'})({})`unicorns`);
-expectType<ExecaSyncReturnValue<Buffer>>($({encoding: 'buffer'})({}).sync`unicorns`);
+expectType<ExecaChildProcess<Uint8Array>>($({encoding: 'buffer'})({})`unicorns`);
+expectType<ExecaReturnValue<Uint8Array>>(await $({encoding: 'buffer'})({})`unicorns`);
+expectType<ExecaSyncReturnValue<Uint8Array>>($({encoding: 'buffer'})({}).sync`unicorns`);
 
-expectType<ExecaChildProcess<Buffer>>($({encoding: 'buffer'})({})`unicorns foo`);
-expectType<ExecaReturnValue<Buffer>>(await $({encoding: 'buffer'})({})`unicorns foo`);
-expectType<ExecaSyncReturnValue<Buffer>>($({encoding: 'buffer'})({}).sync`unicorns foo`);
+expectType<ExecaChildProcess<Uint8Array>>($({encoding: 'buffer'})({})`unicorns foo`);
+expectType<ExecaReturnValue<Uint8Array>>(await $({encoding: 'buffer'})({})`unicorns foo`);
+expectType<ExecaSyncReturnValue<Uint8Array>>($({encoding: 'buffer'})({}).sync`unicorns foo`);
 
 expectType<ExecaReturnValue>(await $`unicorns ${'foo'}`);
 expectType<ExecaSyncReturnValue>($.sync`unicorns ${'foo'}`);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -148,6 +148,7 @@ expectError(execa('unicorns', {encoding: 'unknownEncoding'}));
 execa('unicorns', {execPath: '/path'});
 execa('unicorns', {buffer: false});
 execa('unicorns', {input: ''});
+execa('unicorns', {input: new Uint8Array()});
 execa('unicorns', {input: process.stdin});
 execa('unicorns', {inputFile: ''});
 execa('unicorns', {stdin: 'pipe'});

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,4 +1,3 @@
-import {Buffer} from 'node:buffer';
 import {ChildProcess} from 'node:child_process';
 
 const normalizeArgs = (file, args = []) => {
@@ -65,8 +64,8 @@ const parseExpression = expression => {
 			return expression.stdout;
 		}
 
-		if (Buffer.isBuffer(expression.stdout)) {
-			return expression.stdout.toString();
+		if (ArrayBuffer.isView(expression.stdout)) {
+			return new TextDecoder().decode(expression.stdout);
 		}
 
 		throw new TypeError(`Unexpected "${typeOfStdout}" stdout in template expression`);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,7 +1,7 @@
 import {once} from 'node:events';
 import {setTimeout} from 'node:timers/promises';
 import {finished} from 'node:stream/promises';
-import getStream, {getStreamAsBuffer} from 'get-stream';
+import getStream, {getStreamAsBuffer, getStreamAsArrayBuffer} from 'get-stream';
 import mergeStreams from '@sindresorhus/merge-streams';
 
 // `all` interleaves `stdout` and `stderr`
@@ -43,7 +43,7 @@ const getStreamPromise = (stream, {encoding, buffer, maxBuffer}) => {
 	}
 
 	if (encoding === 'buffer') {
-		return getStreamAsBuffer(stream, {maxBuffer});
+		return getStreamAsArrayBuffer(stream, {maxBuffer}).then(arrayBuffer => new Uint8Array(arrayBuffer));
 	}
 
 	return applyEncoding(stream, maxBuffer, encoding);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -42,7 +42,7 @@ const getStreamPromise = (stream, {encoding, buffer, maxBuffer}) => {
 		return getStream(stream, {maxBuffer});
 	}
 
-	if (encoding === null || encoding === 'buffer') {
+	if (encoding === 'buffer') {
 		return getStreamAsBuffer(stream, {maxBuffer});
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -400,19 +400,19 @@ The numeric exit code of the process that was run.
 
 #### stdout
 
-Type: `string | Buffer`
+Type: `string | Uint8Array`
 
 The output of the process on stdout.
 
 #### stderr
 
-Type: `string | Buffer`
+Type: `string | Uint8Array`
 
 The output of the process on stderr.
 
 #### all
 
-Type: `string | Buffer | undefined`
+Type: `string | Uint8Array | undefined`
 
 The output of the process with `stdout` and `stderr` interleaved.
 
@@ -690,10 +690,10 @@ We recommend against using this option since it is:
 
 #### encoding
 
-Type: `string | null`\
+Type: `string`\
 Default: `utf8`
 
-Specify the character encoding used to decode the `stdout` and `stderr` output. If set to `'buffer'` or `null`, then `stdout` and `stderr` will be a `Buffer` instead of a string.
+Specify the character encoding used to decode the `stdout` and `stderr` output. If set to `'buffer'`, then `stdout` and `stderr` will be a `Uint8Array` instead of a string.
 
 #### timeout
 

--- a/test/command.js
+++ b/test/command.js
@@ -131,13 +131,13 @@ test('$ allows execa return value array interpolation', async t => {
 });
 
 test('$ allows execa return value buffer interpolation', async t => {
-	const foo = await $({encoding: null})`echo.js foo`;
+	const foo = await $({encoding: 'buffer'})`echo.js foo`;
 	const {stdout} = await $`echo.js ${foo} bar`;
 	t.is(stdout, 'foo\nbar');
 });
 
 test('$ allows execa return value buffer array interpolation', async t => {
-	const foo = await $({encoding: null})`echo.js foo`;
+	const foo = await $({encoding: 'buffer'})`echo.js foo`;
 	const {stdout} = await $`echo.js ${[foo, 'bar']}`;
 	t.is(stdout, 'foo\nbar');
 });
@@ -264,13 +264,13 @@ test('$.sync allows execa return value array interpolation', t => {
 });
 
 test('$.sync allows execa return value buffer interpolation', t => {
-	const foo = $({encoding: null}).sync`echo.js foo`;
+	const foo = $({encoding: 'buffer'}).sync`echo.js foo`;
 	const {stdout} = $.sync`echo.js ${foo} bar`;
 	t.is(stdout, 'foo\nbar');
 });
 
 test('$.sync allows execa return value buffer array interpolation', t => {
-	const foo = $({encoding: null}).sync`echo.js foo`;
+	const foo = $({encoding: 'buffer'}).sync`echo.js foo`;
 	const {stdout} = $.sync`echo.js ${[foo, 'bar']}`;
 	t.is(stdout, 'foo\nbar');
 });

--- a/test/stream.js
+++ b/test/stream.js
@@ -62,7 +62,6 @@ const checkBufferEncoding = async (t, encoding) => {
 };
 
 test('can pass encoding "buffer"', checkBufferEncoding, 'buffer');
-test('can pass encoding null', checkBufferEncoding, null);
 
 test('validate unknown encodings', async t => {
 	await t.throwsAsync(execa('noop.js', {encoding: 'unknownEncoding'}), {code: 'ERR_UNKNOWN_ENCODING'});

--- a/test/stream.js
+++ b/test/stream.js
@@ -22,10 +22,16 @@ setFixtureDir();
 
 const nonFileUrl = new URL('https://example.com');
 
-test('buffer', async t => {
+test('encoding option can be buffer', async t => {
 	const {stdout} = await execa('noop.js', ['foo'], {encoding: 'buffer'});
 	t.true(ArrayBuffer.isView(stdout));
-	t.is(new TextDecoder().decode(stdout), 'foo');
+	t.is(textDecoder.decode(stdout), 'foo');
+});
+
+test('encoding option can be buffer - Sync', t => {
+	const {stdout} = execaSync('noop.js', ['foo'], {encoding: 'buffer'});
+	t.true(ArrayBuffer.isView(stdout));
+	t.is(textDecoder.decode(stdout), 'foo');
 });
 
 const checkEncoding = async (t, encoding) => {
@@ -109,6 +115,7 @@ test('stdin option can be a sync iterable of strings', async t => {
 });
 
 const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
 const binaryFoo = textEncoder.encode('foo');
 const binaryBar = textEncoder.encode('bar');
 
@@ -223,7 +230,7 @@ test('input option can be a String', async t => {
 });
 
 test('input option can be a Uint8Array', async t => {
-	const {stdout} = await execa('stdin.js', {input: Uint8Array.from('foo', c => c.codePointAt(0))});
+	const {stdout} = await execa('stdin.js', {input: binaryFoo});
 	t.is(stdout, 'foo');
 });
 
@@ -511,7 +518,7 @@ test('input option can be used with $.sync', t => {
 });
 
 test('input option can be a Uint8Array - sync', t => {
-	const {stdout} = execaSync('stdin.js', {input: Uint8Array.from('foo', c => c.codePointAt(0))});
+	const {stdout} = execaSync('stdin.js', {input: binaryFoo});
 	t.is(stdout, 'foo');
 });
 

--- a/test/stream.js
+++ b/test/stream.js
@@ -23,9 +23,9 @@ setFixtureDir();
 const nonFileUrl = new URL('https://example.com');
 
 test('buffer', async t => {
-	const {stdout} = await execa('noop.js', ['foo'], {encoding: null});
-	t.true(Buffer.isBuffer(stdout));
-	t.is(stdout.toString(), 'foo');
+	const {stdout} = await execa('noop.js', ['foo'], {encoding: 'buffer'});
+	t.true(ArrayBuffer.isView(stdout));
+	t.is(new TextDecoder().decode(stdout), 'foo');
 });
 
 const checkEncoding = async (t, encoding) => {
@@ -222,6 +222,11 @@ test('input option can be a String', async t => {
 	t.is(stdout, 'foobar');
 });
 
+test('input option can be a Uint8Array', async t => {
+	const {stdout} = await execa('stdin.js', {input: Uint8Array.from('foo', c => c.codePointAt(0))});
+	t.is(stdout, 'foo');
+});
+
 test('input option cannot be a String when stdin is set', t => {
 	t.throws(() => {
 		execa('stdin.js', {input: 'foobar', stdin: 'ignore'});
@@ -232,11 +237,6 @@ test('input option cannot be a String when stdio is set', t => {
 	t.throws(() => {
 		execa('stdin.js', {input: 'foobar', stdio: 'ignore'});
 	}, {message: /`input` and `stdin` options/});
-});
-
-test('input option can be a Buffer', async t => {
-	const {stdout} = await execa('stdin.js', {input: 'testing12'});
-	t.is(stdout, 'testing12');
 });
 
 const createNoFileReadable = value => {
@@ -510,9 +510,9 @@ test('input option can be used with $.sync', t => {
 	t.is(stdout, 'foobar');
 });
 
-test('input option can be a Buffer - sync', t => {
-	const {stdout} = execaSync('stdin.js', {input: Buffer.from('testing12', 'utf8')});
-	t.is(stdout, 'testing12');
+test('input option can be a Uint8Array - sync', t => {
+	const {stdout} = execaSync('stdin.js', {input: Uint8Array.from('foo', c => c.codePointAt(0))});
+	t.is(stdout, 'foo');
 });
 
 test('opts.stdout:ignore - stdout will not collect data', async t => {


### PR DESCRIPTION
Fixes #584.

Allow `stdout` and `stderr` to be an ArrayBuffer to provide a more fine-grained control to users