### PR TITLE
Allow the `execPath` option to be a file URL

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,7 +84,7 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 
 	@default process.execPath
 	*/
-	readonly execPath?: string;
+	readonly execPath?: string | URL;
 
 	/**
 	Buffer the output from the spawned process. When set to `false`, you must read the output of `stdout` and `stderr` (or `all` if the `all` option is `true`). Otherwise the returned promise will not be resolved/rejected.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -146,6 +146,7 @@ execa('unicorns', {localDir: '.'});
 execa('unicorns', {localDir: new URL('file:///test')});
 expectError(execa('unicorns', {encoding: 'unknownEncoding'}));
 execa('unicorns', {execPath: '/path'});
+execa('unicorns', {execPath: new URL('file:///test')});
 execa('unicorns', {buffer: false});
 execa('unicorns', {input: ''});
 execa('unicorns', {input: new Uint8Array()});

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"get-stream": "^8.0.1",
 		"human-signals": "^6.0.0",
 		"is-stream": "^3.0.0",
-		"npm-run-path": "^5.1.0",
+		"npm-run-path": "^5.2.0",
 		"onetime": "^7.0.0",
 		"signal-exit": "^4.1.0",
 		"strip-final-newline": "^4.0.0"

--- a/readme.md
+++ b/readme.md
@@ -530,7 +530,7 @@ Preferred path to find locally installed binaries in (use with `preferLocal`).
 
 #### execPath
 
-Type: `string`\
+Type: `string | URL`\
 Default: `process.execPath` (Current Node.js executable)
 
 Path to the Node.js executable to use in child processes.

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,8 @@ process.env.FOO = 'foo';
 
 const ENOENT_REGEXP = process.platform === 'win32' ? /failed with exit code 1/ : /spawn.* ENOENT/;
 
+const identity = value => value;
+
 test('execa()', async t => {
 	const {stdout} = await execa('noop.js', ['foo']);
 	t.is(stdout, 'foo');
@@ -111,11 +113,15 @@ test('localDir option', async t => {
 	t.true(envPaths.some(envPath => envPath.endsWith('.bin')));
 });
 
-test.serial('execPath option', async t => {
-	const {path: execPath} = await getNode('16.0.0');
+const testExecPath = async (t, mapPath) => {
+	const {path} = await getNode('16.0.0');
+	const execPath = mapPath(path);
 	const {stdout} = await execa('node', ['-p', 'process.env.Path || process.env.PATH'], {preferLocal: true, execPath});
 	t.true(stdout.includes('16.0.0'));
-});
+};
+
+test.serial('execPath option', testExecPath, identity);
+test.serial('execPath option can be a file URL', testExecPath, pathToFileURL);
 
 test('stdin errors are handled', async t => {
 	const subprocess = execa('noop.js');


### PR DESCRIPTION
Part of #458.

This allows the `execPath` option to be a file URL.