### PR TITLE
Fix `verbose` logs interleaving

### DIFF
--- a/lib/verbose.js
+++ b/lib/verbose.js
@@ -1,3 +1,4 @@
+import {writeFileSync} from 'node:fs';
 import {debuglog} from 'node:util';
 import process from 'node:process';
 
@@ -15,5 +16,7 @@ export const logCommand = (escapedCommand, {verbose}) => {
 		return;
 	}
 
-	process.stderr.write(`[${getTimestamp()}] ${escapedCommand}\n`);
+	// Write synchronously to ensure it is written before spawning the child process.
+	// This guarantees this line is written to `stderr` before the child process prints anything.
+	writeFileSync(process.stderr.fd, `[${getTimestamp()}] ${escapedCommand}\n`);
 };


### PR DESCRIPTION
Fixes #598.

When printing `verbose` logs, they must be synchronous to guarantee that they are printed before the child process's `stdout`/`stderr`.