### PR TITLE
Improve performance of `childProcess.all` when `stdout` or `stderr` is `undefined`

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -7,11 +7,19 @@ import mergeStreams from '@sindresorhus/merge-streams';
 
 // `all` interleaves `stdout` and `stderr`
 export const makeAllStream = (spawned, {all}) => {
-	if (!all || (!spawned.stdout && !spawned.stderr)) {
+	if (!all) {
 		return;
 	}
 
-	return mergeStreams([spawned.stdout, spawned.stderr].filter(Boolean));
+	if (!spawned.stdout) {
+		return spawned.stderr;
+	}
+
+	if (!spawned.stderr) {
+		return spawned.stdout;
+	}
+
+	return mergeStreams([spawned.stdout, spawned.stderr]);
 };
 
 // On failure, `result.stdout|stderr|all` should contain the currently buffered stream

--- a/test/stream.js
+++ b/test/stream.js
@@ -70,6 +70,15 @@ test('result.all is undefined if ignored', async t => {
 	t.is(all, undefined);
 });
 
+const testAllIgnore = async (t, streamName, otherStreamName) => {
+	const childProcess = execa('noop.js', {[otherStreamName]: 'ignore', all: true});
+	t.is(childProcess.all, childProcess[streamName]);
+	await childProcess;
+};
+
+test('can use all: true with stdout: ignore', testAllIgnore, 'stderr', 'stdout');
+test('can use all: true with stderr: ignore', testAllIgnore, 'stdout', 'stderr');
+
 const testIgnore = async (t, streamName, execaMethod) => {
 	const result = await execaMethod('noop.js', {[streamName]: 'ignore'});
 	t.is(result[streamName], undefined);
@@ -143,14 +152,6 @@ test('buffer: false > promise rejects when process returns non-zero', async t =>
 test('buffer: false > emits end event when promise is rejected', async t => {
 	const subprocess = execa('wrong command', {buffer: false, reject: false});
 	await t.notThrowsAsync(Promise.all([subprocess, pEvent(subprocess.stdout, 'end')]));
-});
-
-test('can use all: true with stdout: ignore', async t => {
-	await t.notThrowsAsync(execa('max-buffer.js', {buffer: false, stdout: 'ignore', all: true}));
-});
-
-test('can use all: true with stderr: ignore', async t => {
-	await t.notThrowsAsync(execa('max-buffer.js', ['stderr'], {buffer: false, stderr: 'ignore', all: true}));
 });
 
 const BUFFER_TIMEOUT = 1e3;


### PR DESCRIPTION
When `childProcess.stderr` is `undefined` (e.g. when the `stderr` option is `ignore`, `inherit`, etc.) but the `all` option is `true`, `childProcess.all` is currently a `PassThrough` piped from `childProcess.stdout`. However, in that case, `childProcess.all` could simplify be a reference to `childProcess.stdout`, there is no need to create two distinct streams.

Same for when `childProcess.stdout` is `undefined`.