### PR TITLE
Refactor `stdio` normalization logic

### DIFF
--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -5,13 +5,10 @@ import {handleInputOption, handleInputFileOption} from './input.js';
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async/sync mode
 export const handleInput = (addProperties, options) => {
 	const stdio = normalizeStdio(options);
-	const stdioArray = arrifyStdio(stdio);
-	const stdioStreams = stdioArray.map((stdioOption, index) => getStdioStream(stdioOption, index, addProperties, options));
-	options.stdio = transformStdio(stdio, stdioStreams);
+	const stdioStreams = stdio.map((stdioOption, index) => getStdioStream(stdioOption, index, addProperties, options));
+	options.stdio = transformStdio(stdioStreams);
 	return stdioStreams;
 };
-
-const arrifyStdio = (stdio = []) => Array.isArray(stdio) ? stdio : [stdio, stdio, stdio];
 
 const getStdioStream = (stdioOption, index, addProperties, {input, inputFile}) => {
 	let stdioStream = getInitialStdioStream(stdioOption, index);
@@ -55,8 +52,6 @@ For example, you can use the \`pathToFileURL()\` method of the \`url\` core modu
 
 // When the `std*: Iterable | WebStream | URL | filePath`, `input` or `inputFile` option is used, we pipe to `spawned.std*`.
 // Therefore the `std*` options must be either `pipe` or `overlapped`. Other values do not set `spawned.std*`.
-const transformStdio = (stdio, stdioStreams) => Array.isArray(stdio)
-	? stdio.map((stdioItem, index) => transformStdioItem(stdioItem, stdioStreams[index]))
-	: stdio;
+const transformStdio = stdioStreams => stdioStreams.map(stdioStream => transformStdioItem(stdioStream));
 
-const transformStdioItem = (stdioItem, {type}) => type !== 'native' && stdioItem !== 'overlapped' ? 'pipe' : stdioItem;
+const transformStdioItem = stdioStream => stdioStream.type !== 'native' && stdioStream.value !== 'overlapped' ? 'pipe' : stdioStream.value;

--- a/lib/stdio/normalize.js
+++ b/lib/stdio/normalize.js
@@ -1,7 +1,7 @@
 // Add support for `stdin`/`stdout`/`stderr` as an alias for `stdio`
 export const normalizeStdio = options => {
 	if (!options) {
-		return;
+		return [undefined, undefined, undefined];
 	}
 
 	const {stdio} = options;
@@ -15,7 +15,7 @@ export const normalizeStdio = options => {
 	}
 
 	if (typeof stdio === 'string') {
-		return stdio;
+		return [stdio, stdio, stdio];
 	}
 
 	if (!Array.isArray(stdio)) {
@@ -33,18 +33,5 @@ const aliases = ['stdin', 'stdout', 'stderr'];
 // Same but for `execaNode()`, i.e. push `ipc` unless already present
 export const normalizeStdioNode = options => {
 	const stdio = normalizeStdio(options);
-
-	if (stdio === 'ipc') {
-		return 'ipc';
-	}
-
-	if (stdio === undefined || typeof stdio === 'string') {
-		return [stdio, stdio, stdio, 'ipc'];
-	}
-
-	if (stdio.includes('ipc')) {
-		return stdio;
-	}
-
-	return [...stdio, 'ipc'];
+	return stdio.includes('ipc') ? stdio : [...stdio, 'ipc'];
 };

--- a/test/stdio/normalize.js
+++ b/test/stdio/normalize.js
@@ -18,12 +18,12 @@ const macroTitle = name => (title, input) => `${name} ${(inspect(input))}`;
 const stdioMacro = (...args) => macro(...args, normalizeStdio);
 stdioMacro.title = macroTitle('execa()');
 
-test(stdioMacro, undefined, undefined);
-test(stdioMacro, null, undefined);
+test(stdioMacro, undefined, [undefined, undefined, undefined]);
+test(stdioMacro, null, [undefined, undefined, undefined]);
 
-test(stdioMacro, {stdio: 'inherit'}, 'inherit');
-test(stdioMacro, {stdio: 'pipe'}, 'pipe');
-test(stdioMacro, {stdio: 'ignore'}, 'ignore');
+test(stdioMacro, {stdio: 'inherit'}, ['inherit', 'inherit', 'inherit']);
+test(stdioMacro, {stdio: 'pipe'}, ['pipe', 'pipe', 'pipe']);
+test(stdioMacro, {stdio: 'ignore'}, ['ignore', 'ignore', 'ignore']);
 test(stdioMacro, {stdio: [0, 1, 2]}, [0, 1, 2]);
 
 test(stdioMacro, {}, [undefined, undefined, undefined]);
@@ -52,7 +52,7 @@ forkMacro.title = macroTitle('execaNode()');
 
 test(forkMacro, undefined, [undefined, undefined, undefined, 'ipc']);
 test(forkMacro, {stdio: 'ignore'}, ['ignore', 'ignore', 'ignore', 'ipc']);
-test(forkMacro, {stdio: 'ipc'}, 'ipc');
+test(forkMacro, {stdio: 'ipc'}, ['ipc', 'ipc', 'ipc']);
 test(forkMacro, {stdio: [0, 1, 2]}, [0, 1, 2, 'ipc']);
 test(forkMacro, {stdio: [0, 1, 2, 3]}, [0, 1, 2, 3, 'ipc']);
 test(forkMacro, {stdio: [0, 1, 2, 'ipc']}, [0, 1, 2, 'ipc']);


### PR DESCRIPTION
When a user passes `stdio: undefined` or `stdio: 'pipe'`, we currently keep it as is.
This PR normalizes it instead to `stdio: [undefined, undefined, undefined]` and `stdio: ['pipe', 'pipe', 'pipe']`.

According to [Node.js documentation](https://nodejs.org/api/child_process.html#optionsstdio), this is the same:

> For convenience, options.stdio may be one of the following strings:
>    'pipe': equivalent to ['pipe', 'pipe', 'pipe'] (the default)

I also checked the Node.js source code. Our tests also pass.

Finally, users cannot access the actual options being passed, so if the behavior is the same, there is no difference from a user standpoint.

Normalizing `stdio` to be always an array is helping working with that option without having duplicate logic (one for when it is an array, one for when it is not). 

I.e. this PR does not change any behavior, it is just meant to simplify working on the `stdio` option.