### PR TITLE
Simplify `std*` options logic

### DIFF
--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -32,11 +32,13 @@ const addPropertiesAsync = {
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, after spawning, in async mode
 // When multiple input streams are used, we merge them to ensure the output stream ends only once each input stream has ended
-export const pipeOutputAsync = (spawned, stdioStreams) => {
+export const pipeOutputAsync = (spawned, stdioStreamsGroups) => {
 	const inputStreamsGroups = {};
 
-	for (const stdioStream of stdioStreams) {
-		pipeStdioOption(spawned.stdio[stdioStream.index], stdioStream, inputStreamsGroups);
+	for (const stdioStreams of stdioStreamsGroups) {
+		for (const stdioStream of stdioStreams) {
+			pipeStdioOption(spawned, stdioStream, inputStreamsGroups);
+		}
 	}
 
 	for (const [index, inputStreams] of Object.entries(inputStreamsGroups)) {
@@ -45,13 +47,13 @@ export const pipeOutputAsync = (spawned, stdioStreams) => {
 	}
 };
 
-const pipeStdioOption = (childStream, {type, value, direction, index}, inputStreamsGroups) => {
+const pipeStdioOption = (spawned, {type, value, direction, index}, inputStreamsGroups) => {
 	if (type === 'native') {
 		return;
 	}
 
 	if (direction === 'output') {
-		childStream.pipe(value);
+		spawned.stdio[index].pipe(value);
 	} else {
 		inputStreamsGroups[index] = [...(inputStreamsGroups[index] ?? []), value];
 	}

--- a/lib/stdio/direction.js
+++ b/lib/stdio/direction.js
@@ -26,12 +26,15 @@ const getStreamDirection = stdioStream => KNOWN_DIRECTIONS[stdioStream.index] ??
 // `stdin`/`stdout`/`stderr` have a known direction
 const KNOWN_DIRECTIONS = ['input', 'output', 'output'];
 
+const anyDirection = () => undefined;
+const alwaysInput = () => 'input';
+
 // `string` can only be added through the `input` option, i.e. does not need to be handled here
 const guessStreamDirection = {
-	fileUrl: () => undefined,
-	filePath: () => undefined,
-	iterable: () => 'input',
-	uint8Array: () => 'input',
+	fileUrl: anyDirection,
+	filePath: anyDirection,
+	iterable: alwaysInput,
+	uint8Array: alwaysInput,
 	webStream: stdioOption => isWritableStream(stdioOption) ? 'output' : 'input',
 	nodeStream(stdioOption) {
 		if (isNodeReadableStream(stdioOption)) {

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -13,7 +13,7 @@ export const handleInput = (addProperties, options) => {
 		.map(stdioStreams => addStreamDirection(stdioStreams))
 		.map(stdioStreams => addStreamsProperties(stdioStreams, addProperties));
 	options.stdio = transformStdio(stdioStreamsGroups);
-	return {stdioStreams: stdioStreamsGroups.flat(), stdioLength: stdioStreamsGroups.length};
+	return stdioStreamsGroups;
 };
 
 // We make sure passing an array with a single item behaves the same as passing that item without an array.

--- a/lib/stdio/sync.js
+++ b/lib/stdio/sync.js
@@ -6,9 +6,9 @@ import {bufferToUint8Array} from './utils.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in sync mode
 export const handleInputSync = options => {
-	const {stdioStreams, stdioLength} = handleInput(addPropertiesSync, options);
-	addInputOptionSync(stdioStreams, options);
-	return {stdioStreams, stdioLength};
+	const stdioStreamsGroups = handleInput(addPropertiesSync, options);
+	addInputOptionSync(stdioStreamsGroups, options);
+	return stdioStreamsGroups;
 };
 
 const forbiddenIfStreamSync = ({value, optionName}) => {
@@ -42,8 +42,8 @@ const addPropertiesSync = {
 	},
 };
 
-const addInputOptionSync = (stdioStreams, options) => {
-	const inputs = stdioStreams.filter(({type}) => type === 'string' || type === 'uint8Array');
+const addInputOptionSync = (stdioStreamsGroups, options) => {
+	const inputs = stdioStreamsGroups.flat().filter(({type}) => type === 'string' || type === 'uint8Array');
 	if (inputs.length === 0) {
 		return;
 	}
@@ -56,13 +56,15 @@ const addInputOptionSync = (stdioStreams, options) => {
 const serializeInput = ({type, value}) => type === 'string' ? value : new TextDecoder().decode(value);
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, after spawning, in sync mode
-export const pipeOutputSync = (stdioStreams, result) => {
+export const pipeOutputSync = (stdioStreamsGroups, result) => {
 	if (result.output === null) {
 		return;
 	}
 
-	for (const stdioStream of stdioStreams) {
-		pipeStdioOptionSync(result.output[stdioStream.index], stdioStream);
+	for (const stdioStreams of stdioStreamsGroups) {
+		for (const stdioStream of stdioStreams) {
+			pipeStdioOptionSync(result.output[stdioStream.index], stdioStream);
+		}
 	}
 };
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -35,10 +35,9 @@ const getBufferedData = async (streamPromise, encoding) => {
 	}
 };
 
-const getStdioPromise = ({stream, index, stdioStreams, encoding, buffer, maxBuffer}) => {
-	const stdioStream = stdioStreams.find(stdioStream => stdioStream.index === index);
-	return stdioStream?.direction === 'output' ? getStreamPromise(stream, {encoding, buffer, maxBuffer}) : undefined;
-};
+const getStdioPromise = ({stream, index, stdioStreamsGroups, encoding, buffer, maxBuffer}) => stdioStreamsGroups[index]?.[0]?.direction === 'output'
+	? getStreamPromise(stream, {encoding, buffer, maxBuffer})
+	: undefined;
 
 const getStreamPromise = async (stream, {encoding, buffer, maxBuffer}) => {
 	if (!stream || !buffer) {
@@ -67,7 +66,7 @@ const applyEncoding = (contents, encoding) => {
 const isUtf8Encoding = encoding => encoding === 'utf8' || encoding === 'utf-8';
 
 // Retrieve streams created by the `std*` options
-const getCustomStreams = stdioStreams => stdioStreams.filter(({type}) => type !== 'native');
+const getCustomStreams = stdioStreamsGroups => stdioStreamsGroups.flat().filter(({type}) => type !== 'native');
 
 // Some `stdout`/`stderr` options create a stream, e.g. when passing a file path.
 // The `.pipe()` method automatically ends that stream when `childProcess.stdout|stderr` ends.
@@ -99,9 +98,9 @@ const throwOnStreamError = async stream => {
 // However `.pipe()` only does so when the source stream ended, not when it errored.
 // Therefore, when `childProcess.stdin|stdout|stderr` errors, those streams must be manually destroyed.
 const cleanupStdioStreams = (customStreams, error) => {
-	for (const customStream of customStreams) {
-		if (!STANDARD_STREAMS.includes(customStream.value)) {
-			customStream.value.destroy(error);
+	for (const {value} of customStreams) {
+		if (!STANDARD_STREAMS.includes(value)) {
+			value.destroy(error);
 		}
 	}
 };
@@ -111,13 +110,13 @@ export const getSpawnedResult = async (
 	spawned,
 	{encoding, buffer, maxBuffer, timeout, killSignal, cleanup, detached},
 	context,
-	stdioStreams,
+	stdioStreamsGroups,
 ) => {
 	const finalizers = [];
 	cleanupOnExit(spawned, cleanup, detached, finalizers);
-	const customStreams = getCustomStreams(stdioStreams);
+	const customStreams = getCustomStreams(stdioStreamsGroups);
 
-	const stdioPromises = spawned.stdio.map((stream, index) => getStdioPromise({stream, index, stdioStreams, encoding, buffer, maxBuffer}));
+	const stdioPromises = spawned.stdio.map((stream, index) => getStdioPromise({stream, index, stdioStreamsGroups, encoding, buffer, maxBuffer}));
 	const allPromise = getStreamPromise(spawned.all, {encoding, buffer, maxBuffer: maxBuffer * 2});
 
 	try {


### PR DESCRIPTION
This PR refactors the logic related to the `std*` options, to simplify it. It does not change the behavior.