### PR TITLE
Fix processes not exiting on `inputFile` validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ import {makeError} from './lib/error.js';
 import {normalizeStdio, normalizeStdioNode} from './lib/stdio.js';
 import {spawnedKill, spawnedCancel, setupTimeout, validateTimeout, setExitHandler} from './lib/kill.js';
 import {addPipeMethods} from './lib/pipe.js';
-import {handleInput, getSpawnedResult, makeAllStream, handleInputSync} from './lib/stream.js';
+import {validateInputOptions, handleInput, getSpawnedResult, makeAllStream, handleInputSync} from './lib/stream.js';
 import {mergePromise, getSpawnedPromise} from './lib/promise.js';
 import {joinCommand, parseCommand, parseTemplates, getEscapedCommand} from './lib/command.js';
 import {logCommand, verboseDefault} from './lib/verbose.js';
@@ -82,6 +82,7 @@ export function execa(file, args, options) {
 	logCommand(escapedCommand, parsed.options);
 
 	validateTimeout(parsed.options);
+	validateInputOptions(parsed.options);
 
 	let spawned;
 	try {
@@ -174,11 +175,12 @@ export function execaSync(file, args, options) {
 	const escapedCommand = getEscapedCommand(file, args);
 	logCommand(escapedCommand, parsed.options);
 
-	const input = handleInputSync(parsed.options);
+	validateInputOptions(parsed.options);
+	const inputOption = handleInputSync(parsed.options);
 
 	let result;
 	try {
-		result = childProcess.spawnSync(parsed.file, parsed.args, {...parsed.options, input});
+		result = childProcess.spawnSync(parsed.file, parsed.args, {...parsed.options, input: inputOption});
 	} catch (error) {
 		throw makeError({
 			error,

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -4,53 +4,35 @@ import {isStream} from 'is-stream';
 import getStream, {getStreamAsBuffer} from 'get-stream';
 import mergeStreams from '@sindresorhus/merge-streams';
 
-const validateInputOptions = input => {
-	if (input !== undefined) {
+export const validateInputOptions = ({input, inputFile}) => {
+	if (input !== undefined && inputFile !== undefined) {
 		throw new TypeError('The `input` and `inputFile` options cannot be both set.');
 	}
 };
 
-const getInputSync = ({input, inputFile}) => {
-	if (typeof inputFile !== 'string') {
-		return input;
-	}
-
-	validateInputOptions(input);
-	return readFileSync(inputFile);
-};
-
 // `input` and `inputFile` option in sync mode
-export const handleInputSync = options => {
-	const input = getInputSync(options);
+export const handleInputSync = ({input, inputFile}) => {
+	const inputOption = typeof inputFile === 'string' ? readFileSync(inputFile) : input;
 
-	if (isStream(input)) {
+	if (isStream(inputOption)) {
 		throw new TypeError('The `input` option cannot be a stream in sync mode');
 	}
 
-	return input;
-};
-
-const getInput = ({input, inputFile}) => {
-	if (typeof inputFile !== 'string') {
-		return input;
-	}
-
-	validateInputOptions(input);
-	return createReadStream(inputFile);
+	return inputOption;
 };
 
 // `input` and `inputFile` option in async mode
-export const handleInput = (spawned, options) => {
-	const input = getInput(options);
+export const handleInput = (spawned, {input, inputFile}) => {
+	const inputOption = typeof inputFile === 'string' ? createReadStream(inputFile) : input;
 
-	if (input === undefined) {
+	if (inputOption === undefined) {
 		return;
 	}
 
-	if (isStream(input)) {
-		input.pipe(spawned.stdin);
+	if (isStream(inputOption)) {
+		inputOption.pipe(spawned.stdin);
 	} else {
-		spawned.stdin.end(input);
+		spawned.stdin.end(inputOption);
 	}
 };
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^20.8.9",
-		"ava": "^5.3.1",
+		"ava": "^6.0.1",
 		"c8": "^8.0.1",
 		"get-node": "^15.0.0",
 		"is-running": "^2.1.0",

--- a/test/node.js
+++ b/test/node.js
@@ -100,4 +100,6 @@ test('node\'s forked script has a communication channel', async t => {
 
 	const message = await pEvent(subprocess, 'message');
 	t.is(message, 'pong');
+
+	subprocess.kill();
 });


### PR DESCRIPTION
When both the `input` and `inputFile` options are specified, Execa throws. However, when doing so, the spawned process is not terminated, and keeps running.

This bug was not previously reported because Ava v3 terminates the test process even if some other processes are hanging. Ava v4 now captures this bug, so this PR upgrades Ava as well.