### PR TITLE
Add passing the same transform multiple times

### DIFF
--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -21,17 +21,28 @@ export const handleInput = (addProperties, options) => {
 // For example, `stdout: ['ignore']` behaves the same as `stdout: 'ignore'`.
 const getStdioStreams = (stdioOption, index) => {
 	const optionName = getOptionName(index);
-	const stdioOptions = Array.isArray(stdioOption) ? [...new Set(stdioOption)] : [stdioOption];
-	const isStdioArray = stdioOptions.length > 1;
-	validateStdioArray(stdioOptions, isStdioArray, optionName);
-	return stdioOptions.map(stdioOption => getStdioStream({stdioOption, optionName, index, isStdioArray}));
+	const stdioOptions = Array.isArray(stdioOption) ? stdioOption : [stdioOption];
+	const rawStdioStreams = stdioOptions.map(stdioOption => getStdioStream(stdioOption, optionName, index));
+	const stdioStreams = filterDuplicates(rawStdioStreams);
+	const isStdioArray = stdioStreams.length > 1;
+	validateStdioArray(stdioStreams, isStdioArray, optionName);
+	return stdioStreams.map(stdioStream => handleNativeStream(stdioStream, isStdioArray));
 };
 
 const getOptionName = index => KNOWN_OPTION_NAMES[index] ?? `stdio[${index}]`;
 const KNOWN_OPTION_NAMES = ['stdin', 'stdout', 'stderr'];
 
-const validateStdioArray = (stdioOptions, isStdioArray, optionName) => {
-	if (stdioOptions.length === 0) {
+const getStdioStream = (stdioOption, optionName, index) => {
+	const type = getStdioOptionType(stdioOption, optionName);
+	return {type, value: stdioOption, optionName, index};
+};
+
+const filterDuplicates = stdioStreams => stdioStreams.filter((stdioStreamOne, indexOne) =>
+	stdioStreams.every((stdioStreamTwo, indexTwo) =>
+		stdioStreamOne.value !== stdioStreamTwo.value || indexOne >= indexTwo || stdioStreamOne.type === 'generator'));
+
+const validateStdioArray = (stdioStreams, isStdioArray, optionName) => {
+	if (stdioStreams.length === 0) {
 		throw new TypeError(`The \`${optionName}\` option must not be an empty array.`);
 	}
 
@@ -39,22 +50,16 @@ const validateStdioArray = (stdioOptions, isStdioArray, optionName) => {
 		return;
 	}
 
-	for (const invalidStdioOption of INVALID_STDIO_ARRAY_OPTIONS) {
-		if (stdioOptions.includes(invalidStdioOption)) {
-			throw new Error(`The \`${optionName}\` option must not include \`${invalidStdioOption}\`.`);
+	for (const {value, optionName} of stdioStreams) {
+		if (INVALID_STDIO_ARRAY_OPTIONS.has(value)) {
+			throw new Error(`The \`${optionName}\` option must not include \`${value}\`.`);
 		}
 	}
 };
 
 // Using those `stdio` values together with others for the same stream does not make sense, so we make it fail.
 // However, we do allow it if the array has a single item.
-const INVALID_STDIO_ARRAY_OPTIONS = ['ignore', 'ipc'];
-
-const getStdioStream = ({stdioOption, optionName, index, isStdioArray}) => {
-	const type = getStdioOptionType(stdioOption, optionName);
-	const stdioStream = {type, value: stdioOption, optionName, index};
-	return handleNativeStream(stdioStream, isStdioArray);
-};
+const INVALID_STDIO_ARRAY_OPTIONS = new Set(['ignore', 'ipc']);
 
 const validateStreams = stdioStreams => {
 	for (const stdioStream of stdioStreams) {

--- a/test/stdio/generator.js
+++ b/test/stdio/generator.js
@@ -339,6 +339,11 @@ const testAppendOutput = async (t, reversed) => {
 test('Can use multiple generators as output', testAppendOutput, false);
 test('Can use multiple generators as output, reversed', testAppendOutput, true);
 
+test('Can use multiple identical generators', async t => {
+	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {stdout: [appendGenerator, appendGenerator]});
+	t.is(stdout, `${foobarString}${casedSuffix}${casedSuffix}`);
+});
+
 const maxBuffer = 10;
 
 test('Generators take "maxBuffer" into account', async t => {


### PR DESCRIPTION
The `stdin`/`stdout`/`stderr`/`stdio` options allow passing an array of values. We skip duplicate values, since there is no good reason to pass duplicates there. For example, `{ stdout: [fileUrl, fileUrl] }` does not make sense, and would result in `stdout` being piped twice to the same file.

However, there is a potentially legitimate use case for duplicates: transforms. For example, the following one, if `thirdPartyTransform` might add secret values, but should not read any:

```js
await execa('...', { stdout: [filterSecretsTransform, thirdPartyTransform, filterSecretsTransform] })
```

This PR allows duplicates with transforms.