### PR TITLE
Allow the first argument of `execa()` to be a file URL

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -554,13 +554,13 @@ ExecaChildPromise<StdoutStderrType> &
 Promise<ExecaReturnValue<StdoutStderrType>>;
 
 /**
-Executes a command using `file ...arguments`. `arguments` are specified as an array of strings. Returns a `childProcess`.
+Executes a command using `file ...arguments`. `file` is a string or a file URL. `arguments` are an array of strings. Returns a `childProcess`.
 
 Arguments are automatically escaped. They can contain any character, including spaces.
 
 This is the preferred method when executing single commands.
 
-@param file - The program/script to execute.
+@param file - The program/script to execute, as a string or file URL
 @param arguments - Arguments to pass to `file` on execution.
 @returns An `ExecaChildProcess` that is both:
 	- a `Promise` resolving or rejecting with a `childProcessResult`.
@@ -665,18 +665,19 @@ setTimeout(() => {
 ```
 */
 export function execa<EncodingType extends EncodingOption = DefaultEncodingOption>(
-	file: string,
+	file: string | URL,
 	arguments?: readonly string[],
 	options?: Options<EncodingType>
 ): ExecaChildProcess<GetStdoutStderrType<EncodingType>>;
 export function execa<EncodingType extends EncodingOption = DefaultEncodingOption>(
-	file: string, options?: Options<EncodingType>
+	file: string | URL,
+	options?: Options<EncodingType>
 ): ExecaChildProcess<GetStdoutStderrType<EncodingType>>;
 
 /**
 Same as `execa()` but synchronous.
 
-@param file - The program/script to execute.
+@param file - The program/script to execute, as a string or file URL
 @param arguments - Arguments to pass to `file` on execution.
 @returns A `childProcessResult` object
 @throws A `childProcessResult` error
@@ -734,12 +735,13 @@ try {
 ```
 */
 export function execaSync<EncodingType extends EncodingOption = DefaultEncodingOption>(
-	file: string,
+	file: string | URL,
 	arguments?: readonly string[],
 	options?: SyncOptions<EncodingType>
 ): ExecaSyncReturnValue<GetStdoutStderrType<EncodingType>>;
 export function execaSync<EncodingType extends EncodingOption = DefaultEncodingOption>(
-	file: string, options?: SyncOptions<EncodingType>
+	file: string | URL,
+	options?: SyncOptions<EncodingType>
 ): ExecaSyncReturnValue<GetStdoutStderrType<EncodingType>>;
 
 /**
@@ -984,7 +986,7 @@ await $$`echo rainbows`;
 export const $: Execa$;
 
 /**
-Execute a Node.js script as a child process.
+Executes a Node.js file using `node scriptPath ...arguments`. `file` is a string or a file URL. `arguments` are an array of strings. Returns a `childProcess`.
 
 Arguments are automatically escaped. They can contain any character, including spaces.
 
@@ -995,7 +997,7 @@ Like [`child_process#fork()`](https://nodejs.org/api/child_process.html#child_pr
   - the `shell` option cannot be used
   - an extra channel [`ipc`](https://nodejs.org/api/child_process.html#child_process_options_stdio) is passed to `stdio`
 
-@param scriptPath - Node.js script to execute.
+@param scriptPath - Node.js script to execute, as a string or file URL
 @param arguments - Arguments to pass to `scriptPath` on execution.
 @returns An `ExecaChildProcess` that is both:
 	- a `Promise` resolving or rejecting with a `childProcessResult`.
@@ -1010,10 +1012,11 @@ await execaNode('scriptPath', ['argument']);
 ```
 */
 export function execaNode<EncodingType extends EncodingOption = DefaultEncodingOption>(
-	scriptPath: string,
+	scriptPath: string | URL,
 	arguments?: readonly string[],
 	options?: NodeOptions<EncodingType>
 ): ExecaChildProcess<GetStdoutStderrType<EncodingType>>;
 export function execaNode<EncodingType extends EncodingOption = DefaultEncodingOption>(
-	scriptPath: string, options?: NodeOptions<EncodingType>
+	scriptPath: string | URL,
+	options?: NodeOptions<EncodingType>
 ): ExecaChildProcess<GetStdoutStderrType<EncodingType>>;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import {Buffer} from 'node:buffer';
 import path from 'node:path';
 import childProcess from 'node:child_process';
 import process from 'node:process';
+import {fileURLToPath} from 'node:url';
 import crossSpawn from 'cross-spawn';
 import stripFinalNewline from 'strip-final-newline';
 import {npmRunPathEnv} from 'npm-run-path';
@@ -27,6 +28,18 @@ const getEnv = ({env: envOption, extendEnv, preferLocal, localDir, execPath}) =>
 	}
 
 	return env;
+};
+
+const getFilePath = file => {
+	if (file instanceof URL) {
+		return fileURLToPath(file);
+	}
+
+	if (typeof file !== 'string') {
+		throw new TypeError('First argument must be a string or a file URL.');
+	}
+
+	return file;
 };
 
 const handleArguments = (file, args, options = {}) => {
@@ -76,12 +89,13 @@ const handleOutput = (options, value, error) => {
 };
 
 export function execa(file, args, options) {
-	const parsed = handleArguments(file, args, options);
+	const filePath = getFilePath(file);
+	const parsed = handleArguments(filePath, args, options);
 	const stdioStreams = handleInputAsync(parsed.options);
 	validateTimeout(parsed.options);
 
-	const command = joinCommand(file, args);
-	const escapedCommand = getEscapedCommand(file, args);
+	const command = joinCommand(filePath, args);
+	const escapedCommand = getEscapedCommand(filePath, args);
 	logCommand(escapedCommand, parsed.options);
 
 	let spawned;
@@ -168,11 +182,12 @@ export function execa(file, args, options) {
 }
 
 export function execaSync(file, args, options) {
-	const parsed = handleArguments(file, args, options);
+	const filePath = getFilePath(file);
+	const parsed = handleArguments(filePath, args, options);
 	const stdioStreams = handleInputSync(parsed.options);
 
-	const command = joinCommand(file, args);
-	const escapedCommand = getEscapedCommand(file, args);
+	const command = joinCommand(filePath, args);
+	const escapedCommand = getEscapedCommand(filePath, args);
 	logCommand(escapedCommand, parsed.options);
 
 	let result;
@@ -294,7 +309,7 @@ export function execaNode(scriptPath, args, options = {}) {
 		nodePath,
 		[
 			...nodeOptions,
-			scriptPath,
+			getFilePath(scriptPath),
 			...(Array.isArray(args) ? args : []),
 		],
 		{

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -230,7 +230,9 @@ execa('unicorns').kill('SIGKILL', {forceKillAfterTimeout: false});
 execa('unicorns').kill('SIGKILL', {forceKillAfterTimeout: 42});
 execa('unicorns').kill('SIGKILL', {forceKillAfterTimeout: undefined});
 
+expectError(execa(['unicorns', 'arg']));
 expectType<ExecaChildProcess>(execa('unicorns'));
+expectType<ExecaChildProcess>(execa(new URL('file:///test')));
 expectType<ExecaReturnValue>(await execa('unicorns'));
 expectType<ExecaReturnValue>(
 	await execa('unicorns', {encoding: 'utf8'}),
@@ -247,7 +249,9 @@ expectType<ExecaReturnValue<Buffer>>(
 	await execa('unicorns', ['foo'], {encoding: null}),
 );
 
+expectError(execaSync(['unicorns', 'arg']));
 expectType<ExecaSyncReturnValue>(execaSync('unicorns'));
+expectType<ExecaSyncReturnValue>(execaSync(new URL('file:///test')));
 expectType<ExecaSyncReturnValue>(
 	execaSync('unicorns', {encoding: 'utf8'}),
 );
@@ -284,8 +288,10 @@ expectType<ExecaSyncReturnValue>(execaCommandSync('unicorns foo', {encoding: 'ut
 expectType<ExecaSyncReturnValue<Buffer>>(execaCommandSync('unicorns foo', {encoding: 'buffer'}));
 expectType<ExecaSyncReturnValue<Buffer>>(execaCommandSync('unicorns foo', {encoding: null}));
 
+expectError(execaNode(['unicorns', 'arg']));
 expectType<ExecaChildProcess>(execaNode('unicorns'));
 expectType<ExecaReturnValue>(await execaNode('unicorns'));
+expectType<ExecaReturnValue>(await execaNode(new URL('file:///test')));
 expectType<ExecaReturnValue>(
 	await execaNode('unicorns', {encoding: 'utf8'}),
 );

--- a/readme.md
+++ b/readme.md
@@ -238,7 +238,7 @@ setTimeout(() => {
 
 #### execa(file, arguments?, options?)
 
-Executes a command using `file ...arguments`. `arguments` are specified as an array of strings. Returns a [`childProcess`](#childprocess).
+Executes a command using `file ...arguments`. `file` is a string or a file URL. `arguments` are an array of strings. Returns a [`childProcess`](#childprocess).
 
 Arguments are [automatically escaped](#shell-syntax). They can contain any character, including spaces.
 
@@ -246,7 +246,7 @@ This is the preferred method when executing single commands.
 
 #### execaNode(scriptPath, arguments?, options?)
 
-Executes a Node.js file using `node scriptPath ...arguments`. `arguments` are specified as an array of strings. Returns a [`childProcess`](#childprocess).
+Executes a Node.js file using `node scriptPath ...arguments`. `file` is a string or a file URL. `arguments` are an array of strings. Returns a [`childProcess`](#childprocess).
 
 Arguments are [automatically escaped](#shell-syntax). They can contain any character, including spaces.
 

--- a/test/helpers/fixtures-dir.js
+++ b/test/helpers/fixtures-dir.js
@@ -4,7 +4,8 @@ import {fileURLToPath} from 'node:url';
 import pathKey from 'path-key';
 
 export const PATH_KEY = pathKey();
-export const FIXTURES_DIR = fileURLToPath(new URL('../fixtures', import.meta.url));
+export const FIXTURES_DIR_URL = new URL('../fixtures/', import.meta.url);
+export const FIXTURES_DIR = fileURLToPath(FIXTURES_DIR_URL);
 
 // Add the fixtures directory to PATH so fixtures can be executed without adding
 // `node`. This is only meant to make writing tests simpler.


### PR DESCRIPTION
Part of https://github.com/sindresorhus/execa/issues/458

This allows the first argument to `execa()`, `execaSync()` and `execaNode()` to be  a file URL.

This does not add this to `execaCommand()` nor `$`, since those command expects both the command and the argument to be a single string. Therefore, using a file URL does not make sense there.