### PR TITLE
Do not fail CI on Codecov errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,4 +26,4 @@ jobs:
       - uses: codecov/codecov-action@v3
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == 20
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
Part of #595.

The Codecov action (in this repo and my own repos) has always been flaky. Network requests tend to randomly fail.

This makes our CI tests fail too.

```
[2023-12-14T20:20:24.660Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=github-action-3.1.4-uploader-0.7.1&token=*******&branch=sync-alias&build=7214107933&build_url=https%3A%2F%2Fgithub.com%2Fsindresorhus%2Fexeca%2Factions%2Fruns%2F7214107933&commit=f7614f029ed2815b09972c14d8ed12f8f1b6da5c&job=CI&pr=594&service=github-actions&slug=sindresorhus%2Fexeca&name=&tag=&flags=&parent=
[2023-12-14T20:20:24.865Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
Error: Codecov: Failed to properly upload: The process '/home/runner/work/_actions/codecov/codecov-action/v3/dist/codecov' failed with exit code 255
```

Retrying usually fixes this, but this PR would make things easier.