### PR TITLE
Add support for file URLs with the `inputFile` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -309,7 +309,7 @@ export type Options<EncodingType extends EncodingOption = DefaultEncodingOption>
 
 	If the input is not a file, use the `input` option instead.
 	*/
-	readonly inputFile?: string;
+	readonly inputFile?: string | URL;
 } & CommonOptions<EncodingType>;
 
 export type SyncOptions<EncodingType extends EncodingOption = DefaultEncodingOption> = {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -152,6 +152,7 @@ execa('unicorns', {input: ''});
 execa('unicorns', {input: Buffer.from('')});
 execa('unicorns', {input: process.stdin});
 execa('unicorns', {inputFile: ''});
+execa('unicorns', {inputFile: new URL('file:///test')});
 execa('unicorns', {stdin: 'pipe'});
 execa('unicorns', {stdin: 'overlapped'});
 execa('unicorns', {stdin: 'ipc'});

--- a/readme.md
+++ b/readme.md
@@ -555,7 +555,7 @@ If the input is a file, use the [`inputFile` option](#inputfile) instead.
 
 #### inputFile
 
-Type: `string`
+Type: `string | URL`
 
 Use a file as input to the the `stdin` of your binary.
 


### PR DESCRIPTION
Part of #458.

This allows `inputFile` to be a file URL.
This was actually added by previous PRs, so this just documents it.