### PR TITLE
Fix type of `result.stdio[number]`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -150,7 +150,12 @@ OptionsType
 type MapStdioOptions<
 	StdioOptionsArrayType extends StdioOptionsArray,
 	OptionsType extends Options = Options,
-> = {[StreamIndex in keyof StdioOptionsArrayType & string]: StdioOutput<StreamIndex, OptionsType>};
+> = {
+	[StreamIndex in keyof StdioOptionsArrayType]: StdioOutput<
+	StreamIndex extends string ? StreamIndex : string,
+	OptionsType
+	>
+};
 
 export type Options<IsSync extends boolean = boolean> = {
 	/**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -78,6 +78,7 @@ try {
 	expectType<string>(unicornsResult.stderr);
 	expectType<string>(unicornsResult.stdio[2]);
 	expectType<string | undefined>(unicornsResult.all);
+	expectType<string | undefined>(unicornsResult.stdio[3 as number]);
 
 	const bufferResult = await execaBufferPromise;
 	expectType<Uint8Array>(bufferResult.stdout);


### PR DESCRIPTION
The type of `result.stdio[number]` when `number` is wide (as opposed to being a literal type like `1`) is currently incorrect. This PR fixes this.