### PR TITLE
Improve documentation of synchronous methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,12 +118,10 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	- `'inherit'`: Re-use the current process' `stdin`.
 	- an integer: Re-use a specific file descriptor from the current process.
 	- a Node.js `Readable` stream.
-
-	Unless the synchronous methods are used, the value can also be a:
-	- file path. If relative, it must start with `.`.
-	- file URL.
-	- web [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
-	- [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)
+	- a file path. If relative, it must start with `.`.
+	- a file URL.
+	- a web [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+	- an [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or an [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
@@ -140,11 +138,9 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	- `'inherit'`: Re-use the current process' `stdout`.
 	- an integer: Re-use a specific file descriptor from the current process.
 	- a Node.js `Writable` stream.
-
-	Unless the synchronous methods are used, the value can also be a:
-	- file path. If relative, it must start with `.`.
-	- file URL.
-	- web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
+	- a file path. If relative, it must start with `.`.
+	- a file URL.
+	- a web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
@@ -161,11 +157,9 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 	- `'inherit'`: Re-use the current process' `stderr`.
 	- an integer: Re-use a specific file descriptor from the current process.
 	- a Node.js `Writable` stream.
-
-	Unless the synchronous methods are used, the value can also be a:
-	- file path. If relative, it must start with `.`.
-	- file URL.
-	- web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
+	- a file path. If relative, it must start with `.`.
+	- a file URL.
+	- a web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
@@ -351,8 +345,7 @@ export type CommonOptions<EncodingType extends EncodingOption = DefaultEncodingO
 
 export type Options<EncodingType extends EncodingOption = DefaultEncodingOption> = {
 	/**
-	Write some input to the child process' `stdin`.\
-	Streams are not allowed when using the synchronous methods.
+	Write some input to the child process' `stdin`.
 
 	See also the `inputFile` and `stdin` options.
 	*/
@@ -493,7 +486,6 @@ export type ExecaReturnValue<StdoutStderrType extends StdoutStderrAll = string> 
 
 	This is `undefined` if either:
 	- the `all` option is `false` (default value)
-	- the synchronous methods are used
   - both `stdout` and `stderr` options are set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio)
 	*/
 	all?: StdoutStderrType;
@@ -560,7 +552,6 @@ export type ExecaChildPromise<StdoutStderrType extends StdoutStderrAll> = {
 
 	This is `undefined` if either:
 	- the `all` option is `false` (the default value)
-	- the synchronous methods are used
 	- both `stdout` and `stderr` options are set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio)
 	*/
 	all?: Readable;
@@ -737,6 +728,8 @@ export function execa<EncodingType extends EncodingOption = DefaultEncodingOptio
 /**
 Same as `execa()` but synchronous.
 
+Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be a stream nor an iterable.
+
 @param file - The program/script to execute, as a string or file URL
 @param arguments - Arguments to pass to `file` on execution.
 @returns A `childProcessResult` object
@@ -833,6 +826,8 @@ export function execaCommand<EncodingType extends EncodingOption = DefaultEncodi
 /**
 Same as `execaCommand()` but synchronous.
 
+Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be a stream nor an iterable.
+
 @param command - The program/script to execute and its arguments.
 @returns A `childProcessResult` object
 @throws A `childProcessResult` error
@@ -892,6 +887,8 @@ type Execa$<StdoutStderrType extends StdoutStderrAll = string> = {
 	/**
 	Same as $\`command\` but synchronous.
 
+	Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be a stream nor an iterable.
+
 	@returns A `childProcessResult` object
 	@throws A `childProcessResult` error
 
@@ -941,6 +938,8 @@ type Execa$<StdoutStderrType extends StdoutStderrAll = string> = {
 
 	/**
 	Same as $\`command\` but synchronous.
+
+	Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be a stream nor an iterable.
 
 	@returns A `childProcessResult` object
 	@throws A `childProcessResult` error

--- a/readme.md
+++ b/readme.md
@@ -289,6 +289,8 @@ This is the preferred method when executing a user-supplied `command` string, su
 
 Same as [`execa()`](#execacommandcommand-options) but synchronous.
 
+Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`serialization`](#serialization) and [`signal`](#signal). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio) and [`input`](#input) options cannot be a stream nor an iterable.
+
 Returns or throws a [`childProcessResult`](#childProcessResult).
 
 ### $.sync\`command\`
@@ -296,11 +298,15 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 Same as [$\`command\`](#command) but synchronous.
 
+Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`serialization`](#serialization) and [`signal`](#signal). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio) and [`input`](#input) options cannot be a stream nor an iterable.
+
 Returns or throws a [`childProcessResult`](#childProcessResult).
 
 ### execaCommandSync(command, options?)
 
 Same as [`execaCommand()`](#execacommand-command-options) but synchronous.
+
+Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`serialization`](#serialization) and [`signal`](#signal). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio) and [`input`](#input) options cannot be a stream nor an iterable.
 
 Returns or throws a [`childProcessResult`](#childProcessResult).
 
@@ -337,7 +343,6 @@ Stream [combining/interleaving](#ensuring-all-output-is-interleaved) [`stdout`](
 
 This is `undefined` if either:
 - the [`all` option](#all-2) is `false` (the default value)
-- the [synchronous methods](#execasyncfile-arguments-options) are used
 - both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio)
 
 #### pipeStdout(target)
@@ -423,7 +428,6 @@ The output of the process with `stdout` and `stderr` [interleaved](#ensuring-all
 
 This is `undefined` if either:
 - the [`all` option](#all-2) is `false` (the default value)
-- the [synchronous methods](#execasyncfile-arguments-options) are used
 - both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio)
 
 #### failed
@@ -554,8 +558,7 @@ If the spawned process fails, [`error.stdout`](#stdout), [`error.stderr`](#stder
 
 Type: `string | Uint8Array | stream.Readable`
 
-Write some input to the child process' `stdin`.\
-Streams are not allowed when using the [synchronous methods](#execasyncfile-arguments-options).
+Write some input to the child process' `stdin`.
 
 See also the [`inputFile`](#inputfile) and [`stdin`](#stdin) options.
 
@@ -580,12 +583,10 @@ Default: `inherit` with [`$`](#command), `pipe` otherwise
 - `'inherit'`: Re-use the current process' `stdin`.
 - an integer: Re-use a specific file descriptor from the current process.
 - a [Node.js `Readable` stream](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr).
-
-Unless the [synchronous methods](#execasyncfile-arguments-options) are used, the value can also be a:
-- file path. If relative, it must start with `.`.
-- file URL.
-- web [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
-- [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)
+- a file path. If relative, it must start with `.`.
+- a file URL.
+- a web [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+- an [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol) or an [`AsyncIterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
@@ -602,11 +603,9 @@ Default: `pipe`
 - `'inherit'`: Re-use the current process' `stdout`.
 - an integer: Re-use a specific file descriptor from the current process.
 - a [Node.js `Writable` stream](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr).
-
-Unless the [synchronous methods](#execasyncfile-arguments-options) are used, the value can also be a:
-- file path. If relative, it must start with `.`.
-- file URL.
-- web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
+- a file path. If relative, it must start with `.`.
+- a file URL.
+- a web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
@@ -623,11 +622,9 @@ Default: `pipe`
 - `'inherit'`: Re-use the current process' `stderr`.
 - an integer: Re-use a specific file descriptor from the current process.
 - a [Node.js `Writable` stream](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr).
-
-Unless the [synchronous methods](#execasyncfile-arguments-options) are used, the value can also be a:
-- file path. If relative, it must start with `.`.
-- file URL.
-- web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
+- a file path. If relative, it must start with `.`.
+- a file URL.
+- a web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 


### PR DESCRIPTION
The synchronous methods have multiple limitations. At the moment, those are documented in each method or option that has the limitation. 

This PR lists all the limitations directly in the documentation of the synchronous methods instead. This makes the documentation of the methods and options simpler. This also makes it more discouraging to use the synchronous methods by listing their limitations upfront.