### PR TITLE
Refactor `stdio` option logic

### DIFF
--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -22,8 +22,8 @@ const addPropertiesAsync = {
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, after spawning, in async mode
 export const pipeOutputAsync = (spawned, stdioStreams) => {
-	for (const [index, stdioStream] of stdioStreams.entries()) {
-		pipeStdioOption(spawned.stdio[index], stdioStream);
+	for (const stdioStream of stdioStreams) {
+		pipeStdioOption(spawned.stdio[stdioStream.index], stdioStream);
 	}
 };
 

--- a/lib/stdio/direction.js
+++ b/lib/stdio/direction.js
@@ -1,0 +1,42 @@
+import {
+	isStream as isNodeStream,
+	isReadableStream as isNodeReadableStream,
+	isWritableStream as isNodeWritableStream,
+} from 'is-stream';
+import {isWritableStream} from './type.js';
+
+// For `stdio[index]` beyond stdin/stdout/stderr, we need to guess whether the value passed is intended for inputs or outputs.
+// This allows us to know whether to pipe _into_ or _from_ the stream.
+export const addStreamDirection = stdioStream => {
+	const direction = getStreamDirection(stdioStream);
+	return addDirection(stdioStream, direction);
+};
+
+const getStreamDirection = stdioStream => KNOWN_DIRECTIONS[stdioStream.index] ?? guessStreamDirection[stdioStream.type](stdioStream.value);
+
+// `stdin`/`stdout`/`stderr` have a known direction
+const KNOWN_DIRECTIONS = ['input', 'output', 'output'];
+
+// `stringOrBuffer` type always applies to `stdin`, i.e. does not need to be handled here
+const guessStreamDirection = {
+	filePath: () => undefined,
+	iterable: () => 'input',
+	webStream: stdioOption => isWritableStream(stdioOption) ? 'output' : 'input',
+	nodeStream(stdioOption) {
+		if (isNodeReadableStream(stdioOption)) {
+			return isNodeWritableStream(stdioOption) ? undefined : 'input';
+		}
+
+		return 'output';
+	},
+	native(stdioOption) {
+		if (isNodeStream(stdioOption)) {
+			return guessStreamDirection.nodeStream(stdioOption);
+		}
+	},
+};
+
+const addDirection = (stdioStream, direction = DEFAULT_DIRECTION) => ({...stdioStream, direction});
+
+// When the ambiguity remains, we default to `output` since it is the most common use case for additional file descriptors.
+const DEFAULT_DIRECTION = 'output';

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -1,43 +1,34 @@
-import {getStdioOptionType, isRegularUrl, isUnknownStdioString, isInputDirection} from './type.js';
+import {getStdioOptionType, isRegularUrl, isUnknownStdioString} from './type.js';
+import {addStreamDirection} from './direction.js';
 import {normalizeStdio} from './normalize.js';
 import {handleInputOption, handleInputFileOption} from './input.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async/sync mode
 export const handleInput = (addProperties, options) => {
 	const stdio = normalizeStdio(options);
-	const stdioStreams = stdio.map((stdioOption, index) => getStdioStream(stdioOption, index, addProperties, options));
+	const stdioStreams = stdio
+		.map((stdioOption, index) => getStdioStream(stdioOption, index, options))
+		.map(stdioStream => addStreamDirection(stdioStream))
+		.map(stdioStream => addStreamProperties(stdioStream, addProperties));
 	options.stdio = transformStdio(stdioStreams);
 	return stdioStreams;
 };
 
-const getStdioStream = (stdioOption, index, addProperties, {input, inputFile}) => {
-	let stdioStream = getInitialStdioStream(stdioOption, index);
+const getStdioStream = (stdioOption, index, {input, inputFile}) => {
+	const optionName = getOptionName(index);
+	const type = getStdioOptionType(stdioOption);
+	let stdioStream = {type, value: stdioOption, optionName, index};
 
-	stdioStream = handleInputOption(stdioStream, index, input);
-	stdioStream = handleInputFileOption(stdioStream, index, inputFile, input);
+	stdioStream = handleInputOption(stdioStream, input);
+	stdioStream = handleInputFileOption(stdioStream, inputFile, input);
 
 	validateFileStdio(stdioStream);
 
-	return {
-		...stdioStream,
-		...addProperties[stdioStream.direction][stdioStream.type]?.(stdioStream),
-	};
+	return stdioStream;
 };
 
-const getInitialStdioStream = (stdioOption, index) => {
-	const type = getStdioOptionType(stdioOption);
-	const {
-		optionName = `stdio[${index}]`,
-		direction = isInputDirection[type](stdioOption) ? 'input' : 'output',
-	} = KNOWN_STREAMS[index] ?? {};
-	return {type, value: stdioOption, optionName, direction};
-};
-
-const KNOWN_STREAMS = [
-	{optionName: 'stdin', direction: 'input'},
-	{optionName: 'stdout', direction: 'output'},
-	{optionName: 'stderr', direction: 'output'},
-];
+const getOptionName = index => KNOWN_OPTION_NAMES[index] ?? `stdio[${index}]`;
+const KNOWN_OPTION_NAMES = ['stdin', 'stdout', 'stderr'];
 
 const validateFileStdio = ({type, value, optionName}) => {
 	if (isRegularUrl(value)) {
@@ -49,6 +40,14 @@ For example, you can use the \`pathToFileURL()\` method of the \`url\` core modu
 		throw new TypeError(`The \`${optionName}: filePath\` option must either be an absolute file path or start with \`.\`.`);
 	}
 };
+
+// Some `stdio` values require Execa to create streams.
+// For example, file paths create file read/write streams.
+// Those transformations are specified in `addProperties`, which is both direction-specific and type-specific.
+const addStreamProperties = (stdioStream, addProperties) => ({
+	...stdioStream,
+	...addProperties[stdioStream.direction][stdioStream.type]?.(stdioStream),
+});
 
 // When the `std*: Iterable | WebStream | URL | filePath`, `input` or `inputFile` option is used, we pipe to `spawned.std*`.
 // Therefore the `std*` options must be either `pipe` or `overlapped`. Other values do not set `spawned.std*`.

--- a/lib/stdio/input.js
+++ b/lib/stdio/input.js
@@ -1,8 +1,8 @@
 import {isStream as isNodeStream} from 'is-stream';
 
 // Override the `stdin` option with the `input` option
-export const handleInputOption = (stdioStream, index, input) => {
-	if (input === undefined || index !== 0) {
+export const handleInputOption = (stdioStream, input) => {
+	if (input === undefined || stdioStream.index !== 0) {
 		return stdioStream;
 	}
 
@@ -13,8 +13,8 @@ export const handleInputOption = (stdioStream, index, input) => {
 };
 
 // Override the `stdin` option with the `inputFile` option
-export const handleInputFileOption = (stdioStream, index, inputFile, input) => {
-	if (inputFile === undefined || index !== 0) {
+export const handleInputFileOption = (stdioStream, inputFile, input) => {
+	if (inputFile === undefined || stdioStream.index !== 0) {
 		return stdioStream;
 	}
 

--- a/lib/stdio/sync.js
+++ b/lib/stdio/sync.js
@@ -14,6 +14,8 @@ const forbiddenIfStreamSync = ({value, optionName}) => {
 	if (isNodeStream(value)) {
 		forbiddenIfSync({type: 'nodeStream', optionName});
 	}
+
+	return {};
 };
 
 const forbiddenIfSync = ({type, optionName}) => {
@@ -49,8 +51,8 @@ export const pipeOutputSync = (stdioStreams, result) => {
 		return;
 	}
 
-	for (const [index, stdioStream] of stdioStreams.entries()) {
-		pipeStdioOptionSync(result.output[index], stdioStream);
+	for (const stdioStream of stdioStreams) {
+		pipeStdioOptionSync(result.output[stdioStream.index], stdioStream);
 	}
 };
 

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -1,9 +1,5 @@
 import {isAbsolute} from 'node:path';
-import {
-	isStream as isNodeStream,
-	isReadableStream as isNodeReadableStream,
-	isWritableStream as isNodeWritableStream,
-} from 'is-stream';
+import {isStream as isNodeStream} from 'is-stream';
 
 // The `stdin`/`stdout`/`stderr` option can be of many types. This detects it.
 export const getStdioOptionType = stdioOption => {
@@ -38,23 +34,12 @@ export const isUnknownStdioString = (type, stdioOption) => type === 'native' && 
 const KNOWN_STDIO_STRINGS = new Set(['ipc', 'ignore', 'inherit', 'overlapped', 'pipe']);
 
 const isReadableStream = stdioOption => Object.prototype.toString.call(stdioOption) === '[object ReadableStream]';
-const isWritableStream = stdioOption => Object.prototype.toString.call(stdioOption) === '[object WritableStream]';
+export const isWritableStream = stdioOption => Object.prototype.toString.call(stdioOption) === '[object WritableStream]';
 const isWebStream = stdioOption => isReadableStream(stdioOption) || isWritableStream(stdioOption);
 
 const isIterableObject = stdinOption => typeof stdinOption === 'object'
 	&& stdinOption !== null
 	&& (typeof stdinOption[Symbol.asyncIterator] === 'function' || typeof stdinOption[Symbol.iterator] === 'function');
-
-// For `stdio[index]` beyond stdin/stdout/stderr, we need to guess whether the value passed is intended for inputs or outputs.
-// When ambiguous, we default to `output` since it is the most common use case for additional file descriptors.
-// For the same reason, Duplex streams and TransformStreams are considered as outputs.
-// `nodeStream` and `stringOrBuffer` types always apply to `stdin`, i.e. missing here.
-export const isInputDirection = {
-	filePath: () => false,
-	webStream: stdioOption => !isWritableStream(stdioOption),
-	native: stdioOption => (isNodeReadableStream(stdioOption) && !isNodeWritableStream(stdioOption)) || stdioOption === 0,
-	iterable: () => true,
-};
 
 // Convert types to human-friendly strings for error messages
 export const TYPE_TO_MESSAGE = {


### PR DESCRIPTION
This PR refactors the logic related to the `stdin`/`stdout`/`stderr`/`stdio` options.
This refactoring will help implementing #620, in another PR.
This does not change any behavior, only moves logic around.