### PR TITLE
Fix using multiple `stdin` values

### DIFF
--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -1,5 +1,6 @@
 import {createReadStream, createWriteStream} from 'node:fs';
 import {Readable, Writable} from 'node:stream';
+import mergeStreams from '@sindresorhus/merge-streams';
 import {handleInput} from './handle.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async mode
@@ -21,13 +22,21 @@ const addPropertiesAsync = {
 };
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, after spawning, in async mode
+// When multiple input streams are used, we merge them to ensure the output stream ends only once each input stream has ended
 export const pipeOutputAsync = (spawned, stdioStreams) => {
+	const inputStreamsGroups = {};
+
 	for (const stdioStream of stdioStreams) {
-		pipeStdioOption(spawned.stdio[stdioStream.index], stdioStream);
+		pipeStdioOption(spawned.stdio[stdioStream.index], stdioStream, inputStreamsGroups);
+	}
+
+	for (const [index, inputStreams] of Object.entries(inputStreamsGroups)) {
+		const value = inputStreams.length === 1 ? inputStreams[0] : mergeStreams(inputStreams);
+		value.pipe(spawned.stdio[index]);
 	}
 };
 
-const pipeStdioOption = (childStream, {type, value, direction}) => {
+const pipeStdioOption = (childStream, {type, value, direction, index}, inputStreamsGroups) => {
 	if (type === 'native') {
 		return;
 	}
@@ -42,5 +51,5 @@ const pipeStdioOption = (childStream, {type, value, direction}) => {
 		return;
 	}
 
-	value.pipe(childStream);
+	inputStreamsGroups[index] = [...(inputStreamsGroups[index] ?? []), value];
 };

--- a/test/stdio/iterable.js
+++ b/test/stdio/iterable.js
@@ -61,3 +61,11 @@ test('stdin option can be an infinite iterable', async t => {
 		abort();
 	}
 });
+
+const testMultipleIterable = async (t, fixtureName, getOptions) => {
+	const {stdout} = await execa(fixtureName, getOptions([stringGenerator(), asyncGenerator()]));
+	t.is(stdout, 'foobarfoobar');
+};
+
+test('stdin option can be multiple iterables', testMultipleIterable, 'stdin.js', getStdinOption);
+test('stdio[*] option can be multiple iterables', testMultipleIterable, 'stdin-fd3.js', getStdioOption);


### PR DESCRIPTION
This PR fixes a bug when using multiple values with the `stdin` option. 

Since each value calls `stdinValue.pipe(childProcess.stdin)`, and `.pipe()` ends the writable stream when the readable stream ends, then the first `stdin` option value that ends prevents other `stdin` option values from writing to `childProcess.stdin` anymore.

This PR fixes this by using `merge-streams`, which waits for all streams to end before ending the writable stream.