### PR TITLE
Refactor `cleanup` option to use `async/await`

### DIFF
--- a/lib/kill.js
+++ b/lib/kill.js
@@ -96,7 +96,9 @@ export const setExitHandler = async (spawned, {cleanup, detached}, timedPromise)
 		spawned.kill();
 	});
 
-	return timedPromise.finally(() => {
+	try {
+		return await timedPromise;
+	} finally {
 		removeExitHandler();
-	});
+	}
 };

--- a/test/stream.js
+++ b/test/stream.js
@@ -173,7 +173,7 @@ if (process.platform !== 'win32') {
 }
 
 test('Errors on streams should make the process exit', async t => {
-	const childProcess = execa('forever');
+	const childProcess = execa('forever.js');
 	childProcess.stdout.destroy();
 	await t.throwsAsync(childProcess, {code: 'ERR_STREAM_PREMATURE_CLOSE'});
 });


### PR DESCRIPTION
This refactors the `cleanup` option's logic to use `async/await`.