### PR TITLE
Allow passing generators to the `std*` options

### DIFF
--- a/docs/transform.md
+++ b/docs/transform.md
@@ -28,6 +28,8 @@ The transform can `yield` either a `string` or an `Uint8Array`, regardless of th
 `yield` can be called 0, 1 or multiple times. Not calling `yield` enables filtering a specific chunk.
 
 ```js
+import {execa} from 'execa';
+
 const transform = async function * (chunks) {
 	for await (const chunk of chunks) {
 		if (!chunk.includes('secret')) {

--- a/docs/transform.md
+++ b/docs/transform.md
@@ -1,0 +1,55 @@
+# Transforms
+
+## Summary
+
+Transforms map or filter the input or output of a child process. They are defined by passing an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to the [`stdin`](../readme.md#stdin), [`stdout`](../readme.md#stdout-1), [`stderr`](../readme.md#stderr-1) or [`stdio`](../readme.md#stdio-1) option.
+
+```js
+import {execa} from 'execa';
+
+const transform = async function * (chunks) {
+	for await (const chunk of chunks) {
+		yield chunk.toUpperCase();
+	}
+};
+
+const {stdout} = await execa('echo', ['hello'], {stdout: transform});
+console.log(stdout); // HELLO
+```
+
+## Encoding
+
+The `chunks` argument passed to the transform is an [`AsyncIterable<string>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols). If the [`encoding`](../readme.md#encoding) option is `buffer`, it is an `AsyncIterable<Uint8Array>` instead.
+
+The transform can `yield` either a `string` or an `Uint8Array`, regardless of the `chunks` argument's type.
+
+## Filtering
+
+`yield` can be called 0, 1 or multiple times. Not calling `yield` enables filtering a specific chunk.
+
+```js
+const transform = async function * (chunks) {
+	for await (const chunk of chunks) {
+		if (!chunk.includes('secret')) {
+			yield chunk;
+		}
+	}
+};
+
+const {stdout} = await execa('echo', ['This is a secret.'], {stdout: transform});
+console.log(stdout); // ''
+```
+
+## Combining
+
+The [`stdin`](../readme.md#stdin), [`stdout`](../readme.md#stdout-1), [`stderr`](../readme.md#stderr-1) and [`stdio`](../readme.md#stdio-1) options can accept an array of values. While this is not specific to transforms, this can be useful with them too. For example, the following transform impacts the value printed by `inherit`.
+
+```js
+await execa('echo', ['hello'], {stdout: [transform, 'inherit']});
+```
+
+This also allows using multiple transforms.
+
+```js
+await execa('echo', ['hello'], {stdout: [transform, otherTransform]});
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,8 @@ type CommonStdioOption<IsSync extends boolean = boolean> =
 	| undefined
 	| URL
 	| {file: string}
+	// TODO: Use either `Iterable<string>` or `Iterable<Uint8Array>` based on whether `encoding: 'buffer'` is used.
+	// See https://github.com/sindresorhus/execa/issues/694
 	| IfAsync<IsSync, ((chunks: Iterable<string | Uint8Array>) => AsyncGenerator<string | Uint8Array, void, void>)>;
 
 type InputStdioOption<IsSync extends boolean = boolean> =

--- a/index.d.ts
+++ b/index.d.ts
@@ -244,7 +244,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-	This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the input. Please see the [full documentation here](https://github.com/sindresorhus/execa/tree/main/docs/transform.md).
+	This can also be an async generator function to transform the input. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
 
 	@default `inherit` with `$`, `pipe` otherwise
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,13 +18,14 @@ type BaseStdioOption =
 	| 'ignore'
 	| 'inherit';
 
-type CommonStdioOption =
+type CommonStdioOption<IsSync extends boolean = boolean> =
 	| BaseStdioOption
 	| 'ipc'
 	| number
 	| undefined
 	| URL
-	| {file: string};
+	| {file: string}
+	| IfAsync<IsSync, ((chunks: Iterable<string | Uint8Array>) => AsyncGenerator<string | Uint8Array, void, void>)>;
 
 type InputStdioOption<IsSync extends boolean = boolean> =
 	| Uint8Array
@@ -39,14 +40,14 @@ type OutputStdioOption<IsSync extends boolean = boolean> = IfAsync<IsSync,
 | WritableStream>;
 
 export type StdinOption<IsSync extends boolean = boolean> =
-	CommonStdioOption | InputStdioOption<IsSync>
-	| Array<CommonStdioOption | InputStdioOption<IsSync>>;
+	CommonStdioOption<IsSync> | InputStdioOption<IsSync>
+	| Array<CommonStdioOption<IsSync> | InputStdioOption<IsSync>>;
 export type StdoutStderrOption<IsSync extends boolean = boolean> =
-	CommonStdioOption | OutputStdioOption<IsSync>
-	| Array<CommonStdioOption | OutputStdioOption<IsSync>>;
+	CommonStdioOption<IsSync> | OutputStdioOption<IsSync>
+	| Array<CommonStdioOption<IsSync> | OutputStdioOption<IsSync>>;
 export type StdioOption<IsSync extends boolean = boolean> =
-	CommonStdioOption | InputStdioOption | OutputStdioOption<IsSync>
-	| Array<CommonStdioOption | InputStdioOption | OutputStdioOption<IsSync>>;
+	CommonStdioOption<IsSync> | InputStdioOption | OutputStdioOption<IsSync>
+	| Array<CommonStdioOption<IsSync> | InputStdioOption | OutputStdioOption<IsSync>>;
 
 type StdioOptionsArray<IsSync extends boolean = boolean> = readonly [
 	StdinOption<IsSync>,
@@ -241,6 +242,8 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
+	This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the input. Please see the [full documentation here](https://github.com/sindresorhus/execa/tree/main/docs/transform.md).
+
 	@default `inherit` with `$`, `pipe` otherwise
 	*/
 	readonly stdin?: StdinOption<IsSync>;
@@ -260,6 +263,8 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
+	This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the output. Please see the [full documentation here](https://github.com/sindresorhus/execa/tree/main/docs/transform.md).
+
 	@default 'pipe'
 	*/
 	readonly stdout?: StdoutStderrOption<IsSync>;
@@ -278,6 +283,8 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 	- a web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
+
+	This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the output. Please see the [full documentation here](https://github.com/sindresorhus/execa/tree/main/docs/transform.md).
 
 	@default 'pipe'
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -265,7 +265,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-	This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the output. Please see the [full documentation here](https://github.com/sindresorhus/execa/tree/main/docs/transform.md).
+	This can also be an async generator function to transform the output. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
 
 	@default 'pipe'
 	*/
@@ -286,7 +286,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-	This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the output. Please see the [full documentation here](https://github.com/sindresorhus/execa/tree/main/docs/transform.md).
+	This can also be an async generator function to transform the output. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
 
 	@default 'pipe'
 	*/

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -551,7 +551,7 @@ expectType<string | undefined>(noRejectsSyncResult.message);
 expectType<string | undefined>(noRejectsSyncResult.shortMessage);
 expectType<string | undefined>(noRejectsSyncResult.originalMessage);
 
-const stringGenerator = function * () {
+const emptyStringGenerator = function * () {
 	yield '';
 };
 
@@ -568,6 +568,40 @@ const asyncStringGenerator = async function * () {
 };
 
 const fileUrl = new URL('file:///test');
+
+const stringOrUint8ArrayGenerator = async function * (chunks: Iterable<string | Uint8Array>) {
+	for await (const chunk of chunks) {
+		yield chunk;
+	}
+};
+
+const booleanGenerator = async function * (chunks: Iterable<boolean>) {
+	for await (const chunk of chunks) {
+		yield chunk;
+	}
+};
+
+const arrayGenerator = async function * (chunks: string[]) {
+	for await (const chunk of chunks) {
+		yield chunk;
+	}
+};
+
+const invalidReturnGenerator = async function * (chunks: Iterable<string>) {
+	for await (const chunk of chunks) {
+		yield chunk;
+	}
+
+	return false;
+};
+
+const syncGenerator = function * (chunks: Iterable<string>) {
+	for (const chunk of chunks) {
+		yield chunk;
+	}
+
+	return false;
+};
 
 expectAssignable<Options>({cleanup: false});
 expectNotAssignable<SyncOptions>({cleanup: false});
@@ -642,10 +676,10 @@ expectError(execa('unicorns', {stdin: [new WritableStream()]}));
 expectError(execaSync('unicorns', {stdin: [new WritableStream()]}));
 execa('unicorns', {stdin: new Uint8Array()});
 execaSync('unicorns', {stdin: new Uint8Array()});
-execa('unicorns', {stdin: stringGenerator()});
-expectError(execaSync('unicorns', {stdin: stringGenerator()}));
-execa('unicorns', {stdin: [stringGenerator()]});
-expectError(execaSync('unicorns', {stdin: [stringGenerator()]}));
+execa('unicorns', {stdin: emptyStringGenerator()});
+expectError(execaSync('unicorns', {stdin: emptyStringGenerator()}));
+execa('unicorns', {stdin: [emptyStringGenerator()]});
+expectError(execaSync('unicorns', {stdin: [emptyStringGenerator()]}));
 execa('unicorns', {stdin: binaryGenerator()});
 expectError(execaSync('unicorns', {stdin: binaryGenerator()}));
 execa('unicorns', {stdin: [binaryGenerator()]});
@@ -670,6 +704,14 @@ execa('unicorns', {stdin: 1});
 execaSync('unicorns', {stdin: 1});
 execa('unicorns', {stdin: [1]});
 execaSync('unicorns', {stdin: [1]});
+execa('unicorns', {stdin: stringOrUint8ArrayGenerator});
+expectError(execaSync('unicorns', {stdin: stringOrUint8ArrayGenerator}));
+execa('unicorns', {stdin: [stringOrUint8ArrayGenerator]});
+expectError(execaSync('unicorns', {stdin: [stringOrUint8ArrayGenerator]}));
+expectError(execa('unicorns', {stdin: booleanGenerator}));
+expectError(execa('unicorns', {stdin: arrayGenerator}));
+expectError(execa('unicorns', {stdin: invalidReturnGenerator}));
+expectError(execa('unicorns', {stdin: syncGenerator}));
 execa('unicorns', {stdin: undefined});
 execaSync('unicorns', {stdin: undefined});
 execa('unicorns', {stdin: [undefined]});
@@ -728,6 +770,14 @@ execa('unicorns', {stdout: 1});
 execaSync('unicorns', {stdout: 1});
 execa('unicorns', {stdout: [1]});
 execaSync('unicorns', {stdout: [1]});
+execa('unicorns', {stdout: stringOrUint8ArrayGenerator});
+expectError(execaSync('unicorns', {stdout: stringOrUint8ArrayGenerator}));
+execa('unicorns', {stdout: [stringOrUint8ArrayGenerator]});
+expectError(execaSync('unicorns', {stdout: [stringOrUint8ArrayGenerator]}));
+expectError(execa('unicorns', {stdout: booleanGenerator}));
+expectError(execa('unicorns', {stdout: arrayGenerator}));
+expectError(execa('unicorns', {stdout: invalidReturnGenerator}));
+expectError(execa('unicorns', {stdout: syncGenerator}));
 execa('unicorns', {stdout: undefined});
 execaSync('unicorns', {stdout: undefined});
 execa('unicorns', {stdout: [undefined]});
@@ -786,6 +836,14 @@ execa('unicorns', {stderr: 1});
 execaSync('unicorns', {stderr: 1});
 execa('unicorns', {stderr: [1]});
 execaSync('unicorns', {stderr: [1]});
+execa('unicorns', {stderr: stringOrUint8ArrayGenerator});
+expectError(execaSync('unicorns', {stderr: stringOrUint8ArrayGenerator}));
+execa('unicorns', {stderr: [stringOrUint8ArrayGenerator]});
+expectError(execaSync('unicorns', {stderr: [stringOrUint8ArrayGenerator]}));
+expectError(execa('unicorns', {stderr: booleanGenerator}));
+expectError(execa('unicorns', {stderr: arrayGenerator}));
+expectError(execa('unicorns', {stderr: invalidReturnGenerator}));
+expectError(execa('unicorns', {stderr: syncGenerator}));
 execa('unicorns', {stderr: undefined});
 execaSync('unicorns', {stderr: undefined});
 execa('unicorns', {stderr: [undefined]});
@@ -822,6 +880,8 @@ expectError(execa('unicorns', {stdio: 'ipc'}));
 expectError(execaSync('unicorns', {stdio: 'ipc'}));
 expectError(execa('unicorns', {stdio: 1}));
 expectError(execaSync('unicorns', {stdio: 1}));
+expectError(execa('unicorns', {stdio: stringOrUint8ArrayGenerator}));
+expectError(execaSync('unicorns', {stdio: stringOrUint8ArrayGenerator}));
 expectError(execa('unicorns', {stdio: fileUrl}));
 expectError(execaSync('unicorns', {stdio: fileUrl}));
 expectError(execa('unicorns', {stdio: {file: './test'}}));
@@ -834,8 +894,8 @@ expectError(execa('unicorns', {stdio: new WritableStream()}));
 expectError(execaSync('unicorns', {stdio: new WritableStream()}));
 expectError(execa('unicorns', {stdio: new ReadableStream()}));
 expectError(execaSync('unicorns', {stdio: new ReadableStream()}));
-expectError(execa('unicorns', {stdio: stringGenerator()}));
-expectError(execaSync('unicorns', {stdio: stringGenerator()}));
+expectError(execa('unicorns', {stdio: emptyStringGenerator()}));
+expectError(execaSync('unicorns', {stdio: emptyStringGenerator()}));
 expectError(execa('unicorns', {stdio: asyncStringGenerator()}));
 expectError(execaSync('unicorns', {stdio: asyncStringGenerator()}));
 expectError(execa('unicorns', {stdio: ['pipe', 'pipe']}));
@@ -873,6 +933,7 @@ execa('unicorns', {
 		'inherit',
 		process.stdin,
 		1,
+		stringOrUint8ArrayGenerator,
 		undefined,
 		fileUrl,
 		{file: './test'},
@@ -881,7 +942,7 @@ execa('unicorns', {
 		new WritableStream(),
 		new ReadableStream(),
 		new Uint8Array(),
-		stringGenerator(),
+		emptyStringGenerator(),
 		asyncStringGenerator(),
 	],
 });
@@ -900,11 +961,12 @@ execaSync('unicorns', {
 		new Uint8Array(),
 	],
 });
+expectError(execaSync('unicorns', {stdio: [stringOrUint8ArrayGenerator]}));
 expectError(execaSync('unicorns', {stdio: [new Writable()]}));
 expectError(execaSync('unicorns', {stdio: [new Readable()]}));
 expectError(execaSync('unicorns', {stdio: [new WritableStream()]}));
 expectError(execaSync('unicorns', {stdio: [new ReadableStream()]}));
-expectError(execaSync('unicorns', {stdio: [stringGenerator()]}));
+expectError(execaSync('unicorns', {stdio: [emptyStringGenerator()]}));
 expectError(execaSync('unicorns', {stdio: [asyncStringGenerator()]}));
 execa('unicorns', {
 	stdio: [
@@ -916,6 +978,7 @@ execa('unicorns', {
 		['inherit'],
 		[process.stdin],
 		[1],
+		[stringOrUint8ArrayGenerator],
 		[undefined],
 		[fileUrl],
 		[{file: './test'}],
@@ -924,7 +987,7 @@ execa('unicorns', {
 		[new WritableStream()],
 		[new ReadableStream()],
 		[new Uint8Array()],
-		[stringGenerator()],
+		[emptyStringGenerator()],
 		[asyncStringGenerator()],
 	],
 });
@@ -944,11 +1007,12 @@ execaSync('unicorns', {
 		[new Uint8Array()],
 	],
 });
+expectError(execaSync('unicorns', {stdio: [[stringOrUint8ArrayGenerator]]}));
 expectError(execaSync('unicorns', {stdio: [[new Writable()]]}));
 expectError(execaSync('unicorns', {stdio: [[new Readable()]]}));
 expectError(execaSync('unicorns', {stdio: [[new WritableStream()]]}));
 expectError(execaSync('unicorns', {stdio: [[new ReadableStream()]]}));
-expectError(execaSync('unicorns', {stdio: [[stringGenerator()]]}));
+expectError(execaSync('unicorns', {stdio: [[emptyStringGenerator()]]}));
 expectError(execaSync('unicorns', {stdio: [[asyncStringGenerator()]]}));
 execa('unicorns', {serialization: 'advanced'});
 expectError(execaSync('unicorns', {serialization: 'advanced'}));

--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -4,6 +4,7 @@ import {Readable, Writable} from 'node:stream';
 import mergeStreams from '@sindresorhus/merge-streams';
 import {handleInput} from './handle.js';
 import {TYPE_TO_MESSAGE} from './type.js';
+import {generatorToTransformStream, pipeGenerator} from './generator.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async mode
 export const handleInputAsync = options => handleInput(addPropertiesAsync, options);
@@ -14,6 +15,7 @@ const forbiddenIfAsync = ({type, optionName}) => {
 
 const addPropertiesAsync = {
 	input: {
+		generator: generatorToTransformStream,
 		fileUrl: ({value}) => ({value: createReadStream(value)}),
 		filePath: ({value}) => ({value: createReadStream(value.file)}),
 		webStream: ({value}) => ({value: Readable.fromWeb(value)}),
@@ -22,6 +24,7 @@ const addPropertiesAsync = {
 		uint8Array: ({value}) => ({value: Readable.from(Buffer.from(value))}),
 	},
 	output: {
+		generator: generatorToTransformStream,
 		fileUrl: ({value}) => ({value: createWriteStream(value)}),
 		filePath: ({value}) => ({value: createWriteStream(value.file)}),
 		webStream: ({value}) => ({value: Writable.fromWeb(value)}),
@@ -36,8 +39,15 @@ export const pipeOutputAsync = (spawned, stdioStreamsGroups) => {
 	const inputStreamsGroups = {};
 
 	for (const stdioStreams of stdioStreamsGroups) {
-		for (const stdioStream of stdioStreams) {
-			pipeStdioOption(spawned, stdioStream, inputStreamsGroups);
+		const generatorStreams = sortGeneratorStreams(stdioStreams.filter(({type}) => type === 'generator'));
+		const nonGeneratorStreams = stdioStreams.filter(({type}) => type !== 'generator');
+
+		for (const generatorStream of generatorStreams) {
+			pipeGenerator(spawned, generatorStream);
+		}
+
+		for (const nonGeneratorStream of nonGeneratorStreams) {
+			pipeStdioOption(spawned, nonGeneratorStream, inputStreamsGroups);
 		}
 	}
 
@@ -46,6 +56,8 @@ export const pipeOutputAsync = (spawned, stdioStreamsGroups) => {
 		value.pipe(spawned.stdio[index]);
 	}
 };
+
+const sortGeneratorStreams = generatorStreams => generatorStreams[0]?.direction === 'input' ? generatorStreams.reverse() : generatorStreams;
 
 const pipeStdioOption = (spawned, {type, value, direction, index}, inputStreamsGroups) => {
 	if (type === 'native') {

--- a/lib/stdio/direction.js
+++ b/lib/stdio/direction.js
@@ -31,6 +31,7 @@ const alwaysInput = () => 'input';
 
 // `string` can only be added through the `input` option, i.e. does not need to be handled here
 const guessStreamDirection = {
+	generator: anyDirection,
 	fileUrl: anyDirection,
 	filePath: anyDirection,
 	iterable: alwaysInput,

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -2,24 +2,26 @@ import {Duplex, Readable, PassThrough, getDefaultHighWaterMark} from 'node:strea
 import {callbackify} from 'node:util';
 import {setTimeout} from 'node:timers/promises';
 
-// Generators can be used to transform/filter standard streams.
-// Generators have a simple syntax, yet allows all of the following:
-//  - Sharing state between chunks, by using logic before the `for` loop
-//  - Flushing logic, by using logic after the `for` loop
-//  - Asynchronous logic
-//  - Emitting multiple chunks from a single source chunk, even if spaced in time, by using multiple `yield`
-//  - Filtering, by using no `yield`
-// Therefore, there is no need to allow Node.js or web transform streams.
-// The `highWaterMark` is kept as the default value, since this is what `childProcess.std*` uses.
-// We ensure `objectMode` is `false` for better buffering.
-// Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
-// We return a `Duplex`, created by `Duplex.from()` made of a writable stream and a readable stream, piped to each other.
-//  - The writable stream is a simple `PassThrough`, so it only forwards data to the readable part.
-//  - The `PassThrough` is read as an iterable using `passThrough.iterator()`.
-//  - This iterable is transformed to another iterable, by applying the encoding generators.
-//    Those convert the chunk type from `Buffer` to `string | Uint8Array` depending on the encoding option.
-//  - This new iterable is transformed again to another one, this time by applying the user-supplied generator.
-//  - Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
+/*
+ * Generators can be used to transform/filter standard streams.
+ * Generators have a simple syntax, yet allows all of the following:
+ *  - Sharing state between chunks, by using logic before the `for` loop
+ *  - Flushing logic, by using logic after the `for` loop
+ *  - Asynchronous logic
+ *  - Emitting multiple chunks from a single source chunk, even if spaced in time, by using multiple `yield`
+ *  - Filtering, by using no `yield`
+ * Therefore, there is no need to allow Node.js or web transform streams.
+ * The `highWaterMark` is kept as the default value, since this is what `childProcess.std*` uses.
+ * We ensure `objectMode` is `false` for better buffering.
+ * Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
+ * We return a `Duplex`, created by `Duplex.from()` made of a writable stream and a readable stream, piped to each other.
+ *  - The writable stream is a simple `PassThrough`, so it only forwards data to the readable part.
+ *  - The `PassThrough` is read as an iterable using `passThrough.iterator()`.
+ *  - This iterable is transformed to another iterable, by applying the encoding generators.
+ *    Those convert the chunk type from `Buffer` to `string | Uint8Array` depending on the encoding option.
+ *  - This new iterable is transformed again to another one, this time by applying the user-supplied generator.
+ *  - Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
+ */
 export const generatorToTransformStream = ({value}, {encoding}) => {
 	const objectMode = false;
 	const highWaterMark = getDefaultHighWaterMark(objectMode);
@@ -32,11 +34,13 @@ export const generatorToTransformStream = ({value}, {encoding}) => {
 	return {value: duplexStream};
 };
 
-// When an error is thrown in a generator, the PassThrough is aborted.
-// This creates a race condition for which error is propagated, due to the Duplex throwing twice:
-//  - The writable side is aborted (PassThrough)
-//  - The readable side propagate the generator's error
-// In order for the later to win that race, we need to wait one microtask.
+/*
+ * When an error is thrown in a generator, the PassThrough is aborted.
+ * This creates a race condition for which error is propagated, due to the Duplex throwing twice:
+ *  - The writable side is aborted (PassThrough)
+ *  - The readable side propagate the generator's error
+ * In order for the later to win that race, we need to wait one microtask.
+ */
 const destroyPassThrough = callbackify(async error => {
 	await setTimeout(0);
 	throw error;
@@ -48,13 +52,15 @@ const applyEncoding = (iterable, encoding) => encoding === 'buffer'
 	? encodingStartBufferGenerator(iterable)
 	: encodingStartStringGenerator(iterable);
 
-// Chunks might be Buffer, Uint8Array or strings since:
-//  - `childProcess.stdout|stderr` emits Buffers
-//  - `childProcess.stdin.write()` accepts Buffer, Uint8Array or string
-//  - Previous generators might return Uint8Array or string
-// However, those are converted to Buffer:
-//  - on writes: `Duplex.writable` `decodeStrings: true` default option
-//  - on reads: `Duplex.readable` `readableEncoding: null` default option
+/*
+ * Chunks might be Buffer, Uint8Array or strings since:
+ *  - `childProcess.stdout|stderr` emits Buffers
+ *  - `childProcess.stdin.write()` accepts Buffer, Uint8Array or string
+ *  - Previous generators might return Uint8Array or string
+ * However, those are converted to Buffer:
+ *  - on writes: `Duplex.writable` `decodeStrings: true` default option
+ *  - on reads: `Duplex.readable` `readableEncoding: null` default option
+ */
 const encodingStartStringGenerator = async function * (chunks) {
 	const textDecoder = new TextDecoder();
 

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -1,24 +1,24 @@
 import {Duplex, Readable, PassThrough, getDefaultHighWaterMark} from 'node:stream';
 
 /*
- * Generators can be used to transform/filter standard streams.
- * Generators have a simple syntax, yet allows all of the following:
- *  - Sharing state between chunks, by using logic before the `for` loop
- *  - Flushing logic, by using logic after the `for` loop
- *  - Asynchronous logic
- *  - Emitting multiple chunks from a single source chunk, even if spaced in time, by using multiple `yield`
- *  - Filtering, by using no `yield`
- * Therefore, there is no need to allow Node.js or web transform streams.
- * The `highWaterMark` is kept as the default value, since this is what `childProcess.std*` uses.
- * We ensure `objectMode` is `false` for better buffering.
- * Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
- * We return a `Duplex`, created by `Duplex.from()` made of a writable stream and a readable stream, piped to each other.
- *  - The writable stream is a simple `PassThrough`, so it only forwards data to the readable part.
- *  - The `PassThrough` is read as an iterable using `passThrough.iterator()`.
- *  - This iterable is transformed to another iterable, by applying the encoding generators.
- *    Those convert the chunk type from `Buffer` to `string | Uint8Array` depending on the encoding option.
- *  - This new iterable is transformed again to another one, this time by applying the user-supplied generator.
- *  - Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
+ Generators can be used to transform/filter standard streams.
+ Generators have a simple syntax, yet allows all of the following:
+  - Sharing state between chunks, by using logic before the `for` loop
+  - Flushing logic, by using logic after the `for` loop
+  - Asynchronous logic
+  - Emitting multiple chunks from a single source chunk, even if spaced in time, by using multiple `yield`
+  - Filtering, by using no `yield`
+ Therefore, there is no need to allow Node.js or web transform streams.
+ The `highWaterMark` is kept as the default value, since this is what `childProcess.std*` uses.
+ We ensure `objectMode` is `false` for better buffering.
+ Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
+ We return a `Duplex`, created by `Duplex.from()` made of a writable stream and a readable stream, piped to each other.
+  - The writable stream is a simple `PassThrough`, so it only forwards data to the readable part.
+  - The `PassThrough` is read as an iterable using `passThrough.iterator()`.
+  - This iterable is transformed to another iterable, by applying the encoding generators.
+    Those convert the chunk type from `Buffer` to `string | Uint8Array` depending on the encoding option.
+  - This new iterable is transformed again to another one, this time by applying the user-supplied generator.
+  - Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
  */
 export const generatorToTransformStream = ({value}, {encoding}) => {
 	const objectMode = false;
@@ -33,12 +33,12 @@ export const generatorToTransformStream = ({value}, {encoding}) => {
 };
 
 /*
- * When an error is thrown in a generator, the PassThrough is aborted.
- * This creates a race condition for which error is propagated, due to the Duplex throwing twice:
- *  - The writable side is aborted (PassThrough)
- *  - The readable side propagate the generator's error
- * In order for the later to win that race, we need to wait one microtask.
- * We wait one macrotask instead to be on the safe side.
+ When an error is thrown in a generator, the PassThrough is aborted.
+ This creates a race condition for which error is propagated, due to the Duplex throwing twice:
+  - The writable side is aborted (PassThrough)
+  - The readable side propagate the generator's error
+ In order for the later to win that race, we need to wait one microtask.
+ We wait one macrotask instead to be on the safe side.
  */
 const destroyPassThrough = (error, done) => {
 	setTimeout(() => {
@@ -53,13 +53,13 @@ const applyEncoding = (iterable, encoding) => encoding === 'buffer'
 	: encodingStartStringGenerator(iterable);
 
 /*
- * Chunks might be Buffer, Uint8Array or strings since:
- *  - `childProcess.stdout|stderr` emits Buffers
- *  - `childProcess.stdin.write()` accepts Buffer, Uint8Array or string
- *  - Previous generators might return Uint8Array or string
- * However, those are converted to Buffer:
- *  - on writes: `Duplex.writable` `decodeStrings: true` default option
- *  - on reads: `Duplex.readable` `readableEncoding: null` default option
+ Chunks might be Buffer, Uint8Array or strings since:
+  - `childProcess.stdout|stderr` emits Buffers
+  - `childProcess.stdin.write()` accepts Buffer, Uint8Array or string
+  - Previous generators might return Uint8Array or string
+ However, those are converted to Buffer:
+  - on writes: `Duplex.writable` `decodeStrings: true` default option
+  - on reads: `Duplex.readable` `readableEncoding: null` default option
  */
 const encodingStartStringGenerator = async function * (chunks) {
 	const textDecoder = new TextDecoder();

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -1,6 +1,4 @@
 import {Duplex, Readable, PassThrough, getDefaultHighWaterMark} from 'node:stream';
-import {callbackify} from 'node:util';
-import {setTimeout} from 'node:timers/promises';
 
 /*
  * Generators can be used to transform/filter standard streams.
@@ -42,10 +40,11 @@ export const generatorToTransformStream = ({value}, {encoding}) => {
  * In order for the later to win that race, we need to wait one microtask.
  * We wait one macrotask instead to be on the safe side.
  */
-const destroyPassThrough = callbackify(async error => {
-	await setTimeout(0);
-	throw error;
-});
+const destroyPassThrough = (error, done) => {
+	setTimeout(() => {
+		done(error);
+	}, 0);
+};
 
 // When using generators, add an internal generator that converts chunks from `Buffer` to `string` or `Uint8Array`.
 // This allows generator functions to operate with those types instead.

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -38,7 +38,8 @@ export const generatorToTransformStream = ({value}, {encoding}) => {
   - The writable side is aborted (PassThrough)
   - The readable side propagate the generator's error
  In order for the later to win that race, we need to wait one microtask.
- We wait one macrotask instead to be on the safe side.
+  - However we wait one macrotask instead to be on the safe side
+  - See https://github.com/sindresorhus/execa/pull/693#discussion_r1453809450
  */
 const destroyPassThrough = (error, done) => {
 	setTimeout(() => {

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -13,6 +13,13 @@ import {setTimeout} from 'node:timers/promises';
 // The `highWaterMark` is kept as the default value, since this is what `childProcess.std*` uses.
 // We ensure `objectMode` is `false` for better buffering.
 // Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
+// We return a `Duplex`, created by `Duplex.from()` made of a writable stream and a readable stream, piped to each other.
+//  - The writable stream is a simple `PassThrough`, so it only forwards data to the readable part.
+//  - The `PassThrough` is read as an iterable using `passThrough.iterator()`.
+//  - This iterable is transformed to another iterable, by applying the encoding generators.
+//    Those convert the chunk type from `Buffer` to `string | Uint8Array` depending on the encoding option.
+//  - This new iterable is transformed again to another one, this time by applying the user-supplied generator.
+//  - Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
 export const generatorToTransformStream = ({value}, {encoding}) => {
 	const objectMode = false;
 	const highWaterMark = getDefaultHighWaterMark(objectMode);

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -40,6 +40,7 @@ export const generatorToTransformStream = ({value}, {encoding}) => {
  *  - The writable side is aborted (PassThrough)
  *  - The readable side propagate the generator's error
  * In order for the later to win that race, we need to wait one microtask.
+ * We wait one macrotask instead to be on the safe side.
  */
 const destroyPassThrough = callbackify(async error => {
 	await setTimeout(0);

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -1,0 +1,86 @@
+import {Duplex, Readable, PassThrough, getDefaultHighWaterMark} from 'node:stream';
+import {callbackify} from 'node:util';
+import {setTimeout} from 'node:timers/promises';
+
+// Generators can be used to transform/filter standard streams.
+// Generators have a simple syntax, yet allows all of the following:
+//  - Sharing state between chunks, by using logic before the `for` loop
+//  - Flushing logic, by using logic after the `for` loop
+//  - Asynchronous logic
+//  - Emitting multiple chunks from a single source chunk, even if spaced in time, by using multiple `yield`
+//  - Filtering, by using no `yield`
+// Therefore, there is no need to allow Node.js or web transform streams.
+// The `highWaterMark` is kept as the default value, since this is what `childProcess.std*` uses.
+// We ensure `objectMode` is `false` for better buffering.
+// Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
+export const generatorToTransformStream = ({value}, {encoding}) => {
+	const objectMode = false;
+	const highWaterMark = getDefaultHighWaterMark(objectMode);
+	const passThrough = new PassThrough({objectMode, highWaterMark, destroy: destroyPassThrough});
+	const iterable = passThrough.iterator();
+	const encodedIterable = applyEncoding(iterable, encoding);
+	const mappedIterable = value(encodedIterable);
+	const readableStream = Readable.from(mappedIterable, {objectMode, highWaterMark});
+	const duplexStream = Duplex.from({writable: passThrough, readable: readableStream});
+	return {value: duplexStream};
+};
+
+// When an error is thrown in a generator, the PassThrough is aborted.
+// This creates a race condition for which error is propagated, due to the Duplex throwing twice:
+//  - The writable side is aborted (PassThrough)
+//  - The readable side propagate the generator's error
+// In order for the later to win that race, we need to wait one microtask.
+const destroyPassThrough = callbackify(async error => {
+	await setTimeout(0);
+	throw error;
+});
+
+// When using generators, add an internal generator that converts chunks from `Buffer` to `string` or `Uint8Array`.
+// This allows generator functions to operate with those types instead.
+const applyEncoding = (iterable, encoding) => encoding === 'buffer'
+	? encodingStartBufferGenerator(iterable)
+	: encodingStartStringGenerator(iterable);
+
+// Chunks might be Buffer, Uint8Array or strings since:
+//  - `childProcess.stdout|stderr` emits Buffers
+//  - `childProcess.stdin.write()` accepts Buffer, Uint8Array or string
+//  - Previous generators might return Uint8Array or string
+// However, those are converted to Buffer:
+//  - on writes: `Duplex.writable` `decodeStrings: true` default option
+//  - on reads: `Duplex.readable` `readableEncoding: null` default option
+const encodingStartStringGenerator = async function * (chunks) {
+	const textDecoder = new TextDecoder();
+
+	for await (const chunk of chunks) {
+		yield textDecoder.decode(chunk, {stream: true});
+	}
+
+	const lastChunk = textDecoder.decode();
+	if (lastChunk !== '') {
+		yield lastChunk;
+	}
+};
+
+const encodingStartBufferGenerator = async function * (chunks) {
+	for await (const chunk of chunks) {
+		yield new Uint8Array(chunk);
+	}
+};
+
+// `childProcess.stdin|stdout|stderr|stdio` is directly mutated.
+export const pipeGenerator = (spawned, {value, direction, index}) => {
+	if (direction === 'output') {
+		spawned.stdio[index].pipe(value);
+	}	else {
+		value.pipe(spawned.stdio[index]);
+	}
+
+	const streamProperty = PROCESS_STREAM_PROPERTIES[index];
+	if (streamProperty !== undefined) {
+		spawned[streamProperty] = value;
+	}
+
+	spawned.stdio[index] = value;
+};
+
+const PROCESS_STREAM_PROPERTIES = ['stdin', 'stdout', 'stderr'];

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -1,25 +1,31 @@
 import {Duplex, Readable, PassThrough, getDefaultHighWaterMark} from 'node:stream';
 
 /*
- Generators can be used to transform/filter standard streams.
- Generators have a simple syntax, yet allows all of the following:
-  - Sharing state between chunks, by using logic before the `for` loop
-  - Flushing logic, by using logic after the `for` loop
-  - Asynchronous logic
-  - Emitting multiple chunks from a single source chunk, even if spaced in time, by using multiple `yield`
-  - Filtering, by using no `yield`
- Therefore, there is no need to allow Node.js or web transform streams.
- The `highWaterMark` is kept as the default value, since this is what `childProcess.std*` uses.
- We ensure `objectMode` is `false` for better buffering.
- Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
- We return a `Duplex`, created by `Duplex.from()` made of a writable stream and a readable stream, piped to each other.
-  - The writable stream is a simple `PassThrough`, so it only forwards data to the readable part.
-  - The `PassThrough` is read as an iterable using `passThrough.iterator()`.
-  - This iterable is transformed to another iterable, by applying the encoding generators.
-    Those convert the chunk type from `Buffer` to `string | Uint8Array` depending on the encoding option.
-  - This new iterable is transformed again to another one, this time by applying the user-supplied generator.
-  - Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
- */
+Generators can be used to transform/filter standard streams.
+
+Generators have a simple syntax, yet allows all of the following:
+- Sharing state between chunks, by using logic before the `for` loop
+- Flushing logic, by using logic after the `for` loop
+- Asynchronous logic
+- Emitting multiple chunks from a single source chunk, even if spaced in time, by using multiple `yield`
+- Filtering, by using no `yield`
+
+Therefore, there is no need to allow Node.js or web transform streams.
+
+The `highWaterMark` is kept as the default value, since this is what `childProcess.std*` uses.
+
+We ensure `objectMode` is `false` for better buffering.
+
+Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
+
+We return a `Duplex`, created by `Duplex.from()` made of a writable stream and a readable stream, piped to each other.
+- The writable stream is a simple `PassThrough`, so it only forwards data to the readable part.
+- The `PassThrough` is read as an iterable using `passThrough.iterator()`.
+- This iterable is transformed to another iterable, by applying the encoding generators.
+	Those convert the chunk type from `Buffer` to `string | Uint8Array` depending on the encoding option.
+- This new iterable is transformed again to another one, this time by applying the user-supplied generator.
+- Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
+*/
 export const generatorToTransformStream = ({value}, {encoding}) => {
 	const objectMode = false;
 	const highWaterMark = getDefaultHighWaterMark(objectMode);
@@ -33,14 +39,16 @@ export const generatorToTransformStream = ({value}, {encoding}) => {
 };
 
 /*
- When an error is thrown in a generator, the PassThrough is aborted.
- This creates a race condition for which error is propagated, due to the Duplex throwing twice:
-  - The writable side is aborted (PassThrough)
-  - The readable side propagate the generator's error
- In order for the later to win that race, we need to wait one microtask.
-  - However we wait one macrotask instead to be on the safe side
-  - See https://github.com/sindresorhus/execa/pull/693#discussion_r1453809450
- */
+When an error is thrown in a generator, the PassThrough is aborted.
+
+This creates a race condition for which error is propagated, due to the Duplex throwing twice:
+- The writable side is aborted (PassThrough)
+- The readable side propagate the generator's error
+
+In order for the later to win that race, we need to wait one microtask.
+- However we wait one macrotask instead to be on the safe side
+- See https://github.com/sindresorhus/execa/pull/693#discussion_r1453809450
+*/
 const destroyPassThrough = (error, done) => {
 	setTimeout(() => {
 		done(error);
@@ -54,14 +62,15 @@ const applyEncoding = (iterable, encoding) => encoding === 'buffer'
 	: encodingStartStringGenerator(iterable);
 
 /*
- Chunks might be Buffer, Uint8Array or strings since:
-  - `childProcess.stdout|stderr` emits Buffers
-  - `childProcess.stdin.write()` accepts Buffer, Uint8Array or string
-  - Previous generators might return Uint8Array or string
- However, those are converted to Buffer:
-  - on writes: `Duplex.writable` `decodeStrings: true` default option
-  - on reads: `Duplex.readable` `readableEncoding: null` default option
- */
+Chunks might be Buffer, Uint8Array or strings since:
+- `childProcess.stdout|stderr` emits Buffers
+- `childProcess.stdin.write()` accepts Buffer, Uint8Array or string
+- Previous generators might return Uint8Array or string
+
+However, those are converted to Buffer:
+- on writes: `Duplex.writable` `decodeStrings: true` default option
+- on reads: `Duplex.readable` `readableEncoding: null` default option
+*/
 const encodingStartStringGenerator = async function * (chunks) {
 	const textDecoder = new TextDecoder();
 

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -11,7 +11,7 @@ export const handleInput = (addProperties, options) => {
 	const stdioStreamsGroups = [[...stdinStreams, ...handleInputOptions(options)], ...otherStreamsGroups]
 		.map(stdioStreams => validateStreams(stdioStreams))
 		.map(stdioStreams => addStreamDirection(stdioStreams))
-		.map(stdioStreams => addStreamsProperties(stdioStreams, addProperties));
+		.map(stdioStreams => addStreamsProperties(stdioStreams, addProperties, options));
 	options.stdio = transformStdio(stdioStreamsGroups);
 	return stdioStreamsGroups;
 };
@@ -51,7 +51,7 @@ const validateStdioArray = (stdioOptions, isStdioArray, optionName) => {
 const INVALID_STDIO_ARRAY_OPTIONS = ['ignore', 'ipc'];
 
 const getStdioStream = ({stdioOption, optionName, index, isStdioArray}) => {
-	const type = getStdioOptionType(stdioOption);
+	const type = getStdioOptionType(stdioOption, optionName);
 	const stdioStream = {type, value: stdioOption, optionName, index};
 	return handleNativeStream(stdioStream, isStdioArray);
 };
@@ -78,9 +78,9 @@ For example, you can use the \`pathToFileURL()\` method of the \`url\` core modu
 // Some `stdio` values require Execa to create streams.
 // For example, file paths create file read/write streams.
 // Those transformations are specified in `addProperties`, which is both direction-specific and type-specific.
-const addStreamsProperties = (stdioStreams, addProperties) => stdioStreams.map(stdioStream => ({
+const addStreamsProperties = (stdioStreams, addProperties, options) => stdioStreams.map(stdioStream => ({
 	...stdioStream,
-	...addProperties[stdioStream.direction][stdioStream.type]?.(stdioStream),
+	...addProperties[stdioStream.direction][stdioStream.type]?.(stdioStream, options),
 }));
 
 // When the `std*: Iterable | WebStream | URL | filePath`, `input` or `inputFile` option is used, we pipe to `spawned.std*`.

--- a/lib/stdio/sync.js
+++ b/lib/stdio/sync.js
@@ -25,6 +25,7 @@ const forbiddenIfSync = ({type, optionName}) => {
 
 const addPropertiesSync = {
 	input: {
+		generator: forbiddenIfSync,
 		fileUrl: ({value}) => ({value: bufferToUint8Array(readFileSync(value)), type: 'uint8Array'}),
 		filePath: ({value}) => ({value: bufferToUint8Array(readFileSync(value.file)), type: 'uint8Array'}),
 		webStream: forbiddenIfSync,
@@ -33,6 +34,7 @@ const addPropertiesSync = {
 		native: forbiddenIfStreamSync,
 	},
 	output: {
+		generator: forbiddenIfSync,
 		filePath: ({value}) => ({value: value.file}),
 		webStream: forbiddenIfSync,
 		nodeStream: forbiddenIfSync,

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -2,7 +2,15 @@ import {isStream as isNodeStream} from 'is-stream';
 import {isUint8Array} from './utils.js';
 
 // The `stdin`/`stdout`/`stderr` option can be of many types. This detects it.
-export const getStdioOptionType = stdioOption => {
+export const getStdioOptionType = (stdioOption, optionName) => {
+	if (isAsyncGenerator(stdioOption)) {
+		return 'generator';
+	}
+
+	if (isSyncGenerator(stdioOption)) {
+		throw new TypeError(`The \`${optionName}\` option must use an asynchronous generator, not a synchronous one.`);
+	}
+
 	if (isUrl(stdioOption)) {
 		return 'fileUrl';
 	}
@@ -30,6 +38,9 @@ export const getStdioOptionType = stdioOption => {
 	return 'native';
 };
 
+const isAsyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object AsyncGeneratorFunction]';
+const isSyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object GeneratorFunction]';
+
 export const isUrl = stdioOption => Object.prototype.toString.call(stdioOption) === '[object URL]';
 export const isRegularUrl = stdioOption => isUrl(stdioOption) && stdioOption.protocol !== 'file:';
 
@@ -53,6 +64,7 @@ const isIterableObject = stdioOption => typeof stdioOption === 'object'
 
 // Convert types to human-friendly strings for error messages
 export const TYPE_TO_MESSAGE = {
+	generator: 'a generator',
 	fileUrl: 'a file URL',
 	filePath: 'a file path string',
 	webStream: 'a web stream',

--- a/readme.md
+++ b/readme.md
@@ -601,7 +601,7 @@ Default: `inherit` with [`$`](#command), `pipe` otherwise
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the input. Please see the [full documentation here](docs/transform.md).
+This can also be an async generator function to transform the input. [Learn more.](docs/transform.md)
 
 #### stdout
 
@@ -622,7 +622,7 @@ Default: `pipe`
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the output. Please see the [full documentation here](docs/transform.md).
+This can also be an async generator function to transform the output. [Learn more.](docs/transform.md)
 
 #### stderr
 
@@ -643,7 +643,7 @@ Default: `pipe`
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the output. Please see the [full documentation here](docs/transform.md).
+This can also be an async generator function to transform the output. [Learn more.](docs/transform.md)
 
 #### stdio
 

--- a/readme.md
+++ b/readme.md
@@ -582,7 +582,7 @@ See also the [`input`](#input) and [`stdin`](#stdin) options.
 
 #### stdin
 
-Type: `string | number | stream.Readable | ReadableStream | URL | Uint8Array | Iterable<string | Uint8Array> | AsyncIterable<string | Uint8Array>` (or a tuple of those types)\
+Type: `string | number | stream.Readable | ReadableStream | URL | Uint8Array | Iterable<string | Uint8Array> | AsyncIterable<string | Uint8Array> | AsyncGeneratorFunction<string | Uint8Array>` (or a tuple of those types)\
 Default: `inherit` with [`$`](#command), `pipe` otherwise
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard input. This can be:
@@ -601,9 +601,11 @@ Default: `inherit` with [`$`](#command), `pipe` otherwise
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
+This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the input. Please see the [full documentation here](docs/transform.md).
+
 #### stdout
 
-Type: `string | number | stream.Writable | WritableStream | URL` (or a tuple of those types)\
+Type: `string | number | stream.Writable | WritableStream | URL | AsyncGeneratorFunction<string | Uint8Array>` (or a tuple of those types)\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard output. This can be:
@@ -620,9 +622,11 @@ Default: `pipe`
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
+This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the output. Please see the [full documentation here](docs/transform.md).
+
 #### stderr
 
-Type: `string | number | stream.Writable | WritableStream | URL` (or a tuple of those types)`\
+Type: `string | number | stream.Writable | WritableStream | URL | AsyncGeneratorFunction<string | Uint8Array>` (or a tuple of those types)`\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard error. This can be:
@@ -639,9 +643,11 @@ Default: `pipe`
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
+This can also be an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to transform the output. Please see the [full documentation here](docs/transform.md).
+
 #### stdio
 
-Type: `string | Array<string | number | stream.Readable | stream.Writable | ReadableStream | WritableStream | URL | Uint8Array | Iterable<string | Uint8Array> | AsyncIterable<string | Uint8Array>>` (or a tuple of those types)\
+Type: `string | Array<string | number | stream.Readable | stream.Writable | ReadableStream | WritableStream | URL | Uint8Array | Iterable<string | Uint8Array> | AsyncIterable<string | Uint8Array> | AsyncGeneratorFunction<string | Uint8Array>>` (or a tuple of those types)\
 Default: `pipe`
 
 Like the [`stdin`](#stdin), [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options but for all file descriptors at once. For example, `{stdio: ['ignore', 'pipe', 'pipe']}` is the same as `{stdin: 'ignore', stdout: 'pipe', stderr: 'pipe'}`.

--- a/test/fixtures/all-fail.js
+++ b/test/fixtures/all-fail.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import process from 'node:process';
+
+console.log('stdout');
+console.error('stderr');
+process.exit(1);

--- a/test/fixtures/all.js
+++ b/test/fixtures/all.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+console.log('stdout');
+console.error('stderr');

--- a/test/fixtures/nested-inherit.js
+++ b/test/fixtures/nested-inherit.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import {execa} from '../../index.js';
+
+const uppercaseGenerator = async function * (chunks) {
+	for await (const chunk of chunks) {
+		yield chunk.toUpperCase();
+	}
+};
+
+await execa('noop-fd.js', ['1'], {stdout: ['inherit', uppercaseGenerator]});

--- a/test/fixtures/noop-fail.js
+++ b/test/fixtures/noop-fail.js
@@ -2,5 +2,5 @@
 import process from 'node:process';
 import {writeSync} from 'node:fs';
 
-writeSync(Number(process.argv[2]), 'foobar');
+writeSync(Number(process.argv[2]), process.argv[3] || 'foobar');
 process.exit(2);

--- a/test/stdio/generator.js
+++ b/test/stdio/generator.js
@@ -1,0 +1,400 @@
+import {Buffer} from 'node:buffer';
+import {readFile, writeFile, rm} from 'node:fs/promises';
+import {getDefaultHighWaterMark, PassThrough} from 'node:stream';
+import {setTimeout} from 'node:timers/promises';
+import test from 'ava';
+import getStream from 'get-stream';
+import tempfile from 'tempfile';
+import {execa, execaSync} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {getStdio} from '../helpers/stdio.js';
+
+setFixtureDir();
+
+const foobarString = 'foobar';
+const foobarUppercase = foobarString.toUpperCase();
+const foobarBuffer = Buffer.from(foobarString);
+const foobarUint8Array = new TextEncoder().encode(foobarString);
+
+const uppercaseGenerator = async function * (chunks) {
+	for await (const chunk of chunks) {
+		yield chunk.toUpperCase();
+	}
+};
+
+const testGeneratorInput = async (t, index) => {
+	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [foobarUint8Array, uppercaseGenerator]));
+	t.is(stdout, foobarUppercase);
+};
+
+test('Can use generators with result.stdin', testGeneratorInput, 0);
+test('Can use generators with result.stdio[*] as input', testGeneratorInput, 3);
+
+const testGeneratorInputPipe = async (t, index, useShortcutProperty, encoding) => {
+	const childProcess = execa('stdin-fd.js', [`${index}`], getStdio(index, uppercaseGenerator));
+	const stream = useShortcutProperty ? childProcess.stdin : childProcess.stdio[index];
+	stream.end(encoding === 'buffer' ? foobarBuffer : foobarBuffer.toString(encoding), encoding);
+	const {stdout} = await childProcess;
+	t.is(stdout, foobarUppercase);
+};
+
+test('Can use generators with childProcess.stdio[0] and default encoding', testGeneratorInputPipe, 0, false, 'utf8');
+test('Can use generators with childProcess.stdin and default encoding', testGeneratorInputPipe, 0, true, 'utf8');
+test('Can use generators with childProcess.stdio[0] and encoding "buffer"', testGeneratorInputPipe, 0, false, 'buffer');
+test('Can use generators with childProcess.stdin and encoding "buffer"', testGeneratorInputPipe, 0, true, 'buffer');
+test('Can use generators with childProcess.stdio[0] and encoding "hex"', testGeneratorInputPipe, 0, false, 'hex');
+test('Can use generators with childProcess.stdin and encoding "hex"', testGeneratorInputPipe, 0, true, 'hex');
+
+test('Can use generators with childProcess.stdio[*] as input', async t => {
+	const childProcess = execa('stdin-fd.js', ['3'], getStdio(3, [new Uint8Array(), uppercaseGenerator]));
+	childProcess.stdio[3].write(foobarUint8Array);
+	const {stdout} = await childProcess;
+	t.is(stdout, foobarUppercase);
+});
+
+const testGeneratorOutput = async (t, index, reject, useShortcutProperty) => {
+	const fixtureName = reject ? 'noop-fd.js' : 'noop-fail.js';
+	const {stdout, stderr, stdio} = await execa(fixtureName, [`${index}`, foobarString], {...getStdio(index, uppercaseGenerator), reject});
+	const result = useShortcutProperty ? [stdout, stderr][index - 1] : stdio[index];
+	t.is(result, foobarUppercase);
+};
+
+test('Can use generators with result.stdio[1]', testGeneratorOutput, 1, true, false);
+test('Can use generators with result.stdout', testGeneratorOutput, 1, true, true);
+test('Can use generators with result.stdio[2]', testGeneratorOutput, 2, true, false);
+test('Can use generators with result.stderr', testGeneratorOutput, 2, true, true);
+test('Can use generators with result.stdio[*] as output', testGeneratorOutput, 3, true, false);
+test('Can use generators with error.stdio[1]', testGeneratorOutput, 1, false, false);
+test('Can use generators with error.stdout', testGeneratorOutput, 1, false, true);
+test('Can use generators with error.stdio[2]', testGeneratorOutput, 2, false, false);
+test('Can use generators with error.stderr', testGeneratorOutput, 2, false, true);
+test('Can use generators with error.stdio[*] as output', testGeneratorOutput, 3, false, false);
+
+const testGeneratorOutputPipe = async (t, index, useShortcutProperty) => {
+	const childProcess = execa('noop-fd.js', [`${index}`, foobarString], {...getStdio(index, uppercaseGenerator), buffer: false});
+	const stream = useShortcutProperty ? [childProcess.stdout, childProcess.stderr][index - 1] : childProcess.stdio[index];
+	const [result] = await Promise.all([getStream(stream), childProcess]);
+	t.is(result, foobarUppercase);
+};
+
+test('Can use generators with childProcess.stdio[1]', testGeneratorOutputPipe, 1, false);
+test('Can use generators with childProcess.stdout', testGeneratorOutputPipe, 1, true);
+test('Can use generators with childProcess.stdio[2]', testGeneratorOutputPipe, 2, false);
+test('Can use generators with childProcess.stderr', testGeneratorOutputPipe, 2, true);
+test('Can use generators with childProcess.stdio[*] as output', testGeneratorOutputPipe, 3, false);
+
+const testGeneratorAll = async (t, reject) => {
+	const fixtureName = reject ? 'all.js' : 'all-fail.js';
+	const {all} = await execa(fixtureName, {all: true, reject, stdout: uppercaseGenerator, stderr: uppercaseGenerator});
+	t.is(all, 'STDOUT\nSTDERR');
+};
+
+test('Can use generators with result.all', testGeneratorAll, true);
+test('Can use generators with error.all', testGeneratorAll, false);
+
+test('Can use generators with input option', async t => {
+	const {stdout} = await execa('stdin-fd.js', ['0'], {stdin: uppercaseGenerator, input: foobarUint8Array});
+	t.is(stdout, foobarUppercase);
+});
+
+const syncGenerator = function * () {};
+
+const testSyncGenerator = (t, index) => {
+	t.throws(() => {
+		execa('empty.js', getStdio(index, syncGenerator));
+	}, {message: /asynchronous generator/});
+};
+
+test('Cannot use sync generators with stdin', testSyncGenerator, 0);
+test('Cannot use sync generators with stdout', testSyncGenerator, 1);
+test('Cannot use sync generators with stderr', testSyncGenerator, 2);
+test('Cannot use sync generators with stdio[*]', testSyncGenerator, 3);
+
+const testSyncMethods = (t, index) => {
+	t.throws(() => {
+		execaSync('empty.js', getStdio(index, uppercaseGenerator));
+	}, {message: /cannot be a generator/});
+};
+
+test('Cannot use generators with sync methods and stdin', testSyncMethods, 0);
+test('Cannot use generators with sync methods and stdout', testSyncMethods, 1);
+test('Cannot use generators with sync methods and stderr', testSyncMethods, 2);
+test('Cannot use generators with sync methods and stdio[*]', testSyncMethods, 3);
+
+const repeatHighWaterMark = 10;
+
+const writerGenerator = async function * (chunks) {
+	// eslint-disable-next-line no-unused-vars
+	for await (const chunk of chunks) {
+		for (let index = 0; index < getDefaultHighWaterMark() * repeatHighWaterMark; index += 1) {
+			yield '.';
+		}
+	}
+};
+
+const passThroughGenerator = async function * (chunks) {
+	for await (const chunk of chunks) {
+		yield `${chunk.length}`;
+	}
+};
+
+test('Stream respects highWaterMark', async t => {
+	const index = 1;
+	const {stdout} = await execa('noop-fd.js', [`${index}`], getStdio(index, [writerGenerator, passThroughGenerator]));
+	t.is(stdout, `${getDefaultHighWaterMark()}`.repeat(repeatHighWaterMark));
+});
+
+const typeofGenerator = async function * (chunks) {
+	for await (const chunk of chunks) {
+		yield Object.prototype.toString.call(chunk);
+	}
+};
+
+const testGeneratorFirstEncoding = async (t, input, encoding) => {
+	const childProcess = execa('stdin.js', {stdin: typeofGenerator, encoding});
+	childProcess.stdin.end(input);
+	const {stdout} = await childProcess;
+	const output = Buffer.from(stdout, encoding).toString();
+	t.is(output, encoding === 'buffer' ? '[object Uint8Array]' : '[object String]');
+};
+
+test('First generator argument is string with default encoding, with string writes', testGeneratorFirstEncoding, foobarString, 'utf8');
+test('First generator argument is string with default encoding, with Buffer writes', testGeneratorFirstEncoding, foobarBuffer, 'utf8');
+test('First generator argument is string with default encoding, with Uint8Array writes', testGeneratorFirstEncoding, foobarUint8Array, 'utf8');
+test('First generator argument is Uint8Array with encoding "buffer", with string writes', testGeneratorFirstEncoding, foobarString, 'buffer');
+test('First generator argument is Uint8Array with encoding "buffer", with Buffer writes', testGeneratorFirstEncoding, foobarBuffer, 'buffer');
+test('First generator argument is Uint8Array with encoding "buffer", with Uint8Array writes', testGeneratorFirstEncoding, foobarUint8Array, 'buffer');
+test('First generator argument is Uint8Array with encoding "hex", with string writes', testGeneratorFirstEncoding, foobarString, 'hex');
+test('First generator argument is Uint8Array with encoding "hex", with Buffer writes', testGeneratorFirstEncoding, foobarBuffer, 'hex');
+test('First generator argument is Uint8Array with encoding "hex", with Uint8Array writes', testGeneratorFirstEncoding, foobarUint8Array, 'hex');
+
+const outputGenerator = async function * (input, chunks) {
+	// eslint-disable-next-line no-unused-vars
+	for await (const chunk of chunks) {
+		yield input;
+	}
+};
+
+const testGeneratorNextEncoding = async (t, input, encoding) => {
+	const {stdout} = await execa('noop.js', ['other'], {stdout: [outputGenerator.bind(undefined, input), typeofGenerator], encoding});
+	const output = Buffer.from(stdout, encoding).toString();
+	t.is(output, encoding === 'buffer' ? '[object Uint8Array]' : '[object String]');
+};
+
+test('Next generator argument is string with default encoding, with string writes', testGeneratorNextEncoding, foobarString, 'utf8');
+test('Next generator argument is string with default encoding, with Buffer writes', testGeneratorNextEncoding, foobarBuffer, 'utf8');
+test('Next generator argument is string with default encoding, with Uint8Array writes', testGeneratorNextEncoding, foobarUint8Array, 'utf8');
+test('Next generator argument is Uint8Array with encoding "buffer", with string writes', testGeneratorNextEncoding, foobarString, 'buffer');
+test('Next generator argument is Uint8Array with encoding "buffer", with Buffer writes', testGeneratorNextEncoding, foobarBuffer, 'buffer');
+test('Next generator argument is Uint8Array with encoding "buffer", with Uint8Array writes', testGeneratorNextEncoding, foobarUint8Array, 'buffer');
+test('Next generator argument is Uint8Array with encoding "hex", with string writes', testGeneratorNextEncoding, foobarString, 'hex');
+test('Next generator argument is Uint8Array with encoding "hex", with Buffer writes', testGeneratorNextEncoding, foobarBuffer, 'hex');
+test('Next generator argument is Uint8Array with encoding "hex", with Uint8Array writes', testGeneratorNextEncoding, foobarUint8Array, 'hex');
+
+const testGeneratorReturnType = async (t, input, encoding) => {
+	const {stdout} = await execa('noop.js', ['other'], {stdout: outputGenerator.bind(undefined, input), encoding});
+	const output = Buffer.from(stdout, encoding).toString();
+	t.is(output, foobarString);
+};
+
+test('Generator can return string with default encoding', testGeneratorReturnType, foobarString, 'utf8');
+test('Generator can return Uint8Array with default encoding', testGeneratorReturnType, foobarUint8Array, 'utf8');
+test('Generator can return string with encoding "buffer"', testGeneratorReturnType, foobarString, 'buffer');
+test('Generator can return Uint8Array with encoding "buffer"', testGeneratorReturnType, foobarUint8Array, 'buffer');
+test('Generator can return string with encoding "hex"', testGeneratorReturnType, foobarString, 'hex');
+test('Generator can return Uint8Array with encoding "hex"', testGeneratorReturnType, foobarUint8Array, 'hex');
+
+const multibyteChar = '\u{1F984}';
+const multibyteString = `${multibyteChar}${multibyteChar}`;
+const multibyteUint8Array = new TextEncoder().encode(multibyteString);
+const breakingLength = multibyteUint8Array.length * 0.75;
+const brokenSymbol = '\uFFFD';
+
+const noopGenerator = async function * (chunks) {
+	for await (const chunk of chunks) {
+		yield chunk;
+	}
+};
+
+test('Generator handles multibyte characters with Uint8Array', async t => {
+	const childProcess = execa('stdin.js', {stdin: noopGenerator});
+	childProcess.stdin.write(multibyteUint8Array.slice(0, breakingLength));
+	await setTimeout(0);
+	childProcess.stdin.end(multibyteUint8Array.slice(breakingLength));
+	const {stdout} = await childProcess;
+	t.is(stdout, multibyteString);
+});
+
+test('Generator handles partial multibyte characters with Uint8Array', async t => {
+	const {stdout} = await execa('stdin.js', {stdin: [multibyteUint8Array.slice(0, breakingLength), noopGenerator]});
+	t.is(stdout, `${multibyteChar}${brokenSymbol}`);
+});
+
+// eslint-disable-next-line require-yield
+const noYieldGenerator = async function * (chunks) {
+	// eslint-disable-next-line no-empty, no-unused-vars
+	for await (const chunk of chunks) {}
+};
+
+test('Generator can filter by not calling yield', async t => {
+	const {stdout} = await execa('noop.js', {stdout: noYieldGenerator});
+	t.is(stdout, '');
+});
+
+const prefix = '> ';
+const suffix = ' <';
+
+const multipleYieldGenerator = async function * (chunks) {
+	for await (const chunk of chunks) {
+		yield prefix;
+		await setTimeout(0);
+		yield chunk;
+		await setTimeout(0);
+		yield suffix;
+	}
+};
+
+test('Generator can yield multiple times at different moments', async t => {
+	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {stdout: multipleYieldGenerator});
+	t.is(stdout, `${prefix}${foobarString}${suffix}`);
+});
+
+const testInputFile = async (t, getOptions, reversed) => {
+	const filePath = tempfile();
+	await writeFile(filePath, foobarString);
+	const {stdin, ...options} = getOptions(filePath);
+	const reversedStdin = reversed ? stdin.reverse() : stdin;
+	const {stdout} = await execa('stdin-fd.js', ['0'], {...options, stdin: reversedStdin});
+	t.is(stdout, foobarUppercase);
+	await rm(filePath);
+};
+
+test('Can use generators with a file as input', testInputFile, filePath => ({stdin: [{file: filePath}, uppercaseGenerator]}), false);
+test('Can use generators with a file as input, reversed', testInputFile, filePath => ({stdin: [{file: filePath}, uppercaseGenerator]}), true);
+test('Can use generators with inputFile option', testInputFile, filePath => ({inputFile: filePath, stdin: uppercaseGenerator}), false);
+
+const testOutputFile = async (t, reversed) => {
+	const filePath = tempfile();
+	const stdoutOption = [uppercaseGenerator, {file: filePath}];
+	const reversedStdoutOption = reversed ? stdoutOption.reverse() : stdoutOption;
+	const {stdout} = await execa('noop-fd.js', ['1'], {stdout: reversedStdoutOption});
+	t.is(stdout, foobarUppercase);
+	t.is(await readFile(filePath, 'utf8'), foobarUppercase);
+	await rm(filePath);
+};
+
+test('Can use generators with a file as output', testOutputFile, false);
+test('Can use generators with a file as output, reversed', testOutputFile, true);
+
+test('Can use generators to a Writable stream', async t => {
+	const passThrough = new PassThrough();
+	const [{stdout}, streamOutput] = await Promise.all([
+		execa('noop-fd.js', ['1', foobarString], {stdout: [uppercaseGenerator, passThrough]}),
+		getStream(passThrough),
+	]);
+	t.is(stdout, foobarUppercase);
+	t.is(streamOutput, foobarUppercase);
+});
+
+test('Can use generators from a Readable stream', async t => {
+	const passThrough = new PassThrough();
+	const childProcess = execa('stdin-fd.js', ['0'], {stdin: [passThrough, uppercaseGenerator]});
+	passThrough.end(foobarString);
+	const {stdout} = await childProcess;
+	t.is(stdout, foobarUppercase);
+});
+
+test('Can use generators with "inherit"', async t => {
+	const {stdout} = await execa('nested-inherit.js');
+	t.is(stdout, foobarUppercase);
+});
+
+const casedSuffix = 'k';
+
+const appendGenerator = async function * (chunks) {
+	for await (const chunk of chunks) {
+		yield `${chunk}${casedSuffix}`;
+	}
+};
+
+const testAppendInput = async (t, reversed) => {
+	const stdin = [foobarUint8Array, uppercaseGenerator, appendGenerator];
+	const reversedStdin = reversed ? stdin.reverse() : stdin;
+	const {stdout} = await execa('stdin-fd.js', ['0'], {stdin: reversedStdin});
+	const reversedSuffix = reversed ? casedSuffix.toUpperCase() : casedSuffix;
+	t.is(stdout, `${foobarUppercase}${reversedSuffix}`);
+};
+
+test('Can use multiple generators as input', testAppendInput, false);
+test('Can use multiple generators as input, reversed', testAppendInput, true);
+
+const testAppendOutput = async (t, reversed) => {
+	const stdoutOption = [uppercaseGenerator, appendGenerator];
+	const reversedStdoutOption = reversed ? stdoutOption.reverse() : stdoutOption;
+	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {stdout: reversedStdoutOption});
+	const reversedSuffix = reversed ? casedSuffix.toUpperCase() : casedSuffix;
+	t.is(stdout, `${foobarUppercase}${reversedSuffix}`);
+};
+
+test('Can use multiple generators as output', testAppendOutput, false);
+test('Can use multiple generators as output, reversed', testAppendOutput, true);
+
+const maxBuffer = 10;
+
+test('Generators take "maxBuffer" into account', async t => {
+	const bigString = '.'.repeat(maxBuffer);
+	const {stdout} = await execa('noop.js', {maxBuffer, stdout: outputGenerator.bind(undefined, bigString)});
+	t.is(stdout, bigString);
+
+	await t.throwsAsync(execa('noop.js', {maxBuffer, stdout: outputGenerator.bind(undefined, `${bigString}.`)}));
+});
+
+const timeoutGenerator = async function * (timeout, chunks) {
+	for await (const chunk of chunks) {
+		await setTimeout(timeout);
+		yield chunk;
+	}
+};
+
+test('Generators are awaited on success', async t => {
+	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {maxBuffer, stdout: timeoutGenerator.bind(undefined, 1e3)});
+	t.is(stdout, foobarString);
+});
+
+// eslint-disable-next-line require-yield
+const throwingGenerator = async function * (chunks) {
+	// eslint-disable-next-line no-unreachable-loop
+	for await (const chunk of chunks) {
+		throw new Error(`Generator error ${chunk}`);
+	}
+};
+
+test('Generators errors make process fail', async t => {
+	await t.throwsAsync(
+		execa('noop-fd.js', ['1', foobarString], {stdout: throwingGenerator}),
+		{message: /Generator error foobar/},
+	);
+});
+
+// eslint-disable-next-line require-yield
+const errorHandlerGenerator = async function * (state, chunks) {
+	try {
+		// eslint-disable-next-line no-unused-vars
+		for await (const chunk of chunks) {
+			await setTimeout(1e8);
+		}
+	} catch (error) {
+		state.error = error;
+	}
+};
+
+test.serial('Process streams failures make generators throw', async t => {
+	const state = {};
+	const childProcess = execa('noop-fail.js', ['1'], {stdout: errorHandlerGenerator.bind(undefined, state)});
+	const error = new Error('test');
+	childProcess.stdout.emit('error', error);
+	const thrownError = await t.throwsAsync(childProcess);
+	t.is(error, thrownError);
+	await setTimeout(0);
+	t.is(state.error.code, 'ABORT_ERR');
+});


### PR DESCRIPTION
Fixes #20 (second most upvoted issue). Also fixes #21 and fixes #121 (third most upvoted issue).

This allows transforming a child process' input and ouput by passing an async generator to the `stdin`/`stdout`/`stderr`/`stdio` option.

```js
const transform = async function * (chunks) {
	for await (const chunk of chunks) {
		yield chunk.toUpperCase();
	}
};

const {stdout} = await execa('echo', ['hello'], {stdout: transform});
console.log(stdout); // HELLO
```

Using generators is much simpler for users than creating web or Node.js `Transform` streams (which are used under-the-hood). Unlike regular functions, it still enables init and flushing logic (before and after the `for await` loop, which can be particularly helpful (and necessary for issues like #121).

IMHO There are many use cases for this. I have been needed this feature myself in production several times. For example, I've been needed to use `stdout: 'inherit'` but filtering secret values. This is now easy by using the `{ stdout: [filterSecretTransform, 'inherit'] }` option. I think the fact that those are among our most upvoted issues is telling.

This PR intentionally currently leaves out two points for the moment:
  - Splitting chunks line-wise. At the moment, a chunk is basically a single write, except for chunks >16KB which are split. Doing so would be required for #121.
  - Allowing generators to return or take as input other types than string and `Uint8Array`. Especially objects. Basically for the underlying stream to use `objectMode: true`. This is the issue at #21.

For a fuller description of the feature from a user standpoint, I have created the [following documentation](https://github.com/sindresorhus/execa/blob/transforms/docs/transform.md).