### PR TITLE
Refactor execa promise to use `async/await`

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,3 +1,5 @@
+import {once} from 'node:events';
+
 // eslint-disable-next-line unicorn/prefer-top-level-await
 const nativePromisePrototype = (async () => {})().constructor.prototype;
 
@@ -19,18 +21,7 @@ export const mergePromise = (spawned, promise) => {
 };
 
 // Use promises instead of `child_process` events
-export const getSpawnedPromise = spawned => new Promise((resolve, reject) => {
-	spawned.on('exit', (exitCode, signal) => {
-		resolve({exitCode, signal});
-	});
-
-	spawned.on('error', error => {
-		reject(error);
-	});
-
-	if (spawned.stdin) {
-		spawned.stdin.on('error', error => {
-			reject(error);
-		});
-	}
-});
+export const getSpawnedPromise = async spawned => {
+	const [exitCode, signal] = await once(spawned, 'exit');
+	return {exitCode, signal};
+};

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -77,6 +77,10 @@ const waitForStreamEnd = ({value, type, direction}, processDone) => {
 		: Promise.race([processDone, throwOnStreamError(value)]);
 };
 
+const throwIfStreamError = (stream, processDone) => stream === null
+	? undefined
+	: Promise.race([processDone, throwOnStreamError(stream)]);
+
 const throwOnStreamError = async stream => {
 	const [error] = await once(stream, 'error');
 	throw error;
@@ -110,6 +114,7 @@ export const getSpawnedResult = async (
 			stdoutPromise,
 			stderrPromise,
 			allPromise,
+			throwIfStreamError(spawned.stdin, processDone),
 			...stdioStreams.map(stdioStream => waitForStreamEnd(stdioStream, processDone)),
 		]);
 	} catch (error) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import process from 'node:process';
+import {setTimeout} from 'node:timers/promises';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import test from 'ava';
 import isRunning from 'is-running';
@@ -124,10 +125,17 @@ const testExecPath = async (t, mapPath) => {
 test.serial('execPath option', testExecPath, identity);
 test.serial('execPath option can be a file URL', testExecPath, pathToFileURL);
 
-test('stdin errors are handled', async t => {
-	const subprocess = execa('noop.js');
+const emitStdinError = async subprocess => {
+	await setTimeout(0);
 	subprocess.stdin.emit('error', new Error('test'));
-	await t.throwsAsync(subprocess, {message: /test/});
+};
+
+test('stdin errors are handled', async t => {
+	const subprocess = execa('forever.js');
+	await Promise.all([
+		t.throwsAsync(subprocess, {message: /test/}),
+		emitStdinError(subprocess),
+	]);
 });
 
 test('child process errors are handled', async t => {


### PR DESCRIPTION
This PR refactors the child process `exit`/`error` events logic to use `async`/`await`. This does not change the behavior.