### PR TITLE
Refactor `childProcess.kill()` to use `async/await`

### DIFF
--- a/lib/kill.js
+++ b/lib/kill.js
@@ -1,40 +1,36 @@
 import os from 'node:os';
+import {setTimeout as pSetTimeout} from 'node:timers/promises';
 import {onExit} from 'signal-exit';
 
 const DEFAULT_FORCE_KILL_TIMEOUT = 1000 * 5;
 
 // Monkey-patches `childProcess.kill()` to add `forceKillAfterTimeout` behavior
-export const spawnedKill = (kill, signal = 'SIGTERM', options = {}) => {
+export const spawnedKill = (kill, signal = 'SIGTERM', {forceKillAfterTimeout = true} = {}) => {
 	const killResult = kill(signal);
-	setKillTimeout(kill, signal, options, killResult);
+	const timeout = getForceKillAfterTimeout(signal, forceKillAfterTimeout, killResult);
+	setKillTimeout(kill, timeout);
 	return killResult;
 };
 
-const setKillTimeout = (kill, signal, options, killResult) => {
-	if (!shouldForceKill(signal, options, killResult)) {
+const setKillTimeout = async (kill, timeout) => {
+	if (timeout === undefined) {
 		return;
 	}
 
-	const timeout = getForceKillAfterTimeout(options);
-	const t = setTimeout(() => {
-		kill('SIGKILL');
-	}, timeout);
-
-	// Guarded because there's no `.unref()` when `execa` is used in the renderer
-	// process in Electron. This cannot be tested since we don't run tests in
-	// Electron.
-	// istanbul ignore else
-	if (t.unref) {
-		t.unref();
-	}
+	await pSetTimeout(timeout, undefined, {ref: false});
+	kill('SIGKILL');
 };
 
-const shouldForceKill = (signal, {forceKillAfterTimeout}, killResult) => isSigterm(signal) && forceKillAfterTimeout !== false && killResult;
+const shouldForceKill = (signal, forceKillAfterTimeout, killResult) => isSigterm(signal) && forceKillAfterTimeout !== false && killResult;
 
 const isSigterm = signal => signal === os.constants.signals.SIGTERM
-		|| (typeof signal === 'string' && signal.toUpperCase() === 'SIGTERM');
+	|| (typeof signal === 'string' && signal.toUpperCase() === 'SIGTERM');
 
-const getForceKillAfterTimeout = ({forceKillAfterTimeout = true}) => {
+const getForceKillAfterTimeout = (signal, forceKillAfterTimeout, killResult) => {
+	if (!shouldForceKill(signal, forceKillAfterTimeout, killResult)) {
+		return;
+	}
+
 	if (forceKillAfterTimeout === true) {
 		return DEFAULT_FORCE_KILL_TIMEOUT;
 	}


### PR DESCRIPTION
This refactors the `childProcess.kill()`s logic to use `async/await`.