### PR TITLE
Allow Node.js streams with synchronous methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,25 +38,35 @@ type CommonStdioOption<IsSync extends boolean = boolean> =
 
 type InputStdioOption<IsSync extends boolean = boolean> =
 	| Uint8Array
+	| Readable
 	| IfAsync<IsSync,
 	| Iterable<string | Uint8Array>
 	| AsyncIterable<string | Uint8Array>
-	| Readable
 	| ReadableStream>;
 
-type OutputStdioOption<IsSync extends boolean = boolean> = IfAsync<IsSync,
-| Writable
-| WritableStream>;
+type OutputStdioOption<IsSync extends boolean = boolean> =
+	| Writable
+	| IfAsync<IsSync, WritableStream>;
 
+type StdinSingleOption<IsSync extends boolean = boolean> =
+	| CommonStdioOption<IsSync>
+	| InputStdioOption<IsSync>;
 export type StdinOption<IsSync extends boolean = boolean> =
-	CommonStdioOption<IsSync> | InputStdioOption<IsSync>
-	| Array<CommonStdioOption<IsSync> | InputStdioOption<IsSync>>;
+	| StdinSingleOption<IsSync>
+	| Array<StdinSingleOption<IsSync>>;
+type StdoutStderrSingleOption<IsSync extends boolean = boolean> =
+  | CommonStdioOption<IsSync>
+  | OutputStdioOption<IsSync>;
 export type StdoutStderrOption<IsSync extends boolean = boolean> =
-	CommonStdioOption<IsSync> | OutputStdioOption<IsSync>
-	| Array<CommonStdioOption<IsSync> | OutputStdioOption<IsSync>>;
+	| StdoutStderrSingleOption<IsSync>
+	| Array<StdoutStderrSingleOption<IsSync>>;
+type StdioSingleOption<IsSync extends boolean = boolean> =
+	| CommonStdioOption<IsSync>
+	| InputStdioOption<IsSync>
+	| OutputStdioOption<IsSync>;
 export type StdioOption<IsSync extends boolean = boolean> =
-	CommonStdioOption<IsSync> | InputStdioOption | OutputStdioOption<IsSync>
-	| Array<CommonStdioOption<IsSync> | InputStdioOption | OutputStdioOption<IsSync>>;
+	| StdioSingleOption<IsSync>
+	| Array<StdioSingleOption<IsSync>>;
 
 type StdioOptionsArray<IsSync extends boolean = boolean> = readonly [
 	StdinOption<IsSync>,
@@ -225,7 +235,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	See also the `inputFile` and `stdin` options.
 	*/
-	readonly input?: string | Uint8Array | IfAsync<IsSync, Readable>;
+	readonly input?: string | Uint8Array | Readable;
 
 	/**
 	Use a file as input to the child process' `stdin`.
@@ -879,7 +889,7 @@ export function execa<OptionsType extends Options = {}>(
 /**
 Same as `execa()` but synchronous.
 
-Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be a stream nor an iterable.
+Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be an array, an iterable or a web stream. Node.js streams must have a file descriptor unless the `input` option is used.
 
 @param file - The program/script to execute, as a string or file URL
 @param arguments - Arguments to pass to `file` on execution.
@@ -978,7 +988,7 @@ export function execaCommand<OptionsType extends Options = {}>(
 /**
 Same as `execaCommand()` but synchronous.
 
-Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be a stream nor an iterable.
+Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be an array, an iterable or a web stream. Node.js streams must have a file descriptor unless the `input` option is used.
 
 @param command - The program/script to execute and its arguments.
 @returns A `childProcessResult` object
@@ -1035,7 +1045,7 @@ type Execa$<OptionsType extends CommonOptions = {}> = {
 	/**
 	Same as $\`command\` but synchronous.
 
-	Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be a stream nor an iterable.
+	Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be an array, an iterable or a web stream. Node.js streams must have a file descriptor unless the `input` option is used.
 
 	@returns A `childProcessResult` object
 	@throws A `childProcessResult` error
@@ -1087,7 +1097,7 @@ type Execa$<OptionsType extends CommonOptions = {}> = {
 	/**
 	Same as $\`command\` but synchronous.
 
-	Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be a stream nor an iterable.
+	Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization` and `signal`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be an array, an iterable or a web stream. Node.js streams must have a file descriptor unless the `input` option is used.
 
 	@returns A `childProcessResult` object
 	@throws A `childProcessResult` error

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -629,7 +629,7 @@ execaSync('unicorns', {input: ''});
 execa('unicorns', {input: new Uint8Array()});
 execaSync('unicorns', {input: new Uint8Array()});
 execa('unicorns', {input: process.stdin});
-expectError(execaSync('unicorns', {input: process.stdin}));
+execaSync('unicorns', {input: process.stdin});
 execa('unicorns', {inputFile: ''});
 execaSync('unicorns', {inputFile: ''});
 execa('unicorns', {inputFile: fileUrl});
@@ -655,13 +655,13 @@ execaSync('unicorns', {stdin: 'inherit'});
 execa('unicorns', {stdin: ['inherit']});
 execaSync('unicorns', {stdin: ['inherit']});
 execa('unicorns', {stdin: process.stdin});
-expectError(execaSync('unicorns', {stdin: process.stdin}));
+execaSync('unicorns', {stdin: process.stdin});
 execa('unicorns', {stdin: [process.stdin]});
-expectError(execaSync('unicorns', {stdin: [process.stdin]}));
+execaSync('unicorns', {stdin: [process.stdin]});
 execa('unicorns', {stdin: new Readable()});
-expectError(execaSync('unicorns', {stdin: new Readable()}));
+execaSync('unicorns', {stdin: new Readable()});
 execa('unicorns', {stdin: [new Readable()]});
-expectError(execaSync('unicorns', {stdin: [new Readable()]}));
+execaSync('unicorns', {stdin: [new Readable()]});
 expectError(execa('unicorns', {stdin: new Writable()}));
 expectError(execaSync('unicorns', {stdin: new Writable()}));
 expectError(execa('unicorns', {stdin: [new Writable()]}));
@@ -751,13 +751,13 @@ execaSync('unicorns', {stdout: 'inherit'});
 execa('unicorns', {stdout: ['inherit']});
 execaSync('unicorns', {stdout: ['inherit']});
 execa('unicorns', {stdout: process.stdout});
-expectError(execaSync('unicorns', {stdout: process.stdout}));
+execaSync('unicorns', {stdout: process.stdout});
 execa('unicorns', {stdout: [process.stdout]});
-expectError(execaSync('unicorns', {stdout: [process.stdout]}));
+execaSync('unicorns', {stdout: [process.stdout]});
 execa('unicorns', {stdout: new Writable()});
-expectError(execaSync('unicorns', {stdout: new Writable()}));
+execaSync('unicorns', {stdout: new Writable()});
 execa('unicorns', {stdout: [new Writable()]});
-expectError(execaSync('unicorns', {stdout: [new Writable()]}));
+execaSync('unicorns', {stdout: [new Writable()]});
 expectError(execa('unicorns', {stdout: new Readable()}));
 expectError(execaSync('unicorns', {stdout: new Readable()}));
 expectError(execa('unicorn', {stdout: [new Readable()]}));
@@ -829,13 +829,13 @@ execaSync('unicorns', {stderr: 'inherit'});
 execa('unicorns', {stderr: ['inherit']});
 execaSync('unicorns', {stderr: ['inherit']});
 execa('unicorns', {stderr: process.stderr});
-expectError(execaSync('unicorns', {stderr: process.stderr}));
+execaSync('unicorns', {stderr: process.stderr});
 execa('unicorns', {stderr: [process.stderr]});
-expectError(execaSync('unicorns', {stderr: [process.stderr]}));
+execaSync('unicorns', {stderr: [process.stderr]});
 execa('unicorns', {stderr: new Writable()});
-expectError(execaSync('unicorns', {stderr: new Writable()}));
+execaSync('unicorns', {stderr: new Writable()});
 execa('unicorns', {stderr: [new Writable()]});
-expectError(execaSync('unicorns', {stderr: [new Writable()]}));
+execaSync('unicorns', {stderr: [new Writable()]});
 expectError(execa('unicorns', {stderr: new Readable()}));
 expectError(execaSync('unicorns', {stderr: new Readable()}));
 expectError(execa('unicorns', {stderr: [new Readable()]}));
@@ -939,17 +939,17 @@ expectError(execaSync('unicorns', {stdio: asyncStringGenerator()}));
 expectError(execa('unicorns', {stdio: ['pipe', 'pipe']}));
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe']}));
 execa('unicorns', {stdio: [new Readable(), 'pipe', 'pipe']});
-expectError(execaSync('unicorns', {stdio: [new Readable(), 'pipe', 'pipe']}));
+execaSync('unicorns', {stdio: [new Readable(), 'pipe', 'pipe']});
 execa('unicorns', {stdio: [[new Readable()], ['pipe'], ['pipe']]});
-expectError(execaSync('unicorns', {stdio: [[new Readable()], ['pipe'], ['pipe']]}));
+execaSync('unicorns', {stdio: [[new Readable()], ['pipe'], ['pipe']]});
 execa('unicorns', {stdio: ['pipe', new Writable(), 'pipe']});
-expectError(execaSync('unicorns', {stdio: ['pipe', new Writable(), 'pipe']}));
+execaSync('unicorns', {stdio: ['pipe', new Writable(), 'pipe']});
 execa('unicorns', {stdio: [['pipe'], [new Writable()], ['pipe']]});
-expectError(execaSync('unicorns', {stdio: [['pipe'], [new Writable()], ['pipe']]}));
+execaSync('unicorns', {stdio: [['pipe'], [new Writable()], ['pipe']]});
 execa('unicorns', {stdio: ['pipe', 'pipe', new Writable()]});
-expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', new Writable()]}));
+execaSync('unicorns', {stdio: ['pipe', 'pipe', new Writable()]});
 execa('unicorns', {stdio: [['pipe'], ['pipe'], [new Writable()]]});
-expectError(execaSync('unicorns', {stdio: [['pipe'], ['pipe'], [new Writable()]]}));
+execaSync('unicorns', {stdio: [['pipe'], ['pipe'], [new Writable()]]});
 expectError(execa('unicorns', {stdio: [new Writable(), 'pipe', 'pipe']}));
 expectError(execaSync('unicorns', {stdio: [new Writable(), 'pipe', 'pipe']}));
 expectError(execa('unicorns', {stdio: [[new Writable()], ['pipe'], ['pipe']]}));
@@ -998,13 +998,13 @@ execaSync('unicorns', {
 		undefined,
 		fileUrl,
 		{file: './test'},
+		new Writable(),
+		new Readable(),
 		new Uint8Array(),
 	],
 });
 expectError(execaSync('unicorns', {stdio: [stringOrUint8ArrayGenerator]}));
 expectError(execaSync('unicorns', {stdio: [{transform: stringOrUint8ArrayGenerator}]}));
-expectError(execaSync('unicorns', {stdio: [new Writable()]}));
-expectError(execaSync('unicorns', {stdio: [new Readable()]}));
 expectError(execaSync('unicorns', {stdio: [new WritableStream()]}));
 expectError(execaSync('unicorns', {stdio: [new ReadableStream()]}));
 expectError(execaSync('unicorns', {stdio: [emptyStringGenerator()]}));
@@ -1047,13 +1047,13 @@ execaSync('unicorns', {
 		[undefined],
 		[fileUrl],
 		[{file: './test'}],
+		[new Writable()],
+		[new Readable()],
 		[new Uint8Array()],
 	],
 });
 expectError(execaSync('unicorns', {stdio: [[stringOrUint8ArrayGenerator]]}));
 expectError(execaSync('unicorns', {stdio: [[{transform: stringOrUint8ArrayGenerator}]]}));
-expectError(execaSync('unicorns', {stdio: [[new Writable()]]}));
-expectError(execaSync('unicorns', {stdio: [[new Readable()]]}));
 expectError(execaSync('unicorns', {stdio: [[new WritableStream()]]}));
 expectError(execaSync('unicorns', {stdio: [[new ReadableStream()]]}));
 expectError(execaSync('unicorns', {stdio: [[emptyStringGenerator()]]}));

--- a/lib/stdio/sync.js
+++ b/lib/stdio/sync.js
@@ -1,5 +1,4 @@
 import {readFileSync, writeFileSync} from 'node:fs';
-import {isStream as isNodeStream} from 'is-stream';
 import {handleInput} from './handle.js';
 import {TYPE_TO_MESSAGE} from './type.js';
 import {bufferToUint8Array} from './utils.js';
@@ -9,14 +8,6 @@ export const handleInputSync = options => {
 	const stdioStreamsGroups = handleInput(addPropertiesSync, options, true);
 	addInputOptionSync(stdioStreamsGroups, options);
 	return stdioStreamsGroups;
-};
-
-const forbiddenIfStreamSync = ({value, optionName}) => {
-	if (isNodeStream(value)) {
-		forbiddenIfSync({type: 'nodeStream', optionName});
-	}
-
-	return {};
 };
 
 const forbiddenIfSync = ({type, optionName}) => {
@@ -31,7 +22,6 @@ const addPropertiesSync = {
 		webStream: forbiddenIfSync,
 		nodeStream: forbiddenIfSync,
 		iterable: forbiddenIfSync,
-		native: forbiddenIfStreamSync,
 	},
 	output: {
 		generator: forbiddenIfSync,
@@ -40,12 +30,11 @@ const addPropertiesSync = {
 		nodeStream: forbiddenIfSync,
 		iterable: forbiddenIfSync,
 		uint8Array: forbiddenIfSync,
-		native: forbiddenIfStreamSync,
 	},
 };
 
 const addInputOptionSync = (stdioStreamsGroups, options) => {
-	const inputs = stdioStreamsGroups.flat().filter(({type}) => type === 'string' || type === 'uint8Array');
+	const inputs = stdioStreamsGroups.flat().filter(({direction, type}) => direction === 'input' && (type === 'string' || type === 'uint8Array'));
 	if (inputs.length === 0) {
 		return;
 	}

--- a/readme.md
+++ b/readme.md
@@ -292,7 +292,7 @@ This is the preferred method when executing a user-supplied `command` string, su
 
 Same as [`execa()`](#execacommandcommand-options) but synchronous.
 
-Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`serialization`](#serialization) and [`signal`](#signal). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio-1) and [`input`](#input) options cannot be a stream nor an iterable.
+Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`serialization`](#serialization) and [`signal`](#signal). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio-1) and [`input`](#input) options cannot be an array, an iterable or a web stream. Node.js streams [must have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr) unless the `input` option is used.
 
 Returns or throws a [`childProcessResult`](#childProcessResult).
 
@@ -301,7 +301,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 Same as [$\`command\`](#command) but synchronous.
 
-Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`serialization`](#serialization) and [`signal`](#signal). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio-1) and [`input`](#input) options cannot be a stream nor an iterable.
+Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`serialization`](#serialization) and [`signal`](#signal). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio-1) and [`input`](#input) options cannot be an array, an iterable or a web stream. Node.js streams [must have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr) unless the `input` option is used.
 
 Returns or throws a [`childProcessResult`](#childProcessResult).
 
@@ -309,7 +309,7 @@ Returns or throws a [`childProcessResult`](#childProcessResult).
 
 Same as [`execaCommand()`](#execacommand-command-options) but synchronous.
 
-Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`serialization`](#serialization) and [`signal`](#signal). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio-1) and [`input`](#input) options cannot be a stream nor an iterable.
+Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`serialization`](#serialization) and [`signal`](#signal). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio-1) and [`input`](#input) options cannot be an array, an iterable or a web stream. Node.js streams [must have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr) unless the `input` option is used.
 
 Returns or throws a [`childProcessResult`](#childProcessResult).
 
@@ -833,7 +833,7 @@ The [`stdin`](#stdin), [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options c
 The following example redirects `stdout` to both the terminal and an `output.txt` file, while also retrieving its value programmatically.
 
 ```js
-const {stdout} = await execa('npm', ['install'], {stdout: ['inherit', './output.txt', 'pipe']})
+const {stdout} = await execa('npm', ['install'], {stdout: ['inherit', './output.txt', 'pipe']});
 console.log(stdout);
 ```
 
@@ -852,8 +852,8 @@ This limitation can be worked around by passing either:
   - `[nodeStream, 'pipe']` instead of `nodeStream`
 
 ```diff
-- await execa(..., { stdout: nodeStream })
-+ await execa(..., { stdout: [nodeStream, 'pipe'] })
+- await execa(..., {stdout: nodeStream});
++ await execa(..., {stdout: [nodeStream, 'pipe']});
 ```
 
 ### Retry on error

--- a/test/helpers/stdio.js
+++ b/test/helpers/stdio.js
@@ -2,7 +2,7 @@ import process from 'node:process';
 
 export const identity = value => value;
 
-export const getStdio = (indexOrName, stdioOption, length) => {
+export const getStdio = (indexOrName, stdioOption, length = 3) => {
 	if (typeof indexOrName === 'string') {
 		return {[indexOrName]: stdioOption};
 	}


### PR DESCRIPTION
`child_process.spawnSync()` allows passing a Node.js stream to the `stdio` option, providing it has a file descriptor. Therefore, we should allow it as well with the `stdin`, `stdout`, `stderr` and `stdio` options.