### PR TITLE
Handle `inputFile` missing file

### DIFF
--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -1,39 +1,132 @@
+import {createReadStream, readFileSync} from 'node:fs';
 import {Readable} from 'node:stream';
 import {isStream} from 'is-stream';
 
 const aliases = ['stdin', 'stdout', 'stderr'];
+
+const arrifyStdio = (stdio = []) => Array.isArray(stdio) ? stdio : [stdio, stdio, stdio];
 
 const isIterableStdin = stdinOption => typeof stdinOption === 'object'
 	&& stdinOption !== null
 	&& !isStream(stdinOption)
 	&& (typeof stdinOption[Symbol.asyncIterator] === 'function' || typeof stdinOption[Symbol.iterator] === 'function');
 
-const transformStdioItem = (stdioItem, index) => {
-	if (index === 0 && isIterableStdin(stdioItem)) {
-		return 'pipe';
+const getIterableStdin = stdioArray => isIterableStdin(stdioArray[0])
+	? stdioArray[0]
+	: undefined;
+
+// Check whether the `stdin` option results in `spawned.stdin` being `undefined`.
+// We use a deny list instead of an allow list to be forward compatible with new options.
+const cannotPipeStdio = stdioOption => NO_PIPE_STDIN.has(stdioOption)
+	|| isStream(stdioOption)
+	|| typeof stdioOption === 'number'
+	|| isIterableStdin(stdioOption);
+
+const NO_PIPE_STDIN = new Set(['ipc', 'ignore', 'inherit']);
+
+const validateInputOptions = (stdioArray, input, inputFile) => {
+	if (input !== undefined && inputFile !== undefined) {
+		throw new TypeError('The `input` and `inputFile` options cannot be both set.');
 	}
 
-	return stdioItem;
+	const noPipeStdin = cannotPipeStdio(stdioArray[0]);
+	if (noPipeStdin && input !== undefined) {
+		throw new TypeError('The `input` and `stdin` options cannot be both set.');
+	}
+
+	if (noPipeStdin && inputFile !== undefined) {
+		throw new TypeError('The `inputFile` and `stdin` options cannot be both set.');
+	}
 };
 
-const transformStdio = stdio => Array.isArray(stdio)
-	? stdio.map((stdioItem, index) => transformStdioItem(stdioItem, index))
-	: stdio;
+const getStdioStreams = (stdioArray, {input, inputFile}) => {
+	const iterableStdin = getIterableStdin(stdioArray);
 
-const getStdioStreams = stdio => {
-	if (!Array.isArray(stdio) || !isIterableStdin(stdio[0])) {
+	if (iterableStdin !== undefined) {
+		return {stdinStream: Readable.from(iterableStdin)};
+	}
+
+	if (inputFile !== undefined) {
+		return {stdinStream: createReadStream(inputFile)};
+	}
+
+	if (input === undefined) {
 		return {};
 	}
 
-	const stdinIterableStream = Readable.from(stdio[0]);
-	return {stdinIterableStream};
+	if (isStream(input)) {
+		return {stdinStream: input};
+	}
+
+	return {stdinInput: input};
 };
 
+// When the `stdin: iterable`, `input` or `inputFile` option is used, we pipe to `spawned.stdin`.
+// Therefore the `stdin` option must be either `pipe` or `overlapped`. Other values do not set `spawned.stdin`.
+const willPipeStdin = (index, {stdinStream, stdinInput}) =>
+	index === 0 && (stdinStream !== undefined || stdinInput !== undefined);
+
+const transformStdioItem = (stdioItem, index, stdioStreams) =>
+	willPipeStdin(index, stdioStreams) && stdioItem !== 'overlapped' ? 'pipe' : stdioItem;
+
+const transformStdio = (stdio, stdioStreams) => Array.isArray(stdio)
+	? stdio.map((stdioItem, index) => transformStdioItem(stdioItem, index, stdioStreams))
+	: stdio;
+
+// Handle `input`, `inputFile` and `stdin` options, before spawning, in async mode
 export const handleStdioOption = options => {
 	const stdio = normalizeStdio(options);
-	const stdioStreams = getStdioStreams(stdio);
-	options.stdio = transformStdio(stdio);
+	const stdioArray = arrifyStdio(stdio);
+	validateInputOptions(stdioArray, options.input, options.inputFile);
+	const stdioStreams = getStdioStreams(stdioArray, options);
+	options.stdio = transformStdio(stdio, stdioStreams);
 	return stdioStreams;
+};
+
+// Handle `input`, `inputFile` and `stdin` options, after spawning, in async mode
+export const pipeStdioOption = (spawned, {stdinStream, stdinInput}) => {
+	if (stdinStream !== undefined) {
+		stdinStream.pipe(spawned.stdin);
+		return;
+	}
+
+	if (stdinInput !== undefined) {
+		spawned.stdin.end(stdinInput);
+	}
+};
+
+const validateInputOptionsSync = (stdioArray, input) => {
+	if (getIterableStdin(stdioArray) !== undefined) {
+		throw new TypeError('The `stdin` option cannot be an iterable in sync mode');
+	}
+
+	if (isStream(input)) {
+		throw new TypeError('The `input` option cannot be a stream in sync mode');
+	}
+};
+
+const getInputOption = (stdio, {input, inputFile}) => {
+	const stdioArray = arrifyStdio(stdio);
+	validateInputOptions(stdioArray, input, inputFile);
+	validateInputOptionsSync(stdioArray, input);
+
+	if (inputFile !== undefined) {
+		return readFileSync(inputFile);
+	}
+
+	return input;
+};
+
+// Handle `input`, `inputFile` and `stdin` options, before spawning, in sync mode
+export const handleInputOption = options => {
+	const stdio = normalizeStdio(options);
+
+	const input = getInputOption(stdio, options);
+	if (input !== undefined) {
+		options.input = input;
+	}
+
+	options.stdio = stdio;
 };
 
 const hasAlias = options => aliases.some(alias => options[alias] !== undefined);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,60 +1,7 @@
 import {once} from 'node:events';
-import {createReadStream, readFileSync} from 'node:fs';
 import {setTimeout} from 'node:timers/promises';
-import {isStream} from 'is-stream';
 import getStream, {getStreamAsBuffer} from 'get-stream';
 import mergeStreams from '@sindresorhus/merge-streams';
-
-export const validateInputOptions = ({input, inputFile}, {stdinIterableStream}) => {
-	if (input !== undefined && inputFile !== undefined) {
-		throw new TypeError('The `input` and `inputFile` options cannot be both set.');
-	}
-
-	if (stdinIterableStream !== undefined) {
-		if (input !== undefined) {
-			throw new TypeError('The `stdin` option cannot be an iterable when the `input` option is set.');
-		}
-
-		if (inputFile !== undefined) {
-			throw new TypeError('The `stdin` option cannot be an iterable when the `inputFile` option is set.');
-		}
-	}
-};
-
-// `input` and `inputFile` option in sync mode
-export const handleInputSync = ({input, inputFile}, {stdinIterableStream}) => {
-	if (stdinIterableStream !== undefined) {
-		throw new TypeError('The `stdin` option cannot be an iterable in sync mode');
-	}
-
-	const inputOption = typeof inputFile === 'string' ? readFileSync(inputFile) : input;
-
-	if (isStream(inputOption)) {
-		throw new TypeError('The `input` option cannot be a stream in sync mode');
-	}
-
-	return inputOption;
-};
-
-// `input` and `inputFile` option in async mode
-export const handleInput = (spawned, {input, inputFile}, {stdinIterableStream}) => {
-	if (stdinIterableStream !== undefined) {
-		stdinIterableStream.pipe(spawned.stdin);
-		return;
-	}
-
-	const inputOption = typeof inputFile === 'string' ? createReadStream(inputFile) : input;
-
-	if (inputOption === undefined) {
-		return;
-	}
-
-	if (isStream(inputOption)) {
-		inputOption.pipe(spawned.stdin);
-	} else {
-		spawned.stdin.end(inputOption);
-	}
-};
 
 // `all` interleaves `stdout` and `stderr`
 export const makeAllStream = (spawned, {all}) => {
@@ -116,11 +63,11 @@ const throwOnStreamError = async stream => {
 };
 
 // Retrieve result of child process: exit code, signal, error, streams (stdout/stderr/all)
-export const getSpawnedResult = async (spawned, {encoding, buffer, maxBuffer}, {stdinIterableStream}, processDone) => {
+export const getSpawnedResult = async (spawned, {encoding, buffer, maxBuffer}, {stdinStream}, processDone) => {
 	const stdoutPromise = getStreamPromise(spawned.stdout, {encoding, buffer, maxBuffer});
 	const stderrPromise = getStreamPromise(spawned.stderr, {encoding, buffer, maxBuffer});
 	const allPromise = getStreamPromise(spawned.all, {encoding, buffer, maxBuffer: maxBuffer * 2});
-	const processDoneOrStreamsError = Promise.race([processDone, ...throwOnStreamsError([stdinIterableStream])]);
+	const processDoneOrStreamsError = Promise.race([processDone, ...throwOnStreamsError([stdinStream])]);
 
 	try {
 		return await Promise.all([processDoneOrStreamsError, stdoutPromise, stderrPromise, allPromise]);

--- a/test/stream.js
+++ b/test/stream.js
@@ -149,13 +149,13 @@ test('stdin option cannot be an async iterable with execa.sync()', t => {
 test('stdin option cannot be an iterable when "input" is used', t => {
 	t.throws(() => {
 		execa('stdin.js', {stdin: ['foo', 'bar'], input: 'foobar'});
-	}, {message: /when the `input` option/});
+	}, {message: /`input` and `stdin` options/});
 });
 
 test('stdin option cannot be an iterable when "inputFile" is used', t => {
 	t.throws(() => {
 		execa('stdin.js', {stdin: ['foo', 'bar'], inputFile: 'dummy.txt'});
-	}, {message: /when the `inputFile` option/});
+	}, {message: /`inputFile` and `stdin` options/});
 });
 
 test('stdin option cannot be a generic iterable string', async t => {
@@ -172,6 +172,18 @@ test('input option can be a String', async t => {
 	t.is(stdout, 'foobar');
 });
 
+test('input option cannot be a String when stdin is set', t => {
+	t.throws(() => {
+		execa('stdin.js', {input: 'foobar', stdin: 'ignore'});
+	}, {message: /`input` and `stdin` options/});
+});
+
+test('input option cannot be a String when stdio is set', t => {
+	t.throws(() => {
+		execa('stdin.js', {input: 'foobar', stdio: 'ignore'});
+	}, {message: /`input` and `stdin` options/});
+});
+
 test('input option can be a Buffer', async t => {
 	const {stdout} = await execa('stdin.js', {input: 'testing12'});
 	t.is(stdout, 'testing12');
@@ -183,6 +195,12 @@ test('input can be a Stream', async t => {
 	stream.end();
 	const {stdout} = await execa('stdin.js', {input: stream});
 	t.is(stdout, 'howdy');
+});
+
+test('input option cannot be a Stream when stdin is set', t => {
+	t.throws(() => {
+		execa('stdin.js', {input: new Stream.PassThrough(), stdin: 'ignore'});
+	}, {message: /`input` and `stdin` options/});
 });
 
 test('input option can be used with $', async t => {
@@ -208,6 +226,16 @@ test('inputFile and input cannot be both set', t => {
 	t.throws(() => execa('stdin.js', {inputFile: '', input: ''}), {
 		message: /cannot be both set/,
 	});
+});
+
+test('inputFile option cannot be set when stdin is set', t => {
+	t.throws(() => {
+		execa('stdin.js', {inputFile: '', stdin: 'ignore'});
+	}, {message: /`inputFile` and `stdin` options/});
+});
+
+test('inputFile errors should be handled', async t => {
+	await t.throwsAsync(execa('stdin.js', {inputFile: 'unknown'}), {code: 'ENOENT'});
 });
 
 test('you can write to child.stdin', async t => {


### PR DESCRIPTION
Fixes #608.

To fix this, the `inputFile` option is re-using the error handling from the `stdin: iterable` option.
However, those two options were handled in different parts of the code.

Therefore, this PR is doing some rather big refactoring, merging the `inputFile`, `input` and `stdin: iterable` options. This should make it easier to maintain this part of the code.

It does not change behavior, except for the stream created by `inputFile` now being properly handled.

Additionally, this PR now validates that users are not passing both the `input`/`inputFile` options and the `stdin` option (except for `null`, `undefined`, `pipe` or `overlapped`) since those contradict each other and it always indicates a user mistake. For example, a user doing `execa(..., { input: '...', stdin: 'inherit' })` might not realize that those options cannot be used together. At the moment, they get some strange error message: this PR gives a more explicit description on how to fix the problem.