### PR TITLE
Add race condition-related tests

### DIFF
--- a/test/fixtures/noop-delay.js
+++ b/test/fixtures/noop-delay.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {setTimeout} from 'node:timers/promises';
+
+console.log(process.argv[2]);
+await setTimeout((Number(process.argv[3]) || 1) * 1e3);

--- a/test/fixtures/noop-fail.js
+++ b/test/fixtures/noop-fail.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import process from 'node:process';
+
+console.log(process.argv[2]);
+process.exit(2);


### PR DESCRIPTION
Fixes #616.

This adds some tests related to the race condition that happens when we redirect a child process's `stdin`/`stdout`/`stderr` right after spawning it.

Since it's been just spawned, it might already have read/written from/to its standard streams, before we get a chance to pipe from/to them. 

However, things work mostly correctly thanks to proper behavior from both the OS and the runtime, as described in the end of my comment [here](https://github.com/sindresorhus/execa/issues/616#issue-2045039886).

Unfortunately, there is one of those assumptions that does not seem to hold true. Namely, a process's `stdout`/`stderr` might be lost if either:
  - It already exited before `await childProcess` was called. This is most likely to happen for users that do not call that statement right away.
  - It already exited before we pipe its `stdout`/`stderr` (when using the `stdio: filePath | fileURL | WritableStream` option). This might happen if the child process is very fast. This includes when the child process fails very fast, although in that case the user gets the exit code at least, but might be missing some precious error logs.

I am not sure there is something we can do about this. At the OS-level, the process spawning syscalls just sets up the standard streams. Reading/writing them must happen after spawning. And the process might have already exited. I do not think this is not specific to Node.js.