### PR TITLE
Fix inconsistency between `result.stdout` and `error.stdout`

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ const handleArguments = (rawFile, rawArgs, rawOptions = {}) => {
 };
 
 const handleOutput = (options, value) => {
-	if (typeof value !== 'string' && !ArrayBuffer.isView(value)) {
+	if (value === undefined || value === null) {
 		return;
 	}
 
@@ -107,7 +107,6 @@ export function execa(rawFile, rawArgs, rawOptions) {
 		const errorPromise = Promise.reject(makeError({
 			error,
 			stdio: Array.from({length: stdioLength}),
-			all: options.all ? '' : undefined,
 			command,
 			escapedCommand,
 			options,
@@ -202,7 +201,7 @@ export function execaSync(rawFile, rawArgs, rawOptions) {
 
 	pipeOutputSync(stdioStreams, result);
 
-	const output = result.output || [undefined, undefined, undefined];
+	const output = result.output || Array.from({length: 3});
 	const stdio = output.map(stdioOutput => handleOutput(options, stdioOutput));
 
 	if (result.error || result.status !== 0 || result.signal !== null) {

--- a/lib/error.js
+++ b/lib/error.js
@@ -37,8 +37,6 @@ export const makeError = ({
 	isCanceled,
 	options: {timeout, cwd = process.cwd()},
 }) => {
-	stdio = stdio.map(stdioOutput => stdioOutput ?? '');
-
 	// `signal` and `exitCode` emitted on `spawned.on('exit')` event can be `null`.
 	// We normalize them to `undefined`
 	exitCode = exitCode === null ? undefined : exitCode;


### PR DESCRIPTION
Fixes #674.