### PR TITLE
Fix Node.js streams not being cleaned up on process error

### DIFF
--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -7,13 +7,13 @@ export const handleInputAsync = options => handleInput(addPropertiesAsync, optio
 
 const addPropertiesAsync = {
 	input: {
-		filePath: ({value}) => ({value: createReadStream(value), autoDestroy: true}),
-		webStream: ({value}) => ({value: Readable.fromWeb(value), autoDestroy: true}),
-		iterable: ({value}) => ({value: Readable.from(value), autoDestroy: true}),
+		filePath: ({value}) => ({value: createReadStream(value)}),
+		webStream: ({value}) => ({value: Readable.fromWeb(value)}),
+		iterable: ({value}) => ({value: Readable.from(value)}),
 	},
 	output: {
-		filePath: ({value}) => ({value: createWriteStream(value), autoDestroy: true}),
-		webStream: ({value}) => ({value: Writable.fromWeb(value), autoDestroy: true}),
+		filePath: ({value}) => ({value: createWriteStream(value)}),
+		webStream: ({value}) => ({value: Writable.fromWeb(value)}),
 		iterable({optionName}) {
 			throw new TypeError(`The \`${optionName}\` option cannot be an iterable.`);
 		},

--- a/lib/stdio/native.js
+++ b/lib/stdio/native.js
@@ -45,4 +45,4 @@ const getStandardStream = (index, value, optionName) => {
 	return standardStream;
 };
 
-const STANDARD_STREAMS = [process.stdin, process.stdout, process.stderr];
+export const STANDARD_STREAMS = [process.stdin, process.stdout, process.stderr];

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,10 +1,10 @@
 import {Buffer} from 'node:buffer';
 import {once} from 'node:events';
 import {finished} from 'node:stream/promises';
-import process from 'node:process';
 import getStream, {getStreamAsArrayBuffer} from 'get-stream';
 import mergeStreams from '@sindresorhus/merge-streams';
 import {throwOnTimeout, cleanupOnExit} from './kill.js';
+import {STANDARD_STREAMS} from './stdio/native.js';
 
 // `all` interleaves `stdout` and `stderr`
 export const makeAllStream = (spawned, {all}) => {
@@ -80,8 +80,8 @@ const throwOnCustomStreamsError = customStreams => customStreams
 	.filter(({value, type, direction}) => !shouldWaitForCustomStream(value, type, direction))
 	.map(({value}) => throwOnStreamError(value));
 
-const shouldWaitForCustomStream = (value, type, direction) => type === 'filePath'
-	|| (direction === 'output' && value !== process.stdout && value !== process.stderr);
+const shouldWaitForCustomStream = (value, type, direction) => (type === 'filePath' || direction === 'output')
+	&& !STANDARD_STREAMS.includes(value);
 
 const throwIfStreamError = stream => stream === null ? [] : [throwOnStreamError(stream)];
 
@@ -95,7 +95,7 @@ const throwOnStreamError = async stream => {
 // Therefore, when `childProcess.stdin|stdout|stderr` errors, those streams must be manually destroyed.
 const cleanupStdioStreams = (customStreams, error) => {
 	for (const customStream of customStreams) {
-		if (customStream.autoDestroy) {
+		if (!STANDARD_STREAMS.includes(customStream.value)) {
 			customStream.value.destroy(error);
 		}
 	}

--- a/test/stdio/array.js
+++ b/test/stdio/array.js
@@ -255,3 +255,15 @@ test('stdin can be ["overlapped", "pipe"]', testOverlapped, getStdinOption);
 test('stdout can be ["overlapped", "pipe"]', testOverlapped, getStdoutOption);
 test('stderr can be ["overlapped", "pipe"]', testOverlapped, getStderrOption);
 test('stdio[*] can be ["overlapped", "pipe"]', testOverlapped, getStdioOption);
+
+const testDestroyStandard = async (t, optionName) => {
+	await t.throwsAsync(
+		execa('forever.js', {timeout: 1, [optionName]: [process[optionName], 'pipe']}),
+		{message: /timed out/},
+	);
+	t.false(process[optionName].destroyed);
+};
+
+test('Does not destroy process.stdin on errors', testDestroyStandard, 'stdin');
+test('Does not destroy process.stdout on errors', testDestroyStandard, 'stdout');
+test('Does not destroy process.stderr on errors', testDestroyStandard, 'stderr');


### PR DESCRIPTION
When passing the `{ stdout: [nodeStream, ...] }` option (or `stderr`), the Node.js stream ends when the process ends. This is due to Execa calling `childProcess.stdout.pipe()`, which itself calls `nodeStream.end()` under the hood.

The same happens for the `{ stdin: [nodeStream, ...] }` option. This is due to the Node.js stream naturally ending once its data has been fully read.

This PR ensures that when the process promise throws (e.g. due to the `timeout` option), the Node.js stream is also properly destroyed. At the moment, this is only done for web streams.