### PR TITLE
Fix tests about iterables

### DIFF
--- a/test/helpers/generator.js
+++ b/test/helpers/generator.js
@@ -1,0 +1,23 @@
+import {setTimeout} from 'node:timers/promises';
+
+export const stringGenerator = function * () {
+	yield * ['foo', 'bar'];
+};
+
+const textEncoder = new TextEncoder();
+const binaryFoo = textEncoder.encode('foo');
+const binaryBar = textEncoder.encode('bar');
+
+export const binaryGenerator = function * () {
+	yield * [binaryFoo, binaryBar];
+};
+
+export const asyncGenerator = async function * () {
+	await setTimeout(0);
+	yield * ['foo', 'bar'];
+};
+
+// eslint-disable-next-line require-yield
+export const throwingGenerator = function * () {
+	throw new Error('generator error');
+};

--- a/test/stdio/input.js
+++ b/test/stdio/input.js
@@ -4,6 +4,7 @@ import test from 'ava';
 import {execa, execaSync, $} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {getStdinOption, getPlainStdioOption, getScriptSync, identity} from '../helpers/stdio.js';
+import {stringGenerator} from '../helpers/generator.js';
 
 setFixtureDir();
 
@@ -16,8 +17,8 @@ const testInputOptionError = (t, stdin, inputName) => {
 	}, {message: new RegExp(`\`${inputName}\` and \`stdin\` options`)});
 };
 
-test('stdin option cannot be an iterable when "input" is used', testInputOptionError, ['foo', 'bar'], 'input');
-test('stdin option cannot be an iterable when "inputFile" is used', testInputOptionError, ['foo', 'bar'], 'inputFile');
+test('stdin option cannot be an iterable when "input" is used', testInputOptionError, stringGenerator(), 'input');
+test('stdin option cannot be an iterable when "inputFile" is used', testInputOptionError, stringGenerator(), 'inputFile');
 test('stdin option cannot be a file URL when "input" is used', testInputOptionError, pathToFileURL('unknown'), 'input');
 test('stdin option cannot be a file URL when "inputFile" is used', testInputOptionError, pathToFileURL('unknown'), 'inputFile');
 test('stdin option cannot be a file path when "input" is used', testInputOptionError, './unknown', 'input');

--- a/test/stdio/iterable.js
+++ b/test/stdio/iterable.js
@@ -2,39 +2,21 @@ import test from 'ava';
 import {execa, execaSync} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {getStdinOption, getStdoutOption, getStderrOption, getStdioOption} from '../helpers/stdio.js';
+import {stringGenerator, binaryGenerator, asyncGenerator, throwingGenerator} from '../helpers/generator.js';
 
 setFixtureDir();
-
-const textEncoder = new TextEncoder();
-const binaryFoo = textEncoder.encode('foo');
-const binaryBar = textEncoder.encode('bar');
-
-const stringGenerator = function * () {
-	yield * ['foo', 'bar'];
-};
-
-const binaryGenerator = function * () {
-	yield * [binaryFoo, binaryBar];
-};
-
-// eslint-disable-next-line require-yield
-const throwingGenerator = function * () {
-	throw new Error('generator error');
-};
 
 const testIterable = async (t, stdioOption, fixtureName, getOptions) => {
 	const {stdout} = await execa(fixtureName, getOptions(stdioOption));
 	t.is(stdout, 'foobar');
 };
 
-test('stdin option can be a sync iterable of strings', testIterable, ['foo', 'bar'], 'stdin.js', getStdinOption);
-test('stdio[*] option can be a sync iterable of strings', testIterable, ['foo', 'bar'], 'stdin-fd3.js', getStdioOption);
-test('stdin option can be a sync iterable of Uint8Arrays', testIterable, [binaryFoo, binaryBar], 'stdin.js', getStdinOption);
-test('stdio[*] option can be a sync iterable of Uint8Arrays', testIterable, [binaryFoo, binaryBar], 'stdin-fd3.js', getStdioOption);
-test('stdin option can be an sync iterable of strings', testIterable, stringGenerator(), 'stdin.js', getStdinOption);
-test('stdio[*] option can be an sync iterable of strings', testIterable, stringGenerator(), 'stdin-fd3.js', getStdioOption);
-test('stdin option can be an sync iterable of Uint8Arrays', testIterable, binaryGenerator(), 'stdin.js', getStdinOption);
-test('stdio[*] option can be an sync iterable of Uint8Arrays', testIterable, binaryGenerator(), 'stdin-fd3.js', getStdioOption);
+test('stdin option can be an iterable of strings', testIterable, stringGenerator(), 'stdin.js', getStdinOption);
+test('stdio[*] option can be an iterable of strings', testIterable, stringGenerator(), 'stdin-fd3.js', getStdioOption);
+test('stdin option can be an iterable of Uint8Arrays', testIterable, binaryGenerator(), 'stdin.js', getStdinOption);
+test('stdio[*] option can be an iterable of Uint8Arrays', testIterable, binaryGenerator(), 'stdin-fd3.js', getStdioOption);
+test('stdin option can be an async iterable', testIterable, asyncGenerator(), 'stdin.js', getStdinOption);
+test('stdio[*] option can be an async iterable', testIterable, asyncGenerator(), 'stdin-fd3.js', getStdioOption);
 
 const testIterableSync = (t, stdioOption, fixtureName, getOptions) => {
 	t.throws(() => {
@@ -42,10 +24,10 @@ const testIterableSync = (t, stdioOption, fixtureName, getOptions) => {
 	}, {message: /an iterable in sync mode/});
 };
 
-test('stdin option cannot be a sync iterable - sync', testIterableSync, ['foo', 'bar'], 'stdin.js', getStdinOption);
-test('stdio[*] option cannot be a sync iterable - sync', testIterableSync, ['foo', 'bar'], 'stdin-fd3.js', getStdioOption);
-test('stdin option cannot be an async iterable - sync', testIterableSync, stringGenerator(), 'stdin.js', getStdinOption);
-test('stdio[*] option cannot be an async iterable - sync', testIterableSync, stringGenerator(), 'stdin-fd3.js', getStdioOption);
+test('stdin option cannot be a sync iterable - sync', testIterableSync, stringGenerator(), 'stdin.js', getStdinOption);
+test('stdio[*] option cannot be a sync iterable - sync', testIterableSync, stringGenerator(), 'stdin-fd3.js', getStdioOption);
+test('stdin option cannot be an async iterable - sync', testIterableSync, asyncGenerator(), 'stdin.js', getStdinOption);
+test('stdio[*] option cannot be an async iterable - sync', testIterableSync, asyncGenerator(), 'stdin-fd3.js', getStdioOption);
 
 const testIterableError = async (t, fixtureName, getOptions) => {
 	const {originalMessage} = await t.throwsAsync(execa(fixtureName, getOptions(throwingGenerator())));
@@ -57,7 +39,7 @@ test('stdio[*] option handles errors in iterables', testIterableError, 'stdin-fd
 
 const testNoIterableOutput = (t, getOptions, execaMethod) => {
 	t.throws(() => {
-		execaMethod('noop.js', getOptions(['foo', 'bar']));
+		execaMethod('noop.js', getOptions(stringGenerator()));
 	}, {message: /cannot be an iterable/});
 };
 


### PR DESCRIPTION
With #620, `stdin: iterable` will not allow Arrays as iterables anymore. This is ok since this is not a good use case for the `stdin: iterable` feature (users can use `input: array.join('')` instead), which is intended for generators instead, especially async ones.

This PR fixes the tests about iterables so they use generators instead of arrays.