### PR TITLE
Use `async/await` instead of direct `Promise` manipulation

### DIFF
--- a/lib/kill.js
+++ b/lib/kill.js
@@ -51,27 +51,22 @@ export const spawnedCancel = (spawned, context) => {
 	}
 };
 
-const killAfterTimeout = async (spawned, timeout, killSignal, controller) => {
+const killAfterTimeout = async ({spawned, timeout, killSignal, context, controller}) => {
 	await pSetTimeout(timeout, undefined, {ref: false, signal: controller.signal});
 	spawned.kill(killSignal);
-	throw Object.assign(new Error('Timed out'), {timedOut: true, signal: killSignal});
+	Object.assign(context, {timedOut: true, signal: killSignal});
+	throw new Error('Timed out');
 };
 
 // `timeout` option handling
-export const setupTimeout = async (spawned, {timeout, killSignal = 'SIGTERM'}, spawnedPromise) => {
+export const throwOnTimeout = ({spawned, timeout, killSignal, context, finalizers}) => {
 	if (timeout === 0 || timeout === undefined) {
-		return spawnedPromise;
+		return [];
 	}
 
 	const controller = new AbortController();
-	try {
-		return await Promise.race([
-			spawnedPromise,
-			killAfterTimeout(spawned, timeout, killSignal, controller),
-		]);
-	} finally {
-		controller.abort();
-	}
+	finalizers.push(controller.abort.bind(controller));
+	return [killAfterTimeout({spawned, timeout, killSignal, context, controller})];
 };
 
 export const validateTimeout = ({timeout}) => {
@@ -81,18 +76,13 @@ export const validateTimeout = ({timeout}) => {
 };
 
 // `cleanup` option handling
-export const setExitHandler = async (spawned, {cleanup, detached}, timedPromise) => {
+export const cleanupOnExit = (spawned, cleanup, detached, finalizers) => {
 	if (!cleanup || detached) {
-		return timedPromise;
+		return;
 	}
 
 	const removeExitHandler = onExit(() => {
 		spawned.kill();
 	});
-
-	try {
-		return await timedPromise;
-	} finally {
-		removeExitHandler();
-	}
+	finalizers.push(removeExitHandler);
 };

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,5 +1,3 @@
-import {once} from 'node:events';
-
 // eslint-disable-next-line unicorn/prefer-top-level-await
 const nativePromisePrototype = (async () => {})().constructor.prototype;
 
@@ -14,10 +12,4 @@ export const mergePromise = (spawned, promise) => {
 		const value = descriptor.value.bind(promise);
 		Reflect.defineProperty(spawned, property, {...descriptor, value});
 	}
-};
-
-// Use promises instead of `child_process` events
-export const getSpawnedPromise = async spawned => {
-	const [exitCode, signal] = await once(spawned, 'exit');
-	return {exitCode, signal};
 };

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -4,6 +4,7 @@ import {finished} from 'node:stream/promises';
 import process from 'node:process';
 import getStream, {getStreamAsArrayBuffer} from 'get-stream';
 import mergeStreams from '@sindresorhus/merge-streams';
+import {throwOnTimeout, cleanupOnExit} from './kill.js';
 
 // `all` interleaves `stdout` and `stderr`
 export const makeAllStream = (spawned, {all}) => {
@@ -60,6 +61,9 @@ const applyEncoding = (contents, encoding) => {
 // eslint-disable-next-line unicorn/text-encoding-identifier-case
 const isUtf8Encoding = encoding => encoding === 'utf8' || encoding === 'utf-8';
 
+// Retrieve streams created by the `std*` options
+const getCustomStreams = stdioStreams => stdioStreams.filter(({type}) => type !== 'native' && type !== 'stringOrBuffer');
+
 // Some `stdout`/`stderr` options create a stream, e.g. when passing a file path.
 // The `.pipe()` method automatically ends that stream when `childProcess.stdout|stderr` ends.
 // This makes sure we want for the completion of those streams, in order to catch any error.
@@ -68,19 +72,18 @@ const isUtf8Encoding = encoding => encoding === 'utf8' || encoding === 'utf-8';
 // This is because source streams completion should end destination streams, but not the other way around.
 // This allows for source streams to pipe to multiple destinations.
 // We make an exception for `filePath`, since we create that source stream and we know it is piped to a single destination.
-const waitForStreamEnd = ({value, type, direction}, processDone) => {
-	if (type === 'native' || type === 'stringOrBuffer') {
-		return;
-	}
+const waitForCustomStreamsEnd = customStreams => customStreams
+	.filter(({value, type, direction}) => shouldWaitForCustomStream(value, type, direction))
+	.map(({value}) => finished(value));
 
-	return type === 'filePath' || (direction === 'output' && value !== process.stdout && value !== process.stderr)
-		? finished(value)
-		: Promise.race([processDone, throwOnStreamError(value)]);
-};
+const throwOnCustomStreamsError = customStreams => customStreams
+	.filter(({value, type, direction}) => !shouldWaitForCustomStream(value, type, direction))
+	.map(({value}) => throwOnStreamError(value));
 
-const throwIfStreamError = (stream, processDone) => stream === null
-	? undefined
-	: Promise.race([processDone, throwOnStreamError(stream)]);
+const shouldWaitForCustomStream = (value, type, direction) => type === 'filePath'
+	|| (direction === 'output' && value !== process.stdout && value !== process.stderr);
+
+const throwIfStreamError = stream => stream === null ? [] : [throwOnStreamError(stream)];
 
 const throwOnStreamError = async stream => {
 	const [error] = await once(stream, 'error');
@@ -90,10 +93,10 @@ const throwOnStreamError = async stream => {
 // The streams created by the `std*` options are automatically ended by `.pipe()`.
 // However `.pipe()` only does so when the source stream ended, not when it errored.
 // Therefore, when `childProcess.stdin|stdout|stderr` errors, those streams must be manually destroyed.
-const cleanupStdioStreams = (stdioStreams, error) => {
-	for (const stdioStream of stdioStreams) {
-		if (stdioStream.autoDestroy) {
-			stdioStream.value.destroy(error);
+const cleanupStdioStreams = (customStreams, error) => {
+	for (const customStream of customStreams) {
+		if (customStream.autoDestroy) {
+			customStream.value.destroy(error);
 		}
 	}
 };
@@ -101,32 +104,44 @@ const cleanupStdioStreams = (stdioStreams, error) => {
 // Retrieve result of child process: exit code, signal, error, streams (stdout/stderr/all)
 export const getSpawnedResult = async (
 	spawned,
-	{encoding, buffer, maxBuffer},
+	{encoding, buffer, maxBuffer, timeout, killSignal, cleanup, detached},
+	context,
 	stdioStreams,
-	processDone,
 ) => {
+	const finalizers = [];
+	cleanupOnExit(spawned, cleanup, detached, finalizers);
+	const customStreams = getCustomStreams(stdioStreams);
+
 	const stdoutPromise = getStreamPromise(spawned.stdout, {encoding, buffer, maxBuffer});
 	const stderrPromise = getStreamPromise(spawned.stderr, {encoding, buffer, maxBuffer});
 	const allPromise = getStreamPromise(spawned.all, {encoding, buffer, maxBuffer: maxBuffer * 2});
 
 	try {
-		return await Promise.all([
-			processDone,
-			stdoutPromise,
-			stderrPromise,
-			allPromise,
-			throwIfStreamError(spawned.stdin, processDone),
-			...stdioStreams.map(stdioStream => waitForStreamEnd(stdioStream, processDone)),
+		return await Promise.race([
+			Promise.all([
+				once(spawned, 'exit'),
+				stdoutPromise,
+				stderrPromise,
+				allPromise,
+				...waitForCustomStreamsEnd(customStreams),
+			]),
+			...throwOnCustomStreamsError(customStreams),
+			...throwIfStreamError(spawned.stdin),
+			...throwOnTimeout({spawned, timeout, killSignal, context, finalizers}),
 		]);
 	} catch (error) {
 		spawned.kill();
 		const results = await Promise.all([
-			{error, signal: error.signal, timedOut: error.timedOut},
+			[undefined, context.signal, error],
 			getBufferedData(stdoutPromise, encoding),
 			getBufferedData(stderrPromise, encoding),
 			getBufferedData(allPromise, encoding),
 		]);
-		cleanupStdioStreams(stdioStreams, error);
+		cleanupStdioStreams(customStreams, error);
 		return results;
+	} finally {
+		for (const finalizer of finalizers) {
+			finalizer();
+		}
 	}
 };


### PR DESCRIPTION
This PR refactors the logic to avoid passing promises around. Instead, it uses `async/await`.
This only refactors it, the behavior is not changed.