### PR TITLE
Line-wise transforms

### DIFF
--- a/docs/transform.md
+++ b/docs/transform.md
@@ -53,8 +53,8 @@ await execa('./binary.js', {stdout: {transform, binary: true}});
 ```
 
 This is more efficient and recommended if the data is either:
-  - Binary, i.e. it does not have lines.
-	- Text, but the transform works even if a line or word is split across multiple chunks.
+	- Binary: Which does not have lines.
+	- Text: But the transform works even if a line or word is split across multiple chunks.
 
 ## Combining
 

--- a/docs/transform.md
+++ b/docs/transform.md
@@ -18,12 +18,6 @@ const {stdout} = await execa('echo', ['hello'], {stdout: transform});
 console.log(stdout); // HELLO
 ```
 
-Alternatively, a `{ transform }` plain object can also be passed.
-
-```js
-await execa('echo', ['hello'], {stdout: {transform}});
-```
-
 ## Encoding
 
 The `lines` argument passed to the transform is an [`AsyncIterable<string>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols). If the [`encoding`](../readme.md#encoding) option is `buffer`, it is an `AsyncIterable<Uint8Array>` instead.
@@ -52,7 +46,7 @@ console.log(stdout); // ''
 ## Binary data
 
 The transform iterates over lines by default.\
-However, if the `binary` transform option is `true`, it iterates over arbitrary chunks of data instead.
+However, if a `{transform, binary: true}` plain object is passed, it iterates over arbitrary chunks of data instead.
 
 ```js
 await execa('./binary.js', {stdout: {transform, binary: true}});

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,10 @@ type BaseStdioOption =
 	| 'ignore'
 	| 'inherit';
 
+// @todo Use either `Iterable<string>` or `Iterable<Uint8Array>` based on whether `encoding: 'buffer'` is used.
+// See https://github.com/sindresorhus/execa/issues/694
+type StdioTransform = ((chunks: Iterable<string | Uint8Array>) => AsyncGenerator<string | Uint8Array, void, void>);
+
 type CommonStdioOption<IsSync extends boolean = boolean> =
 	| BaseStdioOption
 	| 'ipc'
@@ -25,9 +29,12 @@ type CommonStdioOption<IsSync extends boolean = boolean> =
 	| undefined
 	| URL
 	| {file: string}
-	// TODO: Use either `Iterable<string>` or `Iterable<Uint8Array>` based on whether `encoding: 'buffer'` is used.
-	// See https://github.com/sindresorhus/execa/issues/694
-	| IfAsync<IsSync, ((chunks: Iterable<string | Uint8Array>) => AsyncGenerator<string | Uint8Array, void, void>)>;
+	| IfAsync<IsSync,
+	| StdioTransform
+	| {
+		transform: StdioTransform;
+		binary?: boolean;
+	}>;
 
 type InputStdioOption<IsSync extends boolean = boolean> =
 	| Uint8Array

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -569,35 +569,35 @@ const asyncStringGenerator = async function * () {
 
 const fileUrl = new URL('file:///test');
 
-const stringOrUint8ArrayGenerator = async function * (chunks: Iterable<string | Uint8Array>) {
-	for await (const chunk of chunks) {
-		yield chunk;
+const stringOrUint8ArrayGenerator = async function * (lines: Iterable<string | Uint8Array>) {
+	for await (const line of lines) {
+		yield line;
 	}
 };
 
-const booleanGenerator = async function * (chunks: Iterable<boolean>) {
-	for await (const chunk of chunks) {
-		yield chunk;
+const booleanGenerator = async function * (lines: Iterable<boolean>) {
+	for await (const line of lines) {
+		yield line;
 	}
 };
 
-const arrayGenerator = async function * (chunks: string[]) {
-	for await (const chunk of chunks) {
-		yield chunk;
+const arrayGenerator = async function * (lines: string[]) {
+	for await (const line of lines) {
+		yield line;
 	}
 };
 
-const invalidReturnGenerator = async function * (chunks: Iterable<string>) {
-	for await (const chunk of chunks) {
-		yield chunk;
+const invalidReturnGenerator = async function * (lines: Iterable<string>) {
+	for await (const line of lines) {
+		yield line;
 	}
 
 	return false;
 };
 
-const syncGenerator = function * (chunks: Iterable<string>) {
-	for (const chunk of chunks) {
-		yield chunk;
+const syncGenerator = function * (lines: Iterable<string>) {
+	for (const line of lines) {
+		yield line;
 	}
 
 	return false;
@@ -712,6 +712,18 @@ expectError(execa('unicorns', {stdin: booleanGenerator}));
 expectError(execa('unicorns', {stdin: arrayGenerator}));
 expectError(execa('unicorns', {stdin: invalidReturnGenerator}));
 expectError(execa('unicorns', {stdin: syncGenerator}));
+execa('unicorns', {stdin: {transform: stringOrUint8ArrayGenerator}});
+expectError(execaSync('unicorns', {stdin: {transform: stringOrUint8ArrayGenerator}}));
+execa('unicorns', {stdin: [{transform: stringOrUint8ArrayGenerator}]});
+expectError(execaSync('unicorns', {stdin: [{transform: stringOrUint8ArrayGenerator}]}));
+expectError(execa('unicorns', {stdin: {transform: booleanGenerator}}));
+expectError(execa('unicorns', {stdin: {transform: arrayGenerator}}));
+expectError(execa('unicorns', {stdin: {transform: invalidReturnGenerator}}));
+expectError(execa('unicorns', {stdin: {transform: syncGenerator}}));
+expectError(execa('unicorns', {stdin: {}}));
+expectError(execa('unicorns', {stdin: {binary: true}}));
+execa('unicorns', {stdin: {transform: stringOrUint8ArrayGenerator, binary: true}});
+expectError(execa('unicorns', {stdin: {transform: stringOrUint8ArrayGenerator, binary: 'true'}}));
 execa('unicorns', {stdin: undefined});
 execaSync('unicorns', {stdin: undefined});
 execa('unicorns', {stdin: [undefined]});
@@ -778,6 +790,18 @@ expectError(execa('unicorns', {stdout: booleanGenerator}));
 expectError(execa('unicorns', {stdout: arrayGenerator}));
 expectError(execa('unicorns', {stdout: invalidReturnGenerator}));
 expectError(execa('unicorns', {stdout: syncGenerator}));
+execa('unicorns', {stdout: {transform: stringOrUint8ArrayGenerator}});
+expectError(execaSync('unicorns', {stdout: {transform: stringOrUint8ArrayGenerator}}));
+execa('unicorns', {stdout: [{transform: stringOrUint8ArrayGenerator}]});
+expectError(execaSync('unicorns', {stdout: [{transform: stringOrUint8ArrayGenerator}]}));
+expectError(execa('unicorns', {stdout: {transform: booleanGenerator}}));
+expectError(execa('unicorns', {stdout: {transform: arrayGenerator}}));
+expectError(execa('unicorns', {stdout: {transform: invalidReturnGenerator}}));
+expectError(execa('unicorns', {stdout: {transform: syncGenerator}}));
+expectError(execa('unicorns', {stdout: {}}));
+expectError(execa('unicorns', {stdout: {binary: true}}));
+execa('unicorns', {stdout: {transform: stringOrUint8ArrayGenerator, binary: true}});
+expectError(execa('unicorns', {stdout: {transform: stringOrUint8ArrayGenerator, binary: 'true'}}));
 execa('unicorns', {stdout: undefined});
 execaSync('unicorns', {stdout: undefined});
 execa('unicorns', {stdout: [undefined]});
@@ -844,6 +868,18 @@ expectError(execa('unicorns', {stderr: booleanGenerator}));
 expectError(execa('unicorns', {stderr: arrayGenerator}));
 expectError(execa('unicorns', {stderr: invalidReturnGenerator}));
 expectError(execa('unicorns', {stderr: syncGenerator}));
+execa('unicorns', {stderr: {transform: stringOrUint8ArrayGenerator}});
+expectError(execaSync('unicorns', {stderr: {transform: stringOrUint8ArrayGenerator}}));
+execa('unicorns', {stderr: [{transform: stringOrUint8ArrayGenerator}]});
+expectError(execaSync('unicorns', {stderr: [{transform: stringOrUint8ArrayGenerator}]}));
+expectError(execa('unicorns', {stderr: {transform: booleanGenerator}}));
+expectError(execa('unicorns', {stderr: {transform: arrayGenerator}}));
+expectError(execa('unicorns', {stderr: {transform: invalidReturnGenerator}}));
+expectError(execa('unicorns', {stderr: {transform: syncGenerator}}));
+expectError(execa('unicorns', {stderr: {}}));
+expectError(execa('unicorns', {stderr: {binary: true}}));
+execa('unicorns', {stderr: {transform: stringOrUint8ArrayGenerator, binary: true}});
+expectError(execa('unicorns', {stderr: {transform: stringOrUint8ArrayGenerator, binary: 'true'}}));
 execa('unicorns', {stderr: undefined});
 execaSync('unicorns', {stderr: undefined});
 execa('unicorns', {stderr: [undefined]});
@@ -882,6 +918,8 @@ expectError(execa('unicorns', {stdio: 1}));
 expectError(execaSync('unicorns', {stdio: 1}));
 expectError(execa('unicorns', {stdio: stringOrUint8ArrayGenerator}));
 expectError(execaSync('unicorns', {stdio: stringOrUint8ArrayGenerator}));
+expectError(execa('unicorns', {stdio: {transform: stringOrUint8ArrayGenerator}}));
+expectError(execaSync('unicorns', {stdio: {transform: stringOrUint8ArrayGenerator}}));
 expectError(execa('unicorns', {stdio: fileUrl}));
 expectError(execaSync('unicorns', {stdio: fileUrl}));
 expectError(execa('unicorns', {stdio: {file: './test'}}));
@@ -934,6 +972,8 @@ execa('unicorns', {
 		process.stdin,
 		1,
 		stringOrUint8ArrayGenerator,
+		{transform: stringOrUint8ArrayGenerator},
+		{transform: stringOrUint8ArrayGenerator, binary: true},
 		undefined,
 		fileUrl,
 		{file: './test'},
@@ -962,6 +1002,7 @@ execaSync('unicorns', {
 	],
 });
 expectError(execaSync('unicorns', {stdio: [stringOrUint8ArrayGenerator]}));
+expectError(execaSync('unicorns', {stdio: [{transform: stringOrUint8ArrayGenerator}]}));
 expectError(execaSync('unicorns', {stdio: [new Writable()]}));
 expectError(execaSync('unicorns', {stdio: [new Readable()]}));
 expectError(execaSync('unicorns', {stdio: [new WritableStream()]}));
@@ -979,6 +1020,8 @@ execa('unicorns', {
 		[process.stdin],
 		[1],
 		[stringOrUint8ArrayGenerator],
+		[{transform: stringOrUint8ArrayGenerator}],
+		[{transform: stringOrUint8ArrayGenerator, binary: true}],
 		[undefined],
 		[fileUrl],
 		[{file: './test'}],
@@ -1008,6 +1051,7 @@ execaSync('unicorns', {
 	],
 });
 expectError(execaSync('unicorns', {stdio: [[stringOrUint8ArrayGenerator]]}));
+expectError(execaSync('unicorns', {stdio: [[{transform: stringOrUint8ArrayGenerator}]]}));
 expectError(execaSync('unicorns', {stdio: [[new Writable()]]}));
 expectError(execaSync('unicorns', {stdio: [[new Readable()]]}));
 expectError(execaSync('unicorns', {stdio: [[new WritableStream()]]}));

--- a/lib/stdio/encoding.js
+++ b/lib/stdio/encoding.js
@@ -7,8 +7,16 @@ export const handleStreamsEncoding = (stdioStreams, {encoding}, isSync) => {
 		return stdioStreams.map(stdioStream => ({...stdioStream, encoding}));
 	}
 
-	const value = encodingEndGenerator.bind(undefined, encoding);
-	return [...stdioStreams, {...stdioStreams[0], type: 'generator', value, encoding: 'buffer'}];
+	const transform = encodingEndGenerator.bind(undefined, encoding);
+	return [
+		...stdioStreams,
+		{
+			...stdioStreams[0],
+			type: 'generator',
+			value: {transform, binary: true},
+			encoding: 'buffer',
+		},
+	];
 };
 
 // eslint-disable-next-line unicorn/text-encoding-identifier-case

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -1,5 +1,7 @@
 import {generatorsToDuplex} from './duplex.js';
 import {getEncodingStartGenerator} from './encoding.js';
+import {getLinesGenerator} from './lines.js';
+import {isGeneratorOptions} from './type.js';
 
 /*
 Generators can be used to transform/filter standard streams.
@@ -20,7 +22,12 @@ We ensure `objectMode` is `false` for better buffering.
 Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
 */
 export const generatorToDuplexStream = ({value, encoding}) => {
-	const generators = [getEncodingStartGenerator(encoding), value];
+	const {transform, binary} = isGeneratorOptions(value) ? value : {transform: value};
+	const generators = [
+		getEncodingStartGenerator(encoding),
+		getLinesGenerator(encoding, binary),
+		transform,
+	].filter(Boolean);
 	const duplexStream = generatorsToDuplex(generators, {objectMode: false});
 	return {value: duplexStream};
 };

--- a/lib/stdio/lines.js
+++ b/lib/stdio/lines.js
@@ -1,0 +1,57 @@
+// Split chunks line-wise
+export const getLinesGenerator = (encoding, binary) => {
+	if (binary) {
+		return;
+	}
+
+	return encoding === 'buffer' ? linesUint8ArrayGenerator : linesStringGenerator;
+};
+
+const linesUint8ArrayGenerator = async function * (chunks) {
+	yield * linesGenerator(chunks, new Uint8Array(0), 0x0A, concatUint8Array);
+};
+
+const concatUint8Array = (firstChunk, secondChunk) => {
+	const chunk = new Uint8Array(firstChunk.length + secondChunk.length);
+	chunk.set(firstChunk, 0);
+	chunk.set(secondChunk, firstChunk.length);
+	return chunk;
+};
+
+const linesStringGenerator = async function * (chunks) {
+	yield * linesGenerator(chunks, '', '\n', concatString);
+};
+
+const concatString = (firstChunk, secondChunk) => `${firstChunk}${secondChunk}`;
+
+// This imperative logic is much faster than using `String.split()` and uses very low memory.
+// Also, it allows sharing it with `Uint8Array`.
+const linesGenerator = async function * (chunks, emptyValue, newline, concat) {
+	let previousChunks = emptyValue;
+
+	for await (const chunk of chunks) {
+		let start = -1;
+
+		for (let end = 0; end < chunk.length; end += 1) {
+			if (chunk[end] === newline) {
+				let line = chunk.slice(start + 1, end + 1);
+
+				if (previousChunks.length > 0) {
+					line = concat(previousChunks, line);
+					previousChunks = emptyValue;
+				}
+
+				yield line;
+				start = end;
+			}
+		}
+
+		if (start !== chunk.length - 1) {
+			previousChunks = concat(previousChunks, chunk.slice(start + 1));
+		}
+	}
+
+	if (previousChunks.length > 0) {
+		yield previousChunks;
+	}
+};

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -35,11 +35,30 @@ export const getStdioOptionType = (stdioOption, optionName) => {
 		return 'iterable';
 	}
 
+	if (isGeneratorOptions(stdioOption)) {
+		return getGeneratorObjectType(stdioOption, optionName);
+	}
+
 	return 'native';
+};
+
+const getGeneratorObjectType = ({transform, binary}, optionName) => {
+	if (!isAsyncGenerator(transform)) {
+		throw new TypeError(`The \`${optionName}.transform\` option must use an asynchronous generator.`);
+	}
+
+	if (binary !== undefined && typeof binary !== 'boolean') {
+		throw new TypeError(`The \`${optionName}.binary\` option must use a boolean.`);
+	}
+
+	return 'generator';
 };
 
 const isAsyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object AsyncGeneratorFunction]';
 const isSyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object GeneratorFunction]';
+export const isGeneratorOptions = stdioOption => typeof stdioOption === 'object'
+	&& stdioOption !== null
+	&& stdioOption.transform !== undefined;
 
 export const isUrl = stdioOption => Object.prototype.toString.call(stdioOption) === '[object URL]';
 export const isRegularUrl = stdioOption => isUrl(stdioOption) && stdioOption.protocol !== 'file:';

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,9 @@ This package improves [`child_process`](https://nodejs.org/api/child_process.htm
 - Improved [Windows support](https://github.com/IndigoUnited/node-cross-spawn#why), including [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) binaries.
 - Executes [locally installed binaries](#preferlocal) without `npx`.
 - [Cleans up](#cleanup) child processes when the parent process ends.
+- Redirect [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1) to files, streams, iterables, strings or `Uint8Array`.
+- [Transform](docs/transform.md) `stdin`/`stdout`/`stderr` with simple functions.
+- Iterate over [each text line](docs/transform.md#binary-data) output by the process.
 - [Graceful termination](#optionsforcekillaftertimeout).
 - Get [interleaved output](#all) from `stdout` and `stderr` similar to what is printed on the terminal.
 - [Strips the final newline](#stripfinalnewline) from the output so you don't have to do `stdout.trim()`.

--- a/test/fixtures/nested-inherit.js
+++ b/test/fixtures/nested-inherit.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import {execa} from '../../index.js';
 
-const uppercaseGenerator = async function * (chunks) {
-	for await (const chunk of chunks) {
-		yield chunk.toUpperCase();
+const uppercaseGenerator = async function * (lines) {
+	for await (const line of lines) {
+		yield line.toUpperCase();
 	}
 };
 

--- a/test/stdio/encoding.js
+++ b/test/stdio/encoding.js
@@ -132,9 +132,9 @@ test('validate unknown encodings', async t => {
 
 const foobarArray = ['fo', 'ob', 'ar', '..'];
 
-const delayedGenerator = async function * (chunks) {
+const delayedGenerator = async function * (lines) {
 	// eslint-disable-next-line no-unused-vars
-	for await (const chunk of chunks) {
+	for await (const line of lines) {
 		yield foobarArray[0];
 		await setTimeout(0);
 		yield foobarArray[1];

--- a/test/stdio/lines.js
+++ b/test/stdio/lines.js
@@ -1,0 +1,94 @@
+import {scheduler} from 'node:timers/promises';
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {getStdio} from '../helpers/stdio.js';
+
+setFixtureDir();
+
+const bigLine = '.'.repeat(1e5);
+const manyChunks = Array.from({length: 1e3}).fill('.');
+
+const inputGenerator = async function * (input, chunks) {
+	// eslint-disable-next-line no-unused-vars
+	for await (const chunk of chunks) {
+		for (const inputItem of input) {
+			yield inputItem;
+			// eslint-disable-next-line no-await-in-loop
+			await scheduler.yield();
+		}
+	}
+};
+
+const resultGenerator = async function * (lines, chunks) {
+	for await (const chunk of chunks) {
+		lines.push(chunk);
+		yield chunk;
+	}
+};
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const stringsToUint8Arrays = (strings, isUint8Array) => isUint8Array
+	? strings.map(string => textEncoder.encode(string))
+	: strings;
+const uint8ArrayToString = (result, isUint8Array) => isUint8Array ? textDecoder.decode(result) : result;
+
+// eslint-disable-next-line max-params
+const testLines = async (t, index, input, expectedLines, isUint8Array) => {
+	const lines = [];
+	const {stdio} = await execa('noop-fd.js', [`${index}`], {
+		...getStdio(index, [
+			inputGenerator.bind(undefined, stringsToUint8Arrays(input, isUint8Array)),
+			resultGenerator.bind(undefined, lines),
+		]),
+		encoding: isUint8Array ? 'buffer' : 'utf8',
+		stripFinalNewline: false,
+	});
+	t.is(uint8ArrayToString(stdio[index], isUint8Array), input.join(''));
+	t.deepEqual(lines, stringsToUint8Arrays(expectedLines, isUint8Array));
+};
+
+test('Split string stdout - n newlines, 1 chunk', testLines, 1, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false);
+test('Split string stderr - n newlines, 1 chunk', testLines, 2, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false);
+test('Split string stdio[*] - n newlines, 1 chunk', testLines, 3, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false);
+test('Split string stdout - no newline, n chunks', testLines, 1, ['aaa', 'bbb', 'ccc'], ['aaabbbccc'], false);
+test('Split string stdout - 0 newlines, 1 chunk', testLines, 1, ['aaa'], ['aaa'], false);
+test('Split string stdout - Windows newlines', testLines, 1, ['aaa\r\nbbb\r\nccc'], ['aaa\r\n', 'bbb\r\n', 'ccc'], false);
+test('Split string stdout - chunk ends with newline', testLines, 1, ['aaa\nbbb\nccc\n'], ['aaa\n', 'bbb\n', 'ccc\n'], false);
+test('Split string stdout - single newline', testLines, 1, ['\n'], ['\n'], false);
+test('Split string stdout - only newlines', testLines, 1, ['\n\n\n'], ['\n', '\n', '\n'], false);
+test('Split string stdout - only Windows newlines', testLines, 1, ['\r\n\r\n\r\n'], ['\r\n', '\r\n', '\r\n'], false);
+test('Split string stdout - line split over multiple chunks', testLines, 1, ['aaa\nb', 'b', 'b\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false);
+test('Split string stdout - 0 newlines, big line', testLines, 1, [bigLine], [bigLine], false);
+test('Split string stdout - 0 newlines, many chunks', testLines, 1, manyChunks, [manyChunks.join('')], false);
+test('Split Uint8Array stdout - n newlines, 1 chunk', testLines, 1, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true);
+test('Split Uint8Array stderr - n newlines, 1 chunk', testLines, 2, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true);
+test('Split Uint8Array stdio[*] - n newlines, 1 chunk', testLines, 3, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true);
+test('Split Uint8Array stdout - no newline, n chunks', testLines, 1, ['aaa', 'bbb', 'ccc'], ['aaabbbccc'], true);
+test('Split Uint8Array stdout - 0 newlines, 1 chunk', testLines, 1, ['aaa'], ['aaa'], true);
+test('Split Uint8Array stdout - Windows newlines', testLines, 1, ['aaa\r\nbbb\r\nccc'], ['aaa\r\n', 'bbb\r\n', 'ccc'], true);
+test('Split Uint8Array stdout - chunk ends with newline', testLines, 1, ['aaa\nbbb\nccc\n'], ['aaa\n', 'bbb\n', 'ccc\n'], true);
+test('Split Uint8Array stdout - single newline', testLines, 1, ['\n'], ['\n'], true);
+test('Split Uint8Array stdout - only newlines', testLines, 1, ['\n\n\n'], ['\n', '\n', '\n'], true);
+test('Split Uint8Array stdout - only Windows newlines', testLines, 1, ['\r\n\r\n\r\n'], ['\r\n', '\r\n', '\r\n'], true);
+test('Split Uint8Array stdout - line split over multiple chunks', testLines, 1, ['aaa\nb', 'b', 'b\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true);
+test('Split Uint8Array stdout - 0 newlines, big line', testLines, 1, [bigLine], [bigLine], true);
+test('Split Uint8Array stdout - 0 newlines, many chunks', testLines, 1, manyChunks, [manyChunks.join('')], true);
+
+const testBinaryOption = async (t, binary, input, expectedLines) => {
+	const lines = [];
+	const {stdout} = await execa('noop-fd.js', ['1'], {
+		stdout: [
+			inputGenerator.bind(undefined, input),
+			{transform: resultGenerator.bind(undefined, lines), binary},
+		],
+	});
+	t.is(stdout, input.join(''));
+	t.deepEqual(lines, expectedLines);
+};
+
+test('Does not split lines when "binary" is true', testBinaryOption, true, ['aaa\nbbb\nccc'], ['aaa\nbbb\nccc']);
+test('Splits lines when "binary" is false', testBinaryOption, false, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc']);
+test('Splits lines when "binary" is undefined', testBinaryOption, undefined, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc']);


### PR DESCRIPTION
Fixes #695  
Fixes #121

This makes transforms operate line-wise by default, unless `{ transform, binary: true }` is used.