### PR TITLE
Document and type `exitCode` being `undefined`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -413,8 +413,10 @@ export type ExecaReturnBase<StdoutStderrType extends StdoutStderrAll> = {
 
 	/**
 	The numeric exit code of the process that was run.
+
+	This is `undefined` when the process could not be spawned or was terminated by a [signal](#signal-1).
 	*/
-	exitCode: number;
+	exitCode?: number;
 
 	/**
 	The output of the process on `stdout`.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -60,7 +60,7 @@ try {
 	const unicornsResult = await execaPromise;
 	expectType<string>(unicornsResult.command);
 	expectType<string>(unicornsResult.escapedCommand);
-	expectType<number>(unicornsResult.exitCode);
+	expectType<number | undefined>(unicornsResult.exitCode);
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.stderr);
 	expectType<string | undefined>(unicornsResult.all);
@@ -75,7 +75,7 @@ try {
 	const execaError = error as ExecaError;
 
 	expectType<string>(execaError.message);
-	expectType<number>(execaError.exitCode);
+	expectType<number | undefined>(execaError.exitCode);
 	expectType<string>(execaError.stdout);
 	expectType<string>(execaError.stderr);
 	expectType<string | undefined>(execaError.all);
@@ -94,7 +94,7 @@ try {
 	const unicornsResult = execaSync('unicorns');
 	expectType<string>(unicornsResult.command);
 	expectType<string>(unicornsResult.escapedCommand);
-	expectType<number>(unicornsResult.exitCode);
+	expectType<number | undefined>(unicornsResult.exitCode);
 	expectType<string>(unicornsResult.stdout);
 	expectType<string>(unicornsResult.stderr);
 	expectError(unicornsResult.all);
@@ -112,7 +112,7 @@ try {
 	const execaError = error as ExecaSyncError;
 
 	expectType<string>(execaError.message);
-	expectType<number>(execaError.exitCode);
+	expectType<number | undefined>(execaError.exitCode);
 	expectType<string>(execaError.stdout);
 	expectType<string>(execaError.stderr);
 	expectError(execaError.all);

--- a/readme.md
+++ b/readme.md
@@ -400,9 +400,11 @@ Since the escaping is fairly basic, this should not be executed directly as a pr
 
 #### exitCode
 
-Type: `number`
+Type: `number | undefined`
 
 The numeric exit code of the process that was run.
+
+This is `undefined` when the process could not be spawned or was terminated by a [signal](#signal-1).
 
 #### stdout
 


### PR DESCRIPTION
`exitCode` can be `undefined`, but we don't properly document nor type this.