### PR TITLE
Allow `stdin`/`stdout`/`stderr` to be an array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -125,7 +125,7 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	- web [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 	- [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)
 
-	This can be an array of values such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
+	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
 	@default `inherit` with `$`, `pipe` otherwise
 	*/
@@ -146,7 +146,7 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	- file URL.
 	- web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 
-	This can be an array of values such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
+	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
 	@default 'pipe'
 	*/
@@ -167,7 +167,7 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	- file URL.
 	- web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 
-	This can be an array of values such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
+	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
 	@default 'pipe'
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,9 +25,15 @@ type OutputStdioOption =
 	| Writable
 	| WritableStream;
 
-export type StdinOption = CommonStdioOption | InputStdioOption;
-export type StdoutStderrOption = CommonStdioOption | OutputStdioOption;
-export type StdioOption = CommonStdioOption | InputStdioOption | OutputStdioOption;
+export type StdinOption =
+	CommonStdioOption | InputStdioOption
+	| Array<CommonStdioOption | InputStdioOption>;
+export type StdoutStderrOption =
+	CommonStdioOption | OutputStdioOption
+	| Array<CommonStdioOption | OutputStdioOption>;
+export type StdioOption =
+	CommonStdioOption | InputStdioOption | OutputStdioOption
+	| Array<CommonStdioOption | InputStdioOption | OutputStdioOption>;
 
 type StdioOptions =
 	| BaseStdioOption
@@ -119,6 +125,8 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	- web [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 	- [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)
 
+	This can be an array of values such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
+
 	@default `inherit` with `$`, `pipe` otherwise
 	*/
 	readonly stdin?: StdinOption;
@@ -138,6 +146,8 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	- file URL.
 	- web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 
+	This can be an array of values such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
+
 	@default 'pipe'
 	*/
 	readonly stdout?: StdoutStderrOption;
@@ -156,6 +166,8 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	- file path. If relative, it must start with `.`.
 	- file URL.
 	- web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
+
+	This can be an array of values such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
 	@default 'pipe'
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -174,6 +174,17 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	readonly stderr?: StdoutStderrOption;
 
 	/**
+	Like the `stdin`, `stdout` and `stderr` options but for all file descriptors at once. For example, `{stdio: ['ignore', 'pipe', 'pipe']}` is the same as `{stdin: 'ignore', stdout: 'pipe', stderr: 'pipe'}`.
+
+	A single string can be used as a shortcut. For example, `{stdio: 'pipe'}` is the same as `{stdin: 'pipe', stdout: 'pipe', stderr: 'pipe'}`.
+
+	The array can have more than 3 items, to create additional file descriptors beyond `stdin`/`stdout`/`stderr`. For example, `{stdio: ['pipe', 'pipe', 'pipe', 'ipc']}` sets a fourth file descriptor `'ipc'`.
+
+	@default 'pipe'
+	*/
+	readonly stdio?: StdioOptions;
+
+	/**
 	Setting this to `false` resolves the promise with the error instead of rejecting it.
 
 	@default true
@@ -219,16 +230,6 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	Explicitly set the value of `argv[0]` sent to the child process. This will be set to `command` or `file` if not specified.
 	*/
 	readonly argv0?: string;
-
-	/**
-	Like the `stdin`, `stdout` and `stderr` options but for all file descriptors at once.
-	The possible values are the same except it can also be:
-	- a single string, to set the same value to each standard stream.
-	- an array with more than 3 values, to create more than 3 file descriptors.
-
-	@default 'pipe'
-	*/
-	readonly stdio?: StdioOptions;
 
 	/**
 	Specify the kind of serialization used for sending messages between processes when using the `stdio: 'ipc'` option or `execaNode()`:

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -160,54 +160,100 @@ execa('unicorns', {input: process.stdin});
 execa('unicorns', {inputFile: ''});
 execa('unicorns', {inputFile: fileUrl});
 execa('unicorns', {stdin: 'pipe'});
+execa('unicorns', {stdin: ['pipe']});
 execa('unicorns', {stdin: 'overlapped'});
+execa('unicorns', {stdin: ['overlapped']});
 execa('unicorns', {stdin: 'ipc'});
+execa('unicorns', {stdin: ['ipc']});
 execa('unicorns', {stdin: 'ignore'});
+execa('unicorns', {stdin: ['ignore']});
 execa('unicorns', {stdin: 'inherit'});
+execa('unicorns', {stdin: ['inherit']});
 execa('unicorns', {stdin: process.stdin});
+execa('unicorns', {stdin: [process.stdin]});
 execa('unicorns', {stdin: new Readable()});
+execa('unicorns', {stdin: [new Readable()]});
 expectError(execa('unicorns', {stdin: new Writable()}));
+expectError(execa('unicorns', {stdin: [new Writable()]}));
 execa('unicorns', {stdin: new ReadableStream()});
+execa('unicorns', {stdin: [new ReadableStream()]});
 expectError(execa('unicorns', {stdin: new WritableStream()}));
-execa('unicorns', {stdin: ['']});
-execa('unicorns', {stdin: [new Uint8Array(0)]});
+expectError(execa('unicorns', {stdin: [new WritableStream()]}));
 execa('unicorns', {stdin: stringGenerator()});
+execa('unicorns', {stdin: [stringGenerator()]});
 execa('unicorns', {stdin: binaryGenerator()});
+execa('unicorns', {stdin: [binaryGenerator()]});
 execa('unicorns', {stdin: asyncStringGenerator()});
-expectError(execa('unicorns', {stdin: [0]}));
+execa('unicorns', {stdin: [asyncStringGenerator()]});
 expectError(execa('unicorns', {stdin: numberGenerator()}));
+expectError(execa('unicorns', {stdin: [numberGenerator()]}));
 execa('unicorns', {stdin: fileUrl});
+execa('unicorns', {stdin: [fileUrl]});
 execa('unicorns', {stdin: './test'});
+execa('unicorns', {stdin: ['./test']});
 execa('unicorns', {stdin: 1});
+execa('unicorns', {stdin: [1]});
 execa('unicorns', {stdin: undefined});
+execa('unicorns', {stdin: [undefined]});
+execa('unicorns', {stdin: ['pipe', 'inherit']});
 execa('unicorns', {stdout: 'pipe'});
+execa('unicorns', {stdout: ['pipe']});
 execa('unicorns', {stdout: 'overlapped'});
+execa('unicorns', {stdout: ['overlapped']});
 execa('unicorns', {stdout: 'ipc'});
+execa('unicorns', {stdout: ['ipc']});
 execa('unicorns', {stdout: 'ignore'});
+execa('unicorns', {stdout: ['ignore']});
 execa('unicorns', {stdout: 'inherit'});
+execa('unicorns', {stdout: ['inherit']});
 execa('unicorns', {stdout: process.stdout});
+execa('unicorns', {stdout: [process.stdout]});
 execa('unicorns', {stdout: new Writable()});
+execa('unicorns', {stdout: [new Writable()]});
 expectError(execa('unicorns', {stdout: new Readable()}));
+expectError(execa('unicorn', {stdout: [new Readable()]}));
 execa('unicorns', {stdout: new WritableStream()});
+execa('unicorns', {stdout: [new WritableStream()]});
 expectError(execa('unicorns', {stdout: new ReadableStream()}));
+expectError(execa('unicorn', {stdout: [new ReadableStream()]}));
 execa('unicorns', {stdout: fileUrl});
+execa('unicorns', {stdout: [fileUrl]});
 execa('unicorns', {stdout: './test'});
+execa('unicorns', {stdout: ['./test']});
 execa('unicorns', {stdout: 1});
+execa('unicorns', {stdout: [1]});
 execa('unicorns', {stdout: undefined});
+execa('unicorns', {stdout: [undefined]});
+execa('unicorns', {stdout: ['pipe', 'inherit']});
 execa('unicorns', {stderr: 'pipe'});
+execa('unicorns', {stderr: ['pipe']});
 execa('unicorns', {stderr: 'overlapped'});
+execa('unicorns', {stderr: ['overlapped']});
 execa('unicorns', {stderr: 'ipc'});
+execa('unicorns', {stderr: ['ipc']});
 execa('unicorns', {stderr: 'ignore'});
+execa('unicorns', {stderr: ['ignore']});
 execa('unicorns', {stderr: 'inherit'});
+execa('unicorns', {stderr: ['inherit']});
 execa('unicorns', {stderr: process.stderr});
+execa('unicorns', {stderr: [process.stderr]});
 execa('unicorns', {stderr: new Writable()});
+execa('unicorns', {stderr: [new Writable()]});
 expectError(execa('unicorns', {stderr: new Readable()}));
+expectError(execa('unicorns', {stderr: [new Readable()]}));
 execa('unicorns', {stderr: new WritableStream()});
+execa('unicorns', {stderr: [new WritableStream()]});
 expectError(execa('unicorns', {stderr: new ReadableStream()}));
+expectError(execa('unicorns', {stderr: [new ReadableStream()]}));
 execa('unicorns', {stderr: fileUrl});
+execa('unicorns', {stderr: [fileUrl]});
 execa('unicorns', {stderr: './test'});
+execa('unicorns', {stderr: ['./test']});
 execa('unicorns', {stderr: 1});
+execa('unicorns', {stderr: [1]});
 execa('unicorns', {stderr: undefined});
+execa('unicorns', {stderr: [undefined]});
+execa('unicorns', {stderr: ['pipe', 'inherit']});
 execa('unicorns', {all: true});
 execa('unicorns', {reject: false});
 execa('unicorns', {stripFinalNewline: false});
@@ -233,11 +279,17 @@ expectError(execa('unicorns', {stdio: stringGenerator()}));
 expectError(execa('unicorns', {stdio: asyncStringGenerator()}));
 expectError(execa('unicorns', {stdio: ['pipe', 'pipe']}));
 execa('unicorns', {stdio: [new Readable(), 'pipe', 'pipe']});
+execa('unicorns', {stdio: [[new Readable()], ['pipe'], ['pipe']]});
 execa('unicorns', {stdio: ['pipe', new Writable(), 'pipe']});
+execa('unicorns', {stdio: [['pipe'], [new Writable()], ['pipe']]});
 execa('unicorns', {stdio: ['pipe', 'pipe', new Writable()]});
+execa('unicorns', {stdio: [['pipe'], ['pipe'], [new Writable()]]});
 expectError(execa('unicorns', {stdio: [new Writable(), 'pipe', 'pipe']}));
+expectError(execa('unicorns', {stdio: [[new Writable()], ['pipe'], ['pipe']]}));
 expectError(execa('unicorns', {stdio: ['pipe', new Readable(), 'pipe']}));
+expectError(execa('unicorns', {stdio: [['pipe'], [new Readable()], ['pipe']]}));
 expectError(execa('unicorns', {stdio: ['pipe', 'pipe', new Readable()]}));
+expectError(execa('unicorns', {stdio: [['pipe'], ['pipe'], [new Readable()]]}));
 execa('unicorns', {
 	stdio: [
 		'pipe',
@@ -256,6 +308,27 @@ execa('unicorns', {
 		new ReadableStream(),
 		stringGenerator(),
 		asyncStringGenerator(),
+	],
+});
+execa('unicorns', {
+	stdio: [
+		['pipe'],
+		['pipe', 'inherit'],
+		['overlapped'],
+		['ipc'],
+		['ignore'],
+		['inherit'],
+		[process.stdin],
+		[1],
+		[undefined],
+		[fileUrl],
+		['./test'],
+		[new Writable()],
+		[new Readable()],
+		[new WritableStream()],
+		[new ReadableStream()],
+		[stringGenerator()],
+		[asyncStringGenerator()],
 	],
 });
 execa('unicorns', {serialization: 'advanced'});

--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -7,13 +7,13 @@ export const handleInputAsync = options => handleInput(addPropertiesAsync, optio
 
 const addPropertiesAsync = {
 	input: {
-		filePath: ({value}) => ({value: createReadStream(value)}),
-		webStream: ({value}) => ({value: Readable.fromWeb(value)}),
-		iterable: ({value}) => ({value: Readable.from(value)}),
+		filePath: ({value}) => ({value: createReadStream(value), autoDestroy: true}),
+		webStream: ({value}) => ({value: Readable.fromWeb(value), autoDestroy: true}),
+		iterable: ({value}) => ({value: Readable.from(value), autoDestroy: true}),
 	},
 	output: {
-		filePath: ({value}) => ({value: createWriteStream(value)}),
-		webStream: ({value}) => ({value: Writable.fromWeb(value)}),
+		filePath: ({value}) => ({value: createWriteStream(value), autoDestroy: true}),
+		webStream: ({value}) => ({value: Writable.fromWeb(value), autoDestroy: true}),
 		iterable({optionName}) {
 			throw new TypeError(`The \`${optionName}\` option cannot be an iterable.`);
 		},

--- a/lib/stdio/direction.js
+++ b/lib/stdio/direction.js
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import {
 	isStream as isNodeStream,
 	isReadableStream as isNodeReadableStream,
@@ -7,9 +8,26 @@ import {isWritableStream} from './type.js';
 
 // For `stdio[index]` beyond stdin/stdout/stderr, we need to guess whether the value passed is intended for inputs or outputs.
 // This allows us to know whether to pipe _into_ or _from_ the stream.
-export const addStreamDirection = stdioStream => {
+// When `stdio[index]` is a single value, this guess is fairly straightforward.
+// However, when it is an array instead, we also need to make sure the different values are not incompatible with each other.
+export const addStreamDirection = stdioStream => Array.isArray(stdioStream)
+	? addStreamArrayDirection(stdioStream)
+	: addStreamSingleDirection(stdioStream);
+
+const addStreamSingleDirection = stdioStream => {
 	const direction = getStreamDirection(stdioStream);
 	return addDirection(stdioStream, direction);
+};
+
+const addStreamArrayDirection = stdioStream => {
+	const directions = stdioStream.map(stdioStreamItem => getStreamDirection(stdioStreamItem));
+
+	if (directions.includes('input') && directions.includes('output')) {
+		throw new TypeError(`The \`${stdioStream[0].optionName}\` option must not be an array of both readable and writable values.`);
+	}
+
+	const direction = directions.find(Boolean);
+	return stdioStream.map(stdioStreamItem => addDirection(stdioStreamItem, direction));
 };
 
 const getStreamDirection = stdioStream => KNOWN_DIRECTIONS[stdioStream.index] ?? guessStreamDirection[stdioStream.type](stdioStream.value);
@@ -30,6 +48,14 @@ const guessStreamDirection = {
 		return 'output';
 	},
 	native(stdioOption) {
+		if ([0, process.stdin].includes(stdioOption)) {
+			return 'input';
+		}
+
+		if ([1, 2, process.stdout, process.stderr].includes(stdioOption)) {
+			return 'output';
+		}
+
 		if (isNodeStream(stdioOption)) {
 			return guessStreamDirection.nodeStream(stdioOption);
 		}
@@ -38,5 +64,8 @@ const guessStreamDirection = {
 
 const addDirection = (stdioStream, direction = DEFAULT_DIRECTION) => ({...stdioStream, direction});
 
+// When ambiguous, we initially keep the direction as `undefined`.
+// This allows arrays of `stdio` values to resolve the ambiguity.
+// For example, `stdio[3]: DuplexStream` is ambiguous, but `stdio[3]: [DuplexStream, WritableStream]` is not.
 // When the ambiguity remains, we default to `output` since it is the most common use case for additional file descriptors.
 const DEFAULT_DIRECTION = 'output';

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -2,33 +2,71 @@ import {getStdioOptionType, isRegularUrl, isUnknownStdioString} from './type.js'
 import {addStreamDirection} from './direction.js';
 import {normalizeStdio} from './normalize.js';
 import {handleInputOption, handleInputFileOption} from './input.js';
+import {handleNativeStream} from './native.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async/sync mode
 export const handleInput = (addProperties, options) => {
 	const stdio = normalizeStdio(options);
 	const stdioStreams = stdio
-		.map((stdioOption, index) => getStdioStream(stdioOption, index, options))
+		.map((stdioOption, index) => getStdioStreams(stdioOption, index, options))
 		.map(stdioStream => addStreamDirection(stdioStream))
-		.map(stdioStream => addStreamProperties(stdioStream, addProperties));
+		.map(stdioStream => addStreamsProperties(stdioStream, addProperties));
 	options.stdio = transformStdio(stdioStreams);
-	return stdioStreams;
+	return stdioStreams.flat();
 };
 
-const getStdioStream = (stdioOption, index, {input, inputFile}) => {
+// We make sure passing an array with a single item behaves the same as passing that item without an array.
+// This is what users would expect.
+// For example, `stdout: ['ignore']` behaves the same as `stdout: 'ignore'`.
+const getStdioStreams = (stdioOption, index, options) => {
 	const optionName = getOptionName(index);
+	const stdioParameters = {...options, optionName, index};
+
+	if (!Array.isArray(stdioOption)) {
+		return getStdioStream(stdioOption, false, stdioParameters);
+	}
+
+	if (stdioOption.length === 0) {
+		throw new TypeError(`The \`${optionName}\` option must not be an empty array.`);
+	}
+
+	const stdioOptionArray = [...new Set(stdioOption)];
+	if (stdioOptionArray.length === 1) {
+		return getStdioStream(stdioOptionArray[0], false, stdioParameters);
+	}
+
+	validateStdioArray(stdioOptionArray, optionName);
+
+	return stdioOptionArray.map(stdioOptionItem => getStdioStream(stdioOptionItem, true, stdioParameters));
+};
+
+const getOptionName = index => KNOWN_OPTION_NAMES[index] ?? `stdio[${index}]`;
+const KNOWN_OPTION_NAMES = ['stdin', 'stdout', 'stderr'];
+
+const validateStdioArray = (stdioOptionArray, optionName) => {
+	for (const invalidStdioOption of INVALID_STDIO_ARRAY_OPTIONS) {
+		if (stdioOptionArray.includes(invalidStdioOption)) {
+			throw new Error(`The \`${optionName}\` option must not include \`${invalidStdioOption}\`.`);
+		}
+	}
+};
+
+// Using those `stdio` values together with others for the same stream does not make sense, so we make it fail.
+// However, we do allow it if the array has a single item.
+const INVALID_STDIO_ARRAY_OPTIONS = ['ignore', 'ipc'];
+
+const getStdioStream = (stdioOption, isStdioArray, {optionName, index, input, inputFile}) => {
 	const type = getStdioOptionType(stdioOption);
 	let stdioStream = {type, value: stdioOption, optionName, index};
 
 	stdioStream = handleInputOption(stdioStream, input);
 	stdioStream = handleInputFileOption(stdioStream, inputFile, input);
+	stdioStream = handleNativeStream(stdioStream, isStdioArray);
 
 	validateFileStdio(stdioStream);
 
 	return stdioStream;
 };
-
-const getOptionName = index => KNOWN_OPTION_NAMES[index] ?? `stdio[${index}]`;
-const KNOWN_OPTION_NAMES = ['stdin', 'stdout', 'stderr'];
 
 const validateFileStdio = ({type, value, optionName}) => {
 	if (isRegularUrl(value)) {
@@ -44,13 +82,24 @@ For example, you can use the \`pathToFileURL()\` method of the \`url\` core modu
 // Some `stdio` values require Execa to create streams.
 // For example, file paths create file read/write streams.
 // Those transformations are specified in `addProperties`, which is both direction-specific and type-specific.
+const addStreamsProperties = (stdioStream, addProperties) => Array.isArray(stdioStream)
+	? stdioStream.map(stdioStreamItem => addStreamProperties(stdioStreamItem, addProperties))
+	: addStreamProperties(stdioStream, addProperties);
+
 const addStreamProperties = (stdioStream, addProperties) => ({
 	...stdioStream,
 	...addProperties[stdioStream.direction][stdioStream.type]?.(stdioStream),
 });
 
 // When the `std*: Iterable | WebStream | URL | filePath`, `input` or `inputFile` option is used, we pipe to `spawned.std*`.
+// When the `std*: Array` option is used, we emulate some of the native values ('inherit', Node.js stream and file descriptor integer). To do so, we also need to pipe to `spawned.std*`.
 // Therefore the `std*` options must be either `pipe` or `overlapped`. Other values do not set `spawned.std*`.
 const transformStdio = stdioStreams => stdioStreams.map(stdioStream => transformStdioItem(stdioStream));
 
-const transformStdioItem = stdioStream => stdioStream.type !== 'native' && stdioStream.value !== 'overlapped' ? 'pipe' : stdioStream.value;
+const transformStdioItem = stdioStream => {
+	if (Array.isArray(stdioStream)) {
+		return stdioStream.some(({value}) => value === 'overlapped') ? 'overlapped' : 'pipe';
+	}
+
+	return stdioStream.type !== 'native' && stdioStream.value !== 'overlapped' ? 'pipe' : stdioStream.value;
+};

--- a/lib/stdio/native.js
+++ b/lib/stdio/native.js
@@ -1,0 +1,44 @@
+import process from 'node:process';
+import {isStream as isNodeStream} from 'is-stream';
+
+// When we use multiple `stdio` values for the same streams, we pass 'pipe' to `child_process.spawn()`.
+// We then emulate the piping done by core Node.js.
+// To do so, we transform the following values:
+//  - Node.js streams are marked as `type: nodeStream`
+//  - 'inherit' becomes `process.stdin|stdout|stderr`
+//  - any file descriptor integer becomes `process.stdio[index]`
+// All of the above transformations tell Execa to perform manual piping.
+export const handleNativeStream = (stdioStream, isStdioArray) => {
+	const {type, value, index, optionName} = stdioStream;
+
+	if (!isStdioArray || type !== 'native') {
+		return stdioStream;
+	}
+
+	if (value === 'inherit') {
+		return {...stdioStream, type: 'nodeStream', value: getStandardStream(index, value, optionName)};
+	}
+
+	if (typeof value === 'number') {
+		return {...stdioStream, type: 'nodeStream', value: getStandardStream(value, value, optionName)};
+	}
+
+	if (isNodeStream(value)) {
+		return {...stdioStream, type: 'nodeStream'};
+	}
+
+	return stdioStream;
+};
+
+// Node.js does not allow to easily retrieve file descriptors beyond stdin/stdout/stderr as streams
+const getStandardStream = (index, value, optionName) => {
+	const standardStream = STANDARD_STREAMS[index];
+
+	if (standardStream === undefined) {
+		throw new TypeError(`The \`${optionName}: ${value}\` option is invalid: no such standard stream.`);
+	}
+
+	return standardStream;
+};
+
+const STANDARD_STREAMS = [process.stdin, process.stdout, process.stderr];

--- a/lib/stdio/native.js
+++ b/lib/stdio/native.js
@@ -30,7 +30,11 @@ export const handleNativeStream = (stdioStream, isStdioArray) => {
 	return stdioStream;
 };
 
-// Node.js does not allow to easily retrieve file descriptors beyond stdin/stdout/stderr as streams
+// Node.js does not allow to easily retrieve file descriptors beyond stdin/stdout/stderr as streams.
+//  - `fs.createReadStream()`/`fs.createWriteStream()` with the `fd` option do not work with character devices that use blocking reads/writes (such as interactive TTYs).
+//  - Using a TCP `Socket` would work but be rather complex to implement.
+// Since this is an edge case, we simply throw an error message.
+// See https://github.com/sindresorhus/execa/pull/643#discussion_r1435905707
 const getStandardStream = (index, value, optionName) => {
 	const standardStream = STANDARD_STREAMS[index];
 

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -37,9 +37,10 @@ const isReadableStream = stdioOption => Object.prototype.toString.call(stdioOpti
 export const isWritableStream = stdioOption => Object.prototype.toString.call(stdioOption) === '[object WritableStream]';
 const isWebStream = stdioOption => isReadableStream(stdioOption) || isWritableStream(stdioOption);
 
-const isIterableObject = stdinOption => typeof stdinOption === 'object'
-	&& stdinOption !== null
-	&& (typeof stdinOption[Symbol.asyncIterator] === 'function' || typeof stdinOption[Symbol.iterator] === 'function');
+const isIterableObject = stdioOption => typeof stdioOption === 'object'
+	&& stdioOption !== null
+	&& !Array.isArray(stdioOption)
+	&& (typeof stdioOption[Symbol.asyncIterator] === 'function' || typeof stdioOption[Symbol.iterator] === 'function');
 
 // Convert types to human-friendly strings for error messages
 export const TYPE_TO_MESSAGE = {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -101,13 +101,14 @@ export const getSpawnedResult = async (
 			...stdioStreams.map(stdioStream => waitForStreamEnd(stdioStream, processDone)),
 		]);
 	} catch (error) {
-		cleanupStdioStreams(stdioStreams);
-		spawned.kill();
 		return Promise.all([
 			{error, signal: error.signal, timedOut: error.timedOut},
 			getBufferedData(spawned.stdout, stdoutPromise),
 			getBufferedData(spawned.stderr, stderrPromise),
 			getBufferedData(spawned.all, allPromise),
 		]);
+	} finally {
+		cleanupStdioStreams(stdioStreams);
+		spawned.kill();
 	}
 };

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -73,6 +73,14 @@ const throwOnStreamError = async stream => {
 	throw error;
 };
 
+const cleanupStdioStreams = stdioStreams => {
+	for (const stdioStream of stdioStreams) {
+		if (stdioStream.autoDestroy) {
+			stdioStream.value.destroy();
+		}
+	}
+};
+
 // Retrieve result of child process: exit code, signal, error, streams (stdout/stderr/all)
 export const getSpawnedResult = async (
 	spawned,
@@ -93,6 +101,7 @@ export const getSpawnedResult = async (
 			...stdioStreams.map(stdioStream => waitForStreamEnd(stdioStream, processDone)),
 		]);
 	} catch (error) {
+		cleanupStdioStreams(stdioStreams);
 		spawned.kill();
 		return Promise.all([
 			{error, signal: error.signal, timedOut: error.timedOut},

--- a/readme.md
+++ b/readme.md
@@ -569,7 +569,7 @@ See also the [`input`](#input) and [`stdin`](#stdin) options.
 
 #### stdin
 
-Type: `string | number | stream.Readable | ReadableStream | URL | Iterable<string | Uint8Array> | AsyncIterable<string | Uint8Array> | StdioOption[]`\
+Type: `string | number | stream.Readable | ReadableStream | URL | Iterable<string | Uint8Array> | AsyncIterable<string | Uint8Array>` (or a tuple of those types)\
 Default: `inherit` with [`$`](#command), `pipe` otherwise
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard input. This can be:
@@ -591,7 +591,7 @@ This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destina
 
 #### stdout
 
-Type: `string | number | stream.Writable | WritableStream | URL | StdoutOption[]`\
+Type: `string | number | stream.Writable | WritableStream | URL` (or a tuple of those types)\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard output. This can be:
@@ -612,7 +612,7 @@ This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destina
 
 #### stderr
 
-Type: `string | number | stream.Writable | WritableStream | URL | StderrOption[]`\
+Type: `string | number | stream.Writable | WritableStream | URL` (or a tuple of those types)`\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard error. This can be:
@@ -633,13 +633,14 @@ This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destina
 
 #### stdio
 
-Type: `string | [StdinOption, StdoutOption, StderrOption] | StdioOption[]`\
+Type: `string | Array<string | number | stream.Readable | stream.Writable | ReadableStream | WritableStream | URL | Iterable<string | Uint8Array> | AsyncIterable<string | Uint8Array>>` (or a tuple of those types)\
 Default: `pipe`
 
-Like the [`stdin`](#stdin), [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options but for all file descriptors at once.\
-The possible values are the same except it can also be:
-- a single string, to set the same value to each standard stream.
-- an array with more than 3 values, to create more than 3 file descriptors.
+Like the [`stdin`](#stdin), [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options but for all file descriptors at once. For example, `{stdio: ['ignore', 'pipe', 'pipe']}` is the same as `{stdin: 'ignore', stdout: 'pipe', stderr: 'pipe'}`.
+
+A single string can be used as a shortcut. For example, `{stdio: 'pipe'}` is the same as `{stdin: 'pipe', stdout: 'pipe', stderr: 'pipe'}`.
+
+The array can have more than 3 items, to create additional file descriptors beyond `stdin`/`stdout`/`stderr`. For example, `{stdio: ['pipe', 'pipe', 'pipe', 'ipc']}` sets a fourth file descriptor `'ipc'`.
 
 #### all
 

--- a/readme.md
+++ b/readme.md
@@ -815,7 +815,7 @@ The [`stdin`](#stdin), [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options c
 The following example redirects `stdout` to both the terminal and an `output.txt` file, while also retrieving its value programmatically.
 
 ```js
-const {stdout} = await execa('npm', ['install'], {stdout:['inherit', './output.txt', 'pipe']})
+const {stdout} = await execa('npm', ['install'], {stdout: ['inherit', './output.txt', 'pipe']})
 console.log(stdout);
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -569,7 +569,7 @@ See also the [`input`](#input) and [`stdin`](#stdin) options.
 
 #### stdin
 
-Type: `string | number | stream.Readable | ReadableStream | URL | Iterable<string | Uint8Array> | AsyncIterable<string | Uint8Array>`\
+Type: `string | number | stream.Readable | ReadableStream | URL | Iterable<string | Uint8Array> | AsyncIterable<string | Uint8Array> | StdioOption[]`\
 Default: `inherit` with [`$`](#command), `pipe` otherwise
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard input. This can be:
@@ -587,9 +587,11 @@ Unless either the [synchronous methods](#execasyncfile-arguments-options), the [
 - web [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
 - [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)
 
+This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
+
 #### stdout
 
-Type: `string | number | stream.Writable | WritableStream | URL`\
+Type: `string | number | stream.Writable | WritableStream | URL | StdoutOption[]`\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard output. This can be:
@@ -606,9 +608,11 @@ Unless either [synchronous methods](#execasyncfile-arguments-options), the value
 - file URL.
 - web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 
+This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
+
 #### stderr
 
-Type: `string | number | stream.Writable | WritableStream | URL`\
+Type: `string | number | stream.Writable | WritableStream | URL | StderrOption[]`\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard error. This can be:
@@ -624,6 +628,8 @@ Unless either [synchronous methods](#execasyncfile-arguments-options), the value
 - file path. If relative, it must start with `.`.
 - file URL.
 - web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
+
+This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
 #### stdio
 
@@ -802,6 +808,18 @@ Default: [`process.execArgv`](https://nodejs.org/api/process.html#process_proces
 List of [CLI options](https://nodejs.org/api/cli.html#cli_options) passed to the Node.js executable.
 
 ## Tips
+
+### Redirect stdin/stdout/stderr to multiple destinations
+
+The [`stdin`](#stdin), [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options can be an array of values.
+The following example redirects `stdout` to both the terminal and an `output.txt` file, while also retrieving its value programmatically.
+
+```js
+const {stdout} = await execa('npm', ['install'], {stdout:['inherit', './output.txt', 'pipe']})
+console.log(stdout);
+```
+
+When combining `inherit` with other values, please note that the child process will not be an interactive TTY, even if the parent process is one.
 
 ### Retry on error
 

--- a/test/fixtures/empty.js
+++ b/test/fixtures/empty.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env node

--- a/test/fixtures/nested-multiple-stderr.js
+++ b/test/fixtures/nested-multiple-stderr.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {execa} from '../../index.js';
+
+const [options] = process.argv.slice(2);
+const result = await execa('noop-err.js', ['foobar'], {stderr: JSON.parse(options)});
+process.stdout.write(`nested ${result.stderr}`);

--- a/test/fixtures/nested-multiple-stdin.js
+++ b/test/fixtures/nested-multiple-stdin.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {execa} from '../../index.js';
+
+const [options] = process.argv.slice(2);
+const childProcess = execa('stdin.js', {stdin: JSON.parse(options)});
+childProcess.stdin.write('foobar');
+const {stdout} = await childProcess;
+console.log(stdout);

--- a/test/fixtures/nested-multiple-stdout.js
+++ b/test/fixtures/nested-multiple-stdout.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {execa} from '../../index.js';
+
+const [options] = process.argv.slice(2);
+const result = await execa('noop.js', ['foobar'], {stdout: JSON.parse(options)});
+process.stderr.write(`nested ${result.stdout}`);

--- a/test/fixtures/nested-stdio.js
+++ b/test/fixtures/nested-stdio.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {execa} from '../../index.js';
+
+const [stdioOption, index, file, ...args] = process.argv.slice(2);
+let optionValue = JSON.parse(stdioOption);
+optionValue = typeof optionValue === 'string' ? process[optionValue] : optionValue;
+optionValue = Array.isArray(optionValue) && typeof optionValue[0] === 'string'
+	? [process[optionValue[0]], ...optionValue.slice(1)]
+	: optionValue;
+const stdio = ['ignore', 'inherit', 'inherit'];
+stdio[index] = optionValue;
+const childProcess = execa(file, args, {stdio});
+
+const shouldPipe = Array.isArray(optionValue) && optionValue.includes('pipe');
+const hasPipe = childProcess.stdio[index] !== null;
+
+if (shouldPipe && !hasPipe) {
+	throw new Error(`childProcess.stdio[${index}] is null.`);
+}
+
+if (!shouldPipe && hasPipe) {
+	throw new Error(`childProcess.stdio[${index}] should be null.`);
+}
+
+await childProcess;

--- a/test/fixtures/stdin-fd3.js
+++ b/test/fixtures/stdin-fd3.js
@@ -2,5 +2,5 @@
 import process from 'node:process';
 import {readFileSync} from 'node:fs';
 
-const fileDescriptorIndex = Number(process.argv[3] || 3);
+const fileDescriptorIndex = Number(process.argv[2] || 3);
 console.log(readFileSync(fileDescriptorIndex, {encoding: 'utf8'}));

--- a/test/stdio/array.js
+++ b/test/stdio/array.js
@@ -1,0 +1,253 @@
+import {readFile, writeFile, rm} from 'node:fs/promises';
+import process from 'node:process';
+import {PassThrough} from 'node:stream';
+import test from 'ava';
+import tempfile from 'tempfile';
+import {execa, execaSync} from '../../index.js';
+import {getStdinOption, getStdoutOption, getStderrOption, getStdioOption} from '../helpers/stdio.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+
+setFixtureDir();
+
+const testEmptyArray = (t, getOptions, optionName, execaMethod) => {
+	t.throws(() => {
+		execaMethod('noop.js', getOptions([]));
+	}, {message: `The \`${optionName}\` option must not be an empty array.`});
+};
+
+test('Cannot pass an empty array to stdin', testEmptyArray, getStdinOption, 'stdin', execa);
+test('Cannot pass an empty array to stdout', testEmptyArray, getStdoutOption, 'stdout', execa);
+test('Cannot pass an empty array to stderr', testEmptyArray, getStderrOption, 'stderr', execa);
+test('Cannot pass an empty array to stdio[*]', testEmptyArray, getStdioOption, 'stdio[3]', execa);
+test('Cannot pass an empty array to stdin - sync', testEmptyArray, getStdinOption, 'stdin', execaSync);
+test('Cannot pass an empty array to stdout - sync', testEmptyArray, getStdoutOption, 'stdout', execaSync);
+test('Cannot pass an empty array to stderr - sync', testEmptyArray, getStderrOption, 'stderr', execaSync);
+test('Cannot pass an empty array to stdio[*] - sync', testEmptyArray, getStdioOption, 'stdio[3]', execaSync);
+
+const testNoPipeOption = async (t, stdioOption, streamName) => {
+	const childProcess = execa('empty.js', {[streamName]: stdioOption});
+	t.is(childProcess[streamName], null);
+	await execa;
+};
+
+test('stdin can be "ignore"', testNoPipeOption, 'ignore', 'stdin');
+test('stdin can be ["ignore"]', testNoPipeOption, ['ignore'], 'stdin');
+test('stdin can be ["ignore", "ignore"]', testNoPipeOption, ['ignore', 'ignore'], 'stdin');
+test('stdin can be "ipc"', testNoPipeOption, 'ipc', 'stdin');
+test('stdin can be ["ipc"]', testNoPipeOption, ['ipc'], 'stdin');
+test('stdin can be "inherit"', testNoPipeOption, 'inherit', 'stdin');
+test('stdin can be ["inherit"]', testNoPipeOption, ['inherit'], 'stdin');
+test('stdin can be 0', testNoPipeOption, 0, 'stdin');
+test('stdin can be [0]', testNoPipeOption, [0], 'stdin');
+test('stdout can be "ignore"', testNoPipeOption, 'ignore', 'stdout');
+test('stdout can be ["ignore"]', testNoPipeOption, ['ignore'], 'stdout');
+test('stdout can be ["ignore", "ignore"]', testNoPipeOption, ['ignore', 'ignore'], 'stdout');
+test('stdout can be "ipc"', testNoPipeOption, 'ipc', 'stdout');
+test('stdout can be ["ipc"]', testNoPipeOption, ['ipc'], 'stdout');
+test('stdout can be "inherit"', testNoPipeOption, 'inherit', 'stdout');
+test('stdout can be ["inherit"]', testNoPipeOption, ['inherit'], 'stdout');
+test('stdout can be 1', testNoPipeOption, 1, 'stdout');
+test('stdout can be [1]', testNoPipeOption, [1], 'stdout');
+test('stderr can be "ignore"', testNoPipeOption, 'ignore', 'stderr');
+test('stderr can be ["ignore"]', testNoPipeOption, ['ignore'], 'stderr');
+test('stderr can be ["ignore", "ignore"]', testNoPipeOption, ['ignore', 'ignore'], 'stderr');
+test('stderr can be "ipc"', testNoPipeOption, 'ipc', 'stderr');
+test('stderr can be ["ipc"]', testNoPipeOption, ['ipc'], 'stderr');
+test('stderr can be "inherit"', testNoPipeOption, 'inherit', 'stderr');
+test('stderr can be ["inherit"]', testNoPipeOption, ['inherit'], 'stderr');
+test('stderr can be 2', testNoPipeOption, 2, 'stderr');
+test('stderr can be [2]', testNoPipeOption, [2], 'stderr');
+
+const testNoPipeStdioOption = async (t, stdioOption) => {
+	const childProcess = execa('empty.js', {stdio: ['pipe', 'pipe', 'pipe', stdioOption]});
+	t.is(childProcess.stdio[3], null);
+	await execa;
+};
+
+test('stdio[*] can be "ignore"', testNoPipeStdioOption, 'ignore');
+test('stdio[*] can be ["ignore"]', testNoPipeStdioOption, ['ignore']);
+test('stdio[*] can be ["ignore", "ignore"]', testNoPipeStdioOption, ['ignore', 'ignore']);
+test('stdio[*] can be "ipc"', testNoPipeStdioOption, 'ipc');
+test('stdio[*] can be ["ipc"]', testNoPipeStdioOption, ['ipc']);
+test('stdio[*] can be "inherit"', testNoPipeStdioOption, 'inherit');
+test('stdio[*] can be ["inherit"]', testNoPipeStdioOption, ['inherit']);
+test('stdio[*] can be 3', testNoPipeStdioOption, 3);
+test('stdio[*] can be [3]', testNoPipeStdioOption, [3]);
+
+const testInvalidArrayValue = (t, invalidStdio, getOptions, execaMethod) => {
+	t.throws(() => {
+		execaMethod('noop.js', getOptions(['pipe', invalidStdio]));
+	}, {message: /must not include/});
+};
+
+test('Cannot pass "ignore" and another value to stdin', testInvalidArrayValue, 'ignore', getStdinOption, execa);
+test('Cannot pass "ignore" and another value to stdout', testInvalidArrayValue, 'ignore', getStdoutOption, execa);
+test('Cannot pass "ignore" and another value to stderr', testInvalidArrayValue, 'ignore', getStderrOption, execa);
+test('Cannot pass "ignore" and another value to stdio[*]', testInvalidArrayValue, 'ignore', getStdioOption, execa);
+test('Cannot pass "ignore" and another value to stdin - sync', testInvalidArrayValue, 'ignore', getStdinOption, execaSync);
+test('Cannot pass "ignore" and another value to stdout - sync', testInvalidArrayValue, 'ignore', getStdoutOption, execaSync);
+test('Cannot pass "ignore" and another value to stderr - sync', testInvalidArrayValue, 'ignore', getStderrOption, execaSync);
+test('Cannot pass "ignore" and another value to stdio[*] - sync', testInvalidArrayValue, 'ignore', getStdioOption, execaSync);
+test('Cannot pass "ipc" and another value to stdin', testInvalidArrayValue, 'ipc', getStdinOption, execa);
+test('Cannot pass "ipc" and another value to stdout', testInvalidArrayValue, 'ipc', getStdoutOption, execa);
+test('Cannot pass "ipc" and another value to stderr', testInvalidArrayValue, 'ipc', getStderrOption, execa);
+test('Cannot pass "ipc" and another value to stdio[*]', testInvalidArrayValue, 'ipc', getStdioOption, execa);
+test('Cannot pass "ipc" and another value to stdin - sync', testInvalidArrayValue, 'ipc', getStdinOption, execaSync);
+test('Cannot pass "ipc" and another value to stdout - sync', testInvalidArrayValue, 'ipc', getStdoutOption, execaSync);
+test('Cannot pass "ipc" and another value to stderr - sync', testInvalidArrayValue, 'ipc', getStderrOption, execaSync);
+test('Cannot pass "ipc" and another value to stdio[*] - sync', testInvalidArrayValue, 'ipc', getStdioOption, execaSync);
+
+const testInputOutput = (t, stdioOption, execaMethod) => {
+	t.throws(() => {
+		execaMethod('noop.js', getStdioOption([new ReadableStream(), stdioOption]));
+	}, {message: /readable and writable/});
+};
+
+test('Cannot pass both readable and writable values to stdio[*] - WritableStream', testInputOutput, new WritableStream(), execa);
+test('Cannot pass both readable and writable values to stdio[*] - 1', testInputOutput, 1, execa);
+test('Cannot pass both readable and writable values to stdio[*] - 2', testInputOutput, 2, execa);
+test('Cannot pass both readable and writable values to stdio[*] - process.stdout', testInputOutput, process.stdout, execa);
+test('Cannot pass both readable and writable values to stdio[*] - process.stderr', testInputOutput, process.stderr, execa);
+test('Cannot pass both readable and writable values to stdio[*] - WritableStream - sync', testInputOutput, new WritableStream(), execaSync);
+test('Cannot pass both readable and writable values to stdio[*] - 1 - sync', testInputOutput, 1, execaSync);
+test('Cannot pass both readable and writable values to stdio[*] - 2 - sync', testInputOutput, 2, execaSync);
+test('Cannot pass both readable and writable values to stdio[*] - process.stdout - sync', testInputOutput, process.stdout, execaSync);
+test('Cannot pass both readable and writable values to stdio[*] - process.stderr - sync', testInputOutput, process.stderr, execaSync);
+
+const testAmbiguousDirection = async (t, execaMethod) => {
+	const [filePathOne, filePathTwo] = [tempfile(), tempfile()];
+	await execaMethod('noop-fd3.js', ['foobar'], getStdioOption([filePathOne, filePathTwo]));
+	t.deepEqual(await Promise.all([readFile(filePathOne, 'utf8'), readFile(filePathTwo, 'utf8')]), ['foobar\n', 'foobar\n']);
+	await Promise.all([rm(filePathOne), rm(filePathTwo)]);
+};
+
+test('stdio[*] default direction is output', testAmbiguousDirection, execa);
+test('stdio[*] default direction is output - sync', testAmbiguousDirection, execaSync);
+
+const testAmbiguousMultiple = async (t, stdioOptions) => {
+	const filePath = tempfile();
+	await writeFile(filePath, 'foobar');
+	const {stdout} = await execa('stdin-fd3.js', getStdioOption([filePath, ...stdioOptions]));
+	t.is(stdout, 'foobar');
+	await rm(filePath);
+};
+
+test('stdio[*] ambiguous direction is influenced by other values like ReadableStream', testAmbiguousMultiple, [new ReadableStream()]);
+test('stdio[*] ambiguous direction is influenced by other values like 0', testAmbiguousMultiple, [0]);
+test('stdio[*] ambiguous direction is influenced by other values like process.stdin', testAmbiguousMultiple, [process.stdin]);
+test('stdio[*] Duplex has an ambiguous direction like ReadableStream', testAmbiguousMultiple, [new PassThrough(), new ReadableStream()]);
+test('stdio[*] Duplex has an ambiguous direction like 0', testAmbiguousMultiple, [new PassThrough(), 0]);
+test('stdio[*] Duplex has an ambiguous direction like process.stdin', testAmbiguousMultiple, [new PassThrough(), process.stdin]);
+
+const testRedirectInput = async (t, stdioOption, index, fixtureName) => {
+	const {stdout} = await execa('nested-stdio.js', [JSON.stringify(stdioOption), String(index), fixtureName], {input: 'foobar'});
+	t.is(stdout, 'foobar');
+};
+
+test.serial('stdio[*] can be 0', testRedirectInput, 0, 3, 'stdin-fd3.js');
+test.serial('stdio[*] can be [0]', testRedirectInput, [0], 3, 'stdin-fd3.js');
+test.serial('stdio[*] can be [0, "pipe"]', testRedirectInput, [0, 'pipe'], 3, 'stdin-fd3.js');
+test.serial('stdio[*] can be process.stdin', testRedirectInput, 'stdin', 3, 'stdin-fd3.js');
+test.serial('stdio[*] can be [process.stdin]', testRedirectInput, ['stdin'], 3, 'stdin-fd3.js');
+test.serial('stdio[*] can be [process.stdin, "pipe"]', testRedirectInput, ['stdin', 'pipe'], 3, 'stdin-fd3.js');
+
+const OUTPUT_DESCRIPTOR_FIXTURES = ['noop.js', 'noop-err.js', 'noop-fd3.js'];
+
+const isStdoutDescriptor = stdioOption => stdioOption === 1
+	|| stdioOption === 'stdout'
+	|| (Array.isArray(stdioOption) && isStdoutDescriptor(stdioOption[0]));
+
+const testRedirectOutput = async (t, stdioOption, index) => {
+	const fixtureName = OUTPUT_DESCRIPTOR_FIXTURES[index - 1];
+	const result = await execa('nested-stdio.js', [JSON.stringify(stdioOption), String(index), fixtureName, 'foobar']);
+	const streamName = isStdoutDescriptor(stdioOption) ? 'stdout' : 'stderr';
+	t.is(result[streamName], 'foobar');
+};
+
+test('stdout can be 2', testRedirectOutput, 2, 1);
+test('stdout can be [2]', testRedirectOutput, [2], 1);
+test('stdout can be [2, "pipe"]', testRedirectOutput, [2, 'pipe'], 1);
+test('stdout can be process.stderr', testRedirectOutput, 'stderr', 1);
+test('stdout can be [process.stderr]', testRedirectOutput, ['stderr'], 1);
+test('stdout can be [process.stderr, "pipe"]', testRedirectOutput, ['stderr', 'pipe'], 1);
+test('stderr can be 1', testRedirectOutput, 1, 2);
+test('stderr can be [1]', testRedirectOutput, [1], 2);
+test('stderr can be [1, "pipe"]', testRedirectOutput, [1, 'pipe'], 2);
+test('stderr can be process.stdout', testRedirectOutput, 'stdout', 2);
+test('stderr can be [process.stdout]', testRedirectOutput, ['stdout'], 2);
+test('stderr can be [process.stdout, "pipe"]', testRedirectOutput, ['stdout', 'pipe'], 2);
+test('stdio[*] can be 1', testRedirectOutput, 1, 3);
+test('stdio[*] can be [1]', testRedirectOutput, [1], 3);
+test('stdio[*] can be [1, "pipe"]', testRedirectOutput, [1, 'pipe'], 3);
+test('stdio[*] can be 2', testRedirectOutput, 2, 3);
+test('stdio[*] can be [2]', testRedirectOutput, [2], 3);
+test('stdio[*] can be [2, "pipe"]', testRedirectOutput, [2, 'pipe'], 3);
+test('stdio[*] can be process.stdout', testRedirectOutput, 'stdout', 3);
+test('stdio[*] can be [process.stdout]', testRedirectOutput, ['stdout'], 3);
+test('stdio[*] can be [process.stdout, "pipe"]', testRedirectOutput, ['stdout', 'pipe'], 3);
+test('stdio[*] can be process.stderr', testRedirectOutput, 'stderr', 3);
+test('stdio[*] can be [process.stderr]', testRedirectOutput, ['stderr'], 3);
+test('stdio[*] can be [process.stderr, "pipe"]', testRedirectOutput, ['stderr', 'pipe'], 3);
+
+const testInheritStdin = async (t, stdin) => {
+	const {stdout} = await execa('nested-multiple-stdin.js', [JSON.stringify(stdin)], {input: 'foobar'});
+	t.is(stdout, 'foobarfoobar');
+};
+
+test('stdin can be ["inherit", "pipe"]', testInheritStdin, ['inherit', 'pipe']);
+test('stdin can be [0, "pipe"]', testInheritStdin, [0, 'pipe']);
+
+const testInheritStdout = async (t, stdout) => {
+	const result = await execa('nested-multiple-stdout.js', [JSON.stringify(stdout)]);
+	t.is(result.stdout, 'foobar');
+	t.is(result.stderr, 'nested foobar');
+};
+
+test('stdout can be ["inherit", "pipe"]', testInheritStdout, ['inherit', 'pipe']);
+test('stdout can be [1, "pipe"]', testInheritStdout, [1, 'pipe']);
+
+const testInheritStderr = async (t, stderr) => {
+	const result = await execa('nested-multiple-stderr.js', [JSON.stringify(stderr)]);
+	t.is(result.stdout, 'nested foobar');
+	t.is(result.stderr, 'foobar');
+};
+
+test('stderr can be ["inherit", "pipe"]', testInheritStderr, ['inherit', 'pipe']);
+test('stderr can be [2, "pipe"]', testInheritStderr, [2, 'pipe']);
+
+const testOverflowStream = async (t, stdio) => {
+	await t.notThrowsAsync(execa('empty.js', {stdio}));
+};
+
+test('stdin can use 4+', testOverflowStream, [4, 'pipe', 'pipe', 'pipe']);
+test('stdin can use [4+]', testOverflowStream, [[4], 'pipe', 'pipe', 'pipe']);
+test('stdout can use 4+', testOverflowStream, ['pipe', 4, 'pipe', 'pipe']);
+test('stdout can use [4+]', testOverflowStream, ['pipe', [4], 'pipe', 'pipe']);
+test('stderr can use 4+', testOverflowStream, ['pipe', 'pipe', 4, 'pipe']);
+test('stderr can use [4+]', testOverflowStream, ['pipe', 'pipe', [4], 'pipe']);
+test('stdio[*] can use 4+', testOverflowStream, ['pipe', 'pipe', 'pipe', 4]);
+test('stdio[*] can use [4+]', testOverflowStream, ['pipe', 'pipe', 'pipe', [4]]);
+test('stdio[*] can use "inherit"', testOverflowStream, ['pipe', 'pipe', 'pipe', 'inherit']);
+test('stdio[*] can use ["inherit"]', testOverflowStream, ['pipe', 'pipe', 'pipe', ['inherit']]);
+
+const testOverflowStreamArray = (t, stdio) => {
+	t.throws(() => {
+		execa('noop.js', {stdio});
+	}, {message: /no such standard stream/});
+};
+
+test('stdin cannot use 4+ and another value', testOverflowStreamArray, [[4, 'pipe'], 'pipe', 'pipe', 'pipe']);
+test('stdout cannot use 4+ and another value', testOverflowStreamArray, ['pipe', [4, 'pipe'], 'pipe', 'pipe']);
+test('stderr cannot use 4+ and another value', testOverflowStreamArray, ['pipe', 'pipe', [4, 'pipe'], 'pipe']);
+test('stdio[*] cannot use 4+ and another value', testOverflowStreamArray, ['pipe', 'pipe', 'pipe', [4, 'pipe']]);
+test('stdio[*] cannot use "inherit" and another value', testOverflowStreamArray, ['pipe', 'pipe', 'pipe', ['inherit', 'pipe']]);
+
+const testOverlapped = async (t, getOptions) => {
+	const {stdout} = await execa('noop.js', ['foobar'], getOptions(['overlapped', 'pipe']));
+	t.is(stdout, 'foobar');
+};
+
+test('stdin can be ["overlapped", "pipe"]', testOverlapped, getStdinOption);
+test('stdout can be ["overlapped", "pipe"]', testOverlapped, getStdoutOption);
+test('stderr can be ["overlapped", "pipe"]', testOverlapped, getStderrOption);
+test('stdio[*] can be ["overlapped", "pipe"]', testOverlapped, getStdioOption);

--- a/test/stdio/array.js
+++ b/test/stdio/array.js
@@ -216,7 +216,8 @@ test('stderr can be ["inherit", "pipe"]', testInheritStderr, ['inherit', 'pipe']
 test('stderr can be [2, "pipe"]', testInheritStderr, [2, 'pipe']);
 
 const testOverflowStream = async (t, stdio) => {
-	await t.notThrowsAsync(execa('empty.js', {stdio}));
+	const {stdout} = await execa('nested.js', [JSON.stringify({stdio}), 'empty.js'], {stdio: ['pipe', 'pipe', 'pipe', 'pipe']});
+	t.is(stdout, '');
 };
 
 if (process.platform === 'linux') {

--- a/test/stdio/array.js
+++ b/test/stdio/array.js
@@ -219,14 +219,17 @@ const testOverflowStream = async (t, stdio) => {
 	await t.notThrowsAsync(execa('empty.js', {stdio}));
 };
 
-test('stdin can use 4+', testOverflowStream, [4, 'pipe', 'pipe', 'pipe']);
-test('stdin can use [4+]', testOverflowStream, [[4], 'pipe', 'pipe', 'pipe']);
-test('stdout can use 4+', testOverflowStream, ['pipe', 4, 'pipe', 'pipe']);
-test('stdout can use [4+]', testOverflowStream, ['pipe', [4], 'pipe', 'pipe']);
-test('stderr can use 4+', testOverflowStream, ['pipe', 'pipe', 4, 'pipe']);
-test('stderr can use [4+]', testOverflowStream, ['pipe', 'pipe', [4], 'pipe']);
-test('stdio[*] can use 4+', testOverflowStream, ['pipe', 'pipe', 'pipe', 4]);
-test('stdio[*] can use [4+]', testOverflowStream, ['pipe', 'pipe', 'pipe', [4]]);
+if (process.platform !== 'darwin') {
+	test('stdin can use 4+', testOverflowStream, [4, 'pipe', 'pipe', 'pipe']);
+	test('stdin can use [4+]', testOverflowStream, [[4], 'pipe', 'pipe', 'pipe']);
+	test('stdout can use 4+', testOverflowStream, ['pipe', 4, 'pipe', 'pipe']);
+	test('stdout can use [4+]', testOverflowStream, ['pipe', [4], 'pipe', 'pipe']);
+	test('stderr can use 4+', testOverflowStream, ['pipe', 'pipe', 4, 'pipe']);
+	test('stderr can use [4+]', testOverflowStream, ['pipe', 'pipe', [4], 'pipe']);
+	test('stdio[*] can use 4+', testOverflowStream, ['pipe', 'pipe', 'pipe', 4]);
+	test('stdio[*] can use [4+]', testOverflowStream, ['pipe', 'pipe', 'pipe', [4]]);
+}
+
 test('stdio[*] can use "inherit"', testOverflowStream, ['pipe', 'pipe', 'pipe', 'inherit']);
 test('stdio[*] can use ["inherit"]', testOverflowStream, ['pipe', 'pipe', 'pipe', ['inherit']]);
 

--- a/test/stdio/array.js
+++ b/test/stdio/array.js
@@ -219,7 +219,7 @@ const testOverflowStream = async (t, stdio) => {
 	await t.notThrowsAsync(execa('empty.js', {stdio}));
 };
 
-if (process.platform !== 'darwin') {
+if (process.platform === 'linux') {
 	test('stdin can use 4+', testOverflowStream, [4, 'pipe', 'pipe', 'pipe']);
 	test('stdin can use [4+]', testOverflowStream, [[4], 'pipe', 'pipe', 'pipe']);
 	test('stdout can use 4+', testOverflowStream, ['pipe', 4, 'pipe', 'pipe']);


### PR DESCRIPTION
Fixes #620
Fixes #25

This allows the `stdin`/`stdout`/`stderr` to be an array of values instead of a single one.

Some interesting use cases: "taping" (mentioned in #25):

```js
const { stdout } = await execa(..., { stdout: ['inherit', 'pipe'] })
```

Or redirecting to both terminal and file:

```js
const { stdout } = await execa(..., { stdout: ['inherit', './path.txt'] })
```

The way this works is: we pass `pipe` to `child_process.spawn()`, and emulate the options ourselves through manual piping. 
One caveat (which is documented by this PR): when using `inherit` + another value, even if the current `stdin`/`stdout`/`stderr` is an interactive TTY, the child process will not be interactive. This contrasts with using `inherit` on its own.