### PR TITLE
Refactor `timeout` option to use `async/await`

### DIFF
--- a/lib/kill.js
+++ b/lib/kill.js
@@ -1,4 +1,5 @@
 import os from 'node:os';
+import {setTimeout as pSetTimeout} from 'node:timers/promises';
 import {onExit} from 'signal-exit';
 
 const DEFAULT_FORCE_KILL_TIMEOUT = 1000 * 5;
@@ -55,29 +56,27 @@ export const spawnedCancel = (spawned, context) => {
 	}
 };
 
-const timeoutKill = (spawned, signal, reject) => {
-	spawned.kill(signal);
-	reject(Object.assign(new Error('Timed out'), {timedOut: true, signal}));
+const killAfterTimeout = async (spawned, timeout, killSignal, controller) => {
+	await pSetTimeout(timeout, undefined, {ref: false, signal: controller.signal});
+	spawned.kill(killSignal);
+	throw Object.assign(new Error('Timed out'), {timedOut: true, signal: killSignal});
 };
 
 // `timeout` option handling
-export const setupTimeout = (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise) => {
+export const setupTimeout = async (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise) => {
 	if (timeout === 0 || timeout === undefined) {
 		return spawnedPromise;
 	}
 
-	let timeoutId;
-	const timeoutPromise = new Promise((resolve, reject) => {
-		timeoutId = setTimeout(() => {
-			timeoutKill(spawned, killSignal, reject);
-		}, timeout);
-	});
-
-	const safeSpawnedPromise = spawnedPromise.finally(() => {
-		clearTimeout(timeoutId);
-	});
-
-	return Promise.race([timeoutPromise, safeSpawnedPromise]);
+	const controller = new AbortController();
+	try {
+		return await Promise.race([
+			spawnedPromise,
+			killAfterTimeout(spawned, timeout, killSignal, controller),
+		]);
+	} finally {
+		controller.abort();
+	}
 };
 
 export const validateTimeout = ({timeout}) => {

--- a/test/kill.js
+++ b/test/kill.js
@@ -184,18 +184,13 @@ test('spawnAndKill cleanup detached SIGKILL', spawnAndKill, ['SIGKILL', true, tr
 // See #128
 test('removes exit handler on exit', async t => {
 	// @todo this relies on `signal-exit` internals
-	const emitter = globalThis[Symbol.for('signal-exit emitter')];
+	const exitListeners = globalThis[Symbol.for('signal-exit emitter')].listeners.exit;
 
 	const subprocess = execa('noop.js');
-	const listener = emitter.listeners.exit.at(-1);
+	const listener = exitListeners.at(-1);
 
-	await new Promise((resolve, reject) => {
-		subprocess.on('error', reject);
-		subprocess.on('exit', resolve);
-	});
-
-	const included = emitter.listeners.exit.includes(listener);
-	t.false(included);
+	await subprocess;
+	t.false(exitListeners.includes(listener));
 });
 
 test('cancel method kills the subprocess', async t => {


### PR DESCRIPTION
This refactors the `timeout` option's logic to use `async/await`.