### PR TITLE
Fix `encoding` option

### DIFF
--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -7,7 +7,7 @@ import {TYPE_TO_MESSAGE} from './type.js';
 import {generatorToTransformStream, pipeGenerator} from './generator.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async mode
-export const handleInputAsync = options => handleInput(addPropertiesAsync, options);
+export const handleInputAsync = options => handleInput(addPropertiesAsync, options, false);
 
 const forbiddenIfAsync = ({type, optionName}) => {
 	throw new TypeError(`The \`${optionName}\` option cannot be ${TYPE_TO_MESSAGE[type]}.`);

--- a/lib/stdio/encoding.js
+++ b/lib/stdio/encoding.js
@@ -1,0 +1,27 @@
+import {StringDecoder} from 'node:string_decoder';
+
+// Apply the `encoding` option using an implicit generator.
+export const handleStreamsEncoding = (stdioStreams, {encoding}, isSync) => {
+	if (stdioStreams[0].direction === 'input' || IGNORED_ENCODINGS.has(encoding) || isSync) {
+		return stdioStreams.map(stdioStream => ({...stdioStream, encoding}));
+	}
+
+	const value = encodingEndGenerator.bind(undefined, encoding);
+	return [...stdioStreams, {...stdioStreams[0], type: 'generator', value, encoding: 'buffer'}];
+};
+
+// eslint-disable-next-line unicorn/text-encoding-identifier-case
+const IGNORED_ENCODINGS = new Set(['utf8', 'utf-8', 'buffer']);
+
+const encodingEndGenerator = async function * (encoding, chunks) {
+	const stringDecoder = new StringDecoder(encoding);
+
+	for await (const chunk of chunks) {
+		yield stringDecoder.write(chunk);
+	}
+
+	const lastChunk = stringDecoder.end();
+	if (lastChunk !== '') {
+		yield lastChunk;
+	}
+};

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -26,7 +26,7 @@ We return a `Duplex`, created by `Duplex.from()` made of a writable stream and a
 - This new iterable is transformed again to another one, this time by applying the user-supplied generator.
 - Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
 */
-export const generatorToTransformStream = ({value}, {encoding}) => {
+export const generatorToTransformStream = ({value, encoding}) => {
 	const objectMode = false;
 	const highWaterMark = getDefaultHighWaterMark(objectMode);
 	const passThrough = new PassThrough({objectMode, highWaterMark, destroy: destroyPassThrough});

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -3,15 +3,17 @@ import {addStreamDirection} from './direction.js';
 import {normalizeStdio} from './normalize.js';
 import {handleNativeStream} from './native.js';
 import {handleInputOptions} from './input.js';
+import {handleStreamsEncoding} from './encoding.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async/sync mode
-export const handleInput = (addProperties, options) => {
+export const handleInput = (addProperties, options, isSync) => {
 	const stdio = normalizeStdio(options);
 	const [stdinStreams, ...otherStreamsGroups] = stdio.map((stdioOption, index) => getStdioStreams(stdioOption, index));
 	const stdioStreamsGroups = [[...stdinStreams, ...handleInputOptions(options)], ...otherStreamsGroups]
 		.map(stdioStreams => validateStreams(stdioStreams))
 		.map(stdioStreams => addStreamDirection(stdioStreams))
-		.map(stdioStreams => addStreamsProperties(stdioStreams, addProperties, options));
+		.map(stdioStreams => handleStreamsEncoding(stdioStreams, options, isSync))
+		.map(stdioStreams => addStreamsProperties(stdioStreams, addProperties));
 	options.stdio = transformStdio(stdioStreamsGroups);
 	return stdioStreamsGroups;
 };
@@ -78,9 +80,9 @@ For example, you can use the \`pathToFileURL()\` method of the \`url\` core modu
 // Some `stdio` values require Execa to create streams.
 // For example, file paths create file read/write streams.
 // Those transformations are specified in `addProperties`, which is both direction-specific and type-specific.
-const addStreamsProperties = (stdioStreams, addProperties, options) => stdioStreams.map(stdioStream => ({
+const addStreamsProperties = (stdioStreams, addProperties) => stdioStreams.map(stdioStream => ({
 	...stdioStream,
-	...addProperties[stdioStream.direction][stdioStream.type]?.(stdioStream, options),
+	...addProperties[stdioStream.direction][stdioStream.type]?.(stdioStream),
 }));
 
 // When the `std*: Iterable | WebStream | URL | filePath`, `input` or `inputFile` option is used, we pipe to `spawned.std*`.

--- a/lib/stdio/sync.js
+++ b/lib/stdio/sync.js
@@ -6,7 +6,7 @@ import {bufferToUint8Array} from './utils.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in sync mode
 export const handleInputSync = options => {
-	const stdioStreamsGroups = handleInput(addPropertiesSync, options);
+	const stdioStreamsGroups = handleInput(addPropertiesSync, options, true);
 	addInputOptionSync(stdioStreamsGroups, options);
 	return stdioStreamsGroups;
 };

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,4 +1,3 @@
-import {Buffer} from 'node:buffer';
 import {once} from 'node:events';
 import {finished} from 'node:stream/promises';
 import getStream, {getStreamAsArrayBuffer} from 'get-stream';
@@ -44,26 +43,13 @@ const getStreamPromise = async (stream, {encoding, buffer, maxBuffer}) => {
 		return;
 	}
 
-	const contents = isUtf8Encoding(encoding)
-		? await getStream(stream, {maxBuffer})
-		: await getStreamAsArrayBuffer(stream, {maxBuffer});
+	const contents = encoding === 'buffer'
+		? await getStreamAsArrayBuffer(stream, {maxBuffer})
+		: await getStream(stream, {maxBuffer});
 	return applyEncoding(contents, encoding);
 };
 
-const applyEncoding = (contents, encoding) => {
-	if (isUtf8Encoding(encoding)) {
-		return contents;
-	}
-
-	if (encoding === 'buffer') {
-		return new Uint8Array(contents);
-	}
-
-	return Buffer.from(contents).toString(encoding);
-};
-
-// eslint-disable-next-line unicorn/text-encoding-identifier-case
-const isUtf8Encoding = encoding => encoding === 'utf8' || encoding === 'utf-8';
+const applyEncoding = (contents, encoding) => encoding === 'buffer' ? new Uint8Array(contents) : contents;
 
 // Retrieve streams created by the `std*` options
 const getCustomStreams = stdioStreamsGroups => stdioStreamsGroups.flat().filter(({type}) => type !== 'native');

--- a/test/stream.js
+++ b/test/stream.js
@@ -117,10 +117,11 @@ test('maxBuffer works with encoding buffer and stderr', testMaxBufferEncoding, 2
 test('maxBuffer works with encoding buffer and stdio[*]', testMaxBufferEncoding, 3);
 
 const testMaxBufferHex = async (t, index) => {
+	const halfMaxBuffer = maxBuffer / 2;
 	const {stdio} = await t.throwsAsync(
-		execa('max-buffer.js', [`${index}`, `${maxBuffer + 1}`], {...fullStdio, maxBuffer, encoding: 'hex'}),
+		execa('max-buffer.js', [`${index}`, `${halfMaxBuffer + 1}`], {...fullStdio, maxBuffer, encoding: 'hex'}),
 	);
-	t.is(stdio[index], Buffer.from('.'.repeat(maxBuffer)).toString('hex'));
+	t.is(stdio[index], Buffer.from('.'.repeat(halfMaxBuffer)).toString('hex'));
 };
 
 test('maxBuffer works with other encodings and stdout', testMaxBufferHex, 1);


### PR DESCRIPTION
This PR fixes the following problems with the `encoding` option, when it is set to something else than `utf8` (the default) or `buffer`, for example when it is set to `hex` or `base64`:
  - The `maxBuffer` option currently applies to the value before encoding. For example, one might want at most 1MB buffered in memory. However, using `encoding: 'hex'` doubles the amount taken in memory (for ASCII text), so that should be taken into account. 
  - The `encoding` applies to `result.stdout`, `error.stdout` but not `childProcess.stdout`. So it does not work for users who rely on manual streaming.
  - The `encoding` logic happens synchronously and all at once at the end, instead of incrementally in a streaming fashion. This blocks the CPU and requires potentially lots of memory.

This PR fixes this by relying on the new "transform" feature. It creates an internal transform which incrementally encodes `stdout`/`stderr` as it is produces. It uses `StringDecoder`, which is what `Buffer` uses under the hood. It correctly handles multibyte sequences split into 2 chunks.

For `execaSync()`, we rely on `child_process.spawnSync()`'s encoding feature instead, so nothing to change there. We have tests though to ensure the result is the same between `execa()` and `execaSync()`.