### PR TITLE
Allow `stdin` to be a file path

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,12 @@ export type StdioOption =
 	| number
 	| undefined;
 
-export type StdinOption = StdioOption | Iterable<string | Uint8Array> | AsyncIterable<string | Uint8Array> | URL;
+export type StdinOption =
+	| StdioOption
+	| Iterable<string | Uint8Array>
+	| AsyncIterable<string | Uint8Array>
+	| URL
+	| string;
 
 type EncodingOption =
   | 'utf8'
@@ -88,7 +93,7 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	/**
 	Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 
-	It can also be a file URL, an [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or an [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), providing neither [`execaSync()`](#execasyncfile-arguments-options), the [`input` option](#input) nor the [`inputFile` option](#inputfile) is used.
+	It can also be a file path, a file URL, an [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or an [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), providing neither [`execaSync()`](#execasyncfile-arguments-options), the [`input` option](#input) nor the [`inputFile` option](#inputfile) is used. If the file path is relative, it must start with `.`.
 
 	@default `inherit` with `$`, `pipe` otherwise
 	*/

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -165,6 +165,7 @@ execa('unicorns', {stdin: binaryGenerator()});
 expectError(execa('unicorns', {stdin: [0]}));
 expectError(execa('unicorns', {stdin: numberGenerator()}));
 execa('unicorns', {stdin: new URL('file:///test')});
+execa('unicorns', {stdin: './test'});
 execa('unicorns', {stdin: 1});
 execa('unicorns', {stdin: undefined});
 execa('unicorns', {stdout: 'pipe'});

--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -1,4 +1,5 @@
 import {createReadStream, readFileSync} from 'node:fs';
+import {isAbsolute} from 'node:path';
 import {Readable} from 'node:stream';
 import {isStream} from 'is-stream';
 
@@ -19,6 +20,7 @@ const isUrlInstance = stdioOption => Object.prototype.toString.call(stdioOption)
 const hasFileProtocol = url => url.protocol === 'file:';
 const isFileUrl = stdioOption => isUrlInstance(stdioOption) && hasFileProtocol(stdioOption);
 const isRegularUrl = stdioOption => isUrlInstance(stdioOption) && !hasFileProtocol(stdioOption);
+const isFilePath = stdioOption => typeof stdioOption === 'string' && (stdioOption.startsWith('.') || isAbsolute(stdioOption));
 
 // Check whether the `stdin` option results in `spawned.stdin` being `undefined`.
 // We use a deny list instead of an allow list to be forward compatible with new options.
@@ -26,7 +28,8 @@ const cannotPipeStdio = stdioOption => NO_PIPE_STDIN.has(stdioOption)
 	|| isStream(stdioOption)
 	|| typeof stdioOption === 'number'
 	|| isIterableStdin(stdioOption)
-	|| isFileUrl(stdioOption);
+	|| isFileUrl(stdioOption)
+	|| isFilePath(stdioOption);
 
 const NO_PIPE_STDIN = new Set(['ipc', 'ignore', 'inherit']);
 
@@ -61,7 +64,7 @@ const getStdioStreams = (stdioArray, {input, inputFile}) => {
 		return {stdinStream: Readable.from(iterableStdin)};
 	}
 
-	if (isFileUrl(stdioArray[0])) {
+	if (isFileUrl(stdioArray[0]) || isFilePath(stdioArray[0])) {
 		return {stdinStream: createReadStream(stdioArray[0])};
 	}
 
@@ -114,7 +117,7 @@ export const pipeStdioOption = (spawned, {stdinStream, stdinInput}) => {
 	}
 };
 
-const transformStdioItemSync = stdioItem => isFileUrl(stdioItem) ? 'pipe' : stdioItem;
+const transformStdioItemSync = stdioItem => isFileUrl(stdioItem) || isFilePath(stdioItem) ? 'pipe' : stdioItem;
 
 const transformStdioSync = stdio => Array.isArray(stdio)
 	? stdio.map(stdioItem => transformStdioItemSync(stdioItem))
@@ -135,7 +138,7 @@ const getInputOption = (stdio, {input, inputFile}) => {
 	validateInputOptions(stdioArray, input, inputFile);
 	validateInputOptionsSync(stdioArray, input);
 
-	if (isFileUrl(stdioArray[0])) {
+	if (isFileUrl(stdioArray[0]) || isFilePath(stdioArray[0])) {
 		return readFileSync(stdioArray[0]);
 	}
 

--- a/lib/stdio.js
+++ b/lib/stdio.js
@@ -20,23 +20,31 @@ const isUrlInstance = stdioOption => Object.prototype.toString.call(stdioOption)
 const hasFileProtocol = url => url.protocol === 'file:';
 const isFileUrl = stdioOption => isUrlInstance(stdioOption) && hasFileProtocol(stdioOption);
 const isRegularUrl = stdioOption => isUrlInstance(stdioOption) && !hasFileProtocol(stdioOption);
-const isFilePath = stdioOption => typeof stdioOption === 'string' && (stdioOption.startsWith('.') || isAbsolute(stdioOption));
+
+const stringIsFilePath = stdioOption => stdioOption.startsWith('.') || isAbsolute(stdioOption);
+const isFilePath = stdioOption => typeof stdioOption === 'string' && stringIsFilePath(stdioOption);
+const isUnknownStdioString = stdioOption => typeof stdioOption === 'string' && !stringIsFilePath(stdioOption) && !KNOWN_STDIO.has(stdioOption);
 
 // Check whether the `stdin` option results in `spawned.stdin` being `undefined`.
 // We use a deny list instead of an allow list to be forward compatible with new options.
-const cannotPipeStdio = stdioOption => NO_PIPE_STDIN.has(stdioOption)
+const cannotPipeStdio = stdioOption => NO_PIPE_STDIO.has(stdioOption)
 	|| isStream(stdioOption)
 	|| typeof stdioOption === 'number'
 	|| isIterableStdin(stdioOption)
 	|| isFileUrl(stdioOption)
 	|| isFilePath(stdioOption);
 
-const NO_PIPE_STDIN = new Set(['ipc', 'ignore', 'inherit']);
+const NO_PIPE_STDIO = new Set(['ipc', 'ignore', 'inherit']);
+const KNOWN_STDIO = new Set([...NO_PIPE_STDIO, 'overlapped', 'pipe']);
 
-const validateFileUrl = stdioOption => {
+const validateFileSdio = stdioOption => {
 	if (isRegularUrl(stdioOption)) {
 		throw new TypeError(`The \`stdin: URL\` option must use the \`file:\` scheme.
 For example, you can use the \`pathToFileURL()\` method of the \`url\` core module.`);
+	}
+
+	if (isUnknownStdioString(stdioOption)) {
+		throw new TypeError('The `stdin: filePath` option must either be an absolute file path or start with `.`.');
 	}
 };
 
@@ -54,7 +62,7 @@ const validateInputOptions = (stdioArray, input, inputFile) => {
 		throw new TypeError('The `inputFile` and `stdin` options cannot be both set.');
 	}
 
-	validateFileUrl(stdioArray[0]);
+	validateFileSdio(stdioArray[0]);
 };
 
 const getStdioStreams = (stdioArray, {input, inputFile}) => {

--- a/readme.md
+++ b/readme.md
@@ -564,7 +564,7 @@ Default: `inherit` with [`$`](#command), `pipe` otherwise
 
 Same options as [`stdio`](https://nodejs.org/dist/latest-v6.x/docs/api/child_process.html#child_process_options_stdio).
 
-It can also be a file URL, an [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or an [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), providing neither [`execaSync()`](#execasyncfile-arguments-options), the [`input` option](#input) nor the [`inputFile` option](#inputfile) is used.
+It can also be a file path, a file URL, an [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or an [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols), providing neither [`execaSync()`](#execasyncfile-arguments-options), the [`input` option](#input) nor the [`inputFile` option](#inputfile) is used. If the file path is relative, it must start with `.`.
 
 #### stdout
 

--- a/test/stream.js
+++ b/test/stream.js
@@ -2,6 +2,7 @@ import {Buffer} from 'node:buffer';
 import {exec} from 'node:child_process';
 import process from 'node:process';
 import fs from 'node:fs';
+import {relative} from 'node:path';
 import Stream from 'node:stream';
 import {promisify} from 'node:util';
 import {pathToFileURL} from 'node:url';
@@ -171,6 +172,18 @@ test('stdin option cannot be a file URL when "inputFile" is used', t => {
 	}, {message: /`inputFile` and `stdin` options/});
 });
 
+test('stdin option cannot be a file path when "input" is used', t => {
+	t.throws(() => {
+		execa('stdin.js', {stdin: './unknown', input: 'foobar'});
+	}, {message: /`input` and `stdin` options/});
+});
+
+test('stdin option cannot be a file path when "inputFile" is used', t => {
+	t.throws(() => {
+		execa('stdin.js', {stdin: './unknown', inputFile: 'dummy.txt'});
+	}, {message: /`inputFile` and `stdin` options/});
+});
+
 test('stdin option cannot be a generic iterable string', async t => {
 	await t.throwsAsync(() => execa('stdin.js', {stdin: 'foobar'}), {code: 'ERR_INVALID_SYNC_FORK_INPUT'});
 });
@@ -229,6 +242,21 @@ test('stdin can be a file URL', async t => {
 	t.is(stdout, 'howdy');
 });
 
+test('stdin can be an absolute file path', async t => {
+	const inputFile = tempfile();
+	fs.writeFileSync(inputFile, 'howdy');
+	const {stdout} = await execa('stdin.js', {stdin: inputFile});
+	t.is(stdout, 'howdy');
+});
+
+test('stdin can be a relative file path', async t => {
+	const inputFile = tempfile();
+	fs.writeFileSync(inputFile, 'howdy');
+	const stdin = relative('.', inputFile);
+	const {stdout} = await execa('stdin.js', {stdin});
+	t.is(stdout, 'howdy');
+});
+
 test('stdin cannot be a non-file URL', async t => {
 	await t.throws(() => {
 		execa('stdin.js', {stdin: new URL('https://example.com')});
@@ -263,6 +291,10 @@ test('inputFile option cannot be set when stdin is set', t => {
 
 test('stdin file URL errors should be handled', async t => {
 	await t.throwsAsync(execa('stdin.js', {stdin: pathToFileURL('unknown')}), {code: 'ENOENT'});
+});
+
+test('stdin file path errors should be handled', async t => {
+	await t.throwsAsync(execa('stdin.js', {stdin: './unknown'}), {code: 'ENOENT'});
 });
 
 test('inputFile errors should be handled', async t => {
@@ -312,6 +344,21 @@ test('stdin can be a file URL - sync', t => {
 	const inputFile = tempfile();
 	fs.writeFileSync(inputFile, 'howdy');
 	const stdin = pathToFileURL(inputFile);
+	const {stdout} = execaSync('stdin.js', {stdin});
+	t.is(stdout, 'howdy');
+});
+
+test('stdin can be an absolute file path - sync', t => {
+	const inputFile = tempfile();
+	fs.writeFileSync(inputFile, 'howdy');
+	const {stdout} = execaSync('stdin.js', {stdin: inputFile});
+	t.is(stdout, 'howdy');
+});
+
+test('stdin can be a relative file path - sync', t => {
+	const inputFile = tempfile();
+	fs.writeFileSync(inputFile, 'howdy');
+	const stdin = relative('.', inputFile);
 	const {stdout} = execaSync('stdin.js', {stdin});
 	t.is(stdout, 'howdy');
 });

--- a/test/stream.js
+++ b/test/stream.js
@@ -184,10 +184,6 @@ test('stdin option cannot be a file path when "inputFile" is used', t => {
 	}, {message: /`inputFile` and `stdin` options/});
 });
 
-test('stdin option cannot be a generic iterable string', async t => {
-	await t.throwsAsync(() => execa('stdin.js', {stdin: 'foobar'}), {code: 'ERR_INVALID_SYNC_FORK_INPUT'});
-});
-
 test('stdin option handles errors in iterables', async t => {
 	const {originalMessage} = await t.throwsAsync(() => execa('stdin.js', {stdin: throwingGenerator()}));
 	t.is(originalMessage, 'generator error');
@@ -242,6 +238,12 @@ test('stdin can be a file URL', async t => {
 	t.is(stdout, 'howdy');
 });
 
+test('stdin cannot be a non-file URL', async t => {
+	await t.throws(() => {
+		execa('stdin.js', {stdin: new URL('https://example.com')});
+	}, {message: /pathToFileURL/});
+});
+
 test('stdin can be an absolute file path', async t => {
 	const inputFile = tempfile();
 	fs.writeFileSync(inputFile, 'howdy');
@@ -257,10 +259,10 @@ test('stdin can be a relative file path', async t => {
 	t.is(stdout, 'howdy');
 });
 
-test('stdin cannot be a non-file URL', async t => {
-	await t.throws(() => {
-		execa('stdin.js', {stdin: new URL('https://example.com')});
-	}, {message: /pathToFileURL/});
+test('stdin option must start with . when being a relative file path', t => {
+	t.throws(() => {
+		execa('stdin.js', {stdin: 'foobar'});
+	}, {message: /absolute file path/});
 });
 
 test('inputFile can be set', async t => {


### PR DESCRIPTION
Part of #592. See also #610.

This allows the `stdin` option to be a file path string. I will send another PR for `stdout`/`stderr`.

It works with both Unix and Windows file paths. 
File paths can be either absolute or relative. It requires relative file paths to start with `.`, which prevents any ambiguity with the already existing string values of the `stdin` option.