### PR TITLE
Allow `nodePath` option to be a file URL

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -367,7 +367,7 @@ export type NodeOptions<EncodingType extends EncodingOption = DefaultEncodingOpt
 
 	@default process.execPath
 	*/
-	readonly nodePath?: string;
+	readonly nodePath?: string | URL;
 
 	/**
 	List of [CLI options](https://nodejs.org/api/cli.html#cli_options) passed to the Node.js executable.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -289,6 +289,9 @@ expectType<ExecaReturnValue<Uint8Array>>(
 	await execaNode('unicorns', ['foo'], {encoding: 'buffer'}),
 );
 
+expectType<ExecaChildProcess>(execaNode('unicorns', {nodePath: './node'}));
+expectType<ExecaChildProcess>(execaNode('unicorns', {nodePath: new URL('file:///test')}));
+
 expectType<ExecaChildProcess>(execaNode('unicorns', {nodeOptions: ['--async-stack-traces']}));
 expectType<ExecaChildProcess>(execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces']}));
 expectType<ExecaChildProcess<Uint8Array>>(

--- a/readme.md
+++ b/readme.md
@@ -789,7 +789,7 @@ This can also be enabled by setting the `NODE_DEBUG=execa` environment variable 
 
 #### nodePath *(For `.node()` only)*
 
-Type: `string`\
+Type: `string | URL`\
 Default: [`process.execPath`](https://nodejs.org/api/process.html#process_process_execpath)
 
 Node.js executable used to create the child process.

--- a/test/node.js
+++ b/test/node.js
@@ -1,4 +1,5 @@
 import process from 'node:process';
+import {pathToFileURL} from 'node:url';
 import test from 'ava';
 import {pEvent} from 'p-event';
 import {execaNode} from '../index.js';
@@ -44,6 +45,12 @@ test('node correctly use nodePath', async t => {
 	});
 
 	t.is(stdout, 'Hello World');
+});
+
+test('The nodePath option can be a file URL', async t => {
+	const nodePath = pathToFileURL(process.execPath);
+	const {stdout} = await execaNode('test/fixtures/noop.js', ['foo'], {nodePath});
+	t.is(stdout, 'foo');
 });
 
 test('node pass on nodeOptions', async t => {


### PR DESCRIPTION
Part of #458.

This allows the `nodePath` option to be a file URL.

This is already supported by upgrading `npm-run-path`, i.e. this PR only adds documentation and tests.