### PR TITLE
Fix `cleanup` option test

### DIFF
--- a/test/kill.js
+++ b/test/kill.js
@@ -167,7 +167,9 @@ const spawnAndKill = async (t, [signal, cleanup, detached, isKilled]) => {
 const exitIfWindows = process.platform === 'win32';
 test('spawnAndKill SIGTERM', spawnAndKill, ['SIGTERM', false, false, exitIfWindows]);
 test('spawnAndKill SIGKILL', spawnAndKill, ['SIGKILL', false, false, exitIfWindows]);
-test('spawnAndKill cleanup SIGTERM', spawnAndKill, ['SIGTERM', true, false, true]);
+// The `cleanup` option can introduce a race condition in this test
+// This is especially true when run concurrently, so we use `test.serial()`
+test.serial('spawnAndKill cleanup SIGTERM', spawnAndKill, ['SIGTERM', true, false, true]);
 test('spawnAndKill cleanup SIGKILL', spawnAndKill, ['SIGKILL', true, false, exitIfWindows]);
 test('spawnAndKill detached SIGTERM', spawnAndKill, ['SIGTERM', false, true, false]);
 test('spawnAndKill detached SIGKILL', spawnAndKill, ['SIGKILL', false, true, false]);


### PR DESCRIPTION
Fixes #597.

This is quite hard to fix this race condition due to the reasons explaining in the issue. 
This fix seems to do the trick, although it's not the perfect fix we'd hope for.