### PR TITLE
Fix `verbose` option tests, again

### DIFF
--- a/test/fixtures/verbose-script.js
+++ b/test/fixtures/verbose-script.js
@@ -2,5 +2,5 @@
 import {$} from '../../index.js';
 
 const $$ = $({stdio: 'inherit'});
-await $$`node -p "one"`;
-await $$`node -p "two"`;
+await $$`node -e console.error("one")`;
+await $$`node -e console.error("two")`;

--- a/test/verbose.js
+++ b/test/verbose.js
@@ -8,17 +8,15 @@ const normalizeTimestamp = output => output.replaceAll(/\d/g, '0');
 const testTimestamp = '[00:00:00.000]';
 
 test('Prints command when "verbose" is true', async t => {
-	const {stdout, stderr, all} = await execa('nested.js', [JSON.stringify({verbose: true}), 'noop.js', 'test'], {all: true});
+	const {stdout, stderr} = await execa('nested.js', [JSON.stringify({verbose: true}), 'noop.js', 'test'], {all: true});
 	t.is(stdout, 'test');
 	t.is(normalizeTimestamp(stderr), `${testTimestamp} noop.js test`);
-	t.is(normalizeTimestamp(all), `${testTimestamp} noop.js test\ntest`);
 });
 
 test('Prints command with NODE_DEBUG=execa', async t => {
-	const {stdout, stderr, all} = await execa('nested.js', [JSON.stringify({}), 'noop.js', 'test'], {all: true, env: {NODE_DEBUG: 'execa'}});
+	const {stdout, stderr} = await execa('nested.js', [JSON.stringify({}), 'noop.js', 'test'], {all: true, env: {NODE_DEBUG: 'execa'}});
 	t.is(stdout, 'test');
 	t.is(normalizeTimestamp(stderr), `${testTimestamp} noop.js test`);
-	t.is(normalizeTimestamp(all), `${testTimestamp} noop.js test\ntest`);
 });
 
 test('Escape verbose command', async t => {
@@ -28,8 +26,8 @@ test('Escape verbose command', async t => {
 
 test('Verbose option works with inherit', async t => {
 	const {all} = await execa('verbose-script.js', {all: true, env: {NODE_DEBUG: 'execa'}});
-	t.is(normalizeTimestamp(all), `${testTimestamp} node -p "\\"one\\""
+	t.is(normalizeTimestamp(all), `${testTimestamp} node -e "console.error(\\"one\\")"
 one
-${testTimestamp} node -p "\\"two\\""
+${testTimestamp} node -e "console.error(\\"two\\")"
 two`);
 });


### PR DESCRIPTION
Follow-up on #600.

While that PR reduced the amount of time the tests were failing, it seems like the synchronous flush is not bullet proof against the race condition, and the tests related to the `verbose` option are still randomly failing.

This PR should fix it for good.