### PR TITLE
Separate generator -> Duplex utility

### DIFF
--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -4,7 +4,7 @@ import {Readable, Writable} from 'node:stream';
 import mergeStreams from '@sindresorhus/merge-streams';
 import {handleInput} from './handle.js';
 import {TYPE_TO_MESSAGE} from './type.js';
-import {generatorToTransformStream, pipeGenerator} from './generator.js';
+import {generatorToDuplexStream, pipeGenerator} from './generator.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async mode
 export const handleInputAsync = options => handleInput(addPropertiesAsync, options, false);
@@ -15,7 +15,7 @@ const forbiddenIfAsync = ({type, optionName}) => {
 
 const addPropertiesAsync = {
 	input: {
-		generator: generatorToTransformStream,
+		generator: generatorToDuplexStream,
 		fileUrl: ({value}) => ({value: createReadStream(value)}),
 		filePath: ({value}) => ({value: createReadStream(value.file)}),
 		webStream: ({value}) => ({value: Readable.fromWeb(value)}),
@@ -24,7 +24,7 @@ const addPropertiesAsync = {
 		uint8Array: ({value}) => ({value: Readable.from(Buffer.from(value))}),
 	},
 	output: {
-		generator: generatorToTransformStream,
+		generator: generatorToDuplexStream,
 		fileUrl: ({value}) => ({value: createWriteStream(value)}),
 		filePath: ({value}) => ({value: createWriteStream(value.file)}),
 		webStream: ({value}) => ({value: Writable.fromWeb(value)}),

--- a/lib/stdio/duplex.js
+++ b/lib/stdio/duplex.js
@@ -1,0 +1,42 @@
+import {Duplex, Readable, PassThrough, getDefaultHighWaterMark} from 'node:stream';
+
+/*
+Transform an array of generator functions into a `Duplex`.
+The `Duplex` is created by `Duplex.from()` made of a writable stream and a readable stream, piped to each other.
+- The writable stream is a simple `PassThrough`, so it only forwards data to the readable part.
+- The `PassThrough` is read as an iterable using `passThrough.iterator()`.
+- This iterable is transformed to another iterable, by applying the encoding generators.
+	Those convert the chunk type from `Buffer` to `string | Uint8Array` depending on the encoding option.
+- This new iterable is transformed again to another one, this time by applying the user-supplied generator.
+- Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
+ */
+export const generatorsToDuplex = (generators, {objectMode}) => {
+	const highWaterMark = getDefaultHighWaterMark(objectMode);
+	const passThrough = new PassThrough({objectMode, highWaterMark, destroy: destroyPassThrough});
+	let iterable = passThrough.iterator();
+
+	for (const generator of generators) {
+		iterable = generator(iterable);
+	}
+
+	const readableStream = Readable.from(iterable, {objectMode, highWaterMark});
+	const duplexStream = Duplex.from({writable: passThrough, readable: readableStream});
+	return duplexStream;
+};
+
+/*
+When an error is thrown in a generator, the PassThrough is aborted.
+
+This creates a race condition for which error is propagated, due to the Duplex throwing twice:
+- The writable side is aborted (PassThrough)
+- The readable side propagate the generator's error
+
+In order for the later to win that race, we need to wait one microtask.
+- However we wait one macrotask instead to be on the safe side
+- See https://github.com/sindresorhus/execa/pull/693#discussion_r1453809450
+*/
+const destroyPassThrough = (error, done) => {
+	setTimeout(() => {
+		done(error);
+	}, 0);
+};

--- a/lib/stdio/duplex.js
+++ b/lib/stdio/duplex.js
@@ -2,6 +2,7 @@ import {Duplex, Readable, PassThrough, getDefaultHighWaterMark} from 'node:strea
 
 /*
 Transform an array of generator functions into a `Duplex`.
+
 The `Duplex` is created by `Duplex.from()` made of a writable stream and a readable stream, piped to each other.
 - The writable stream is a simple `PassThrough`, so it only forwards data to the readable part.
 - The `PassThrough` is read as an iterable using `passThrough.iterator()`.
@@ -9,7 +10,7 @@ The `Duplex` is created by `Duplex.from()` made of a writable stream and a reada
 	Those convert the chunk type from `Buffer` to `string | Uint8Array` depending on the encoding option.
 - This new iterable is transformed again to another one, this time by applying the user-supplied generator.
 - Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
- */
+*/
 export const generatorsToDuplex = (generators, {objectMode}) => {
 	const highWaterMark = getDefaultHighWaterMark(objectMode);
 	const passThrough = new PassThrough({objectMode, highWaterMark, destroy: destroyPassThrough});

--- a/lib/stdio/encoding.js
+++ b/lib/stdio/encoding.js
@@ -1,6 +1,7 @@
 import {StringDecoder} from 'node:string_decoder';
 
 // Apply the `encoding` option using an implicit generator.
+// This encodes the final output of `stdout`/`stderr`.
 export const handleStreamsEncoding = (stdioStreams, {encoding}, isSync) => {
 	if (stdioStreams[0].direction === 'input' || IGNORED_ENCODINGS.has(encoding) || isSync) {
 		return stdioStreams.map(stdioStream => ({...stdioStream, encoding}));
@@ -21,6 +22,41 @@ const encodingEndGenerator = async function * (encoding, chunks) {
 	}
 
 	const lastChunk = stringDecoder.end();
+	if (lastChunk !== '') {
+		yield lastChunk;
+	}
+};
+
+/*
+When using generators, add an internal generator that converts chunks from `Buffer` to `string` or `Uint8Array`.
+This allows generator functions to operate with those types instead.
+Chunks might be Buffer, Uint8Array or strings since:
+- `childProcess.stdout|stderr` emits Buffers
+- `childProcess.stdin.write()` accepts Buffer, Uint8Array or string
+- Previous generators might return Uint8Array or string
+
+However, those are converted to Buffer:
+- on writes: `Duplex.writable` `decodeStrings: true` default option
+- on reads: `Duplex.readable` `readableEncoding: null` default option
+*/
+export const getEncodingStartGenerator = encoding => encoding === 'buffer'
+	? encodingStartBufferGenerator
+	: encodingStartStringGenerator;
+
+const encodingStartBufferGenerator = async function * (chunks) {
+	for await (const chunk of chunks) {
+		yield new Uint8Array(chunk);
+	}
+};
+
+const encodingStartStringGenerator = async function * (chunks) {
+	const textDecoder = new TextDecoder();
+
+	for await (const chunk of chunks) {
+		yield textDecoder.decode(chunk, {stream: true});
+	}
+
+	const lastChunk = textDecoder.decode();
 	if (lastChunk !== '') {
 		yield lastChunk;
 	}

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -1,4 +1,5 @@
-import {Duplex, Readable, PassThrough, getDefaultHighWaterMark} from 'node:stream';
+import {generatorsToDuplex} from './duplex.js';
+import {getEncodingStartGenerator} from './encoding.js';
 
 /*
 Generators can be used to transform/filter standard streams.
@@ -17,77 +18,11 @@ The `highWaterMark` is kept as the default value, since this is what `childProce
 We ensure `objectMode` is `false` for better buffering.
 
 Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
-
-We return a `Duplex`, created by `Duplex.from()` made of a writable stream and a readable stream, piped to each other.
-- The writable stream is a simple `PassThrough`, so it only forwards data to the readable part.
-- The `PassThrough` is read as an iterable using `passThrough.iterator()`.
-- This iterable is transformed to another iterable, by applying the encoding generators.
-	Those convert the chunk type from `Buffer` to `string | Uint8Array` depending on the encoding option.
-- This new iterable is transformed again to another one, this time by applying the user-supplied generator.
-- Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
 */
-export const generatorToTransformStream = ({value, encoding}) => {
-	const objectMode = false;
-	const highWaterMark = getDefaultHighWaterMark(objectMode);
-	const passThrough = new PassThrough({objectMode, highWaterMark, destroy: destroyPassThrough});
-	const iterable = passThrough.iterator();
-	const encodedIterable = applyEncoding(iterable, encoding);
-	const mappedIterable = value(encodedIterable);
-	const readableStream = Readable.from(mappedIterable, {objectMode, highWaterMark});
-	const duplexStream = Duplex.from({writable: passThrough, readable: readableStream});
+export const generatorToDuplexStream = ({value, encoding}) => {
+	const generators = [getEncodingStartGenerator(encoding), value];
+	const duplexStream = generatorsToDuplex(generators, {objectMode: false});
 	return {value: duplexStream};
-};
-
-/*
-When an error is thrown in a generator, the PassThrough is aborted.
-
-This creates a race condition for which error is propagated, due to the Duplex throwing twice:
-- The writable side is aborted (PassThrough)
-- The readable side propagate the generator's error
-
-In order for the later to win that race, we need to wait one microtask.
-- However we wait one macrotask instead to be on the safe side
-- See https://github.com/sindresorhus/execa/pull/693#discussion_r1453809450
-*/
-const destroyPassThrough = (error, done) => {
-	setTimeout(() => {
-		done(error);
-	}, 0);
-};
-
-// When using generators, add an internal generator that converts chunks from `Buffer` to `string` or `Uint8Array`.
-// This allows generator functions to operate with those types instead.
-const applyEncoding = (iterable, encoding) => encoding === 'buffer'
-	? encodingStartBufferGenerator(iterable)
-	: encodingStartStringGenerator(iterable);
-
-/*
-Chunks might be Buffer, Uint8Array or strings since:
-- `childProcess.stdout|stderr` emits Buffers
-- `childProcess.stdin.write()` accepts Buffer, Uint8Array or string
-- Previous generators might return Uint8Array or string
-
-However, those are converted to Buffer:
-- on writes: `Duplex.writable` `decodeStrings: true` default option
-- on reads: `Duplex.readable` `readableEncoding: null` default option
-*/
-const encodingStartStringGenerator = async function * (chunks) {
-	const textDecoder = new TextDecoder();
-
-	for await (const chunk of chunks) {
-		yield textDecoder.decode(chunk, {stream: true});
-	}
-
-	const lastChunk = textDecoder.decode();
-	if (lastChunk !== '') {
-		yield lastChunk;
-	}
-};
-
-const encodingStartBufferGenerator = async function * (chunks) {
-	for await (const chunk of chunks) {
-		yield new Uint8Array(chunk);
-	}
 };
 
 // `childProcess.stdin|stdout|stderr|stdio` is directly mutated.

--- a/test/stdio/encoding.js
+++ b/test/stdio/encoding.js
@@ -4,9 +4,9 @@ import {setTimeout} from 'node:timers/promises';
 import {promisify} from 'node:util';
 import test from 'ava';
 import getStream, {getStreamAsBuffer} from 'get-stream';
-import {execa, execaSync} from '../index.js';
-import {setFixtureDir, FIXTURES_DIR} from './helpers/fixtures-dir.js';
-import {fullStdio} from './helpers/stdio.js';
+import {execa, execaSync} from '../../index.js';
+import {setFixtureDir, FIXTURES_DIR} from '../helpers/fixtures-dir.js';
+import {fullStdio} from '../helpers/stdio.js';
 
 const pExec = promisify(exec);
 


### PR DESCRIPTION
This PR splits the following logic into their own file:
  - Utility converting an array of generators into a `Duplex`
  - Everything related to the `encoding` option

It does not change the code. It just moves lines of code around.