### PR TITLE
Refactor duplicate code between `execa()` and `execaSync()`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -18,9 +18,9 @@ const escapeArg = arg => {
 	return `"${arg.replaceAll('"', '\\"')}"`;
 };
 
-export const joinCommand = (file, args) => normalizeArgs(file, args).join(' ');
+export const joinCommand = (file, rawArgs) => normalizeArgs(file, rawArgs).join(' ');
 
-export const getEscapedCommand = (file, args) => normalizeArgs(file, args).map(arg => escapeArg(arg)).join(' ');
+export const getEscapedCommand = (file, rawArgs) => normalizeArgs(file, rawArgs).map(arg => escapeArg(arg)).join(' ');
 
 const SPACES_REGEXP = / +/g;
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -36,7 +36,7 @@ export const makeError = ({
 	escapedCommand,
 	timedOut,
 	isCanceled,
-	parsed: {options: {timeout, cwd = process.cwd()}},
+	options: {timeout, cwd = process.cwd()},
 }) => {
 	// `signal` and `exitCode` emitted on `spawned.on('exit')` event can be `null`.
 	// We normalize them to `undefined`


### PR DESCRIPTION
Some of the logic between `execa()` and `execaSync()` is duplicated. This PR refactors the code to remove this duplication, without changing any behavior.