### PR TITLE
Wait for `WritableStream` completion

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,6 +1,7 @@
 import {once} from 'node:events';
 import {setTimeout} from 'node:timers/promises';
 import {finished} from 'node:stream/promises';
+import process from 'node:process';
 import getStream, {getStreamAsBuffer, getStreamAsArrayBuffer} from 'get-stream';
 import mergeStreams from '@sindresorhus/merge-streams';
 
@@ -54,16 +55,20 @@ const applyEncoding = async (stream, maxBuffer, encoding) => {
 	return buffer.toString(encoding);
 };
 
-// We need to handle any `error` coming from the `stdin|stdout|stderr` options.
-// However, those might be infinite streams, e.g. a TTY passed as input or output.
-// We wait for completion or not depending on whether `finite` is `true`.
-// In either case, we handle `error` events while the process is running.
-const waitForStreamEnd = ({value, type}, processDone) => {
+// Some `stdout`/`stderr` options create a stream, e.g. when passing a file path.
+// The `.pipe()` method automatically ends that stream when `childProcess.stdout|stderr` ends.
+// This makes sure we want for the completion of those streams, in order to catch any error.
+// Since we want to end those streams, they cannot be infinite, except for `process.stdout|stderr`.
+// However, for the `stdin`/`input`/`inputFile` options, we only wait for errors, not completion.
+// This is because source streams completion should end destination streams, but not the other way around.
+// This allows for source streams to pipe to multiple destinations.
+// We make an exception for `filePath`, since we create that source stream and we know it is piped to a single destination.
+const waitForStreamEnd = ({value, type, direction}, processDone) => {
 	if (type === 'native' || type === 'stringOrBuffer') {
 		return;
 	}
 
-	return type === 'filePath'
+	return type === 'filePath' || (direction === 'output' && value !== process.stdout && value !== process.stderr)
 		? finished(value)
 		: Promise.race([processDone, throwOnStreamError(value)]);
 };


### PR DESCRIPTION
When passing a `WritableStream` to the `stdout`/`stderr` option, Execa should wait for it to complete before resolving.