### PR TITLE
Refactor tests

### DIFF
--- a/test/helpers/stdio.js
+++ b/test/helpers/stdio.js
@@ -1,0 +1,10 @@
+export const getStdinOption = stdioOption => ({stdin: stdioOption});
+export const getStdoutOption = stdioOption => ({stdout: stdioOption});
+export const getStderrOption = stdioOption => ({stderr: stdioOption});
+export const getPlainStdioOption = stdioOption => ({stdio: stdioOption});
+export const getInputOption = input => ({input});
+export const getInputFileOption = inputFile => ({inputFile});
+
+export const getScriptSync = $ => $.sync;
+
+export const identity = value => value;

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,6 +1,6 @@
 import {PassThrough, Readable} from 'node:stream';
 import {spawn} from 'node:child_process';
-import {readFile} from 'node:fs/promises';
+import {readFile, rm} from 'node:fs/promises';
 import tempfile from 'tempfile';
 import test from 'ava';
 import getStream from 'get-stream';
@@ -32,10 +32,11 @@ test('pipeAll() can pipe stdout to streams', pipeToStream, 'noop.js', 'pipeAll',
 test('pipeAll() can pipe stderr to streams', pipeToStream, 'noop-err.js', 'pipeAll', 'stderr');
 
 const pipeToFile = async (t, fixtureName, funcName, streamName) => {
-	const file = tempfile({extension: '.txt'});
+	const file = tempfile();
 	const result = await execa(fixtureName, ['test'], {all: true})[funcName](file);
 	t.is(result[streamName], 'test');
 	t.is(await readFile(file, 'utf8'), 'test\n');
+	await rm(file);
 };
 
 // `test.serial()` is due to a race condition: `execa(...).pipe*(file)` might resolve before the file stream has resolved

--- a/test/stdio/file-descriptor.js
+++ b/test/stdio/file-descriptor.js
@@ -1,0 +1,32 @@
+import {readFile, open, rm} from 'node:fs/promises';
+import test from 'ava';
+import tempfile from 'tempfile';
+import {execa, execaSync} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {getStdinOption, getStdoutOption, getStderrOption} from '../helpers/stdio.js';
+
+setFixtureDir();
+
+const getStdinProp = ({stdin}) => stdin;
+
+const testFileDescriptorOption = async (t, fixtureName, getOptions, execaMethod) => {
+	const filePath = tempfile();
+	const fileDescriptor = await open(filePath, 'w');
+	await execaMethod(fixtureName, ['foobar'], getOptions(fileDescriptor));
+	t.is(await readFile(filePath, 'utf8'), 'foobar\n');
+	await rm(filePath);
+};
+
+test('pass `stdout` to a file descriptor', testFileDescriptorOption, 'noop.js', getStdoutOption, execa);
+test('pass `stderr` to a file descriptor', testFileDescriptorOption, 'noop-err.js', getStderrOption, execa);
+test('pass `stdout` to a file descriptor - sync', testFileDescriptorOption, 'noop.js', getStdoutOption, execaSync);
+test('pass `stderr` to a file descriptor - sync', testFileDescriptorOption, 'noop-err.js', getStderrOption, execaSync);
+
+const testStdinWrite = async (t, getStreamProp, fixtureName, getOptions) => {
+	const subprocess = execa(fixtureName, getOptions('pipe'));
+	getStreamProp(subprocess).end('unicorns');
+	const {stdout} = await subprocess;
+	t.is(stdout, 'unicorns');
+};
+
+test('you can write to child.stdin', testStdinWrite, getStdinProp, 'stdin.js', getStdinOption);

--- a/test/stdio/file-path.js
+++ b/test/stdio/file-path.js
@@ -1,0 +1,162 @@
+import {readFile, writeFile, rm} from 'node:fs/promises';
+import {relative, dirname, basename} from 'node:path';
+import process from 'node:process';
+import {pathToFileURL} from 'node:url';
+import test from 'ava';
+import tempfile from 'tempfile';
+import {execa, execaSync, $} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {getStdinOption, getStdoutOption, getStderrOption, getInputFileOption, getScriptSync, identity} from '../helpers/stdio.js';
+
+setFixtureDir();
+
+const nonFileUrl = new URL('https://example.com');
+
+const getRelativePath = filePath => relative('.', filePath);
+
+const testStdinFile = async (t, mapFilePath, getOptions, execaMethod) => {
+	const filePath = tempfile();
+	await writeFile(filePath, 'foobar');
+	const {stdout} = await execaMethod('stdin.js', getOptions(mapFilePath(filePath)));
+	t.is(stdout, 'foobar');
+	await rm(filePath);
+};
+
+test('inputFile can be a file URL', testStdinFile, pathToFileURL, getInputFileOption, execa);
+test('stdin can be a file URL', testStdinFile, pathToFileURL, getStdinOption, execa);
+test('inputFile can be an absolute file path', testStdinFile, identity, getInputFileOption, execa);
+test('stdin can be an absolute file path', testStdinFile, identity, getStdinOption, execa);
+test('inputFile can be a relative file path', testStdinFile, getRelativePath, getInputFileOption, execa);
+test('stdin can be a relative file path', testStdinFile, getRelativePath, getStdinOption, execa);
+test('inputFile can be a file URL - sync', testStdinFile, pathToFileURL, getInputFileOption, execaSync);
+test('stdin can be a file URL - sync', testStdinFile, pathToFileURL, getStdinOption, execaSync);
+test('inputFile can be an absolute file path - sync', testStdinFile, identity, getInputFileOption, execaSync);
+test('stdin can be an absolute file path - sync', testStdinFile, identity, getStdinOption, execaSync);
+test('inputFile can be a relative file path - sync', testStdinFile, getRelativePath, getInputFileOption, execaSync);
+test('stdin can be a relative file path - sync', testStdinFile, getRelativePath, getStdinOption, execaSync);
+
+// eslint-disable-next-line max-params
+const testOutputFile = async (t, mapFile, fixtureName, getOptions, execaMethod) => {
+	const filePath = tempfile();
+	await execaMethod(fixtureName, ['foobar'], getOptions(mapFile(filePath)));
+	t.is(await readFile(filePath, 'utf8'), 'foobar\n');
+	await rm(filePath);
+};
+
+test('stdout can be a file URL', testOutputFile, pathToFileURL, 'noop.js', getStdoutOption, execa);
+test('stderr can be a file URL', testOutputFile, pathToFileURL, 'noop-err.js', getStderrOption, execa);
+test('stdout can be an absolute file path', testOutputFile, identity, 'noop.js', getStdoutOption, execa);
+test('stderr can be an absolute file path', testOutputFile, identity, 'noop-err.js', getStderrOption, execa);
+test('stdout can be a relative file path', testOutputFile, getRelativePath, 'noop.js', getStdoutOption, execa);
+test('stderr can be a relative file path', testOutputFile, getRelativePath, 'noop-err.js', getStderrOption, execa);
+test('stdout can be a file URL - sync', testOutputFile, pathToFileURL, 'noop.js', getStdoutOption, execaSync);
+test('stderr can be a file URL - sync', testOutputFile, pathToFileURL, 'noop-err.js', getStderrOption, execaSync);
+test('stdout can be an absolute file path - sync', testOutputFile, identity, 'noop.js', getStdoutOption, execaSync);
+test('stderr can be an absolute file path - sync', testOutputFile, identity, 'noop-err.js', getStderrOption, execaSync);
+test('stdout can be a relative file path - sync', testOutputFile, getRelativePath, 'noop.js', getStdoutOption, execaSync);
+test('stderr can be a relative file path - sync', testOutputFile, getRelativePath, 'noop-err.js', getStderrOption, execaSync);
+
+const testStdioNonFileUrl = (t, getOptions, execaMethod) => {
+	t.throws(() => {
+		execaMethod('noop.js', getOptions(nonFileUrl));
+	}, {message: /pathToFileURL/});
+};
+
+test('inputFile cannot be a non-file URL', testStdioNonFileUrl, getInputFileOption, execa);
+test('stdin cannot be a non-file URL', testStdioNonFileUrl, getStdinOption, execa);
+test('stdout cannot be a non-file URL', testStdioNonFileUrl, getStdoutOption, execa);
+test('stderr cannot be a non-file URL', testStdioNonFileUrl, getStderrOption, execa);
+test('inputFile cannot be a non-file URL - sync', testStdioNonFileUrl, getInputFileOption, execaSync);
+test('stdin cannot be a non-file URL - sync', testStdioNonFileUrl, getStdinOption, execaSync);
+test('stdout cannot be a non-file URL - sync', testStdioNonFileUrl, getStdoutOption, execaSync);
+test('stderr cannot be a non-file URL - sync', testStdioNonFileUrl, getStderrOption, execaSync);
+
+const testInputFileValidUrl = async (t, execaMethod) => {
+	const filePath = tempfile();
+	await writeFile(filePath, 'foobar');
+	const currentCwd = process.cwd();
+	process.chdir(dirname(filePath));
+
+	try {
+		const {stdout} = await execaMethod('stdin.js', {inputFile: basename(filePath)});
+		t.is(stdout, 'foobar');
+	} finally {
+		process.chdir(currentCwd);
+		await rm(filePath);
+	}
+};
+
+test.serial('inputFile does not need to start with . when being a relative file path', testInputFileValidUrl, execa);
+test.serial('inputFile does not need to start with . when being a relative file path - sync', testInputFileValidUrl, execaSync);
+
+const testStdioValidUrl = (t, getOptions, execaMethod) => {
+	t.throws(() => {
+		execaMethod('noop.js', getOptions('foobar'));
+	}, {message: /absolute file path/});
+};
+
+test('stdin must start with . when being a relative file path', testStdioValidUrl, getStdinOption, execa);
+test('stdout must start with . when being a relative file path', testStdioValidUrl, getStdoutOption, execa);
+test('stderr must start with . when being a relative file path', testStdioValidUrl, getStderrOption, execa);
+test('stdin must start with . when being a relative file path - sync', testStdioValidUrl, getStdinOption, execaSync);
+test('stdout must start with . when being a relative file path - sync', testStdioValidUrl, getStdoutOption, execaSync);
+test('stderr must start with . when being a relative file path - sync', testStdioValidUrl, getStderrOption, execaSync);
+
+const testFileError = async (t, mapFile, getOptions) => {
+	await t.throwsAsync(
+		execa('noop.js', getOptions(mapFile('./unknown/file'))),
+		{code: 'ENOENT'},
+	);
+};
+
+test('inputFile file URL errors should be handled', testFileError, pathToFileURL, getInputFileOption);
+test('stdin file URL errors should be handled', testFileError, pathToFileURL, getStdinOption);
+test('stdout file URL errors should be handled', testFileError, pathToFileURL, getStdoutOption);
+test('stderr file URL errors should be handled', testFileError, pathToFileURL, getStderrOption);
+test('inputFile file path errors should be handled', testFileError, identity, getInputFileOption);
+test('stdin file path errors should be handled', testFileError, identity, getStdinOption);
+test('stdout file path errors should be handled', testFileError, identity, getStdoutOption);
+test('stderr file path errors should be handled', testFileError, identity, getStderrOption);
+
+const testFileErrorSync = (t, mapFile, getOptions) => {
+	t.throws(() => {
+		execaSync('noop.js', getOptions(mapFile('./unknown/file')));
+	}, {code: 'ENOENT'});
+};
+
+test('inputFile file URL errors should be handled - sync', testFileErrorSync, pathToFileURL, getInputFileOption);
+test('stdin file URL errors should be handled - sync', testFileErrorSync, pathToFileURL, getStdinOption);
+test('stdout file URL errors should be handled - sync', testFileErrorSync, pathToFileURL, getStdoutOption);
+test('stderr file URL errors should be handled - sync', testFileErrorSync, pathToFileURL, getStderrOption);
+test('inputFile file path errors should be handled - sync', testFileErrorSync, identity, getInputFileOption);
+test('stdin file path errors should be handled - sync', testFileErrorSync, identity, getStdinOption);
+test('stdout file path errors should be handled - sync', testFileErrorSync, identity, getStdoutOption);
+test('stderr file path errors should be handled - sync', testFileErrorSync, identity, getStderrOption);
+
+const testInputFile = async (t, execaMethod) => {
+	const inputFile = tempfile();
+	await writeFile(inputFile, 'foobar');
+	const {stdout} = await execaMethod('stdin.js', {inputFile});
+	t.is(stdout, 'foobar');
+	await rm(inputFile);
+};
+
+test('inputFile can be set', testInputFile, execa);
+test('inputFile can be set - sync', testInputFile, execa);
+
+const testInputFileScript = async (t, getExecaMethod) => {
+	const inputFile = tempfile();
+	await writeFile(inputFile, 'foobar');
+	const {stdout} = await getExecaMethod($({inputFile}))`stdin.js`;
+	t.is(stdout, 'foobar');
+	await rm(inputFile);
+};
+
+test('inputFile can be set with $', testInputFileScript, identity);
+test('inputFile can be set with $.sync', testInputFileScript, getScriptSync);
+
+test('inputFile option cannot be set when stdin is set', t => {
+	t.throws(() => {
+		execa('stdin.js', {inputFile: '', stdin: 'ignore'});
+	}, {message: /`inputFile` and `stdin` options/});
+});

--- a/test/stdio/input.js
+++ b/test/stdio/input.js
@@ -1,0 +1,66 @@
+import {Readable} from 'node:stream';
+import {pathToFileURL} from 'node:url';
+import test from 'ava';
+import {execa, execaSync, $} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {getStdinOption, getPlainStdioOption, getScriptSync, identity} from '../helpers/stdio.js';
+
+setFixtureDir();
+
+const textEncoder = new TextEncoder();
+const binaryFoobar = textEncoder.encode('foobar');
+
+const testInputOptionError = (t, stdin, inputName) => {
+	t.throws(() => {
+		execa('stdin.js', {stdin, [inputName]: 'foobar'});
+	}, {message: new RegExp(`\`${inputName}\` and \`stdin\` options`)});
+};
+
+test('stdin option cannot be an iterable when "input" is used', testInputOptionError, ['foo', 'bar'], 'input');
+test('stdin option cannot be an iterable when "inputFile" is used', testInputOptionError, ['foo', 'bar'], 'inputFile');
+test('stdin option cannot be a file URL when "input" is used', testInputOptionError, pathToFileURL('unknown'), 'input');
+test('stdin option cannot be a file URL when "inputFile" is used', testInputOptionError, pathToFileURL('unknown'), 'inputFile');
+test('stdin option cannot be a file path when "input" is used', testInputOptionError, './unknown', 'input');
+test('stdin option cannot be a file path when "inputFile" is used', testInputOptionError, './unknown', 'inputFile');
+test('stdin option cannot be a ReadableStream when "input" is used', testInputOptionError, new ReadableStream(), 'input');
+test('stdin option cannot be a ReadableStream when "inputFile" is used', testInputOptionError, new ReadableStream(), 'inputFile');
+
+const testInput = async (t, input, execaMethod) => {
+	const {stdout} = await execaMethod('stdin.js', {input});
+	t.is(stdout, 'foobar');
+};
+
+test('input option can be a String', testInput, 'foobar', execa);
+test('input option can be a String - sync', testInput, 'foobar', execaSync);
+test('input option can be a Uint8Array', testInput, binaryFoobar, execa);
+test('input option can be a Uint8Array - sync', testInput, binaryFoobar, execaSync);
+
+const testInputScript = async (t, getExecaMethod) => {
+	const {stdout} = await getExecaMethod($({input: 'foobar'}))`stdin.js`;
+	t.is(stdout, 'foobar');
+};
+
+test('input option can be used with $', testInputScript, identity);
+test('input option can be used with $.sync', testInputScript, getScriptSync);
+
+const testInputWithStdinError = (t, input, getOptions, execaMethod) => {
+	t.throws(() => {
+		execaMethod('stdin.js', {input, ...getOptions('ignore')});
+	}, {message: /`input` and `stdin` options/});
+};
+
+test('input option cannot be a String when stdin is set', testInputWithStdinError, 'foobar', getStdinOption, execa);
+test('input option cannot be a String when stdio is set', testInputWithStdinError, 'foobar', getPlainStdioOption, execa);
+test('input option cannot be a String when stdin is set - sync', testInputWithStdinError, 'foobar', getStdinOption, execaSync);
+test('input option cannot be a String when stdio is set - sync', testInputWithStdinError, 'foobar', getPlainStdioOption, execaSync);
+test('input option cannot be a Node.js Readable when stdin is set', testInputWithStdinError, new Readable(), getStdinOption, execa);
+test('input option cannot be a Node.js Readable when stdio is set', testInputWithStdinError, new Readable(), getPlainStdioOption, execa);
+
+const testInputAndInputFile = async (t, execaMethod) => {
+	t.throws(() => execaMethod('stdin.js', {inputFile: '', input: ''}), {
+		message: /cannot be both set/,
+	});
+};
+
+test('inputFile and input cannot be both set', testInputAndInputFile, execa);
+test('inputFile and input cannot be both set - sync', testInputAndInputFile, execaSync);

--- a/test/stdio/iterable.js
+++ b/test/stdio/iterable.js
@@ -1,0 +1,60 @@
+import test from 'ava';
+import {execa, execaSync} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {getStdinOption, getStdoutOption, getStderrOption} from '../helpers/stdio.js';
+
+setFixtureDir();
+
+const textEncoder = new TextEncoder();
+const binaryFoo = textEncoder.encode('foo');
+const binaryBar = textEncoder.encode('bar');
+
+const stringGenerator = function * () {
+	yield * ['foo', 'bar'];
+};
+
+const binaryGenerator = function * () {
+	yield * [binaryFoo, binaryBar];
+};
+
+// eslint-disable-next-line require-yield
+const throwingGenerator = function * () {
+	throw new Error('generator error');
+};
+
+const testIterable = async (t, stdioOption, fixtureName, getOptions) => {
+	const {stdout} = await execa(fixtureName, getOptions(stdioOption));
+	t.is(stdout, 'foobar');
+};
+
+test('stdin option can be a sync iterable of strings', testIterable, ['foo', 'bar'], 'stdin.js', getStdinOption);
+test('stdin option can be a sync iterable of Uint8Arrays', testIterable, [binaryFoo, binaryBar], 'stdin.js', getStdinOption);
+test('stdin option can be an sync iterable of strings', testIterable, stringGenerator(), 'stdin.js', getStdinOption);
+test('stdin option can be an sync iterable of Uint8Arrays', testIterable, binaryGenerator(), 'stdin.js', getStdinOption);
+
+const testIterableSync = (t, stdioOption, fixtureName, getOptions) => {
+	t.throws(() => {
+		execaSync(fixtureName, getOptions(stdioOption));
+	}, {message: /an iterable in sync mode/});
+};
+
+test('stdin option cannot be a sync iterable - sync', testIterableSync, ['foo', 'bar'], 'stdin.js', getStdinOption);
+test('stdin option cannot be an async iterable - sync', testIterableSync, stringGenerator(), 'stdin.js', getStdinOption);
+
+const testIterableError = async (t, fixtureName, getOptions) => {
+	const {originalMessage} = await t.throwsAsync(execa(fixtureName, getOptions(throwingGenerator())));
+	t.is(originalMessage, 'generator error');
+};
+
+test('stdin option handles errors in iterables', testIterableError, 'stdin.js', getStdinOption);
+
+const testNoIterableOutput = (t, getOptions, execaMethod) => {
+	t.throws(() => {
+		execaMethod('noop.js', getOptions(['foo', 'bar']));
+	}, {message: /cannot be an iterable/});
+};
+
+test('stdout option cannot be an iterable', testNoIterableOutput, getStdoutOption, execa);
+test('stderr option cannot be an iterable', testNoIterableOutput, getStderrOption, execa);
+test('stdout option cannot be an iterable - sync', testNoIterableOutput, getStdoutOption, execaSync);
+test('stderr option cannot be an iterable - sync', testNoIterableOutput, getStderrOption, execaSync);

--- a/test/stdio/node-stream.js
+++ b/test/stdio/node-stream.js
@@ -1,0 +1,68 @@
+import {once} from 'node:events';
+import {createReadStream, createWriteStream} from 'node:fs';
+import {readFile, writeFile, rm} from 'node:fs/promises';
+import {Readable, Writable, PassThrough} from 'node:stream';
+import test from 'ava';
+import tempfile from 'tempfile';
+import {execa, execaSync} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {getStdinOption, getStdoutOption, getStderrOption, getInputOption} from '../helpers/stdio.js';
+
+setFixtureDir();
+
+const createNoFileReadable = value => {
+	const stream = new PassThrough();
+	stream.write(value);
+	stream.end();
+	return stream;
+};
+
+const testNodeStreamSync = (t, StreamClass, getOptions, optionName) => {
+	t.throws(() => {
+		execaSync('noop.js', getOptions(new StreamClass()));
+	}, {message: `The \`${optionName}\` option cannot be a Node.js stream in sync mode.`});
+};
+
+test('input cannot be a Node.js Readable - sync', testNodeStreamSync, Readable, getInputOption, 'input');
+
+test('input can be a Node.js Readable without a file descriptor', async t => {
+	const {stdout} = await execa('stdin.js', {input: createNoFileReadable('foobar')});
+	t.is(stdout, 'foobar');
+});
+
+const testNoFileStream = async (t, getOptions, StreamClass) => {
+	await t.throwsAsync(execa('noop.js', getOptions(new StreamClass())), {code: 'ERR_INVALID_ARG_VALUE'});
+};
+
+test('stdin cannot be a Node.js Readable without a file descriptor', testNoFileStream, getStdinOption, Readable);
+test('stdout cannot be a Node.js Writable without a file descriptor', testNoFileStream, getStdoutOption, Writable);
+test('stderr cannot be a Node.js Writable without a file descriptor', testNoFileStream, getStderrOption, Writable);
+
+const testFileReadable = async (t, fixtureName, getOptions) => {
+	const filePath = tempfile();
+	await writeFile(filePath, 'foobar');
+	const stream = createReadStream(filePath);
+	await once(stream, 'open');
+
+	const {stdout} = await execa(fixtureName, getOptions(stream));
+	t.is(stdout, 'foobar');
+
+	await rm(filePath);
+};
+
+test('input can be a Node.js Readable with a file descriptor', testFileReadable, 'stdin.js', getInputOption);
+test('stdin can be a Node.js Readable with a file descriptor', testFileReadable, 'stdin.js', getStdinOption);
+
+const testFileWritable = async (t, getOptions, fixtureName) => {
+	const filePath = tempfile();
+	const stream = createWriteStream(filePath);
+	await once(stream, 'open');
+
+	await execa(fixtureName, ['foobar'], getOptions(stream));
+	t.is(await readFile(filePath, 'utf8'), 'foobar\n');
+
+	await rm(filePath);
+};
+
+test('stdout can be a Node.js Writable with a file descriptor', testFileWritable, getStdoutOption, 'noop.js');
+test('stderr can be a Node.js Writable with a file descriptor', testFileWritable, getStderrOption, 'noop-err.js');

--- a/test/stdio/normalize.js
+++ b/test/stdio/normalize.js
@@ -1,6 +1,6 @@
 import {inspect} from 'node:util';
 import test from 'ava';
-import {normalizeStdio, normalizeStdioNode} from '../lib/stdio/normalize.js';
+import {normalizeStdio, normalizeStdioNode} from '../../lib/stdio/normalize.js';
 
 const macro = (t, input, expected, func) => {
 	if (expected instanceof Error) {

--- a/test/stdio/web-stream.js
+++ b/test/stdio/web-stream.js
@@ -1,0 +1,52 @@
+import {Readable} from 'node:stream';
+import test from 'ava';
+import {execa, execaSync} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {getStdinOption, getStdoutOption, getStderrOption} from '../helpers/stdio.js';
+
+setFixtureDir();
+
+const testReadableStream = async (t, fixtureName, getOptions) => {
+	const readableStream = Readable.toWeb(Readable.from('foobar'));
+	const {stdout} = await execa(fixtureName, getOptions(readableStream));
+	t.is(stdout, 'foobar');
+};
+
+test('stdin can be a ReadableStream', testReadableStream, 'stdin.js', getStdinOption);
+
+const testWritableStream = async (t, fixtureName, getOptions) => {
+	const result = [];
+	const writableStream = new WritableStream({
+		write(chunk) {
+			result.push(chunk);
+		},
+	});
+	await execa(fixtureName, ['foobar'], getOptions(writableStream));
+	t.is(result.join(''), 'foobar\n');
+};
+
+test('stdout can be a WritableStream', testWritableStream, 'noop.js', getStdoutOption);
+test('stderr can be a WritableStream', testWritableStream, 'noop-err.js', getStderrOption);
+
+const testWebStreamSync = (t, StreamClass, getOptions, optionName) => {
+	t.throws(() => {
+		execaSync('noop.js', getOptions(new StreamClass()));
+	}, {message: `The \`${optionName}\` option cannot be a web stream in sync mode.`});
+};
+
+test('stdin cannot be a ReadableStream - sync', testWebStreamSync, ReadableStream, getStdinOption, 'stdin');
+test('stdout cannot be a WritableStream - sync', testWebStreamSync, WritableStream, getStdoutOption, 'stdout');
+test('stderr cannot be a WritableStream - sync', testWebStreamSync, WritableStream, getStderrOption, 'stderr');
+
+const testWritableStreamError = async (t, getOptions) => {
+	const writableStream = new WritableStream({
+		start(controller) {
+			controller.error(new Error('foobar'));
+		},
+	});
+	const {originalMessage} = await t.throwsAsync(execa('noop.js', getOptions(writableStream)));
+	t.is(originalMessage, 'foobar');
+};
+
+test('stdout option handles errors in WritableStream', testWritableStreamError, getStdoutOption);
+test('stderr option handles errors in WritableStream', testWritableStreamError, getStderrOption);

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,38 +1,17 @@
 import {Buffer} from 'node:buffer';
 import {exec} from 'node:child_process';
 import process from 'node:process';
-import {once} from 'node:events';
-import fs from 'node:fs';
-import {readFile, writeFile, rm} from 'node:fs/promises';
-import {relative} from 'node:path';
-import Stream from 'node:stream';
 import {setTimeout} from 'node:timers/promises';
 import {promisify} from 'node:util';
-import {pathToFileURL} from 'node:url';
 import test from 'ava';
 import getStream from 'get-stream';
 import {pEvent} from 'p-event';
-import tempfile from 'tempfile';
-import {execa, execaSync, $} from '../index.js';
+import {execa, execaSync} from '../index.js';
 import {setFixtureDir, FIXTURES_DIR} from './helpers/fixtures-dir.js';
 
 const pExec = promisify(exec);
 
 setFixtureDir();
-
-const nonFileUrl = new URL('https://example.com');
-
-test('encoding option can be buffer', async t => {
-	const {stdout} = await execa('noop.js', ['foo'], {encoding: 'buffer'});
-	t.true(ArrayBuffer.isView(stdout));
-	t.is(textDecoder.decode(stdout), 'foo');
-});
-
-test('encoding option can be buffer - Sync', t => {
-	const {stdout} = execaSync('noop.js', ['foo'], {encoding: 'buffer'});
-	t.true(ArrayBuffer.isView(stdout));
-	t.is(textDecoder.decode(stdout), 'foo');
-});
 
 const checkEncoding = async (t, encoding) => {
 	const {stdout} = await execa('noop-no-newline.js', [STRING_TO_ENCODE], {encoding});
@@ -59,30 +38,21 @@ test('can pass encoding "hex"', checkEncoding, 'hex');
 test('can pass encoding "base64"', checkEncoding, 'base64');
 test('can pass encoding "base64url"', checkEncoding, 'base64url');
 
-const checkBufferEncoding = async (t, encoding) => {
-	const {stdout} = await execa('noop-no-newline.js', [STRING_TO_ENCODE], {encoding});
+const checkBufferEncoding = async (t, execaMethod) => {
+	const {stdout} = await execaMethod('noop-no-newline.js', [STRING_TO_ENCODE], {encoding: 'buffer'});
+	t.true(ArrayBuffer.isView(stdout));
 	t.true(BUFFER_TO_ENCODE.equals(stdout));
 
-	const {stdout: nativeStdout} = await pExec(`node noop-no-newline.js ${STRING_TO_ENCODE}`, {encoding, cwd: FIXTURES_DIR});
+	const {stdout: nativeStdout} = await pExec(`node noop-no-newline.js ${STRING_TO_ENCODE}`, {encoding: 'buffer', cwd: FIXTURES_DIR});
+	t.true(Buffer.isBuffer(nativeStdout));
 	t.true(BUFFER_TO_ENCODE.equals(nativeStdout));
 };
 
-test('can pass encoding "buffer"', checkBufferEncoding, 'buffer');
+test('can pass encoding "buffer"', checkBufferEncoding, execa);
+test('can pass encoding "buffer" - sync', checkBufferEncoding, execaSync);
 
 test('validate unknown encodings', async t => {
 	await t.throwsAsync(execa('noop.js', {encoding: 'unknownEncoding'}), {code: 'ERR_UNKNOWN_ENCODING'});
-});
-
-test('pass `stdout` to a file descriptor', async t => {
-	const file = tempfile({extension: '.txt'});
-	await execa('noop.js', ['foo bar'], {stdout: fs.openSync(file, 'w')});
-	t.is(fs.readFileSync(file, 'utf8'), 'foo bar\n');
-});
-
-test('pass `stderr` to a file descriptor', async t => {
-	const file = tempfile({extension: '.txt'});
-	await execa('noop-err.js', ['foo bar'], {stderr: fs.openSync(file, 'w')});
-	t.is(fs.readFileSync(file, 'utf8'), 'foo bar\n');
 });
 
 test.serial('result.all shows both `stdout` and `stderr` intermixed', async t => {
@@ -95,568 +65,47 @@ test('result.all is undefined unless opts.all is true', async t => {
 	t.is(all, undefined);
 });
 
-test('stdout/stderr/all are undefined if ignored', async t => {
-	const {stdout, stderr, all} = await execa('noop.js', {stdio: 'ignore', all: true});
-	t.is(stdout, undefined);
-	t.is(stderr, undefined);
+test('result.all is undefined if ignored', async t => {
+	const {all} = await execa('noop.js', {stdio: 'ignore', all: true});
 	t.is(all, undefined);
 });
 
-test('stdout/stderr/all are undefined if ignored in sync mode', t => {
-	const {stdout, stderr, all} = execaSync('noop.js', {stdio: 'ignore', all: true});
-	t.is(stdout, undefined);
-	t.is(stderr, undefined);
-	t.is(all, undefined);
-});
-
-test('stdin option can be a sync iterable of strings', async t => {
-	const {stdout} = await execa('stdin.js', {stdin: ['foo', 'bar']});
-	t.is(stdout, 'foobar');
-});
-
-const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
-const binaryFoo = textEncoder.encode('foo');
-const binaryBar = textEncoder.encode('bar');
-
-test('stdin option can be a sync iterable of Uint8Arrays', async t => {
-	const {stdout} = await execa('stdin.js', {stdin: [binaryFoo, binaryBar]});
-	t.is(stdout, 'foobar');
-});
-
-const stringGenerator = function * () {
-	yield * ['foo', 'bar'];
+const testIgnore = async (t, streamName, execaMethod) => {
+	const result = await execaMethod('noop.js', {[streamName]: 'ignore'});
+	t.is(result[streamName], undefined);
 };
 
-const binaryGenerator = function * () {
-	yield * [binaryFoo, binaryBar];
-};
+test('stdout is undefined if ignored', testIgnore, 'stdout', execa);
+test('stderr is undefined if ignored', testIgnore, 'stderr', execa);
+test('stdout is undefined if ignored - sync', testIgnore, 'stdout', execaSync);
+test('stderr is undefined if ignored - sync', testIgnore, 'stderr', execaSync);
 
-const throwingGenerator = function * () {
-	yield 'foo';
-	throw new Error('generator error');
-};
-
-test('stdin option can be an async iterable of strings', async t => {
-	const {stdout} = await execa('stdin.js', {stdin: stringGenerator()});
-	t.is(stdout, 'foobar');
-});
-
-test('stdin option can be an async iterable of Uint8Arrays', async t => {
-	const {stdout} = await execa('stdin.js', {stdin: binaryGenerator()});
-	t.is(stdout, 'foobar');
-});
-
-test('stdin option cannot be a sync iterable with execa.sync()', t => {
-	t.throws(() => {
-		execaSync('stdin.js', {stdin: ['foo', 'bar']});
-	}, {message: /an iterable in sync mode/});
-});
-
-test('stdin option cannot be an async iterable with execa.sync()', t => {
-	t.throws(() => {
-		execaSync('stdin.js', {stdin: stringGenerator()});
-	}, {message: /an iterable in sync mode/});
-});
-
-test('stdin option cannot be an iterable when "input" is used', t => {
-	t.throws(() => {
-		execa('stdin.js', {stdin: ['foo', 'bar'], input: 'foobar'});
-	}, {message: /`input` and `stdin` options/});
-});
-
-test('stdin option cannot be an iterable when "inputFile" is used', t => {
-	t.throws(() => {
-		execa('stdin.js', {stdin: ['foo', 'bar'], inputFile: 'dummy.txt'});
-	}, {message: /`inputFile` and `stdin` options/});
-});
-
-test('stdin option cannot be a file URL when "input" is used', t => {
-	t.throws(() => {
-		execa('stdin.js', {stdin: pathToFileURL('unknown'), input: 'foobar'});
-	}, {message: /`input` and `stdin` options/});
-});
-
-test('stdin option cannot be a file URL when "inputFile" is used', t => {
-	t.throws(() => {
-		execa('stdin.js', {stdin: pathToFileURL('unknown'), inputFile: 'dummy.txt'});
-	}, {message: /`inputFile` and `stdin` options/});
-});
-
-test('stdin option cannot be a file path when "input" is used', t => {
-	t.throws(() => {
-		execa('stdin.js', {stdin: './unknown', input: 'foobar'});
-	}, {message: /`input` and `stdin` options/});
-});
-
-test('stdin option cannot be a file path when "inputFile" is used', t => {
-	t.throws(() => {
-		execa('stdin.js', {stdin: './unknown', inputFile: 'dummy.txt'});
-	}, {message: /`inputFile` and `stdin` options/});
-});
-
-test('stdin option handles errors in iterables', async t => {
-	const {originalMessage} = await t.throwsAsync(execa('stdin.js', {stdin: throwingGenerator()}));
-	t.is(originalMessage, 'generator error');
-});
-
-const testNoIterableOutput = (t, optionName, execaMethod) => {
-	t.throws(() => {
-		execaMethod('noop.js', {[optionName]: ['foo', 'bar']});
-	}, {message: /cannot be an iterable/});
-};
-
-test('stdout option cannot be an iterable', testNoIterableOutput, 'stdout', execa);
-test('stderr option cannot be an iterable', testNoIterableOutput, 'stderr', execa);
-test('stdout option cannot be an iterable - sync', testNoIterableOutput, 'stdout', execaSync);
-test('stderr option cannot be an iterable - sync', testNoIterableOutput, 'stderr', execaSync);
-
-const testWritableStreamError = async (t, streamName) => {
-	const writableStream = new WritableStream({
-		start(controller) {
-			controller.error(new Error('foobar'));
-		},
-	});
-	const {originalMessage} = await t.throwsAsync(execa('noop.js', {[streamName]: writableStream}));
-	t.is(originalMessage, 'foobar');
-};
-
-test('stdout option handles errors in WritableStream', testWritableStreamError, 'stdout');
-test('stderr option handles errors in WritableStream', testWritableStreamError, 'stderr');
-
-test('input option can be a String', async t => {
-	const {stdout} = await execa('stdin.js', {input: 'foobar'});
-	t.is(stdout, 'foobar');
-});
-
-test('input option can be a Uint8Array', async t => {
-	const {stdout} = await execa('stdin.js', {input: binaryFoo});
-	t.is(stdout, 'foo');
-});
-
-test('input option cannot be a String when stdin is set', t => {
-	t.throws(() => {
-		execa('stdin.js', {input: 'foobar', stdin: 'ignore'});
-	}, {message: /`input` and `stdin` options/});
-});
-
-test('input option cannot be a String when stdio is set', t => {
-	t.throws(() => {
-		execa('stdin.js', {input: 'foobar', stdio: 'ignore'});
-	}, {message: /`input` and `stdin` options/});
-});
-
-const createNoFileReadable = value => {
-	const stream = new Stream.PassThrough();
-	stream.write(value);
-	stream.end();
-	return stream;
-};
-
-test('input can be a Node.js Readable without a file descriptor', async t => {
-	const {stdout} = await execa('stdin.js', {input: createNoFileReadable('foobar')});
-	t.is(stdout, 'foobar');
-});
-
-const testNoFileStream = async (t, optionName, StreamClass) => {
-	await t.throwsAsync(execa('noop.js', {[optionName]: new StreamClass()}), {code: 'ERR_INVALID_ARG_VALUE'});
-};
-
-test('stdin cannot be a Node.js Readable without a file descriptor', testNoFileStream, 'stdin', Stream.Readable);
-test('stdout cannot be a Node.js Writable without a file descriptor', testNoFileStream, 'stdout', Stream.Writable);
-test('stderr cannot be a Node.js Writable without a file descriptor', testNoFileStream, 'stderr', Stream.Writable);
-
-const createFileReadable = async value => {
-	const filePath = tempfile();
-	await writeFile(filePath, value);
-	const stream = fs.createReadStream(filePath);
-	await once(stream, 'open');
-	const cleanup = () => rm(filePath);
-	return {stream, cleanup};
-};
-
-const testFileReadable = async (t, optionName) => {
-	const {stream, cleanup} = await createFileReadable('foobar');
-	try {
-		const {stdout} = await execa('stdin.js', {[optionName]: stream});
-		t.is(stdout, 'foobar');
-	} finally {
-		await cleanup();
-	}
-};
-
-test('input can be a Node.js Readable with a file descriptor', testFileReadable, 'input');
-test('stdin can be a Node.js Readable with a file descriptor', testFileReadable, 'stdin');
-
-const createFileWritable = async () => {
-	const filePath = tempfile();
-	const stream = fs.createWriteStream(filePath);
-	await once(stream, 'open');
-	const cleanup = () => rm(filePath);
-	return {stream, filePath, cleanup};
-};
-
-const testFileWritable = async (t, optionName, fixtureName) => {
-	const {stream, filePath, cleanup} = await createFileWritable();
-	try {
-		await execa(fixtureName, ['foobar'], {[optionName]: stream});
-		t.is(await readFile(filePath, 'utf8'), 'foobar\n');
-	} finally {
-		await cleanup();
-	}
-};
-
-test('stdout can be a Node.js Writable with a file descriptor', testFileWritable, 'stdout', 'noop.js');
-test('stderr can be a Node.js Writable with a file descriptor', testFileWritable, 'stderr', 'noop-err.js');
-
-test('input option cannot be a Node.js Readable when stdin is set', t => {
-	t.throws(() => {
-		execa('stdin.js', {input: new Stream.PassThrough(), stdin: 'ignore'});
-	}, {message: /`input` and `stdin` options/});
-});
-
-test('input option can be used with $', async t => {
-	const {stdout} = await $({input: 'foobar'})`stdin.js`;
-	t.is(stdout, 'foobar');
-});
-
-test('stdin can be a ReadableStream', async t => {
-	const stdin = Stream.Readable.toWeb(Stream.Readable.from('howdy'));
-	const {stdout} = await execa('stdin.js', {stdin});
-	t.is(stdout, 'howdy');
-});
-
-const testWritableStream = async (t, streamName, fixtureName) => {
-	const result = [];
-	const writableStream = new WritableStream({
-		write(chunk) {
-			result.push(chunk);
-		},
-	});
-	await execa(fixtureName, ['foobar'], {[streamName]: writableStream});
-	t.is(result.join(''), 'foobar\n');
-};
-
-test('stdout can be a WritableStream', testWritableStream, 'stdout', 'noop.js');
-test('stderr can be a WritableStream', testWritableStream, 'stderr', 'noop-err.js');
-
-test('stdin cannot be a ReadableStream when input is used', t => {
-	const stdin = Stream.Readable.toWeb(Stream.Readable.from('howdy'));
-	t.throws(() => {
-		execa('stdin.js', {stdin, input: 'foobar'});
-	}, {message: /`input` and `stdin` options/});
-});
-
-test('stdin cannot be a ReadableStream when inputFile is used', t => {
-	const stdin = Stream.Readable.toWeb(Stream.Readable.from('howdy'));
-	t.throws(() => {
-		execa('stdin.js', {stdin, inputFile: 'dummy.txt'});
-	}, {message: /`inputFile` and `stdin` options/});
-});
-
-test('stdin can be a file URL', async t => {
-	const inputFile = tempfile();
-	fs.writeFileSync(inputFile, 'howdy');
-	const {stdout} = await execa('stdin.js', {stdin: pathToFileURL(inputFile)});
-	t.is(stdout, 'howdy');
-});
-
-const testOutputFileUrl = async (t, streamName, fixtureName) => {
-	const outputFile = tempfile();
-	await execa(fixtureName, ['foobar'], {[streamName]: pathToFileURL(outputFile)});
-	t.is(await readFile(outputFile, 'utf8'), 'foobar\n');
-};
-
-test('stdout can be a file URL', testOutputFileUrl, 'stdout', 'noop.js');
-test('stderr can be a file URL', testOutputFileUrl, 'stderr', 'noop-err.js');
-
-const testStdioNonFileUrl = (t, streamName, method) => {
-	t.throws(() => {
-		method('noop.js', {[streamName]: nonFileUrl});
-	}, {message: /pathToFileURL/});
-};
-
-test('stdin cannot be a non-file URL', testStdioNonFileUrl, 'stdin', execa);
-test('stdout cannot be a non-file URL', testStdioNonFileUrl, 'stdout', execa);
-test('stderr cannot be a non-file URL', testStdioNonFileUrl, 'stderr', execa);
-test('stdin cannot be a non-file URL - sync', testStdioNonFileUrl, 'stdin', execaSync);
-test('stdout cannot be a non-file URL - sync', testStdioNonFileUrl, 'stdout', execaSync);
-test('stderr cannot be a non-file URL - sync', testStdioNonFileUrl, 'stderr', execaSync);
-
-test('stdin can be an absolute file path', async t => {
-	const inputFile = tempfile();
-	fs.writeFileSync(inputFile, 'howdy');
-	const {stdout} = await execa('stdin.js', {stdin: inputFile});
-	t.is(stdout, 'howdy');
-});
-
-const testOutputAbsoluteFile = async (t, streamName, fixtureName) => {
-	const outputFile = tempfile();
-	await execa(fixtureName, ['foobar'], {[streamName]: outputFile});
-	t.is(await readFile(outputFile, 'utf8'), 'foobar\n');
-};
-
-test('stdout can be an absolute file path', testOutputAbsoluteFile, 'stdout', 'noop.js');
-test('stderr can be an absolute file path', testOutputAbsoluteFile, 'stderr', 'noop-err.js');
-
-test('stdin can be a relative file path', async t => {
-	const inputFile = tempfile();
-	fs.writeFileSync(inputFile, 'howdy');
-	const {stdout} = await execa('stdin.js', {stdin: relative('.', inputFile)});
-	t.is(stdout, 'howdy');
-});
-
-const testOutputRelativeFile = async (t, streamName, fixtureName) => {
-	const outputFile = tempfile();
-	await execa(fixtureName, ['foobar'], {[streamName]: relative('.', outputFile)});
-	t.is(await readFile(outputFile, 'utf8'), 'foobar\n');
-};
-
-test('stdout can be a relative file path', testOutputRelativeFile, 'stdout', 'noop.js');
-test('stderr can be a relative file path', testOutputRelativeFile, 'stderr', 'noop-err.js');
-
-const testStdioValidUrl = (t, streamName, method) => {
-	t.throws(() => {
-		method('noop.js', {[streamName]: 'foobar'});
-	}, {message: /absolute file path/});
-};
-
-test('stdin must start with . when being a relative file path', testStdioValidUrl, 'stdin', execa);
-test('stdout must start with . when being a relative file path', testStdioValidUrl, 'stdout', execa);
-test('stderr must start with . when being a relative file path', testStdioValidUrl, 'stderr', execa);
-test('stdin must start with . when being a relative file path - sync', testStdioValidUrl, 'stdin', execaSync);
-test('stdout must start with . when being a relative file path - sync', testStdioValidUrl, 'stdout', execaSync);
-test('stderr must start with . when being a relative file path - sync', testStdioValidUrl, 'stderr', execaSync);
-
-test('inputFile can be set', async t => {
-	const inputFile = tempfile();
-	fs.writeFileSync(inputFile, 'howdy');
-	const {stdout} = await execa('stdin.js', {inputFile});
-	t.is(stdout, 'howdy');
-});
-
-test('inputFile can be set with $', async t => {
-	const inputFile = tempfile();
-	fs.writeFileSync(inputFile, 'howdy');
-	const {stdout} = await $({inputFile})`stdin.js`;
-	t.is(stdout, 'howdy');
-});
-
-test('inputFile and input cannot be both set', t => {
-	t.throws(() => execa('stdin.js', {inputFile: '', input: ''}), {
-		message: /cannot be both set/,
-	});
-});
-
-test('inputFile option cannot be set when stdin is set', t => {
-	t.throws(() => {
-		execa('stdin.js', {inputFile: '', stdin: 'ignore'});
-	}, {message: /`inputFile` and `stdin` options/});
-});
-
-const testFileUrlError = async (t, streamName) => {
-	await t.throwsAsync(
-		execa('noop.js', {[streamName]: pathToFileURL('./unknown/file')}),
-		{code: 'ENOENT'},
+const testMaxBuffer = async (t, streamName) => {
+	await t.notThrowsAsync(execa('max-buffer.js', [streamName, '10'], {maxBuffer: 10}));
+	const {[streamName]: stream, all} = await t.throwsAsync(
+		execa('max-buffer.js', [streamName, '11'], {maxBuffer: 10, all: true}),
+		{message: new RegExp(`max-buffer.js ${streamName}`)},
 	);
-};
-
-test('stdin file URL errors should be handled', testFileUrlError, 'stdin');
-test('stdout file URL errors should be handled', testFileUrlError, 'stdout');
-test('stderr file URL errors should be handled', testFileUrlError, 'stderr');
-
-const testFileUrlErrorSync = (t, streamName) => {
-	t.throws(() => {
-		execaSync('noop.js', {[streamName]: pathToFileURL('./unknown/file')});
-	}, {code: 'ENOENT'});
-};
-
-test('stdin file URL errors should be handled - sync', testFileUrlErrorSync, 'stdin');
-test('stdout file URL errors should be handled - sync', testFileUrlErrorSync, 'stdout');
-test('stderr file URL errors should be handled - sync', testFileUrlErrorSync, 'stderr');
-
-const testFilePathError = async (t, streamName) => {
-	await t.throwsAsync(
-		execa('noop.js', {[streamName]: './unknown/file'}),
-		{code: 'ENOENT'},
-	);
-};
-
-test('stdin file path errors should be handled', testFilePathError, 'stdin');
-test('stdout file path errors should be handled', testFilePathError, 'stdout');
-test('stderr file path errors should be handled', testFilePathError, 'stderr');
-
-const testFilePathErrorSync = (t, streamName) => {
-	t.throws(() => {
-		execaSync('noop.js', {[streamName]: './unknown/file'});
-	}, {code: 'ENOENT'});
-};
-
-test('stdin file path errors should be handled - sync', testFilePathErrorSync, 'stdin');
-test('stdout file path errors should be handled - sync', testFilePathErrorSync, 'stdout');
-test('stderr file path errors should be handled - sync', testFilePathErrorSync, 'stderr');
-
-test('inputFile errors should be handled', async t => {
-	await t.throwsAsync(execa('stdin.js', {inputFile: 'unknown'}), {code: 'ENOENT'});
-});
-
-test('you can write to child.stdin', async t => {
-	const subprocess = execa('stdin.js');
-	subprocess.stdin.end('unicorns');
-	const {stdout} = await subprocess;
-	t.is(stdout, 'unicorns');
-});
-
-test('input option can be a String - sync', t => {
-	const {stdout} = execaSync('stdin.js', {input: 'foobar'});
-	t.is(stdout, 'foobar');
-});
-
-test('input option can be used with $.sync', t => {
-	const {stdout} = $({input: 'foobar'}).sync`stdin.js`;
-	t.is(stdout, 'foobar');
-});
-
-test('input option can be a Uint8Array - sync', t => {
-	const {stdout} = execaSync('stdin.js', {input: binaryFoo});
-	t.is(stdout, 'foo');
-});
-
-test('opts.stdout:ignore - stdout will not collect data', async t => {
-	const {stdout} = await execa('stdin.js', {
-		input: 'hello',
-		stdio: [undefined, 'ignore', undefined],
-	});
-	t.is(stdout, undefined);
-});
-
-test('input cannot be a Node.js Readable in sync mode', t => {
-	t.throws(() => {
-		execaSync('stdin.js', {input: new Stream.PassThrough()});
-	}, {message: /The `input` option cannot be a Node\.js stream in sync mode/});
-});
-
-test('stdin cannot be a ReadableStream in sync mode', t => {
-	const stdin = Stream.Readable.toWeb(Stream.Readable.from('howdy'));
-	t.throws(() => {
-		execaSync('stdin.js', {stdin});
-	}, {message: /The `stdin` option cannot be a web stream in sync mode/});
-});
-
-const testWritableStreamSync = (t, streamName) => {
-	t.throws(() => {
-		execaSync('noop.js', {[streamName]: new WritableStream()});
-	}, {message: new RegExp(`The \`${streamName}\` option cannot be a web stream in sync mode`)});
-};
-
-test('stdout cannot be a WritableStream in sync mode', testWritableStreamSync, 'stdout');
-test('stderr cannot be a WritableStream in sync mode', testWritableStreamSync, 'stderr');
-
-test('stdin can be a file URL - sync', t => {
-	const inputFile = tempfile();
-	fs.writeFileSync(inputFile, 'howdy');
-	const stdin = pathToFileURL(inputFile);
-	const {stdout} = execaSync('stdin.js', {stdin});
-	t.is(stdout, 'howdy');
-});
-
-const testOutputFileUrlSync = (t, streamName, fixtureName) => {
-	const outputFile = tempfile();
-	execaSync(fixtureName, ['foobar'], {[streamName]: pathToFileURL(outputFile)});
-	t.is(fs.readFileSync(outputFile, 'utf8'), 'foobar\n');
-};
-
-test('stdout can be a file URL - sync', testOutputFileUrlSync, 'stdout', 'noop.js');
-test('stderr can be a file URL - sync', testOutputFileUrlSync, 'stderr', 'noop-err.js');
-
-test('stdin can be an absolute file path - sync', t => {
-	const inputFile = tempfile();
-	fs.writeFileSync(inputFile, 'howdy');
-	const {stdout} = execaSync('stdin.js', {stdin: inputFile});
-	t.is(stdout, 'howdy');
-});
-
-const testOutputAbsoluteFileSync = (t, streamName, fixtureName) => {
-	const outputFile = tempfile();
-	execaSync(fixtureName, ['foobar'], {[streamName]: outputFile});
-	t.is(fs.readFileSync(outputFile, 'utf8'), 'foobar\n');
-};
-
-test('stdout can be an absolute file path - sync', testOutputAbsoluteFileSync, 'stdout', 'noop.js');
-test('stderr can be an absolute file path - sync', testOutputAbsoluteFileSync, 'stderr', 'noop-err.js');
-
-test('stdin can be a relative file path - sync', t => {
-	const inputFile = tempfile();
-	fs.writeFileSync(inputFile, 'howdy');
-	const stdin = relative('.', inputFile);
-	const {stdout} = execaSync('stdin.js', {stdin});
-	t.is(stdout, 'howdy');
-});
-
-const testOutputRelativeFileSync = (t, streamName, fixtureName) => {
-	const outputFile = tempfile();
-	execaSync(fixtureName, ['foobar'], {[streamName]: relative('.', outputFile)});
-	t.is(fs.readFileSync(outputFile, 'utf8'), 'foobar\n');
-};
-
-test('stdout can be a relative file path - sync', testOutputRelativeFileSync, 'stdout', 'noop.js');
-test('stderr can be a relative file path - sync', testOutputRelativeFileSync, 'stderr', 'noop-err.js');
-
-test('inputFile can be set - sync', t => {
-	const inputFile = tempfile();
-	fs.writeFileSync(inputFile, 'howdy');
-	const {stdout} = execaSync('stdin.js', {inputFile});
-	t.is(stdout, 'howdy');
-});
-
-test('inputFile option can be used with $.sync', t => {
-	const inputFile = tempfile();
-	fs.writeFileSync(inputFile, 'howdy');
-	const {stdout} = $({inputFile}).sync`stdin.js`;
-	t.is(stdout, 'howdy');
-});
-
-test('inputFile and input cannot be both set - sync', t => {
-	t.throws(() => execaSync('stdin.js', {inputFile: '', input: ''}), {
-		message: /cannot be both set/,
-	});
-});
-
-test('maxBuffer affects stdout', async t => {
-	await t.notThrowsAsync(execa('max-buffer.js', ['stdout', '10'], {maxBuffer: 10}));
-	const {stdout, all} = await t.throwsAsync(execa('max-buffer.js', ['stdout', '11'], {maxBuffer: 10, all: true}), {message: /max-buffer.js stdout/});
-	t.is(stdout, '.'.repeat(10));
+	t.is(stream, '.'.repeat(10));
 	t.is(all, '.'.repeat(10));
-});
+};
 
-test('maxBuffer affects stderr', async t => {
-	await t.notThrowsAsync(execa('max-buffer.js', ['stderr', '10'], {maxBuffer: 10}));
-	const {stderr, all} = await t.throwsAsync(execa('max-buffer.js', ['stderr', '11'], {maxBuffer: 10, all: true}), {message: /max-buffer.js stderr/});
-	t.is(stderr, '.'.repeat(10));
-	t.is(all, '.'.repeat(10));
-});
+test('maxBuffer affects stdout', testMaxBuffer, 'stdout');
+test('maxBuffer affects stderr', testMaxBuffer, 'stderr');
 
-test('do not buffer stdout when `buffer` set to `false`', async t => {
-	const promise = execa('max-buffer.js', ['stdout', '10'], {buffer: false});
-	const [result, stdout] = await Promise.all([
+const testNoMaxBuffer = async (t, streamName) => {
+	const promise = execa('max-buffer.js', [streamName, '10'], {buffer: false});
+	const [result, output] = await Promise.all([
 		promise,
-		getStream(promise.stdout),
+		getStream(promise[streamName]),
 	]);
 
-	t.is(result.stdout, undefined);
-	t.is(stdout, '.........\n');
-});
+	t.is(result[streamName], undefined);
+	t.is(output, '.........\n');
+};
 
-test('do not buffer stderr when `buffer` set to `false`', async t => {
-	const promise = execa('max-buffer.js', ['stderr', '10'], {buffer: false});
-	const [result, stderr] = await Promise.all([
-		promise,
-		getStream(promise.stderr),
-	]);
-
-	t.is(result.stderr, undefined);
-	t.is(stderr, '.........\n');
-});
+test('do not buffer stdout when `buffer` set to `false`', testNoMaxBuffer, 'stdout');
+test('do not buffer stderr when `buffer` set to `false`', testNoMaxBuffer, 'stderr');
 
 test('do not buffer when streaming', async t => {
 	const {stdout} = execa('max-buffer.js', ['stdout', '21'], {maxBuffer: 10});


### PR DESCRIPTION
This PR refactors the tests related to `stdin`/`stdout`/`stderr`/`stdio`/`input`/`inputFile`. 
It does not change the logic in itself but instead:
  - Split into several smaller files
  - Remove duplicate code by using Ava test macros
  - Turn some sync I/O into async I/O instead, for better parallelism
  - Ensure every test is run on both `execa()` and `execaSync()`