### PR TITLE
Undocument `sudo-prompt`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -886,7 +886,6 @@ console.log('3');
 
 - [gulp-execa](https://github.com/ehmicky/gulp-execa) - Gulp plugin for Execa
 - [nvexeca](https://github.com/ehmicky/nvexeca) - Run Execa using any Node.js version
-- [sudo-prompt](https://github.com/jorangreef/sudo-prompt) - Run commands with elevated privileges.
 
 ## Maintainers
 


### PR DESCRIPTION
Our `readme.md` has a link to `sudo-prompt`.
However, it appears that project has been archived and has been abandoned for several years now. 
Considering this is a security-related package, it might not be advisable to use a project that will not receive any bug fixes or security patches. Therefore, should we undocument it?