### PR TITLE
Improve some tests

### DIFF
--- a/test/node.js
+++ b/test/node.js
@@ -109,4 +109,7 @@ test('node\'s forked script has a communication channel', async t => {
 	t.is(message, 'pong');
 
 	subprocess.kill();
+
+	const {signal} = await t.throwsAsync(subprocess);
+	t.is(signal, 'SIGTERM');
 });


### PR DESCRIPTION
This PR improves some tests related to the `forceKillAfterTimeout` option, mostly removing some code duplication, and ensuring any child process's promise is awaited.