### PR TITLE
Improve types of synchronous methods

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,7 +4,7 @@
 import * as process from 'node:process';
 import {Readable, Writable} from 'node:stream';
 import {createWriteStream} from 'node:fs';
-import {expectType, expectError, expectAssignable} from 'tsd';
+import {expectType, expectError, expectAssignable, expectNotAssignable} from 'tsd';
 import {
 	$,
 	execa,
@@ -12,9 +12,11 @@ import {
 	execaCommand,
 	execaCommandSync,
 	execaNode,
+	type Options,
 	type ExecaReturnValue,
 	type ExecaChildProcess,
 	type ExecaError,
+	type SyncOptions,
 	type ExecaSyncReturnValue,
 	type ExecaSyncError,
 } from './index.js';
@@ -72,7 +74,7 @@ try {
 	expectType<string | undefined>(unicornsResult.signalDescription);
 	expectType<string>(unicornsResult.cwd);
 } catch (error: unknown) {
-	const execaError = error as ExecaError;
+	const execaError = error as ExecaError<false>;
 
 	expectType<string>(execaError.message);
 	expectType<number | undefined>(execaError.exitCode);
@@ -92,6 +94,7 @@ try {
 
 try {
 	const unicornsResult = execaSync('unicorns');
+	expectType<ExecaSyncReturnValue>(unicornsResult);
 	expectType<string>(unicornsResult.command);
 	expectType<string>(unicornsResult.escapedCommand);
 	expectType<number | undefined>(unicornsResult.exitCode);
@@ -103,14 +106,15 @@ try {
 	expectError(unicornsResult.pipeAll);
 	expectType<boolean>(unicornsResult.failed);
 	expectType<boolean>(unicornsResult.timedOut);
-	expectError(unicornsResult.isCanceled);
+	expectType<boolean>(unicornsResult.isCanceled);
 	expectType<boolean>(unicornsResult.isTerminated);
 	expectType<string | undefined>(unicornsResult.signal);
 	expectType<string | undefined>(unicornsResult.signalDescription);
 	expectType<string>(unicornsResult.cwd);
 } catch (error: unknown) {
-	const execaError = error as ExecaSyncError;
+	const execaError = error as ExecaError<true>;
 
+	expectType<ExecaSyncError>(execaError);
 	expectType<string>(execaError.message);
 	expectType<number | undefined>(execaError.exitCode);
 	expectType<string>(execaError.stdout);
@@ -118,7 +122,7 @@ try {
 	expectError(execaError.all);
 	expectType<boolean>(execaError.failed);
 	expectType<boolean>(execaError.timedOut);
-	expectError(execaError.isCanceled);
+	expectType<boolean>(execaError.isCanceled);
 	expectType<boolean>(execaError.isTerminated);
 	expectType<string | undefined>(execaError.signal);
 	expectType<string | undefined>(execaError.signalDescription);
@@ -145,152 +149,301 @@ const asyncStringGenerator = async function * () {
 
 const fileUrl = new URL('file:///test');
 
+expectAssignable<Options>({cleanup: false});
+expectNotAssignable<SyncOptions>({cleanup: false});
+expectAssignable<SyncOptions>({preferLocal: false});
+
 /* eslint-disable @typescript-eslint/no-floating-promises */
 execa('unicorns', {cleanup: false});
+expectError(execaSync('unicorns', {cleanup: false}));
 execa('unicorns', {preferLocal: false});
+execaSync('unicorns', {preferLocal: false});
 execa('unicorns', {localDir: '.'});
+execaSync('unicorns', {localDir: '.'});
 execa('unicorns', {localDir: fileUrl});
+execaSync('unicorns', {localDir: fileUrl});
 expectError(execa('unicorns', {encoding: 'unknownEncoding'}));
+expectError(execaSync('unicorns', {encoding: 'unknownEncoding'}));
 execa('unicorns', {execPath: '/path'});
+execaSync('unicorns', {execPath: '/path'});
 execa('unicorns', {execPath: fileUrl});
+execaSync('unicorns', {execPath: fileUrl});
 execa('unicorns', {buffer: false});
+expectError(execaSync('unicorns', {buffer: false}));
 execa('unicorns', {input: ''});
+execaSync('unicorns', {input: ''});
 execa('unicorns', {input: new Uint8Array()});
+execaSync('unicorns', {input: new Uint8Array()});
 execa('unicorns', {input: process.stdin});
+expectError(execaSync('unicorns', {input: process.stdin}));
 execa('unicorns', {inputFile: ''});
+execaSync('unicorns', {inputFile: ''});
 execa('unicorns', {inputFile: fileUrl});
+execaSync('unicorns', {inputFile: fileUrl});
 execa('unicorns', {stdin: 'pipe'});
+execaSync('unicorns', {stdin: 'pipe'});
 execa('unicorns', {stdin: ['pipe']});
+execaSync('unicorns', {stdin: ['pipe']});
 execa('unicorns', {stdin: 'overlapped'});
+execaSync('unicorns', {stdin: 'overlapped'});
 execa('unicorns', {stdin: ['overlapped']});
+execaSync('unicorns', {stdin: ['overlapped']});
 execa('unicorns', {stdin: 'ipc'});
+execaSync('unicorns', {stdin: 'ipc'});
 execa('unicorns', {stdin: ['ipc']});
+execaSync('unicorns', {stdin: ['ipc']});
 execa('unicorns', {stdin: 'ignore'});
+execaSync('unicorns', {stdin: 'ignore'});
 execa('unicorns', {stdin: ['ignore']});
+execaSync('unicorns', {stdin: ['ignore']});
 execa('unicorns', {stdin: 'inherit'});
+execaSync('unicorns', {stdin: 'inherit'});
 execa('unicorns', {stdin: ['inherit']});
+execaSync('unicorns', {stdin: ['inherit']});
 execa('unicorns', {stdin: process.stdin});
+expectError(execaSync('unicorns', {stdin: process.stdin}));
 execa('unicorns', {stdin: [process.stdin]});
+expectError(execaSync('unicorns', {stdin: [process.stdin]}));
 execa('unicorns', {stdin: new Readable()});
+expectError(execaSync('unicorns', {stdin: new Readable()}));
 execa('unicorns', {stdin: [new Readable()]});
+expectError(execaSync('unicorns', {stdin: [new Readable()]}));
 expectError(execa('unicorns', {stdin: new Writable()}));
+expectError(execaSync('unicorns', {stdin: new Writable()}));
 expectError(execa('unicorns', {stdin: [new Writable()]}));
+expectError(execaSync('unicorns', {stdin: [new Writable()]}));
 execa('unicorns', {stdin: new ReadableStream()});
+expectError(execaSync('unicorns', {stdin: new ReadableStream()}));
 execa('unicorns', {stdin: [new ReadableStream()]});
+expectError(execaSync('unicorns', {stdin: [new ReadableStream()]}));
 expectError(execa('unicorns', {stdin: new WritableStream()}));
+expectError(execaSync('unicorns', {stdin: new WritableStream()}));
 expectError(execa('unicorns', {stdin: [new WritableStream()]}));
+expectError(execaSync('unicorns', {stdin: [new WritableStream()]}));
 execa('unicorns', {stdin: new Uint8Array()});
+execaSync('unicorns', {stdin: new Uint8Array()});
 execa('unicorns', {stdin: stringGenerator()});
+expectError(execaSync('unicorns', {stdin: stringGenerator()}));
 execa('unicorns', {stdin: [stringGenerator()]});
+expectError(execaSync('unicorns', {stdin: [stringGenerator()]}));
 execa('unicorns', {stdin: binaryGenerator()});
+expectError(execaSync('unicorns', {stdin: binaryGenerator()}));
 execa('unicorns', {stdin: [binaryGenerator()]});
+expectError(execaSync('unicorns', {stdin: [binaryGenerator()]}));
 execa('unicorns', {stdin: asyncStringGenerator()});
+expectError(execaSync('unicorns', {stdin: asyncStringGenerator()}));
 execa('unicorns', {stdin: [asyncStringGenerator()]});
+expectError(execaSync('unicorns', {stdin: [asyncStringGenerator()]}));
 expectError(execa('unicorns', {stdin: numberGenerator()}));
+expectError(execaSync('unicorns', {stdin: numberGenerator()}));
 expectError(execa('unicorns', {stdin: [numberGenerator()]}));
+expectError(execaSync('unicorns', {stdin: [numberGenerator()]}));
 execa('unicorns', {stdin: fileUrl});
+execaSync('unicorns', {stdin: fileUrl});
 execa('unicorns', {stdin: [fileUrl]});
+execaSync('unicorns', {stdin: [fileUrl]});
 execa('unicorns', {stdin: {file: './test'}});
+execaSync('unicorns', {stdin: {file: './test'}});
 execa('unicorns', {stdin: [{file: './test'}]});
+execaSync('unicorns', {stdin: [{file: './test'}]});
 execa('unicorns', {stdin: 1});
+execaSync('unicorns', {stdin: 1});
 execa('unicorns', {stdin: [1]});
+execaSync('unicorns', {stdin: [1]});
 execa('unicorns', {stdin: undefined});
+execaSync('unicorns', {stdin: undefined});
 execa('unicorns', {stdin: [undefined]});
+execaSync('unicorns', {stdin: [undefined]});
 execa('unicorns', {stdin: ['pipe', 'inherit']});
+execaSync('unicorns', {stdin: ['pipe', 'inherit']});
 execa('unicorns', {stdout: 'pipe'});
+execaSync('unicorns', {stdout: 'pipe'});
 execa('unicorns', {stdout: ['pipe']});
+execaSync('unicorns', {stdout: ['pipe']});
 execa('unicorns', {stdout: 'overlapped'});
+execaSync('unicorns', {stdout: 'overlapped'});
 execa('unicorns', {stdout: ['overlapped']});
+execaSync('unicorns', {stdout: ['overlapped']});
 execa('unicorns', {stdout: 'ipc'});
+execaSync('unicorns', {stdout: 'ipc'});
 execa('unicorns', {stdout: ['ipc']});
+execaSync('unicorns', {stdout: ['ipc']});
 execa('unicorns', {stdout: 'ignore'});
+execaSync('unicorns', {stdout: 'ignore'});
 execa('unicorns', {stdout: ['ignore']});
+execaSync('unicorns', {stdout: ['ignore']});
 execa('unicorns', {stdout: 'inherit'});
+execaSync('unicorns', {stdout: 'inherit'});
 execa('unicorns', {stdout: ['inherit']});
+execaSync('unicorns', {stdout: ['inherit']});
 execa('unicorns', {stdout: process.stdout});
+expectError(execaSync('unicorns', {stdout: process.stdout}));
 execa('unicorns', {stdout: [process.stdout]});
+expectError(execaSync('unicorns', {stdout: [process.stdout]}));
 execa('unicorns', {stdout: new Writable()});
+expectError(execaSync('unicorns', {stdout: new Writable()}));
 execa('unicorns', {stdout: [new Writable()]});
+expectError(execaSync('unicorns', {stdout: [new Writable()]}));
 expectError(execa('unicorns', {stdout: new Readable()}));
+expectError(execaSync('unicorns', {stdout: new Readable()}));
 expectError(execa('unicorn', {stdout: [new Readable()]}));
+expectError(execaSync('unicorn', {stdout: [new Readable()]}));
 execa('unicorns', {stdout: new WritableStream()});
+expectError(execaSync('unicorns', {stdout: new WritableStream()}));
 execa('unicorns', {stdout: [new WritableStream()]});
+expectError(execaSync('unicorns', {stdout: [new WritableStream()]}));
 expectError(execa('unicorns', {stdout: new ReadableStream()}));
+expectError(execaSync('unicorns', {stdout: new ReadableStream()}));
 expectError(execa('unicorn', {stdout: [new ReadableStream()]}));
+expectError(execaSync('unicorn', {stdout: [new ReadableStream()]}));
 execa('unicorns', {stdout: fileUrl});
+execaSync('unicorns', {stdout: fileUrl});
 execa('unicorns', {stdout: [fileUrl]});
+execaSync('unicorns', {stdout: [fileUrl]});
 execa('unicorns', {stdout: {file: './test'}});
+execaSync('unicorns', {stdout: {file: './test'}});
 execa('unicorns', {stdout: [{file: './test'}]});
+execaSync('unicorns', {stdout: [{file: './test'}]});
 execa('unicorns', {stdout: 1});
+execaSync('unicorns', {stdout: 1});
 execa('unicorns', {stdout: [1]});
+execaSync('unicorns', {stdout: [1]});
 execa('unicorns', {stdout: undefined});
+execaSync('unicorns', {stdout: undefined});
 execa('unicorns', {stdout: [undefined]});
+execaSync('unicorns', {stdout: [undefined]});
 execa('unicorns', {stdout: ['pipe', 'inherit']});
+execaSync('unicorns', {stdout: ['pipe', 'inherit']});
 execa('unicorns', {stderr: 'pipe'});
+execaSync('unicorns', {stderr: 'pipe'});
 execa('unicorns', {stderr: ['pipe']});
+execaSync('unicorns', {stderr: ['pipe']});
 execa('unicorns', {stderr: 'overlapped'});
+execaSync('unicorns', {stderr: 'overlapped'});
 execa('unicorns', {stderr: ['overlapped']});
+execaSync('unicorns', {stderr: ['overlapped']});
 execa('unicorns', {stderr: 'ipc'});
+execaSync('unicorns', {stderr: 'ipc'});
 execa('unicorns', {stderr: ['ipc']});
+execaSync('unicorns', {stderr: ['ipc']});
 execa('unicorns', {stderr: 'ignore'});
+execaSync('unicorns', {stderr: 'ignore'});
 execa('unicorns', {stderr: ['ignore']});
+execaSync('unicorns', {stderr: ['ignore']});
 execa('unicorns', {stderr: 'inherit'});
+execaSync('unicorns', {stderr: 'inherit'});
 execa('unicorns', {stderr: ['inherit']});
+execaSync('unicorns', {stderr: ['inherit']});
 execa('unicorns', {stderr: process.stderr});
+expectError(execaSync('unicorns', {stderr: process.stderr}));
 execa('unicorns', {stderr: [process.stderr]});
+expectError(execaSync('unicorns', {stderr: [process.stderr]}));
 execa('unicorns', {stderr: new Writable()});
+expectError(execaSync('unicorns', {stderr: new Writable()}));
 execa('unicorns', {stderr: [new Writable()]});
+expectError(execaSync('unicorns', {stderr: [new Writable()]}));
 expectError(execa('unicorns', {stderr: new Readable()}));
+expectError(execaSync('unicorns', {stderr: new Readable()}));
 expectError(execa('unicorns', {stderr: [new Readable()]}));
+expectError(execaSync('unicorns', {stderr: [new Readable()]}));
 execa('unicorns', {stderr: new WritableStream()});
+expectError(execaSync('unicorns', {stderr: new WritableStream()}));
 execa('unicorns', {stderr: [new WritableStream()]});
+expectError(execaSync('unicorns', {stderr: [new WritableStream()]}));
 expectError(execa('unicorns', {stderr: new ReadableStream()}));
+expectError(execaSync('unicorns', {stderr: new ReadableStream()}));
 expectError(execa('unicorns', {stderr: [new ReadableStream()]}));
+expectError(execaSync('unicorns', {stderr: [new ReadableStream()]}));
 execa('unicorns', {stderr: fileUrl});
+execaSync('unicorns', {stderr: fileUrl});
 execa('unicorns', {stderr: [fileUrl]});
+execaSync('unicorns', {stderr: [fileUrl]});
 execa('unicorns', {stderr: {file: './test'}});
+execaSync('unicorns', {stderr: {file: './test'}});
 execa('unicorns', {stderr: [{file: './test'}]});
+execaSync('unicorns', {stderr: [{file: './test'}]});
 execa('unicorns', {stderr: 1});
+execaSync('unicorns', {stderr: 1});
 execa('unicorns', {stderr: [1]});
+execaSync('unicorns', {stderr: [1]});
 execa('unicorns', {stderr: undefined});
+execaSync('unicorns', {stderr: undefined});
 execa('unicorns', {stderr: [undefined]});
+execaSync('unicorns', {stderr: [undefined]});
 execa('unicorns', {stderr: ['pipe', 'inherit']});
+execaSync('unicorns', {stderr: ['pipe', 'inherit']});
 execa('unicorns', {all: true});
+expectError(execaSync('unicorns', {all: true}));
 execa('unicorns', {reject: false});
+execaSync('unicorns', {reject: false});
 execa('unicorns', {stripFinalNewline: false});
+execaSync('unicorns', {stripFinalNewline: false});
 execa('unicorns', {extendEnv: false});
+execaSync('unicorns', {extendEnv: false});
 execa('unicorns', {cwd: '.'});
+execaSync('unicorns', {cwd: '.'});
 execa('unicorns', {cwd: fileUrl});
+execaSync('unicorns', {cwd: fileUrl});
 // eslint-disable-next-line @typescript-eslint/naming-convention
 execa('unicorns', {env: {PATH: ''}});
+// eslint-disable-next-line @typescript-eslint/naming-convention
+execaSync('unicorns', {env: {PATH: ''}});
 execa('unicorns', {argv0: ''});
+execaSync('unicorns', {argv0: ''});
 execa('unicorns', {stdio: 'pipe'});
+execaSync('unicorns', {stdio: 'pipe'});
 execa('unicorns', {stdio: 'overlapped'});
+execaSync('unicorns', {stdio: 'overlapped'});
 execa('unicorns', {stdio: 'ignore'});
+execaSync('unicorns', {stdio: 'ignore'});
 execa('unicorns', {stdio: 'inherit'});
+execaSync('unicorns', {stdio: 'inherit'});
 expectError(execa('unicorns', {stdio: 'ipc'}));
+expectError(execaSync('unicorns', {stdio: 'ipc'}));
 expectError(execa('unicorns', {stdio: 1}));
+expectError(execaSync('unicorns', {stdio: 1}));
 expectError(execa('unicorns', {stdio: fileUrl}));
+expectError(execaSync('unicorns', {stdio: fileUrl}));
 expectError(execa('unicorns', {stdio: {file: './test'}}));
+expectError(execaSync('unicorns', {stdio: {file: './test'}}));
 expectError(execa('unicorns', {stdio: new Writable()}));
+expectError(execaSync('unicorns', {stdio: new Writable()}));
 expectError(execa('unicorns', {stdio: new Readable()}));
+expectError(execaSync('unicorns', {stdio: new Readable()}));
 expectError(execa('unicorns', {stdio: new WritableStream()}));
+expectError(execaSync('unicorns', {stdio: new WritableStream()}));
 expectError(execa('unicorns', {stdio: new ReadableStream()}));
+expectError(execaSync('unicorns', {stdio: new ReadableStream()}));
 expectError(execa('unicorns', {stdio: stringGenerator()}));
+expectError(execaSync('unicorns', {stdio: stringGenerator()}));
 expectError(execa('unicorns', {stdio: asyncStringGenerator()}));
+expectError(execaSync('unicorns', {stdio: asyncStringGenerator()}));
 expectError(execa('unicorns', {stdio: ['pipe', 'pipe']}));
+expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe']}));
 execa('unicorns', {stdio: [new Readable(), 'pipe', 'pipe']});
+expectError(execaSync('unicorns', {stdio: [new Readable(), 'pipe', 'pipe']}));
 execa('unicorns', {stdio: [[new Readable()], ['pipe'], ['pipe']]});
+expectError(execaSync('unicorns', {stdio: [[new Readable()], ['pipe'], ['pipe']]}));
 execa('unicorns', {stdio: ['pipe', new Writable(), 'pipe']});
+expectError(execaSync('unicorns', {stdio: ['pipe', new Writable(), 'pipe']}));
 execa('unicorns', {stdio: [['pipe'], [new Writable()], ['pipe']]});
+expectError(execaSync('unicorns', {stdio: [['pipe'], [new Writable()], ['pipe']]}));
 execa('unicorns', {stdio: ['pipe', 'pipe', new Writable()]});
+expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', new Writable()]}));
 execa('unicorns', {stdio: [['pipe'], ['pipe'], [new Writable()]]});
+expectError(execaSync('unicorns', {stdio: [['pipe'], ['pipe'], [new Writable()]]}));
 expectError(execa('unicorns', {stdio: [new Writable(), 'pipe', 'pipe']}));
+expectError(execaSync('unicorns', {stdio: [new Writable(), 'pipe', 'pipe']}));
 expectError(execa('unicorns', {stdio: [[new Writable()], ['pipe'], ['pipe']]}));
+expectError(execaSync('unicorns', {stdio: [[new Writable()], ['pipe'], ['pipe']]}));
 expectError(execa('unicorns', {stdio: ['pipe', new Readable(), 'pipe']}));
+expectError(execaSync('unicorns', {stdio: ['pipe', new Readable(), 'pipe']}));
 expectError(execa('unicorns', {stdio: [['pipe'], [new Readable()], ['pipe']]}));
+expectError(execaSync('unicorns', {stdio: [['pipe'], [new Readable()], ['pipe']]}));
 expectError(execa('unicorns', {stdio: ['pipe', 'pipe', new Readable()]}));
+expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', new Readable()]}));
 expectError(execa('unicorns', {stdio: [['pipe'], ['pipe'], [new Readable()]]}));
+expectError(execaSync('unicorns', {stdio: [['pipe'], ['pipe'], [new Readable()]]}));
 execa('unicorns', {
 	stdio: [
 		'pipe',
@@ -312,6 +465,27 @@ execa('unicorns', {
 		asyncStringGenerator(),
 	],
 });
+execaSync('unicorns', {
+	stdio: [
+		'pipe',
+		'overlapped',
+		'ipc',
+		'ignore',
+		'inherit',
+		process.stdin,
+		1,
+		undefined,
+		fileUrl,
+		{file: './test'},
+		new Uint8Array(),
+	],
+});
+expectError(execaSync('unicorns', {stdio: [new Writable()]}));
+expectError(execaSync('unicorns', {stdio: [new Readable()]}));
+expectError(execaSync('unicorns', {stdio: [new WritableStream()]}));
+expectError(execaSync('unicorns', {stdio: [new ReadableStream()]}));
+expectError(execaSync('unicorns', {stdio: [stringGenerator()]}));
+expectError(execaSync('unicorns', {stdio: [asyncStringGenerator()]}));
 execa('unicorns', {
 	stdio: [
 		['pipe'],
@@ -329,25 +503,63 @@ execa('unicorns', {
 		[new Readable()],
 		[new WritableStream()],
 		[new ReadableStream()],
+		[new Uint8Array()],
 		[stringGenerator()],
 		[asyncStringGenerator()],
 	],
 });
+execaSync('unicorns', {
+	stdio: [
+		['pipe'],
+		['pipe', 'inherit'],
+		['overlapped'],
+		['ipc'],
+		['ignore'],
+		['inherit'],
+		[process.stdin],
+		[1],
+		[undefined],
+		[fileUrl],
+		[{file: './test'}],
+		[new Uint8Array()],
+	],
+});
+expectError(execaSync('unicorns', {stdio: [[new Writable()]]}));
+expectError(execaSync('unicorns', {stdio: [[new Readable()]]}));
+expectError(execaSync('unicorns', {stdio: [[new WritableStream()]]}));
+expectError(execaSync('unicorns', {stdio: [[new ReadableStream()]]}));
+expectError(execaSync('unicorns', {stdio: [[stringGenerator()]]}));
+expectError(execaSync('unicorns', {stdio: [[asyncStringGenerator()]]}));
 execa('unicorns', {serialization: 'advanced'});
+expectError(execaSync('unicorns', {serialization: 'advanced'}));
 execa('unicorns', {detached: true});
+expectError(execaSync('unicorns', {detached: true}));
 execa('unicorns', {uid: 0});
+execaSync('unicorns', {uid: 0});
 execa('unicorns', {gid: 0});
+execaSync('unicorns', {gid: 0});
 execa('unicorns', {shell: true});
+execaSync('unicorns', {shell: true});
 execa('unicorns', {shell: '/bin/sh'});
+execaSync('unicorns', {shell: '/bin/sh'});
 execa('unicorns', {shell: fileUrl});
+execaSync('unicorns', {shell: fileUrl});
 execa('unicorns', {timeout: 1000});
+execaSync('unicorns', {timeout: 1000});
 execa('unicorns', {maxBuffer: 1000});
+execaSync('unicorns', {maxBuffer: 1000});
 execa('unicorns', {killSignal: 'SIGTERM'});
+execaSync('unicorns', {killSignal: 'SIGTERM'});
 execa('unicorns', {killSignal: 9});
+execaSync('unicorns', {killSignal: 9});
 execa('unicorns', {signal: new AbortController().signal});
+expectError(execaSync('unicorns', {signal: new AbortController().signal}));
 execa('unicorns', {windowsVerbatimArguments: true});
+execaSync('unicorns', {windowsVerbatimArguments: true});
 execa('unicorns', {windowsHide: false});
+execaSync('unicorns', {windowsHide: false});
 execa('unicorns', {verbose: false});
+execaSync('unicorns', {verbose: false});
 /* eslint-enable @typescript-eslint/no-floating-promises */
 execa('unicorns').kill();
 execa('unicorns').kill('SIGKILL');
@@ -360,59 +572,59 @@ execa('unicorns').kill('SIGKILL', {forceKillAfterTimeout: undefined});
 expectError(execa(['unicorns', 'arg']));
 expectType<ExecaChildProcess>(execa('unicorns'));
 expectType<ExecaChildProcess>(execa(fileUrl));
-expectType<ExecaReturnValue>(await execa('unicorns'));
-expectType<ExecaReturnValue>(
+expectType<ExecaReturnValue<false>>(await execa('unicorns'));
+expectType<ExecaReturnValue<false>>(
 	await execa('unicorns', {encoding: 'utf8'}),
 );
-expectType<ExecaReturnValue<Uint8Array>>(await execa('unicorns', {encoding: 'buffer'}));
-expectType<ExecaReturnValue>(
+expectType<ExecaReturnValue<false, Uint8Array>>(await execa('unicorns', {encoding: 'buffer'}));
+expectType<ExecaReturnValue<false>>(
 	await execa('unicorns', ['foo'], {encoding: 'utf8'}),
 );
-expectType<ExecaReturnValue<Uint8Array>>(
+expectType<ExecaReturnValue<false, Uint8Array>>(
 	await execa('unicorns', ['foo'], {encoding: 'buffer'}),
 );
 
 expectError(execaSync(['unicorns', 'arg']));
-expectType<ExecaSyncReturnValue>(execaSync('unicorns'));
-expectType<ExecaSyncReturnValue>(execaSync(fileUrl));
-expectType<ExecaSyncReturnValue>(
+expectType<ExecaReturnValue<true>>(execaSync('unicorns'));
+expectType<ExecaReturnValue<true>>(execaSync(fileUrl));
+expectType<ExecaReturnValue<true>>(
 	execaSync('unicorns', {encoding: 'utf8'}),
 );
-expectType<ExecaSyncReturnValue<Uint8Array>>(
+expectType<ExecaReturnValue<true, Uint8Array>>(
 	execaSync('unicorns', {encoding: 'buffer'}),
 );
-expectType<ExecaSyncReturnValue>(
+expectType<ExecaReturnValue<true>>(
 	execaSync('unicorns', ['foo'], {encoding: 'utf8'}),
 );
-expectType<ExecaSyncReturnValue<Uint8Array>>(
+expectType<ExecaReturnValue<true, Uint8Array>>(
 	execaSync('unicorns', ['foo'], {encoding: 'buffer'}),
 );
 
 expectType<ExecaChildProcess>(execaCommand('unicorns'));
-expectType<ExecaReturnValue>(await execaCommand('unicorns'));
-expectType<ExecaReturnValue>(await execaCommand('unicorns', {encoding: 'utf8'}));
-expectType<ExecaReturnValue<Uint8Array>>(await execaCommand('unicorns', {encoding: 'buffer'}));
-expectType<ExecaReturnValue>(await execaCommand('unicorns foo', {encoding: 'utf8'}));
-expectType<ExecaReturnValue<Uint8Array>>(await execaCommand('unicorns foo', {encoding: 'buffer'}));
+expectType<ExecaReturnValue<false>>(await execaCommand('unicorns'));
+expectType<ExecaReturnValue<false>>(await execaCommand('unicorns', {encoding: 'utf8'}));
+expectType<ExecaReturnValue<false, Uint8Array>>(await execaCommand('unicorns', {encoding: 'buffer'}));
+expectType<ExecaReturnValue<false>>(await execaCommand('unicorns foo', {encoding: 'utf8'}));
+expectType<ExecaReturnValue<false, Uint8Array>>(await execaCommand('unicorns foo', {encoding: 'buffer'}));
 
-expectType<ExecaSyncReturnValue>(execaCommandSync('unicorns'));
-expectType<ExecaSyncReturnValue>(execaCommandSync('unicorns', {encoding: 'utf8'}));
-expectType<ExecaSyncReturnValue<Uint8Array>>(execaCommandSync('unicorns', {encoding: 'buffer'}));
-expectType<ExecaSyncReturnValue>(execaCommandSync('unicorns foo', {encoding: 'utf8'}));
-expectType<ExecaSyncReturnValue<Uint8Array>>(execaCommandSync('unicorns foo', {encoding: 'buffer'}));
+expectType<ExecaReturnValue<true>>(execaCommandSync('unicorns'));
+expectType<ExecaReturnValue<true>>(execaCommandSync('unicorns', {encoding: 'utf8'}));
+expectType<ExecaReturnValue<true, Uint8Array>>(execaCommandSync('unicorns', {encoding: 'buffer'}));
+expectType<ExecaReturnValue<true>>(execaCommandSync('unicorns foo', {encoding: 'utf8'}));
+expectType<ExecaReturnValue<true, Uint8Array>>(execaCommandSync('unicorns foo', {encoding: 'buffer'}));
 
 expectError(execaNode(['unicorns', 'arg']));
 expectType<ExecaChildProcess>(execaNode('unicorns'));
-expectType<ExecaReturnValue>(await execaNode('unicorns'));
-expectType<ExecaReturnValue>(await execaNode(fileUrl));
-expectType<ExecaReturnValue>(
+expectType<ExecaReturnValue<false>>(await execaNode('unicorns'));
+expectType<ExecaReturnValue<false>>(await execaNode(fileUrl));
+expectType<ExecaReturnValue<false>>(
 	await execaNode('unicorns', {encoding: 'utf8'}),
 );
-expectType<ExecaReturnValue<Uint8Array>>(await execaNode('unicorns', {encoding: 'buffer'}));
-expectType<ExecaReturnValue>(
+expectType<ExecaReturnValue<false, Uint8Array>>(await execaNode('unicorns', {encoding: 'buffer'}));
+expectType<ExecaReturnValue<false>>(
 	await execaNode('unicorns', ['foo'], {encoding: 'utf8'}),
 );
-expectType<ExecaReturnValue<Uint8Array>>(
+expectType<ExecaReturnValue<false, Uint8Array>>(
 	await execaNode('unicorns', ['foo'], {encoding: 'buffer'}),
 );
 
@@ -429,57 +641,57 @@ expectType<ExecaChildProcess<Uint8Array>>(
 );
 
 expectType<ExecaChildProcess>($`unicorns`);
-expectType<ExecaReturnValue>(await $`unicorns`);
-expectType<ExecaSyncReturnValue>($.sync`unicorns`);
-expectType<ExecaSyncReturnValue>($.s`unicorns`);
+expectType<ExecaReturnValue<false>>(await $`unicorns`);
+expectType<ExecaReturnValue<true>>($.sync`unicorns`);
+expectType<ExecaReturnValue<true>>($.s`unicorns`);
 
 expectType<ExecaChildProcess>($({encoding: 'utf8'})`unicorns`);
-expectType<ExecaReturnValue>(await $({encoding: 'utf8'})`unicorns`);
-expectType<ExecaSyncReturnValue>($({encoding: 'utf8'}).sync`unicorns`);
+expectType<ExecaReturnValue<false>>(await $({encoding: 'utf8'})`unicorns`);
+expectType<ExecaReturnValue<true>>($({encoding: 'utf8'}).sync`unicorns`);
 
 expectType<ExecaChildProcess>($({encoding: 'utf8'})`unicorns foo`);
-expectType<ExecaReturnValue>(await $({encoding: 'utf8'})`unicorns foo`);
-expectType<ExecaSyncReturnValue>($({encoding: 'utf8'}).sync`unicorns foo`);
+expectType<ExecaReturnValue<false>>(await $({encoding: 'utf8'})`unicorns foo`);
+expectType<ExecaReturnValue<true>>($({encoding: 'utf8'}).sync`unicorns foo`);
 
 expectType<ExecaChildProcess<Uint8Array>>($({encoding: 'buffer'})`unicorns`);
-expectType<ExecaReturnValue<Uint8Array>>(await $({encoding: 'buffer'})`unicorns`);
-expectType<ExecaSyncReturnValue<Uint8Array>>($({encoding: 'buffer'}).sync`unicorns`);
+expectType<ExecaReturnValue<false, Uint8Array>>(await $({encoding: 'buffer'})`unicorns`);
+expectType<ExecaReturnValue<true, Uint8Array>>($({encoding: 'buffer'}).sync`unicorns`);
 
 expectType<ExecaChildProcess<Uint8Array>>($({encoding: 'buffer'})`unicorns foo`);
-expectType<ExecaReturnValue<Uint8Array>>(await $({encoding: 'buffer'})`unicorns foo`);
-expectType<ExecaSyncReturnValue<Uint8Array>>($({encoding: 'buffer'}).sync`unicorns foo`);
+expectType<ExecaReturnValue<false, Uint8Array>>(await $({encoding: 'buffer'})`unicorns foo`);
+expectType<ExecaReturnValue<true, Uint8Array>>($({encoding: 'buffer'}).sync`unicorns foo`);
 
 expectType<ExecaChildProcess>($({encoding: 'buffer'})({encoding: 'utf8'})`unicorns`);
-expectType<ExecaReturnValue>(await $({encoding: 'buffer'})({encoding: 'utf8'})`unicorns`);
-expectType<ExecaSyncReturnValue>($({encoding: 'buffer'})({encoding: 'utf8'}).sync`unicorns`);
+expectType<ExecaReturnValue<false>>(await $({encoding: 'buffer'})({encoding: 'utf8'})`unicorns`);
+expectType<ExecaReturnValue<true>>($({encoding: 'buffer'})({encoding: 'utf8'}).sync`unicorns`);
 
 expectType<ExecaChildProcess>($({encoding: 'buffer'})({encoding: 'utf8'})`unicorns foo`);
-expectType<ExecaReturnValue>(await $({encoding: 'buffer'})({encoding: 'utf8'})`unicorns foo`);
-expectType<ExecaSyncReturnValue>($({encoding: 'buffer'})({encoding: 'utf8'}).sync`unicorns foo`);
+expectType<ExecaReturnValue<false>>(await $({encoding: 'buffer'})({encoding: 'utf8'})`unicorns foo`);
+expectType<ExecaReturnValue<true>>($({encoding: 'buffer'})({encoding: 'utf8'}).sync`unicorns foo`);
 
 expectType<ExecaChildProcess<Uint8Array>>($({encoding: 'buffer'})({})`unicorns`);
-expectType<ExecaReturnValue<Uint8Array>>(await $({encoding: 'buffer'})({})`unicorns`);
-expectType<ExecaSyncReturnValue<Uint8Array>>($({encoding: 'buffer'})({}).sync`unicorns`);
+expectType<ExecaReturnValue<false, Uint8Array>>(await $({encoding: 'buffer'})({})`unicorns`);
+expectType<ExecaReturnValue<true, Uint8Array>>($({encoding: 'buffer'})({}).sync`unicorns`);
 
 expectType<ExecaChildProcess<Uint8Array>>($({encoding: 'buffer'})({})`unicorns foo`);
-expectType<ExecaReturnValue<Uint8Array>>(await $({encoding: 'buffer'})({})`unicorns foo`);
-expectType<ExecaSyncReturnValue<Uint8Array>>($({encoding: 'buffer'})({}).sync`unicorns foo`);
+expectType<ExecaReturnValue<false, Uint8Array>>(await $({encoding: 'buffer'})({})`unicorns foo`);
+expectType<ExecaReturnValue<true, Uint8Array>>($({encoding: 'buffer'})({}).sync`unicorns foo`);
 
-expectType<ExecaReturnValue>(await $`unicorns ${'foo'}`);
-expectType<ExecaSyncReturnValue>($.sync`unicorns ${'foo'}`);
-expectType<ExecaReturnValue>(await $`unicorns ${1}`);
-expectType<ExecaSyncReturnValue>($.sync`unicorns ${1}`);
-expectType<ExecaReturnValue>(await $`unicorns ${['foo', 'bar']}`);
-expectType<ExecaSyncReturnValue>($.sync`unicorns ${['foo', 'bar']}`);
-expectType<ExecaReturnValue>(await $`unicorns ${[1, 2]}`);
-expectType<ExecaSyncReturnValue>($.sync`unicorns ${[1, 2]}`);
-expectType<ExecaReturnValue>(await $`unicorns ${await $`echo foo`}`);
-expectError<ExecaReturnValue>(await $`unicorns ${$`echo foo`}`);
-expectType<ExecaSyncReturnValue>($.sync`unicorns ${$.sync`echo foo`}`);
-expectType<ExecaReturnValue>(await $`unicorns ${[await $`echo foo`, 'bar']}`);
-expectError<ExecaReturnValue>(await $`unicorns ${[$`echo foo`, 'bar']}`);
-expectType<ExecaSyncReturnValue>($.sync`unicorns ${[$.sync`echo foo`, 'bar']}`);
-expectType<ExecaReturnValue>(await $`unicorns ${true.toString()}`);
-expectType<ExecaSyncReturnValue>($.sync`unicorns ${false.toString()}`);
-expectError<ExecaReturnValue>(await $`unicorns ${true}`);
-expectError<ExecaSyncReturnValue>($.sync`unicorns ${false}`);
+expectType<ExecaReturnValue<false>>(await $`unicorns ${'foo'}`);
+expectType<ExecaReturnValue<true>>($.sync`unicorns ${'foo'}`);
+expectType<ExecaReturnValue<false>>(await $`unicorns ${1}`);
+expectType<ExecaReturnValue<true>>($.sync`unicorns ${1}`);
+expectType<ExecaReturnValue<false>>(await $`unicorns ${['foo', 'bar']}`);
+expectType<ExecaReturnValue<true>>($.sync`unicorns ${['foo', 'bar']}`);
+expectType<ExecaReturnValue<false>>(await $`unicorns ${[1, 2]}`);
+expectType<ExecaReturnValue<true>>($.sync`unicorns ${[1, 2]}`);
+expectType<ExecaReturnValue<false>>(await $`unicorns ${await $`echo foo`}`);
+expectError<ExecaReturnValue<false>>(await $`unicorns ${$`echo foo`}`);
+expectType<ExecaReturnValue<true>>($.sync`unicorns ${$.sync`echo foo`}`);
+expectType<ExecaReturnValue<false>>(await $`unicorns ${[await $`echo foo`, 'bar']}`);
+expectError<ExecaReturnValue<false>>(await $`unicorns ${[$`echo foo`, 'bar']}`);
+expectType<ExecaReturnValue<true>>($.sync`unicorns ${[$.sync`echo foo`, 'bar']}`);
+expectType<ExecaReturnValue<false>>(await $`unicorns ${true.toString()}`);
+expectType<ExecaReturnValue<true>>($.sync`unicorns ${false.toString()}`);
+expectError<ExecaReturnValue<false>>(await $`unicorns ${true}`);
+expectError<ExecaReturnValue<true>>($.sync`unicorns ${false}`);


### PR DESCRIPTION
This improves the types of synchronous methods:
  - Forbid streams and iterables with the `stdin`, `stdout`, `stderr`, `stdio` and `input` options
  - Forbid the `cleanup`, `buffer`, `all`, `serialization`, `detached` and `signal` options
  - Allows the `inputFile` option to be a file URL
  - Returns the `isCanceled` option (it is always `false` when synchronous, but it is present)
  - Add many type tests