### PR TITLE
Allow any type with transforms

### DIFF
--- a/docs/transform.md
+++ b/docs/transform.md
@@ -56,6 +56,36 @@ This is more efficient and recommended if the data is either:
 	- Binary: Which does not have lines.
 	- Text: But the transform works even if a line or word is split across multiple chunks.
 
+## Object mode
+
+By default, `stdout` and `stderr`'s transforms must return a string or an `Uint8Array`. However, if a `{transform, objectMode: true}` plain object is passed, any type can be returned instead. The process' [`stdout`](../readme.md#stdout)/[`stderr`](../readme.md#stderr) will be an array of values.
+
+```js
+const transform = async function * (lines) {
+	for await (const line of lines) {
+		yield JSON.parse(line)
+	}
+}
+
+const {stdout} = await execa('./jsonlines-output.js', {stdout: {transform, objectMode: true}});
+for (const data of stdout) {
+	console.log(stdout) // {...}
+}
+```
+
+`stdin` can also use `objectMode: true`.
+
+```js
+const transform = async function * (lines) {
+	for await (const line of lines) {
+		yield JSON.stringify(line)
+	}
+}
+
+const input = [{event: 'example'}, {event: 'otherExample'}]
+await execa('./jsonlines-input.js', {stdin: [input, {transform, objectMode: true}]});
+```
+
 ## Combining
 
 The [`stdin`](../readme.md#stdin), [`stdout`](../readme.md#stdout-1), [`stderr`](../readme.md#stderr-1) and [`stdio`](../readme.md#stdio-1) options can accept an array of values. While this is not specific to transforms, this can be useful with them too. For example, the following transform impacts the value printed by `inherit`.

--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ const handleOutput = (options, value) => {
 		return;
 	}
 
+	if (Array.isArray(value)) {
+		return value;
+	}
+
 	if (Buffer.isBuffer(value)) {
 		value = bufferToUint8Array(value);
 	}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -21,16 +21,58 @@ import {
 	type ExecaSyncError,
 } from './index.js';
 
+type AnySyncChunk = string | Uint8Array | undefined;
+type AnyChunk = AnySyncChunk | unknown[];
 expectType<Readable | null>({} as ExecaChildProcess['stdout']);
 expectType<Readable | null>({} as ExecaChildProcess['stderr']);
 expectType<Readable | undefined>({} as ExecaChildProcess['all']);
-expectType<string | Uint8Array | undefined>({} as ExecaReturnValue['stdout']);
-expectType<string | Uint8Array | undefined>({} as ExecaReturnValue['stderr']);
-expectType<string | Uint8Array | undefined>({} as ExecaReturnValue['all']);
-expectType<[undefined, string | Uint8Array | undefined, string | Uint8Array | undefined]>({} as ExecaReturnValue['stdio']);
-expectType<string | Uint8Array | undefined>({} as ExecaSyncReturnValue['stdout']);
-expectType<string | Uint8Array | undefined>({} as ExecaSyncReturnValue['stderr']);
-expectType<[undefined, string | Uint8Array | undefined, string | Uint8Array | undefined]>({} as ExecaSyncReturnValue['stdio']);
+expectType<AnyChunk>({} as ExecaReturnValue['stdout']);
+expectType<AnyChunk>({} as ExecaReturnValue['stderr']);
+expectType<AnyChunk>({} as ExecaReturnValue['all']);
+expectType<[undefined, AnyChunk, AnyChunk]>({} as ExecaReturnValue['stdio']);
+expectType<AnySyncChunk>({} as ExecaSyncReturnValue['stdout']);
+expectType<AnySyncChunk>({} as ExecaSyncReturnValue['stderr']);
+expectType<[undefined, AnySyncChunk, AnySyncChunk]>({} as ExecaSyncReturnValue['stdio']);
+
+const objectGenerator = async function * (lines: Iterable<unknown>) {
+	for await (const line of lines) {
+		yield JSON.parse(line as string) as object;
+	}
+};
+
+const unknownArrayGenerator = async function * (lines: Iterable<unknown>) {
+	for await (const line of lines) {
+		yield line;
+	}
+};
+
+const booleanGenerator = async function * (lines: Iterable<boolean>) {
+	for await (const line of lines) {
+		yield line;
+	}
+};
+
+const arrayGenerator = async function * (lines: string[]) {
+	for await (const line of lines) {
+		yield line;
+	}
+};
+
+const invalidReturnGenerator = async function * (lines: Iterable<string>) {
+	for await (const line of lines) {
+		yield line;
+	}
+
+	return false;
+};
+
+const syncGenerator = function * (lines: Iterable<string>) {
+	for (const line of lines) {
+		yield line;
+	}
+
+	return false;
+};
 
 try {
 	const execaPromise = execa('unicorns', {all: true});
@@ -285,6 +327,70 @@ try {
 
 	const ignoreFd3Result = await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', 'ignore']});
 	expectType<undefined>(ignoreFd3Result.stdio[3]);
+
+	const objectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: true}});
+	expectType<unknown[]>(objectTransformStdoutResult.stdout);
+	expectType<[undefined, unknown[], string]>(objectTransformStdoutResult.stdio);
+
+	const objectTransformStderrResult = await execa('unicorns', {stderr: {transform: objectGenerator, objectMode: true}});
+	expectType<unknown[]>(objectTransformStderrResult.stderr);
+	expectType<[undefined, string, unknown[]]>(objectTransformStderrResult.stdio);
+
+	const objectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, objectMode: true}]});
+	expectType<unknown[]>(objectTransformStdioResult.stderr);
+	expectType<[undefined, string, unknown[]]>(objectTransformStdioResult.stdio);
+
+	const singleObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, objectMode: true}]});
+	expectType<unknown[]>(singleObjectTransformStdoutResult.stdout);
+	expectType<[undefined, unknown[], string]>(singleObjectTransformStdoutResult.stdio);
+
+	const manyObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, objectMode: true}, {transform: objectGenerator, objectMode: true}]});
+	expectType<unknown[]>(manyObjectTransformStdoutResult.stdout);
+	expectType<[undefined, unknown[], string]>(manyObjectTransformStdoutResult.stdio);
+
+	const falseObjectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: false}});
+	expectType<string>(falseObjectTransformStdoutResult.stdout);
+	expectType<[undefined, string, string]>(falseObjectTransformStdoutResult.stdio);
+
+	const falseObjectTransformStderrResult = await execa('unicorns', {stderr: {transform: objectGenerator, objectMode: false}});
+	expectType<string>(falseObjectTransformStderrResult.stderr);
+	expectType<[undefined, string, string]>(falseObjectTransformStderrResult.stdio);
+
+	const falseObjectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, objectMode: false}]});
+	expectType<string>(falseObjectTransformStdioResult.stderr);
+	expectType<[undefined, string, string]>(falseObjectTransformStdioResult.stdio);
+
+	const undefinedObjectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator}});
+	expectType<string>(undefinedObjectTransformStdoutResult.stdout);
+	expectType<[undefined, string, string]>(undefinedObjectTransformStdoutResult.stdio);
+
+	const noObjectTransformStdoutResult = await execa('unicorns', {stdout: objectGenerator});
+	expectType<string>(noObjectTransformStdoutResult.stdout);
+	expectType<[undefined, string, string]>(noObjectTransformStdoutResult.stdio);
+
+	const trueTrueObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: true}, stderr: {transform: objectGenerator, objectMode: true}, all: true});
+	expectType<unknown[]>(trueTrueObjectTransformResult.stdout);
+	expectType<unknown[]>(trueTrueObjectTransformResult.stderr);
+	expectType<unknown[]>(trueTrueObjectTransformResult.all);
+	expectType<[undefined, unknown[], unknown[]]>(trueTrueObjectTransformResult.stdio);
+
+	const trueFalseObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: true}, stderr: {transform: objectGenerator, objectMode: false}, all: true});
+	expectType<unknown[]>(trueFalseObjectTransformResult.stdout);
+	expectType<string>(trueFalseObjectTransformResult.stderr);
+	expectType<unknown[]>(trueFalseObjectTransformResult.all);
+	expectType<[undefined, unknown[], string]>(trueFalseObjectTransformResult.stdio);
+
+	const falseTrueObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: false}, stderr: {transform: objectGenerator, objectMode: true}, all: true});
+	expectType<string>(falseTrueObjectTransformResult.stdout);
+	expectType<unknown[]>(falseTrueObjectTransformResult.stderr);
+	expectType<unknown[]>(falseTrueObjectTransformResult.all);
+	expectType<[undefined, string, unknown[]]>(falseTrueObjectTransformResult.stdio);
+
+	const falseFalseObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: false}, stderr: {transform: objectGenerator, objectMode: false}, all: true});
+	expectType<string>(falseFalseObjectTransformResult.stdout);
+	expectType<string>(falseFalseObjectTransformResult.stderr);
+	expectType<string>(falseFalseObjectTransformResult.all);
+	expectType<[undefined, string, string]>(falseFalseObjectTransformResult.stdio);
 } catch (error: unknown) {
 	const execaError = error as ExecaError;
 
@@ -377,6 +483,30 @@ try {
 	expectType<string>(streamStderrError.stdout);
 	expectType<undefined>(streamStderrError.stderr);
 	expectType<string>(streamStderrError.all);
+
+	const objectTransformStdoutError = error as ExecaError<{stdout: {transform: typeof objectGenerator; objectMode: true}}>;
+	expectType<unknown[]>(objectTransformStdoutError.stdout);
+	expectType<[undefined, unknown[], string]>(objectTransformStdoutError.stdio);
+
+	const objectTransformStderrError = error as ExecaError<{stderr: {transform: typeof objectGenerator; objectMode: true}}>;
+	expectType<unknown[]>(objectTransformStderrError.stderr);
+	expectType<[undefined, string, unknown[]]>(objectTransformStderrError.stdio);
+
+	const objectTransformStdioError = error as ExecaError<{stdio: ['pipe', 'pipe', {transform: typeof objectGenerator; objectMode: true}]}>;
+	expectType<unknown[]>(objectTransformStdioError.stderr);
+	expectType<[undefined, string, unknown[]]>(objectTransformStdioError.stdio);
+
+	const falseObjectTransformStdoutError = error as ExecaError<{stdout: {transform: typeof objectGenerator; objectMode: false}}>;
+	expectType<string>(falseObjectTransformStdoutError.stdout);
+	expectType<[undefined, string, string]>(falseObjectTransformStdoutError.stdio);
+
+	const falseObjectTransformStderrError = error as ExecaError<{stderr: {transform: typeof objectGenerator; objectMode: false}}>;
+	expectType<string>(falseObjectTransformStderrError.stderr);
+	expectType<[undefined, string, string]>(falseObjectTransformStderrError.stdio);
+
+	const falseObjectTransformStdioError = error as ExecaError<{stdio: ['pipe', 'pipe', {transform: typeof objectGenerator; objectMode: false}]}>;
+	expectType<string>(falseObjectTransformStdioError.stderr);
+	expectType<[undefined, string, string]>(falseObjectTransformStdioError.stdio);
 }
 
 const rejectsResult = await execa('unicorns');
@@ -559,49 +689,11 @@ const binaryGenerator = function * () {
 	yield new Uint8Array(0);
 };
 
-const numberGenerator = function * () {
-	yield 0;
-};
-
 const asyncStringGenerator = async function * () {
 	yield '';
 };
 
 const fileUrl = new URL('file:///test');
-
-const stringOrUint8ArrayGenerator = async function * (lines: Iterable<string | Uint8Array>) {
-	for await (const line of lines) {
-		yield line;
-	}
-};
-
-const booleanGenerator = async function * (lines: Iterable<boolean>) {
-	for await (const line of lines) {
-		yield line;
-	}
-};
-
-const arrayGenerator = async function * (lines: string[]) {
-	for await (const line of lines) {
-		yield line;
-	}
-};
-
-const invalidReturnGenerator = async function * (lines: Iterable<string>) {
-	for await (const line of lines) {
-		yield line;
-	}
-
-	return false;
-};
-
-const syncGenerator = function * (lines: Iterable<string>) {
-	for (const line of lines) {
-		yield line;
-	}
-
-	return false;
-};
 
 expectAssignable<Options>({cleanup: false});
 expectNotAssignable<SyncOptions>({cleanup: false});
@@ -664,7 +756,6 @@ execa('unicorns', {stdin: [new Readable()]});
 execaSync('unicorns', {stdin: [new Readable()]});
 expectError(execa('unicorns', {stdin: new Writable()}));
 expectError(execaSync('unicorns', {stdin: new Writable()}));
-expectError(execa('unicorns', {stdin: [new Writable()]}));
 expectError(execaSync('unicorns', {stdin: [new Writable()]}));
 execa('unicorns', {stdin: new ReadableStream()});
 expectError(execaSync('unicorns', {stdin: new ReadableStream()}));
@@ -672,10 +763,15 @@ execa('unicorns', {stdin: [new ReadableStream()]});
 expectError(execaSync('unicorns', {stdin: [new ReadableStream()]}));
 expectError(execa('unicorns', {stdin: new WritableStream()}));
 expectError(execaSync('unicorns', {stdin: new WritableStream()}));
-expectError(execa('unicorns', {stdin: [new WritableStream()]}));
 expectError(execaSync('unicorns', {stdin: [new WritableStream()]}));
 execa('unicorns', {stdin: new Uint8Array()});
 execaSync('unicorns', {stdin: new Uint8Array()});
+execa('unicorns', {stdin: [['foo', 'bar']]});
+expectError(execaSync('unicorns', {stdin: [['foo', 'bar']]}));
+execa('unicorns', {stdin: [[new Uint8Array(), new Uint8Array()]]});
+expectError(execaSync('unicorns', {stdin: [[new Uint8Array(), new Uint8Array()]]}));
+execa('unicorns', {stdin: [[{}, {}]]});
+expectError(execaSync('unicorns', {stdin: [[{}, {}]]}));
 execa('unicorns', {stdin: emptyStringGenerator()});
 expectError(execaSync('unicorns', {stdin: emptyStringGenerator()}));
 execa('unicorns', {stdin: [emptyStringGenerator()]});
@@ -688,10 +784,6 @@ execa('unicorns', {stdin: asyncStringGenerator()});
 expectError(execaSync('unicorns', {stdin: asyncStringGenerator()}));
 execa('unicorns', {stdin: [asyncStringGenerator()]});
 expectError(execaSync('unicorns', {stdin: [asyncStringGenerator()]}));
-expectError(execa('unicorns', {stdin: numberGenerator()}));
-expectError(execaSync('unicorns', {stdin: numberGenerator()}));
-expectError(execa('unicorns', {stdin: [numberGenerator()]}));
-expectError(execaSync('unicorns', {stdin: [numberGenerator()]}));
 execa('unicorns', {stdin: fileUrl});
 execaSync('unicorns', {stdin: fileUrl});
 execa('unicorns', {stdin: [fileUrl]});
@@ -704,26 +796,29 @@ execa('unicorns', {stdin: 1});
 execaSync('unicorns', {stdin: 1});
 execa('unicorns', {stdin: [1]});
 execaSync('unicorns', {stdin: [1]});
-execa('unicorns', {stdin: stringOrUint8ArrayGenerator});
-expectError(execaSync('unicorns', {stdin: stringOrUint8ArrayGenerator}));
-execa('unicorns', {stdin: [stringOrUint8ArrayGenerator]});
-expectError(execaSync('unicorns', {stdin: [stringOrUint8ArrayGenerator]}));
+execa('unicorns', {stdin: unknownArrayGenerator});
+expectError(execaSync('unicorns', {stdin: unknownArrayGenerator}));
+execa('unicorns', {stdin: [unknownArrayGenerator]});
+expectError(execaSync('unicorns', {stdin: [unknownArrayGenerator]}));
 expectError(execa('unicorns', {stdin: booleanGenerator}));
 expectError(execa('unicorns', {stdin: arrayGenerator}));
 expectError(execa('unicorns', {stdin: invalidReturnGenerator}));
 expectError(execa('unicorns', {stdin: syncGenerator}));
-execa('unicorns', {stdin: {transform: stringOrUint8ArrayGenerator}});
-expectError(execaSync('unicorns', {stdin: {transform: stringOrUint8ArrayGenerator}}));
-execa('unicorns', {stdin: [{transform: stringOrUint8ArrayGenerator}]});
-expectError(execaSync('unicorns', {stdin: [{transform: stringOrUint8ArrayGenerator}]}));
+execa('unicorns', {stdin: {transform: unknownArrayGenerator}});
+expectError(execaSync('unicorns', {stdin: {transform: unknownArrayGenerator}}));
+execa('unicorns', {stdin: [{transform: unknownArrayGenerator}]});
+expectError(execaSync('unicorns', {stdin: [{transform: unknownArrayGenerator}]}));
 expectError(execa('unicorns', {stdin: {transform: booleanGenerator}}));
 expectError(execa('unicorns', {stdin: {transform: arrayGenerator}}));
 expectError(execa('unicorns', {stdin: {transform: invalidReturnGenerator}}));
 expectError(execa('unicorns', {stdin: {transform: syncGenerator}}));
 expectError(execa('unicorns', {stdin: {}}));
 expectError(execa('unicorns', {stdin: {binary: true}}));
-execa('unicorns', {stdin: {transform: stringOrUint8ArrayGenerator, binary: true}});
-expectError(execa('unicorns', {stdin: {transform: stringOrUint8ArrayGenerator, binary: 'true'}}));
+expectError(execa('unicorns', {stdin: {objectMode: true}}));
+execa('unicorns', {stdin: {transform: unknownArrayGenerator, binary: true}});
+expectError(execa('unicorns', {stdin: {transform: unknownArrayGenerator, binary: 'true'}}));
+execa('unicorns', {stdin: {transform: unknownArrayGenerator, objectMode: true}});
+expectError(execa('unicorns', {stdin: {transform: unknownArrayGenerator, objectMode: 'true'}}));
 execa('unicorns', {stdin: undefined});
 execaSync('unicorns', {stdin: undefined});
 execa('unicorns', {stdin: [undefined]});
@@ -782,26 +877,29 @@ execa('unicorns', {stdout: 1});
 execaSync('unicorns', {stdout: 1});
 execa('unicorns', {stdout: [1]});
 execaSync('unicorns', {stdout: [1]});
-execa('unicorns', {stdout: stringOrUint8ArrayGenerator});
-expectError(execaSync('unicorns', {stdout: stringOrUint8ArrayGenerator}));
-execa('unicorns', {stdout: [stringOrUint8ArrayGenerator]});
-expectError(execaSync('unicorns', {stdout: [stringOrUint8ArrayGenerator]}));
+execa('unicorns', {stdout: unknownArrayGenerator});
+expectError(execaSync('unicorns', {stdout: unknownArrayGenerator}));
+execa('unicorns', {stdout: [unknownArrayGenerator]});
+expectError(execaSync('unicorns', {stdout: [unknownArrayGenerator]}));
 expectError(execa('unicorns', {stdout: booleanGenerator}));
 expectError(execa('unicorns', {stdout: arrayGenerator}));
 expectError(execa('unicorns', {stdout: invalidReturnGenerator}));
 expectError(execa('unicorns', {stdout: syncGenerator}));
-execa('unicorns', {stdout: {transform: stringOrUint8ArrayGenerator}});
-expectError(execaSync('unicorns', {stdout: {transform: stringOrUint8ArrayGenerator}}));
-execa('unicorns', {stdout: [{transform: stringOrUint8ArrayGenerator}]});
-expectError(execaSync('unicorns', {stdout: [{transform: stringOrUint8ArrayGenerator}]}));
+execa('unicorns', {stdout: {transform: unknownArrayGenerator}});
+expectError(execaSync('unicorns', {stdout: {transform: unknownArrayGenerator}}));
+execa('unicorns', {stdout: [{transform: unknownArrayGenerator}]});
+expectError(execaSync('unicorns', {stdout: [{transform: unknownArrayGenerator}]}));
 expectError(execa('unicorns', {stdout: {transform: booleanGenerator}}));
 expectError(execa('unicorns', {stdout: {transform: arrayGenerator}}));
 expectError(execa('unicorns', {stdout: {transform: invalidReturnGenerator}}));
 expectError(execa('unicorns', {stdout: {transform: syncGenerator}}));
 expectError(execa('unicorns', {stdout: {}}));
 expectError(execa('unicorns', {stdout: {binary: true}}));
-execa('unicorns', {stdout: {transform: stringOrUint8ArrayGenerator, binary: true}});
-expectError(execa('unicorns', {stdout: {transform: stringOrUint8ArrayGenerator, binary: 'true'}}));
+expectError(execa('unicorns', {stdout: {objectMode: true}}));
+execa('unicorns', {stdout: {transform: unknownArrayGenerator, binary: true}});
+expectError(execa('unicorns', {stdout: {transform: unknownArrayGenerator, binary: 'true'}}));
+execa('unicorns', {stdout: {transform: unknownArrayGenerator, objectMode: true}});
+expectError(execa('unicorns', {stdout: {transform: unknownArrayGenerator, objectMode: 'true'}}));
 execa('unicorns', {stdout: undefined});
 execaSync('unicorns', {stdout: undefined});
 execa('unicorns', {stdout: [undefined]});
@@ -860,26 +958,29 @@ execa('unicorns', {stderr: 1});
 execaSync('unicorns', {stderr: 1});
 execa('unicorns', {stderr: [1]});
 execaSync('unicorns', {stderr: [1]});
-execa('unicorns', {stderr: stringOrUint8ArrayGenerator});
-expectError(execaSync('unicorns', {stderr: stringOrUint8ArrayGenerator}));
-execa('unicorns', {stderr: [stringOrUint8ArrayGenerator]});
-expectError(execaSync('unicorns', {stderr: [stringOrUint8ArrayGenerator]}));
+execa('unicorns', {stderr: unknownArrayGenerator});
+expectError(execaSync('unicorns', {stderr: unknownArrayGenerator}));
+execa('unicorns', {stderr: [unknownArrayGenerator]});
+expectError(execaSync('unicorns', {stderr: [unknownArrayGenerator]}));
 expectError(execa('unicorns', {stderr: booleanGenerator}));
 expectError(execa('unicorns', {stderr: arrayGenerator}));
 expectError(execa('unicorns', {stderr: invalidReturnGenerator}));
 expectError(execa('unicorns', {stderr: syncGenerator}));
-execa('unicorns', {stderr: {transform: stringOrUint8ArrayGenerator}});
-expectError(execaSync('unicorns', {stderr: {transform: stringOrUint8ArrayGenerator}}));
-execa('unicorns', {stderr: [{transform: stringOrUint8ArrayGenerator}]});
-expectError(execaSync('unicorns', {stderr: [{transform: stringOrUint8ArrayGenerator}]}));
+execa('unicorns', {stderr: {transform: unknownArrayGenerator}});
+expectError(execaSync('unicorns', {stderr: {transform: unknownArrayGenerator}}));
+execa('unicorns', {stderr: [{transform: unknownArrayGenerator}]});
+expectError(execaSync('unicorns', {stderr: [{transform: unknownArrayGenerator}]}));
 expectError(execa('unicorns', {stderr: {transform: booleanGenerator}}));
 expectError(execa('unicorns', {stderr: {transform: arrayGenerator}}));
 expectError(execa('unicorns', {stderr: {transform: invalidReturnGenerator}}));
 expectError(execa('unicorns', {stderr: {transform: syncGenerator}}));
 expectError(execa('unicorns', {stderr: {}}));
 expectError(execa('unicorns', {stderr: {binary: true}}));
-execa('unicorns', {stderr: {transform: stringOrUint8ArrayGenerator, binary: true}});
-expectError(execa('unicorns', {stderr: {transform: stringOrUint8ArrayGenerator, binary: 'true'}}));
+expectError(execa('unicorns', {stderr: {objectMode: true}}));
+execa('unicorns', {stderr: {transform: unknownArrayGenerator, binary: true}});
+expectError(execa('unicorns', {stderr: {transform: unknownArrayGenerator, binary: 'true'}}));
+execa('unicorns', {stderr: {transform: unknownArrayGenerator, objectMode: true}});
+expectError(execa('unicorns', {stderr: {transform: unknownArrayGenerator, objectMode: 'true'}}));
 execa('unicorns', {stderr: undefined});
 execaSync('unicorns', {stderr: undefined});
 execa('unicorns', {stderr: [undefined]});
@@ -916,10 +1017,10 @@ expectError(execa('unicorns', {stdio: 'ipc'}));
 expectError(execaSync('unicorns', {stdio: 'ipc'}));
 expectError(execa('unicorns', {stdio: 1}));
 expectError(execaSync('unicorns', {stdio: 1}));
-expectError(execa('unicorns', {stdio: stringOrUint8ArrayGenerator}));
-expectError(execaSync('unicorns', {stdio: stringOrUint8ArrayGenerator}));
-expectError(execa('unicorns', {stdio: {transform: stringOrUint8ArrayGenerator}}));
-expectError(execaSync('unicorns', {stdio: {transform: stringOrUint8ArrayGenerator}}));
+expectError(execa('unicorns', {stdio: unknownArrayGenerator}));
+expectError(execaSync('unicorns', {stdio: unknownArrayGenerator}));
+expectError(execa('unicorns', {stdio: {transform: unknownArrayGenerator}}));
+expectError(execaSync('unicorns', {stdio: {transform: unknownArrayGenerator}}));
 expectError(execa('unicorns', {stdio: fileUrl}));
 expectError(execaSync('unicorns', {stdio: fileUrl}));
 expectError(execa('unicorns', {stdio: {file: './test'}}));
@@ -952,7 +1053,6 @@ execa('unicorns', {stdio: [['pipe'], ['pipe'], [new Writable()]]});
 execaSync('unicorns', {stdio: [['pipe'], ['pipe'], [new Writable()]]});
 expectError(execa('unicorns', {stdio: [new Writable(), 'pipe', 'pipe']}));
 expectError(execaSync('unicorns', {stdio: [new Writable(), 'pipe', 'pipe']}));
-expectError(execa('unicorns', {stdio: [[new Writable()], ['pipe'], ['pipe']]}));
 expectError(execaSync('unicorns', {stdio: [[new Writable()], ['pipe'], ['pipe']]}));
 expectError(execa('unicorns', {stdio: ['pipe', new Readable(), 'pipe']}));
 expectError(execaSync('unicorns', {stdio: ['pipe', new Readable(), 'pipe']}));
@@ -971,9 +1071,10 @@ execa('unicorns', {
 		'inherit',
 		process.stdin,
 		1,
-		stringOrUint8ArrayGenerator,
-		{transform: stringOrUint8ArrayGenerator},
-		{transform: stringOrUint8ArrayGenerator, binary: true},
+		unknownArrayGenerator,
+		{transform: unknownArrayGenerator},
+		{transform: unknownArrayGenerator, binary: true},
+		{transform: unknownArrayGenerator, objectMode: true},
 		undefined,
 		fileUrl,
 		{file: './test'},
@@ -1003,8 +1104,8 @@ execaSync('unicorns', {
 		new Uint8Array(),
 	],
 });
-expectError(execaSync('unicorns', {stdio: [stringOrUint8ArrayGenerator]}));
-expectError(execaSync('unicorns', {stdio: [{transform: stringOrUint8ArrayGenerator}]}));
+expectError(execaSync('unicorns', {stdio: [unknownArrayGenerator]}));
+expectError(execaSync('unicorns', {stdio: [{transform: unknownArrayGenerator}]}));
 expectError(execaSync('unicorns', {stdio: [new WritableStream()]}));
 expectError(execaSync('unicorns', {stdio: [new ReadableStream()]}));
 expectError(execaSync('unicorns', {stdio: [emptyStringGenerator()]}));
@@ -1019,9 +1120,10 @@ execa('unicorns', {
 		['inherit'],
 		[process.stdin],
 		[1],
-		[stringOrUint8ArrayGenerator],
-		[{transform: stringOrUint8ArrayGenerator}],
-		[{transform: stringOrUint8ArrayGenerator, binary: true}],
+		[unknownArrayGenerator],
+		[{transform: unknownArrayGenerator}],
+		[{transform: unknownArrayGenerator, binary: true}],
+		[{transform: unknownArrayGenerator, objectMode: true}],
 		[undefined],
 		[fileUrl],
 		[{file: './test'}],
@@ -1030,6 +1132,9 @@ execa('unicorns', {
 		[new WritableStream()],
 		[new ReadableStream()],
 		[new Uint8Array()],
+		[['foo', 'bar']],
+		[[new Uint8Array(), new Uint8Array()]],
+		[[{}, {}]],
 		[emptyStringGenerator()],
 		[asyncStringGenerator()],
 	],
@@ -1052,10 +1157,13 @@ execaSync('unicorns', {
 		[new Uint8Array()],
 	],
 });
-expectError(execaSync('unicorns', {stdio: [[stringOrUint8ArrayGenerator]]}));
-expectError(execaSync('unicorns', {stdio: [[{transform: stringOrUint8ArrayGenerator}]]}));
+expectError(execaSync('unicorns', {stdio: [[unknownArrayGenerator]]}));
+expectError(execaSync('unicorns', {stdio: [[{transform: unknownArrayGenerator}]]}));
 expectError(execaSync('unicorns', {stdio: [[new WritableStream()]]}));
 expectError(execaSync('unicorns', {stdio: [[new ReadableStream()]]}));
+expectError(execaSync('unicorns', {stdio: [[['foo', 'bar']]]}));
+expectError(execaSync('unicorns', {stdio: [[[new Uint8Array(), new Uint8Array()]]]}));
+expectError(execaSync('unicorns', {stdio: [[[{}, {}]]]}));
 expectError(execaSync('unicorns', {stdio: [[emptyStringGenerator()]]}));
 expectError(execaSync('unicorns', {stdio: [[asyncStringGenerator()]]}));
 execa('unicorns', {serialization: 'advanced'});

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,4 +1,5 @@
 import {ChildProcess} from 'node:child_process';
+import {isBinary, binaryToString} from './stdio/utils.js';
 
 const normalizeArgs = (file, args = []) => {
 	if (!Array.isArray(args)) {
@@ -64,8 +65,8 @@ const parseExpression = expression => {
 			return expression.stdout;
 		}
 
-		if (ArrayBuffer.isView(expression.stdout)) {
-			return new TextDecoder().decode(expression.stdout);
+		if (isBinary(expression.stdout)) {
+			return binaryToString(expression.stdout);
 		}
 
 		throw new TypeError(`Unexpected "${typeOfStdout}" stdout in template expression`);

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,7 +1,7 @@
 import process from 'node:process';
 import {signalsByName} from 'human-signals';
 import stripFinalNewline from 'strip-final-newline';
-import {isUint8Array} from './stdio/utils.js';
+import {isBinary, binaryToString} from './stdio/utils.js';
 
 const getErrorPrefix = ({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled}) => {
 	if (timedOut) {
@@ -27,13 +27,17 @@ const getErrorPrefix = ({timedOut, timeout, errorCode, signal, signalDescription
 	return 'failed';
 };
 
-const serializeMessagePart = messagePart => {
-	if (typeof messagePart === 'string') {
-		return messagePart;
+const serializeMessagePart = messagePart => Array.isArray(messagePart)
+	? messagePart.map(messageItem => serializeMessageItem(messageItem)).join('')
+	: serializeMessageItem(messagePart);
+
+const serializeMessageItem = messageItem => {
+	if (typeof messageItem === 'string') {
+		return messageItem;
 	}
 
-	if (isUint8Array(messagePart)) {
-		return new TextDecoder().decode(messagePart);
+	if (isBinary(messageItem)) {
+		return binaryToString(messageItem);
 	}
 
 	return '';

--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -39,14 +39,11 @@ export const pipeOutputAsync = (spawned, stdioStreamsGroups) => {
 	const inputStreamsGroups = {};
 
 	for (const stdioStreams of stdioStreamsGroups) {
-		const generatorStreams = sortGeneratorStreams(stdioStreams.filter(({type}) => type === 'generator'));
-		const nonGeneratorStreams = stdioStreams.filter(({type}) => type !== 'generator');
-
-		for (const generatorStream of generatorStreams) {
+		for (const generatorStream of stdioStreams.filter(({type}) => type === 'generator')) {
 			pipeGenerator(spawned, generatorStream);
 		}
 
-		for (const nonGeneratorStream of nonGeneratorStreams) {
+		for (const nonGeneratorStream of stdioStreams.filter(({type}) => type !== 'generator')) {
 			pipeStdioOption(spawned, nonGeneratorStream, inputStreamsGroups);
 		}
 	}
@@ -56,8 +53,6 @@ export const pipeOutputAsync = (spawned, stdioStreamsGroups) => {
 		value.pipe(spawned.stdio[index]);
 	}
 };
-
-const sortGeneratorStreams = generatorStreams => generatorStreams[0]?.direction === 'input' ? generatorStreams.reverse() : generatorStreams;
 
 const pipeStdioOption = (spawned, {type, value, direction, index}, inputStreamsGroups) => {
 	if (type === 'native') {

--- a/lib/stdio/duplex.js
+++ b/lib/stdio/duplex.js
@@ -11,16 +11,22 @@ The `Duplex` is created by `Duplex.from()` made of a writable stream and a reada
 - This new iterable is transformed again to another one, this time by applying the user-supplied generator.
 - Finally, `Readable.from()` is used to convert this final iterable to a `Readable` stream.
 */
-export const generatorsToDuplex = (generators, {objectMode}) => {
-	const highWaterMark = getDefaultHighWaterMark(objectMode);
-	const passThrough = new PassThrough({objectMode, highWaterMark, destroy: destroyPassThrough});
+export const generatorsToDuplex = (generators, {writableObjectMode, readableObjectMode}) => {
+	const passThrough = new PassThrough({
+		objectMode: writableObjectMode,
+		highWaterMark: getDefaultHighWaterMark(writableObjectMode),
+		destroy: destroyPassThrough,
+	});
 	let iterable = passThrough.iterator();
 
 	for (const generator of generators) {
 		iterable = generator(iterable);
 	}
 
-	const readableStream = Readable.from(iterable, {objectMode, highWaterMark});
+	const readableStream = Readable.from(iterable, {
+		objectMode: readableObjectMode,
+		highWaterMark: getDefaultHighWaterMark(readableObjectMode),
+	});
 	const duplexStream = Duplex.from({writable: passThrough, readable: readableStream});
 	return duplexStream;
 };

--- a/lib/stdio/encoding.js
+++ b/lib/stdio/encoding.js
@@ -1,4 +1,6 @@
 import {StringDecoder} from 'node:string_decoder';
+import {Buffer} from 'node:buffer';
+import {isUint8Array} from './utils.js';
 
 // Apply the `encoding` option using an implicit generator.
 // This encodes the final output of `stdout`/`stderr`.
@@ -8,12 +10,13 @@ export const handleStreamsEncoding = (stdioStreams, {encoding}, isSync) => {
 	}
 
 	const transform = encodingEndGenerator.bind(undefined, encoding);
+	const objectMode = stdioStreams.findLast(({type}) => type === 'generator')?.value.readableObjectMode === true;
 	return [
 		...stdioStreams,
 		{
 			...stdioStreams[0],
 			type: 'generator',
-			value: {transform, binary: true},
+			value: {transform, binary: true, readableObjectMode: objectMode, writableObjectMode: objectMode},
 			encoding: 'buffer',
 		},
 	];
@@ -52,8 +55,16 @@ export const getEncodingStartGenerator = encoding => encoding === 'buffer'
 	: encodingStartStringGenerator;
 
 const encodingStartBufferGenerator = async function * (chunks) {
+	const textEncoder = new TextEncoder();
+
 	for await (const chunk of chunks) {
-		yield new Uint8Array(chunk);
+		if (Buffer.isBuffer(chunk)) {
+			yield new Uint8Array(chunk);
+		} else if (typeof chunk === 'string') {
+			yield textEncoder.encode(chunk);
+		} else {
+			yield chunk;
+		}
 	}
 };
 
@@ -61,7 +72,9 @@ const encodingStartStringGenerator = async function * (chunks) {
 	const textDecoder = new TextDecoder();
 
 	for await (const chunk of chunks) {
-		yield textDecoder.decode(chunk, {stream: true});
+		yield Buffer.isBuffer(chunk) || isUint8Array(chunk)
+			? textDecoder.decode(chunk, {stream: true})
+			: chunk;
 	}
 
 	const lastChunk = textDecoder.decode();

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -2,6 +2,53 @@ import {generatorsToDuplex} from './duplex.js';
 import {getEncodingStartGenerator} from './encoding.js';
 import {getLinesGenerator} from './lines.js';
 import {isGeneratorOptions} from './type.js';
+import {isBinary} from './utils.js';
+
+export const normalizeGenerators = stdioStreams => {
+	const nonGenerators = stdioStreams.filter(({type}) => type !== 'generator');
+	const generators = stdioStreams.filter(({type}) => type === 'generator');
+
+	const newGenerators = Array.from({length: generators.length});
+
+	for (const [index, stdioStream] of Object.entries(generators)) {
+		newGenerators[index] = normalizeGenerator(stdioStream, Number(index), newGenerators);
+	}
+
+	return [...nonGenerators, ...sortGenerators(newGenerators)];
+};
+
+const normalizeGenerator = ({value, ...stdioStream}, index, newGenerators) => {
+	const {transform, binary = false, objectMode = false} = isGeneratorOptions(value) ? value : {transform: value};
+	const objectModes = stdioStream.direction === 'output'
+		? getOutputObjectModes(objectMode, index, newGenerators)
+		: getInputObjectModes(objectMode, index, newGenerators);
+	return {...stdioStream, value: {transform, binary, ...objectModes}};
+};
+
+/*
+`objectMode` determines the return value's type, i.e. the `readableObjectMode`.
+The chunk argument's type is based on the previous generator's return value, i.e. the `writableObjectMode` is based on the previous `readableObjectMode`.
+The last input's generator is read by `childProcess.stdin` which:
+- should not be in `objectMode` for performance reasons.
+- can only be strings, Buffers and Uint8Arrays.
+Therefore its `readableObjectMode` must be `false`.
+The same applies to the first output's generator's `writableObjectMode`.
+*/
+const getOutputObjectModes = (objectMode, index, newGenerators) => {
+	const writableObjectMode = index !== 0 && newGenerators[index - 1].value.readableObjectMode;
+	const readableObjectMode = objectMode;
+	return {writableObjectMode, readableObjectMode};
+};
+
+const getInputObjectModes = (objectMode, index, newGenerators) => {
+	const writableObjectMode = index === 0
+		? objectMode
+		: newGenerators[index - 1].value.readableObjectMode;
+	const readableObjectMode = index !== newGenerators.length - 1 && objectMode;
+	return {writableObjectMode, readableObjectMode};
+};
+
+const sortGenerators = newGenerators => newGenerators[0]?.direction === 'input' ? newGenerators.reverse() : newGenerators;
 
 /*
 Generators can be used to transform/filter standard streams.
@@ -17,19 +64,35 @@ Therefore, there is no need to allow Node.js or web transform streams.
 
 The `highWaterMark` is kept as the default value, since this is what `childProcess.std*` uses.
 
-We ensure `objectMode` is `false` for better buffering.
-
 Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
 */
-export const generatorToDuplexStream = ({value, encoding}) => {
-	const {transform, binary} = isGeneratorOptions(value) ? value : {transform: value};
+export const generatorToDuplexStream = ({
+	value: {transform, binary, writableObjectMode, readableObjectMode},
+	encoding,
+	optionName,
+}) => {
 	const generators = [
 		getEncodingStartGenerator(encoding),
 		getLinesGenerator(encoding, binary),
 		transform,
+		getValidateTransformReturn(readableObjectMode, optionName),
 	].filter(Boolean);
-	const duplexStream = generatorsToDuplex(generators, {objectMode: false});
+	const duplexStream = generatorsToDuplex(generators, {writableObjectMode, readableObjectMode});
 	return {value: duplexStream};
+};
+
+const getValidateTransformReturn = (readableObjectMode, optionName) => readableObjectMode
+	? undefined
+	: validateTransformReturn.bind(undefined, optionName);
+
+const validateTransformReturn = async function * (optionName, chunks) {
+	for await (const chunk of chunks) {
+		if (typeof chunk !== 'string' && !isBinary(chunk)) {
+			throw new Error(`The \`${optionName}\` option's function must return a string or an Uint8Array, not ${typeof chunk}.`);
+		}
+
+		yield chunk;
+	}
 };
 
 // `childProcess.stdin|stdout|stderr|stdio` is directly mutated.

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -4,6 +4,7 @@ import {normalizeStdio} from './normalize.js';
 import {handleNativeStream} from './native.js';
 import {handleInputOptions} from './input.js';
 import {handleStreamsEncoding} from './encoding.js';
+import {normalizeGenerators} from './generator.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async/sync mode
 export const handleInput = (addProperties, options, isSync) => {
@@ -12,6 +13,7 @@ export const handleInput = (addProperties, options, isSync) => {
 	const stdioStreamsGroups = [[...stdinStreams, ...handleInputOptions(options)], ...otherStreamsGroups]
 		.map(stdioStreams => validateStreams(stdioStreams))
 		.map(stdioStreams => addStreamDirection(stdioStreams))
+		.map(stdioStreams => normalizeGenerators(stdioStreams))
 		.map(stdioStreams => handleStreamsEncoding(stdioStreams, options, isSync))
 		.map(stdioStreams => addStreamsProperties(stdioStreams, addProperties));
 	options.stdio = transformStdio(stdioStreamsGroups);

--- a/lib/stdio/lines.js
+++ b/lib/stdio/lines.js
@@ -1,3 +1,5 @@
+import {isUint8Array} from './utils.js';
+
 // Split chunks line-wise
 export const getLinesGenerator = (encoding, binary) => {
 	if (binary) {
@@ -8,7 +10,13 @@ export const getLinesGenerator = (encoding, binary) => {
 };
 
 const linesUint8ArrayGenerator = async function * (chunks) {
-	yield * linesGenerator(chunks, new Uint8Array(0), 0x0A, concatUint8Array);
+	yield * linesGenerator({
+		chunks,
+		emptyValue: new Uint8Array(0),
+		newline: 0x0A,
+		concat: concatUint8Array,
+		isValidType: isUint8Array,
+	});
 };
 
 const concatUint8Array = (firstChunk, secondChunk) => {
@@ -19,17 +27,29 @@ const concatUint8Array = (firstChunk, secondChunk) => {
 };
 
 const linesStringGenerator = async function * (chunks) {
-	yield * linesGenerator(chunks, '', '\n', concatString);
+	yield * linesGenerator({
+		chunks,
+		emptyValue: '',
+		newline: '\n',
+		concat: concatString,
+		isValidType: isString,
+	});
 };
 
 const concatString = (firstChunk, secondChunk) => `${firstChunk}${secondChunk}`;
+const isString = chunk => typeof chunk === 'string';
 
 // This imperative logic is much faster than using `String.split()` and uses very low memory.
 // Also, it allows sharing it with `Uint8Array`.
-const linesGenerator = async function * (chunks, emptyValue, newline, concat) {
+const linesGenerator = async function * ({chunks, emptyValue, newline, concat, isValidType}) {
 	let previousChunks = emptyValue;
 
 	for await (const chunk of chunks) {
+		if (!isValidType(chunk)) {
+			yield chunk;
+			continue;
+		}
+
 		let start = -1;
 
 		for (let end = 0; end < chunk.length; end += 1) {

--- a/lib/stdio/sync.js
+++ b/lib/stdio/sync.js
@@ -1,7 +1,7 @@
 import {readFileSync, writeFileSync} from 'node:fs';
 import {handleInput} from './handle.js';
 import {TYPE_TO_MESSAGE} from './type.js';
-import {bufferToUint8Array} from './utils.js';
+import {bufferToUint8Array, binaryToString} from './utils.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in sync mode
 export const handleInputSync = options => {
@@ -44,7 +44,7 @@ const addInputOptionSync = (stdioStreamsGroups, options) => {
 		: inputs.map(stdioStream => serializeInput(stdioStream)).join('');
 };
 
-const serializeInput = ({type, value}) => type === 'string' ? value : new TextDecoder().decode(value);
+const serializeInput = ({type, value}) => type === 'string' ? value : binaryToString(value);
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, after spawning, in sync mode
 export const pipeOutputSync = (stdioStreamsGroups, result) => {

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -42,16 +42,21 @@ export const getStdioOptionType = (stdioOption, optionName) => {
 	return 'native';
 };
 
-const getGeneratorObjectType = ({transform, binary}, optionName) => {
+const getGeneratorObjectType = ({transform, binary, objectMode}, optionName) => {
 	if (!isAsyncGenerator(transform)) {
 		throw new TypeError(`The \`${optionName}.transform\` option must use an asynchronous generator.`);
 	}
 
-	if (binary !== undefined && typeof binary !== 'boolean') {
-		throw new TypeError(`The \`${optionName}.binary\` option must use a boolean.`);
-	}
+	checkBooleanOption(binary, `${optionName}.binary`);
+	checkBooleanOption(objectMode, `${optionName}.objectMode`);
 
 	return 'generator';
+};
+
+const checkBooleanOption = (value, optionName) => {
+	if (value !== undefined && typeof value !== 'boolean') {
+		throw new TypeError(`The \`${optionName}\` option must use a boolean.`);
+	}
 };
 
 const isAsyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object AsyncGeneratorFunction]';
@@ -78,7 +83,6 @@ const isWebStream = stdioOption => isReadableStream(stdioOption) || isWritableSt
 
 const isIterableObject = stdioOption => typeof stdioOption === 'object'
 	&& stdioOption !== null
-	&& !Array.isArray(stdioOption)
 	&& (typeof stdioOption[Symbol.asyncIterator] === 'function' || typeof stdioOption[Symbol.iterator] === 'function');
 
 // Convert types to human-friendly strings for error messages

--- a/lib/stdio/utils.js
+++ b/lib/stdio/utils.js
@@ -3,3 +3,7 @@ import {Buffer} from 'node:buffer';
 export const bufferToUint8Array = buffer => new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 
 export const isUint8Array = value => Object.prototype.toString.call(value) === '[object Uint8Array]' && !Buffer.isBuffer(value);
+export const isBinary = value => isUint8Array(value) || Buffer.isBuffer(value);
+
+const textDecoder = new TextDecoder();
+export const binaryToString = uint8ArrayOrBuffer => textDecoder.decode(uint8ArrayOrBuffer);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,9 +1,10 @@
 import {once} from 'node:events';
 import {finished} from 'node:stream/promises';
-import getStream, {getStreamAsArrayBuffer} from 'get-stream';
+import getStream, {getStreamAsArrayBuffer, getStreamAsArray} from 'get-stream';
 import mergeStreams from '@sindresorhus/merge-streams';
 import {throwOnTimeout, cleanupOnExit} from './kill.js';
 import {STANDARD_STREAMS} from './stdio/native.js';
+import {generatorToDuplexStream} from './stdio/generator.js';
 
 // `all` interleaves `stdout` and `stderr`
 export const makeAllStream = ({stdout, stderr}, {all}) => all && (stdout || stderr)
@@ -18,17 +19,46 @@ const getBufferedData = async (streamPromise, encoding) => {
 	try {
 		return await streamPromise;
 	} catch (error) {
-		return error.bufferedData === undefined ? undefined : applyEncoding(error.bufferedData, encoding);
+		return error.bufferedData === undefined || Array.isArray(error.bufferedData)
+			? error.bufferedData
+			: applyEncoding(error.bufferedData, encoding);
 	}
 };
 
-const getStdioPromise = ({stream, index, stdioStreamsGroups, encoding, buffer, maxBuffer}) => stdioStreamsGroups[index]?.[0]?.direction === 'output'
-	? getStreamPromise(stream, {encoding, buffer, maxBuffer})
+const getStdioPromise = ({stream, stdioStreams, encoding, buffer, maxBuffer}) => stdioStreams[0].direction === 'output'
+	? getStreamPromise({stream, encoding, buffer, maxBuffer, objectMode: stream?.readableObjectMode})
 	: undefined;
 
-const getStreamPromise = async (stream, {encoding, buffer, maxBuffer}) => {
+const getAllPromise = ({spawned, encoding, buffer, maxBuffer}) => {
+	const stream = getAllStream(spawned, encoding);
+	const objectMode = spawned.stdout?.readableObjectMode || spawned.stderr?.readableObjectMode;
+	return getStreamPromise({stream, encoding, buffer, maxBuffer, objectMode});
+};
+
+// When `childProcess.stdout` is in objectMode but not `childProcess.stderr` (or the opposite), we need to use both:
+//  - `getStreamAsArray()` for the chunks in objectMode, to return as an array without changing each chunk
+//  - `getStreamAsArrayBuffer()` or `getStream()` for the chunks not in objectMode, to convert them from Buffers to string or Uint8Array
+// We do this by emulating the Buffer -> string|Uint8Array conversion performed by `get-stream` with our own, which is identical.
+const getAllStream = ({all, stdout, stderr}, encoding) => all && stdout && stderr && stdout.readableObjectMode !== stderr.readableObjectMode
+	? all.pipe(generatorToDuplexStream({value: allStreamGenerator, encoding}).value)
+	: all;
+
+const allStreamGenerator = {
+	async * transform(chunks) {
+		yield * chunks;
+	},
+	binary: true,
+	writableObjectMode: true,
+	readableObjectMode: true,
+};
+
+const getStreamPromise = async ({stream, encoding, buffer, maxBuffer, objectMode}) => {
 	if (!stream || !buffer) {
 		return;
+	}
+
+	if (objectMode) {
+		return getStreamAsArray(stream, {maxBuffer});
 	}
 
 	const contents = encoding === 'buffer'
@@ -90,8 +120,8 @@ export const getSpawnedResult = async (
 	cleanupOnExit(spawned, cleanup, detached, finalizers);
 	const customStreams = getCustomStreams(stdioStreamsGroups);
 
-	const stdioPromises = spawned.stdio.map((stream, index) => getStdioPromise({stream, index, stdioStreamsGroups, encoding, buffer, maxBuffer}));
-	const allPromise = getStreamPromise(spawned.all, {encoding, buffer, maxBuffer: maxBuffer * 2});
+	const stdioPromises = spawned.stdio.map((stream, index) => getStdioPromise({stream, stdioStreams: stdioStreamsGroups[index], encoding, buffer, maxBuffer}));
+	const allPromise = getAllPromise({spawned, encoding, buffer, maxBuffer: maxBuffer * 2});
 
 	try {
 		return await Promise.race([

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ This package improves [`child_process`](https://nodejs.org/api/child_process.htm
 - Improved [Windows support](https://github.com/IndigoUnited/node-cross-spawn#why), including [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) binaries.
 - Executes [locally installed binaries](#preferlocal) without `npx`.
 - [Cleans up](#cleanup) child processes when the parent process ends.
-- Redirect [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1) to files, streams, iterables, strings or `Uint8Array`.
+- Redirect [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1) from/to files, streams, iterables, strings, `Uint8Array` or [objects](docs/transform.md#object-mode).
 - [Transform](docs/transform.md) `stdin`/`stdout`/`stderr` with simple functions.
 - Iterate over [each text line](docs/transform.md#binary-data) output by the process.
 - [Graceful termination](#optionsforcekillaftertimeout).
@@ -411,23 +411,23 @@ This is `undefined` when the process could not be spawned or was terminated by a
 
 #### stdout
 
-Type: `string | Uint8Array | undefined`
+Type: `string | Uint8Array | unknown[] | undefined`
 
 The output of the process on `stdout`.
 
-This is `undefined` if the [`stdout`](#stdout-1) option is set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio).
+This is `undefined` if the [`stdout`](#stdout-1) option is set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio). This is an array if the `stdout` option is a [transform in object mode](docs/transform.md#object-mode).
 
 #### stderr
 
-Type: `string | Uint8Array | undefined`
+Type: `string | Uint8Array | unknown[] | undefined`
 
 The output of the process on `stderr`.
 
-This is `undefined` if the [`stderr`](#stderr-1) option is set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio).
+This is `undefined` if the [`stderr`](#stderr-1) option is set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio). This is an array if the `stderr` option is a [transform in object mode](docs/transform.md#object-mode).
 
 #### all
 
-Type: `string | Uint8Array | undefined`
+Type: `string | Uint8Array | unknown[] | undefined`
 
 The output of the process with `stdout` and `stderr` [interleaved](#ensuring-all-output-is-interleaved).
 
@@ -435,13 +435,15 @@ This is `undefined` if either:
 - the [`all` option](#all-2) is `false` (the default value)
 - both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio)
 
+This is an array if either the `stdout` or `stderr` option is a [transform in object mode](docs/transform.md#object-mode).
+
 #### stdio
 
-Type: `Array<string | Uint8Array | undefined>`
+Type: `Array<string | Uint8Array | unknown[] | undefined>`
 
 The output of the process on [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1) and [other file descriptors](#stdio-1).
 
-Items are `undefined` when their corresponding [`stdio`](#stdio-1) option is set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio).
+Items are `undefined` when their corresponding [`stdio`](#stdio-1) option is set to [`'inherit'`, `'ipc'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio). Items are arrays when their corresponding `stdio` option is a [transform in object mode](docs/transform.md#object-mode).
 
 #### failed
 

--- a/test/helpers/generator.js
+++ b/test/helpers/generator.js
@@ -1,34 +1,39 @@
-import {setTimeout} from 'node:timers/promises';
+import {foobarObject} from './input.js';
 
-export const stringGenerator = function * () {
-	yield * ['foo', 'bar'];
+export const noopGenerator = objectMode => ({
+	async * transform(lines) {
+		yield * lines;
+	},
+	objectMode,
+});
+
+export const serializeGenerator = {
+	async * transform(objects) {
+		for await (const object of objects) {
+			yield JSON.stringify(object);
+		}
+	},
+	objectMode: true,
 };
 
-const textEncoder = new TextEncoder();
-const binaryFoo = textEncoder.encode('foo');
-const binaryBar = textEncoder.encode('bar');
+export const getOutputsGenerator = (inputs, objectMode) => ({
+	async * transform(lines) {
+	// eslint-disable-next-line no-unused-vars
+		for await (const line of lines) {
+			yield * inputs;
+		}
+	},
+	objectMode,
+});
 
-export const binaryGenerator = function * () {
-	yield * [binaryFoo, binaryBar];
-};
+export const getOutputGenerator = (input, objectMode) => ({
+	async * transform(lines) {
+	// eslint-disable-next-line no-unused-vars
+		for await (const line of lines) {
+			yield input;
+		}
+	},
+	objectMode,
+});
 
-export const asyncGenerator = async function * () {
-	await setTimeout(0);
-	yield * ['foo', 'bar'];
-};
-
-// eslint-disable-next-line require-yield
-export const throwingGenerator = function * () {
-	throw new Error('generator error');
-};
-
-export const infiniteGenerator = () => {
-	const controller = new AbortController();
-
-	const generator = async function * () {
-		yield 'foo';
-		await setTimeout(1e7, undefined, {signal: controller.signal});
-	};
-
-	return {iterable: generator(), abort: controller.abort.bind(controller)};
-};
+export const outputObjectGenerator = getOutputGenerator(foobarObject, true);

--- a/test/helpers/input.js
+++ b/test/helpers/input.js
@@ -1,0 +1,12 @@
+import {Buffer} from 'node:buffer';
+
+const textEncoder = new TextEncoder();
+
+export const foobarString = 'foobar';
+export const foobarUint8Array = textEncoder.encode('foobar');
+export const foobarArrayBuffer = foobarUint8Array.buffer;
+export const foobarUint16Array = new Uint16Array(foobarArrayBuffer);
+export const foobarBuffer = Buffer.from(foobarString);
+export const foobarDataView = new DataView(foobarArrayBuffer);
+export const foobarObject = {foo: 'bar'};
+export const foobarObjectString = JSON.stringify(foobarObject);

--- a/test/stdio/array.js
+++ b/test/stdio/array.js
@@ -4,7 +4,6 @@ import test from 'ava';
 import tempfile from 'tempfile';
 import {execa, execaSync} from '../../index.js';
 import {fullStdio, getStdio, STANDARD_STREAMS} from '../helpers/stdio.js';
-import {stringGenerator} from '../helpers/generator.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 
 setFixtureDir();
@@ -123,7 +122,7 @@ test('stdio[*] default direction is output - sync', testAmbiguousDirection, exec
 const testAmbiguousMultiple = async (t, index) => {
 	const filePath = tempfile();
 	await writeFile(filePath, 'foobar');
-	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [{file: filePath}, stringGenerator()]));
+	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [{file: filePath}, ['foo', 'bar']]));
 	t.is(stdout, 'foobarfoobar');
 	await rm(filePath);
 };

--- a/test/stdio/encoding.js
+++ b/test/stdio/encoding.js
@@ -145,7 +145,10 @@ const delayedGenerator = async function * (lines) {
 	}
 };
 
-test('Handle multibyte characters', async t => {
-	const {stdout} = await execa('noop.js', {stdout: delayedGenerator, encoding: 'base64'});
-	t.is(stdout, btoa(foobarArray.join('')));
-});
+const testMultiByteCharacter = async (t, objectMode) => {
+	const {stdout} = await execa('noop.js', {stdout: {transform: delayedGenerator, objectMode}, encoding: 'base64'});
+	t.is(objectMode ? stdout.join('') : stdout, btoa(foobarArray.join('')));
+};
+
+test('Handle multibyte characters', testMultiByteCharacter, false);
+test('Handle multibyte characters, with objectMode', testMultiByteCharacter, true);

--- a/test/stdio/file-path.js
+++ b/test/stdio/file-path.js
@@ -8,11 +8,10 @@ import {execa, execaSync} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {identity, getStdio} from '../helpers/stdio.js';
 import {runExeca, runExecaSync, runScript, runScriptSync} from '../helpers/run.js';
+import {foobarUint8Array} from '../helpers/input.js';
 
 setFixtureDir();
 
-const textEncoder = new TextEncoder();
-const binaryFoobar = textEncoder.encode('foobar');
 const nonFileUrl = new URL('https://example.com');
 
 const getAbsolutePath = file => ({file});
@@ -26,7 +25,7 @@ const getStdioInput = (index, file) => {
 	}
 
 	if (index === 'binary') {
-		return {input: binaryFoobar};
+		return {input: foobarUint8Array};
 	}
 
 	return getStdioFile(index, file);

--- a/test/stdio/generator.js
+++ b/test/stdio/generator.js
@@ -3,18 +3,21 @@ import {readFile, writeFile, rm} from 'node:fs/promises';
 import {getDefaultHighWaterMark, PassThrough} from 'node:stream';
 import {setTimeout} from 'node:timers/promises';
 import test from 'ava';
-import getStream from 'get-stream';
+import getStream, {getStreamAsArray} from 'get-stream';
 import tempfile from 'tempfile';
 import {execa, execaSync} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {getStdio} from '../helpers/stdio.js';
+import {foobarString, foobarUint8Array, foobarBuffer, foobarObject, foobarObjectString} from '../helpers/input.js';
+import {serializeGenerator, noopGenerator, getOutputsGenerator, getOutputGenerator, outputObjectGenerator} from '../helpers/generator.js';
 
 setFixtureDir();
 
-const foobarString = 'foobar';
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
 const foobarUppercase = foobarString.toUpperCase();
-const foobarBuffer = Buffer.from(foobarString);
-const foobarUint8Array = new TextEncoder().encode(foobarString);
+const foobarHex = foobarBuffer.toString('hex');
 
 const uppercaseGenerator = async function * (lines) {
 	for await (const line of lines) {
@@ -22,75 +25,203 @@ const uppercaseGenerator = async function * (lines) {
 	}
 };
 
-const testGeneratorInput = async (t, index) => {
-	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [foobarUint8Array, uppercaseGenerator]));
-	t.is(stdout, foobarUppercase);
+const uppercaseBufferGenerator = async function * (lines) {
+	for await (const line of lines) {
+		yield textDecoder.decode(line).toUpperCase();
+	}
 };
 
-test('Can use generators with result.stdin', testGeneratorInput, 0);
-test('Can use generators with result.stdio[*] as input', testGeneratorInput, 3);
+const getInputObjectMode = objectMode => objectMode
+	? {input: [foobarObject], generator: serializeGenerator, output: foobarObjectString}
+	: {input: foobarUint8Array, generator: uppercaseGenerator, output: foobarUppercase};
 
-const testGeneratorInputPipe = async (t, index, useShortcutProperty, encoding) => {
-	const childProcess = execa('stdin-fd.js', [`${index}`], getStdio(index, uppercaseGenerator));
-	const stream = useShortcutProperty ? childProcess.stdin : childProcess.stdio[index];
-	stream.end(encoding === 'buffer' ? foobarBuffer : foobarBuffer.toString(encoding), encoding);
-	const {stdout} = await childProcess;
-	t.is(stdout, foobarUppercase);
+const getOutputObjectMode = objectMode => objectMode
+	? {generator: outputObjectGenerator, output: [foobarObject], getStreamMethod: getStreamAsArray}
+	: {generator: uppercaseGenerator, output: foobarUppercase, getStreamMethod: getStream};
+
+const testGeneratorInput = async (t, index, objectMode) => {
+	const {input, generator, output} = getInputObjectMode(objectMode);
+	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [input, generator]));
+	t.is(stdout, output);
 };
 
-test('Can use generators with childProcess.stdio[0] and default encoding', testGeneratorInputPipe, 0, false, 'utf8');
-test('Can use generators with childProcess.stdin and default encoding', testGeneratorInputPipe, 0, true, 'utf8');
-test('Can use generators with childProcess.stdio[0] and encoding "buffer"', testGeneratorInputPipe, 0, false, 'buffer');
-test('Can use generators with childProcess.stdin and encoding "buffer"', testGeneratorInputPipe, 0, true, 'buffer');
-test('Can use generators with childProcess.stdio[0] and encoding "hex"', testGeneratorInputPipe, 0, false, 'hex');
-test('Can use generators with childProcess.stdin and encoding "hex"', testGeneratorInputPipe, 0, true, 'hex');
+test('Can use generators with result.stdin', testGeneratorInput, 0, false);
+test('Can use generators with result.stdio[*] as input', testGeneratorInput, 3, false);
+test('Can use generators with result.stdin, objectMode', testGeneratorInput, 0, true);
+test('Can use generators with result.stdio[*] as input, objectMode', testGeneratorInput, 3, true);
 
-test('Can use generators with childProcess.stdio[*] as input', async t => {
-	const childProcess = execa('stdin-fd.js', ['3'], getStdio(3, [new Uint8Array(), uppercaseGenerator]));
-	childProcess.stdio[3].write(foobarUint8Array);
+const testGeneratorInputPipe = async (t, useShortcutProperty, objectMode, input) => {
+	const {generator, output} = getInputObjectMode(objectMode);
+	const childProcess = execa('stdin-fd.js', ['0'], getStdio(0, generator));
+	const stream = useShortcutProperty ? childProcess.stdin : childProcess.stdio[0];
+	stream.end(...input);
 	const {stdout} = await childProcess;
-	t.is(stdout, foobarUppercase);
-});
+	t.is(stdout, output);
+};
 
-const testGeneratorOutput = async (t, index, reject, useShortcutProperty) => {
+test('Can use generators with childProcess.stdio[0] and default encoding', testGeneratorInputPipe, false, false, [foobarString, 'utf8']);
+test('Can use generators with childProcess.stdin and default encoding', testGeneratorInputPipe, true, false, [foobarString, 'utf8']);
+test('Can use generators with childProcess.stdio[0] and encoding "buffer"', testGeneratorInputPipe, false, false, [foobarBuffer, 'buffer']);
+test('Can use generators with childProcess.stdin and encoding "buffer"', testGeneratorInputPipe, true, false, [foobarBuffer, 'buffer']);
+test('Can use generators with childProcess.stdio[0] and encoding "hex"', testGeneratorInputPipe, false, false, [foobarHex, 'hex']);
+test('Can use generators with childProcess.stdin and encoding "hex"', testGeneratorInputPipe, true, false, [foobarHex, 'hex']);
+test('Can use generators with childProcess.stdio[0], objectMode', testGeneratorInputPipe, false, true, [foobarObject]);
+test('Can use generators with childProcess.stdin, objectMode', testGeneratorInputPipe, true, true, [foobarObject]);
+
+const testGeneratorStdioInputPipe = async (t, objectMode) => {
+	const {input, generator, output} = getInputObjectMode(objectMode);
+	const childProcess = execa('stdin-fd.js', ['3'], getStdio(3, [new Uint8Array(), generator]));
+	childProcess.stdio[3].write(Array.isArray(input) ? input[0] : input);
+	const {stdout} = await childProcess;
+	t.is(stdout, output);
+};
+
+test('Can use generators with childProcess.stdio[*] as input', testGeneratorStdioInputPipe, false);
+test('Can use generators with childProcess.stdio[*] as input, objectMode', testGeneratorStdioInputPipe, true);
+
+const testGeneratorReturn = async (t, index, generators, fixtureName) => {
+	await t.throwsAsync(
+		execa(fixtureName, [`${index}`], getStdio(index, generators)),
+		{message: /a string or an Uint8Array/},
+	);
+};
+
+const inputObjectGenerators = [foobarUint8Array, getOutputGenerator(foobarObject, false), serializeGenerator];
+const lastInputObjectGenerators = [foobarUint8Array, getOutputGenerator(foobarObject, true)];
+const invalidOutputObjectGenerator = getOutputGenerator(foobarObject, false);
+
+test('Generators with result.stdin cannot return an object if not in objectMode', testGeneratorReturn, 0, inputObjectGenerators, 'stdin-fd.js');
+test('Generators with result.stdio[*] as input cannot return an object if not in objectMode', testGeneratorReturn, 3, inputObjectGenerators, 'stdin-fd.js');
+test('The last generator with result.stdin cannot return an object even in objectMode', testGeneratorReturn, 0, lastInputObjectGenerators, 'stdin-fd.js');
+test('The last generator with result.stdio[*] as input cannot return an object even in objectMode', testGeneratorReturn, 3, lastInputObjectGenerators, 'stdin-fd.js');
+test('Generators with result.stdout cannot return an object if not in objectMode', testGeneratorReturn, 1, invalidOutputObjectGenerator, 'noop-fd.js');
+test('Generators with result.stderr cannot return an object if not in objectMode', testGeneratorReturn, 2, invalidOutputObjectGenerator, 'noop-fd.js');
+test('Generators with result.stdio[*] as output cannot return an object if not in objectMode', testGeneratorReturn, 3, invalidOutputObjectGenerator, 'noop-fd.js');
+
+// eslint-disable-next-line max-params
+const testGeneratorOutput = async (t, index, reject, useShortcutProperty, objectMode) => {
+	const {generator, output} = getOutputObjectMode(objectMode);
 	const fixtureName = reject ? 'noop-fd.js' : 'noop-fail.js';
-	const {stdout, stderr, stdio} = await execa(fixtureName, [`${index}`, foobarString], {...getStdio(index, uppercaseGenerator), reject});
+	const {stdout, stderr, stdio} = await execa(fixtureName, [`${index}`, foobarString], {...getStdio(index, generator), reject});
 	const result = useShortcutProperty ? [stdout, stderr][index - 1] : stdio[index];
-	t.is(result, foobarUppercase);
+	t.deepEqual(result, output);
 };
 
-test('Can use generators with result.stdio[1]', testGeneratorOutput, 1, true, false);
-test('Can use generators with result.stdout', testGeneratorOutput, 1, true, true);
-test('Can use generators with result.stdio[2]', testGeneratorOutput, 2, true, false);
-test('Can use generators with result.stderr', testGeneratorOutput, 2, true, true);
-test('Can use generators with result.stdio[*] as output', testGeneratorOutput, 3, true, false);
-test('Can use generators with error.stdio[1]', testGeneratorOutput, 1, false, false);
-test('Can use generators with error.stdout', testGeneratorOutput, 1, false, true);
-test('Can use generators with error.stdio[2]', testGeneratorOutput, 2, false, false);
-test('Can use generators with error.stderr', testGeneratorOutput, 2, false, true);
-test('Can use generators with error.stdio[*] as output', testGeneratorOutput, 3, false, false);
+test('Can use generators with result.stdio[1]', testGeneratorOutput, 1, true, false, false);
+test('Can use generators with result.stdout', testGeneratorOutput, 1, true, true, false);
+test('Can use generators with result.stdio[2]', testGeneratorOutput, 2, true, false, false);
+test('Can use generators with result.stderr', testGeneratorOutput, 2, true, true, false);
+test('Can use generators with result.stdio[*] as output', testGeneratorOutput, 3, true, false, false);
+test('Can use generators with error.stdio[1]', testGeneratorOutput, 1, false, false, false);
+test('Can use generators with error.stdout', testGeneratorOutput, 1, false, true, false);
+test('Can use generators with error.stdio[2]', testGeneratorOutput, 2, false, false, false);
+test('Can use generators with error.stderr', testGeneratorOutput, 2, false, true, false);
+test('Can use generators with error.stdio[*] as output', testGeneratorOutput, 3, false, false, false);
+test('Can use generators with result.stdio[1], objectMode', testGeneratorOutput, 1, true, false, true);
+test('Can use generators with result.stdout, objectMode', testGeneratorOutput, 1, true, true, true);
+test('Can use generators with result.stdio[2], objectMode', testGeneratorOutput, 2, true, false, true);
+test('Can use generators with result.stderr, objectMode', testGeneratorOutput, 2, true, true, true);
+test('Can use generators with result.stdio[*] as output, objectMode', testGeneratorOutput, 3, true, false, true);
+test('Can use generators with error.stdio[1], objectMode', testGeneratorOutput, 1, false, false, true);
+test('Can use generators with error.stdout, objectMode', testGeneratorOutput, 1, false, true, true);
+test('Can use generators with error.stdio[2], objectMode', testGeneratorOutput, 2, false, false, true);
+test('Can use generators with error.stderr, objectMode', testGeneratorOutput, 2, false, true, true);
+test('Can use generators with error.stdio[*] as output, objectMode', testGeneratorOutput, 3, false, false, true);
 
-const testGeneratorOutputPipe = async (t, index, useShortcutProperty) => {
-	const childProcess = execa('noop-fd.js', [`${index}`, foobarString], {...getStdio(index, uppercaseGenerator), buffer: false});
+const testGeneratorOutputPipe = async (t, index, useShortcutProperty, objectMode) => {
+	const {generator, output, getStreamMethod} = getOutputObjectMode(objectMode);
+	const childProcess = execa('noop-fd.js', [`${index}`, foobarString], {...getStdio(index, generator), buffer: false});
 	const stream = useShortcutProperty ? [childProcess.stdout, childProcess.stderr][index - 1] : childProcess.stdio[index];
-	const [result] = await Promise.all([getStream(stream), childProcess]);
-	t.is(result, foobarUppercase);
+	const [result] = await Promise.all([getStreamMethod(stream), childProcess]);
+	t.deepEqual(result, output);
 };
 
-test('Can use generators with childProcess.stdio[1]', testGeneratorOutputPipe, 1, false);
-test('Can use generators with childProcess.stdout', testGeneratorOutputPipe, 1, true);
-test('Can use generators with childProcess.stdio[2]', testGeneratorOutputPipe, 2, false);
-test('Can use generators with childProcess.stderr', testGeneratorOutputPipe, 2, true);
-test('Can use generators with childProcess.stdio[*] as output', testGeneratorOutputPipe, 3, false);
+test('Can use generators with childProcess.stdio[1]', testGeneratorOutputPipe, 1, false, false);
+test('Can use generators with childProcess.stdout', testGeneratorOutputPipe, 1, true, false);
+test('Can use generators with childProcess.stdio[2]', testGeneratorOutputPipe, 2, false, false);
+test('Can use generators with childProcess.stderr', testGeneratorOutputPipe, 2, true, false);
+test('Can use generators with childProcess.stdio[*] as output', testGeneratorOutputPipe, 3, false, false);
+test('Can use generators with childProcess.stdio[1], objectMode', testGeneratorOutputPipe, 1, false, true);
+test('Can use generators with childProcess.stdout, objectMode', testGeneratorOutputPipe, 1, true, true);
+test('Can use generators with childProcess.stdio[2], objectMode', testGeneratorOutputPipe, 2, false, true);
+test('Can use generators with childProcess.stderr, objectMode', testGeneratorOutputPipe, 2, true, true);
+test('Can use generators with childProcess.stdio[*] as output, objectMode', testGeneratorOutputPipe, 3, false, true);
 
-const testGeneratorAll = async (t, reject) => {
+const getAllStdioOption = (stdioOption, encoding, objectMode) => {
+	if (stdioOption) {
+		return 'pipe';
+	}
+
+	if (objectMode) {
+		return outputObjectGenerator;
+	}
+
+	return encoding === 'buffer' ? uppercaseBufferGenerator : uppercaseGenerator;
+};
+
+const getStdoutStderrOutput = (output, stdioOption, encoding, objectMode) => {
+	if (objectMode && !stdioOption) {
+		return [foobarObject];
+	}
+
+	const stdioOutput = stdioOption ? output : output.toUpperCase();
+	return encoding === 'buffer' ? textEncoder.encode(stdioOutput) : stdioOutput;
+};
+
+const getAllOutput = (stdoutOutput, stderrOutput, encoding, objectMode) => {
+	if (objectMode) {
+		return [stdoutOutput, stderrOutput].flat();
+	}
+
+	return encoding === 'buffer'
+		? new Uint8Array([...stdoutOutput, ...stderrOutput])
+		: `${stdoutOutput}${stderrOutput}`;
+};
+
+// eslint-disable-next-line max-params
+const testGeneratorAll = async (t, reject, encoding, objectMode, stdoutOption, stderrOption) => {
 	const fixtureName = reject ? 'all.js' : 'all-fail.js';
-	const {all} = await execa(fixtureName, {all: true, reject, stdout: uppercaseGenerator, stderr: uppercaseGenerator});
-	t.is(all, 'STDOUT\nSTDERR');
+	const {stdout, stderr, all} = await execa(fixtureName, {
+		all: true,
+		reject,
+		stdout: getAllStdioOption(stdoutOption, encoding, objectMode),
+		stderr: getAllStdioOption(stderrOption, encoding, objectMode),
+		encoding,
+		stripFinalNewline: false,
+	});
+
+	const stdoutOutput = getStdoutStderrOutput('stdout\n', stdoutOption, encoding, objectMode);
+	t.deepEqual(stdout, stdoutOutput);
+	const stderrOutput = getStdoutStderrOutput('stderr\n', stderrOption, encoding, objectMode);
+	t.deepEqual(stderr, stderrOutput);
+	const allOutput = getAllOutput(stdoutOutput, stderrOutput, encoding, objectMode);
+	t.deepEqual(all, allOutput);
 };
 
-test('Can use generators with result.all', testGeneratorAll, true);
-test('Can use generators with error.all', testGeneratorAll, false);
+test('Can use generators with result.all = transform + transform', testGeneratorAll, true, 'utf8', false, false, false);
+test('Can use generators with error.all = transform + transform', testGeneratorAll, false, 'utf8', false, false, false);
+test('Can use generators with result.all = transform + transform, encoding "buffer"', testGeneratorAll, true, 'buffer', false, false, false);
+test('Can use generators with error.all = transform + transform, encoding "buffer"', testGeneratorAll, false, 'buffer', false, false, false);
+test('Can use generators with result.all = transform + pipe', testGeneratorAll, true, 'utf8', false, false, true);
+test('Can use generators with error.all = transform + pipe', testGeneratorAll, false, 'utf8', false, false, true);
+test('Can use generators with result.all = transform + pipe, encoding "buffer"', testGeneratorAll, true, 'buffer', false, false, true);
+test('Can use generators with error.all = transform + pipe, encoding "buffer"', testGeneratorAll, false, 'buffer', false, false, true);
+test('Can use generators with result.all = pipe + transform', testGeneratorAll, true, 'utf8', false, true, false);
+test('Can use generators with error.all = pipe + transform', testGeneratorAll, false, 'utf8', false, true, false);
+test('Can use generators with result.all = pipe + transform, encoding "buffer"', testGeneratorAll, true, 'buffer', false, true, false);
+test('Can use generators with error.all = pipe + transform, encoding "buffer"', testGeneratorAll, false, 'buffer', false, true, false);
+test('Can use generators with result.all = transform + transform, objectMode', testGeneratorAll, true, 'utf8', true, false, false);
+test('Can use generators with error.all = transform + transform, objectMode', testGeneratorAll, false, 'utf8', true, false, false);
+test('Can use generators with result.all = transform + transform, objectMode, encoding "buffer"', testGeneratorAll, true, 'buffer', true, false, false);
+test('Can use generators with error.all = transform + transform, objectMode, encoding "buffer"', testGeneratorAll, false, 'buffer', true, false, false);
+test('Can use generators with result.all = transform + pipe, objectMode', testGeneratorAll, true, 'utf8', true, false, true);
+test('Can use generators with error.all = transform + pipe, objectMode', testGeneratorAll, false, 'utf8', true, false, true);
+test('Can use generators with result.all = transform + pipe, objectMode, encoding "buffer"', testGeneratorAll, true, 'buffer', true, false, true);
+test('Can use generators with error.all = transform + pipe, objectMode, encoding "buffer"', testGeneratorAll, false, 'buffer', true, false, true);
+test('Can use generators with result.all = pipe + transform, objectMode', testGeneratorAll, true, 'utf8', true, true, false);
+test('Can use generators with error.all = pipe + transform, objectMode', testGeneratorAll, false, 'utf8', true, true, false);
+test('Can use generators with result.all = pipe + transform, objectMode, encoding "buffer"', testGeneratorAll, true, 'buffer', true, true, false);
+test('Can use generators with error.all = pipe + transform, objectMode, encoding "buffer"', testGeneratorAll, false, 'buffer', true, true, false);
 
 test('Can use generators with input option', async t => {
 	const {stdout} = await execa('stdin-fd.js', ['0'], {stdin: uppercaseGenerator, input: foobarUint8Array});
@@ -118,16 +249,20 @@ test('Cannot use invalid "transform" with stdout', testInvalidGenerator, 1, {tra
 test('Cannot use invalid "transform" with stderr', testInvalidGenerator, 2, {transform: true});
 test('Cannot use invalid "transform" with stdio[*]', testInvalidGenerator, 3, {transform: true});
 
-const testInvalidBinary = (t, index) => {
+const testInvalidBinary = (t, index, optionName) => {
 	t.throws(() => {
-		execa('empty.js', getStdio(index, {transform: uppercaseGenerator, binary: 'true'}));
+		execa('empty.js', getStdio(index, {transform: uppercaseGenerator, [optionName]: 'true'}));
 	}, {message: /a boolean/});
 };
 
-test('Cannot use invalid "binary" with stdin', testInvalidBinary, 0);
-test('Cannot use invalid "binary" with stdout', testInvalidBinary, 1);
-test('Cannot use invalid "binary" with stderr', testInvalidBinary, 2);
-test('Cannot use invalid "binary" with stdio[*]', testInvalidBinary, 3);
+test('Cannot use invalid "binary" with stdin', testInvalidBinary, 0, 'binary');
+test('Cannot use invalid "binary" with stdout', testInvalidBinary, 1, 'binary');
+test('Cannot use invalid "binary" with stderr', testInvalidBinary, 2, 'binary');
+test('Cannot use invalid "binary" with stdio[*]', testInvalidBinary, 3, 'binary');
+test('Cannot use invalid "objectMode" with stdin', testInvalidBinary, 0, 'objectMode');
+test('Cannot use invalid "objectMode" with stdout', testInvalidBinary, 1, 'objectMode');
+test('Cannot use invalid "objectMode" with stderr', testInvalidBinary, 2, 'objectMode');
+test('Cannot use invalid "objectMode" with stdio[*]', testInvalidBinary, 3, 'objectMode');
 
 const testSyncMethods = (t, index) => {
 	t.throws(() => {
@@ -161,103 +296,176 @@ const getLengthGenerator = async function * (chunks) {
 	}
 };
 
-const testHighWaterMark = async (t, passThrough) => {
-	const index = 1;
-	const {stdout} = await execa('noop-fd.js', [`${index}`], getStdio(index, [
-		writerGenerator,
-		...passThrough,
-		{transform: getLengthGenerator, binary: true},
-	]));
+const testHighWaterMark = async (t, passThrough, binary, objectMode) => {
+	const {stdout} = await execa('noop.js', {
+		stdout: [
+			...(objectMode ? [outputObjectGenerator] : []),
+			writerGenerator,
+			...(passThrough ? [{transform: passThroughGenerator, binary}] : []),
+			{transform: getLengthGenerator, binary: true},
+		],
+	});
 	t.is(stdout, `${getDefaultHighWaterMark()}`.repeat(repeatHighWaterMark));
 };
 
-test('Stream respects highWaterMark, no passThrough', testHighWaterMark, []);
-test('Stream respects highWaterMark, line-wise passThrough', testHighWaterMark, [passThroughGenerator]);
-test('Stream respects highWaterMark, binary passThrough', testHighWaterMark, [{transform: passThroughGenerator, binary: true}]);
+test('Stream respects highWaterMark, no passThrough', testHighWaterMark, false, false, false);
+test('Stream respects highWaterMark, line-wise passThrough', testHighWaterMark, true, false, false);
+test('Stream respects highWaterMark, binary passThrough', testHighWaterMark, true, true, false);
+test('Stream respects highWaterMark, objectMode as input but not output', testHighWaterMark, false, false, true);
 
-const typeofGenerator = async function * (lines) {
-	for await (const line of lines) {
-		yield Object.prototype.toString.call(line);
-	}
-};
+const getTypeofGenerator = objectMode => ({
+	async * transform(lines) {
+		for await (const line of lines) {
+			yield Object.prototype.toString.call(line);
+		}
+	},
+	objectMode,
+});
 
-const testGeneratorFirstEncoding = async (t, input, encoding) => {
-	const childProcess = execa('stdin.js', {stdin: typeofGenerator, encoding});
+// eslint-disable-next-line max-params
+const testGeneratorFirstEncoding = async (t, input, encoding, output, objectMode) => {
+	const childProcess = execa('stdin.js', {stdin: getTypeofGenerator(objectMode), encoding});
 	childProcess.stdin.end(input);
 	const {stdout} = await childProcess;
-	const output = Buffer.from(stdout, encoding).toString();
-	t.is(output, encoding === 'buffer' ? '[object Uint8Array]' : '[object String]');
+	const result = Buffer.from(stdout, encoding).toString();
+	t.is(result, output);
 };
 
-test('First generator argument is string with default encoding, with string writes', testGeneratorFirstEncoding, foobarString, 'utf8');
-test('First generator argument is string with default encoding, with Buffer writes', testGeneratorFirstEncoding, foobarBuffer, 'utf8');
-test('First generator argument is string with default encoding, with Uint8Array writes', testGeneratorFirstEncoding, foobarUint8Array, 'utf8');
-test('First generator argument is Uint8Array with encoding "buffer", with string writes', testGeneratorFirstEncoding, foobarString, 'buffer');
-test('First generator argument is Uint8Array with encoding "buffer", with Buffer writes', testGeneratorFirstEncoding, foobarBuffer, 'buffer');
-test('First generator argument is Uint8Array with encoding "buffer", with Uint8Array writes', testGeneratorFirstEncoding, foobarUint8Array, 'buffer');
-test('First generator argument is Uint8Array with encoding "hex", with string writes', testGeneratorFirstEncoding, foobarString, 'hex');
-test('First generator argument is Uint8Array with encoding "hex", with Buffer writes', testGeneratorFirstEncoding, foobarBuffer, 'hex');
-test('First generator argument is Uint8Array with encoding "hex", with Uint8Array writes', testGeneratorFirstEncoding, foobarUint8Array, 'hex');
+test('First generator argument is string with default encoding, with string writes', testGeneratorFirstEncoding, foobarString, 'utf8', '[object String]', false);
+test('First generator argument is string with default encoding, with Buffer writes', testGeneratorFirstEncoding, foobarBuffer, 'utf8', '[object String]', false);
+test('First generator argument is string with default encoding, with Uint8Array writes', testGeneratorFirstEncoding, foobarUint8Array, 'utf8', '[object String]', false);
+test('First generator argument is Uint8Array with encoding "buffer", with string writes', testGeneratorFirstEncoding, foobarString, 'buffer', '[object Uint8Array]', false);
+test('First generator argument is Uint8Array with encoding "buffer", with Buffer writes', testGeneratorFirstEncoding, foobarBuffer, 'buffer', '[object Uint8Array]', false);
+test('First generator argument is Uint8Array with encoding "buffer", with Uint8Array writes', testGeneratorFirstEncoding, foobarUint8Array, 'buffer', '[object Uint8Array]', false);
+test('First generator argument is Uint8Array with encoding "hex", with string writes', testGeneratorFirstEncoding, foobarString, 'hex', '[object String]', false);
+test('First generator argument is Uint8Array with encoding "hex", with Buffer writes', testGeneratorFirstEncoding, foobarBuffer, 'hex', '[object String]', false);
+test('First generator argument is Uint8Array with encoding "hex", with Uint8Array writes', testGeneratorFirstEncoding, foobarUint8Array, 'hex', '[object String]', false);
+test('First generator argument can be string with objectMode', testGeneratorFirstEncoding, foobarString, 'utf8', '[object String]', true);
+test('First generator argument can be objects with objectMode', testGeneratorFirstEncoding, foobarObject, 'utf8', '[object Object]', true);
 
-const outputGenerator = async function * (input, lines) {
-	// eslint-disable-next-line no-unused-vars
-	for await (const line of lines) {
-		yield input;
-	}
+const testEncodingIgnored = async (t, encoding) => {
+	const input = Buffer.from(foobarString).toString(encoding);
+	const childProcess = execa('stdin.js', {stdin: noopGenerator(true)});
+	childProcess.stdin.end(input, encoding);
+	const {stdout} = await childProcess;
+	t.is(stdout, input);
 };
 
-const testGeneratorNextEncoding = async (t, input, encoding) => {
-	const {stdout} = await execa('noop.js', ['other'], {stdout: [outputGenerator.bind(undefined, input), typeofGenerator], encoding});
-	const output = Buffer.from(stdout, encoding).toString();
-	t.is(output, encoding === 'buffer' ? '[object Uint8Array]' : '[object String]');
+test('Write call encoding "utf8" is ignored with objectMode', testEncodingIgnored, 'utf8');
+test('Write call encoding "utf16le" is ignored with objectMode', testEncodingIgnored, 'utf16le');
+test('Write call encoding "hex" is ignored with objectMode', testEncodingIgnored, 'hex');
+test('Write call encoding "base64" is ignored with objectMode', testEncodingIgnored, 'base64');
+
+// eslint-disable-next-line max-params
+const testGeneratorNextEncoding = async (t, input, encoding, firstObjectMode, secondObjectMode, expectedType) => {
+	const {stdout} = await execa('noop.js', ['other'], {
+		stdout: [
+			getOutputGenerator(input, firstObjectMode),
+			getTypeofGenerator(secondObjectMode),
+		],
+		encoding,
+	});
+	const typeofChunk = Array.isArray(stdout) ? stdout[0] : stdout;
+	const output = Buffer.from(typeofChunk, encoding === 'buffer' ? undefined : encoding).toString();
+	t.is(output, `[object ${expectedType}]`);
 };
 
-test('Next generator argument is string with default encoding, with string writes', testGeneratorNextEncoding, foobarString, 'utf8');
-test('Next generator argument is string with default encoding, with Buffer writes', testGeneratorNextEncoding, foobarBuffer, 'utf8');
-test('Next generator argument is string with default encoding, with Uint8Array writes', testGeneratorNextEncoding, foobarUint8Array, 'utf8');
-test('Next generator argument is Uint8Array with encoding "buffer", with string writes', testGeneratorNextEncoding, foobarString, 'buffer');
-test('Next generator argument is Uint8Array with encoding "buffer", with Buffer writes', testGeneratorNextEncoding, foobarBuffer, 'buffer');
-test('Next generator argument is Uint8Array with encoding "buffer", with Uint8Array writes', testGeneratorNextEncoding, foobarUint8Array, 'buffer');
-test('Next generator argument is Uint8Array with encoding "hex", with string writes', testGeneratorNextEncoding, foobarString, 'hex');
-test('Next generator argument is Uint8Array with encoding "hex", with Buffer writes', testGeneratorNextEncoding, foobarBuffer, 'hex');
-test('Next generator argument is Uint8Array with encoding "hex", with Uint8Array writes', testGeneratorNextEncoding, foobarUint8Array, 'hex');
+test('Next generator argument is string with default encoding, with string writes', testGeneratorNextEncoding, foobarString, 'utf8', false, false, 'String');
+test('Next generator argument is string with default encoding, with string writes, objectMode first', testGeneratorNextEncoding, foobarString, 'utf8', true, false, 'String');
+test('Next generator argument is string with default encoding, with string writes, objectMode both', testGeneratorNextEncoding, foobarString, 'utf8', true, true, 'String');
+test('Next generator argument is string with default encoding, with Buffer writes', testGeneratorNextEncoding, foobarBuffer, 'utf8', false, false, 'String');
+test('Next generator argument is string with default encoding, with Buffer writes, objectMode first', testGeneratorNextEncoding, foobarBuffer, 'utf8', true, false, 'String');
+test('Next generator argument is string with default encoding, with Buffer writes, objectMode both', testGeneratorNextEncoding, foobarBuffer, 'utf8', true, true, 'String');
+test('Next generator argument is string with default encoding, with Uint8Array writes', testGeneratorNextEncoding, foobarUint8Array, 'utf8', false, false, 'String');
+test('Next generator argument is string with default encoding, with Uint8Array writes, objectMode first', testGeneratorNextEncoding, foobarUint8Array, 'utf8', true, false, 'String');
+test('Next generator argument is string with default encoding, with Uint8Array writes, objectMode both', testGeneratorNextEncoding, foobarUint8Array, 'utf8', true, true, 'String');
+test('Next generator argument is Uint8Array with encoding "buffer", with string writes', testGeneratorNextEncoding, foobarString, 'buffer', false, false, 'Uint8Array');
+test('Next generator argument is Uint8Array with encoding "buffer", with string writes, objectMode first', testGeneratorNextEncoding, foobarString, 'buffer', true, false, 'Uint8Array');
+test('Next generator argument is Uint8Array with encoding "buffer", with string writes, objectMode both', testGeneratorNextEncoding, foobarString, 'buffer', true, true, 'Uint8Array');
+test('Next generator argument is Uint8Array with encoding "buffer", with Buffer writes', testGeneratorNextEncoding, foobarBuffer, 'buffer', false, false, 'Uint8Array');
+test('Next generator argument is Uint8Array with encoding "buffer", with Buffer writes, objectMode first', testGeneratorNextEncoding, foobarBuffer, 'buffer', true, false, 'Uint8Array');
+test('Next generator argument is Uint8Array with encoding "buffer", with Buffer writes, objectMode both', testGeneratorNextEncoding, foobarBuffer, 'buffer', true, true, 'Uint8Array');
+test('Next generator argument is Uint8Array with encoding "buffer", with Uint8Array writes', testGeneratorNextEncoding, foobarUint8Array, 'buffer', false, false, 'Uint8Array');
+test('Next generator argument is Uint8Array with encoding "buffer", with Uint8Array writes, objectMode first', testGeneratorNextEncoding, foobarUint8Array, 'buffer', true, false, 'Uint8Array');
+test('Next generator argument is Uint8Array with encoding "buffer", with Uint8Array writes, objectMode both', testGeneratorNextEncoding, foobarUint8Array, 'buffer', true, true, 'Uint8Array');
+test('Next generator argument is Uint8Array with encoding "hex", with string writes', testGeneratorNextEncoding, foobarString, 'hex', false, false, 'String');
+test('Next generator argument is Uint8Array with encoding "hex", with Buffer writes', testGeneratorNextEncoding, foobarBuffer, 'hex', false, false, 'String');
+test('Next generator argument is Uint8Array with encoding "hex", with Uint8Array writes', testGeneratorNextEncoding, foobarUint8Array, 'hex', false, false, 'String');
+test('Next generator argument is object with default encoding, with object writes, objectMode first', testGeneratorNextEncoding, foobarObject, 'utf8', true, false, 'Object');
+test('Next generator argument is object with default encoding, with object writes, objectMode both', testGeneratorNextEncoding, foobarObject, 'utf8', true, true, 'Object');
 
-const testGeneratorReturnType = async (t, input, encoding) => {
-	const {stdout} = await execa('noop.js', ['other'], {stdout: outputGenerator.bind(undefined, input), encoding});
-	const output = Buffer.from(stdout, encoding).toString();
+const testFirstOutputGeneratorArgument = async (t, index) => {
+	const {stdio} = await execa('noop-fd.js', [`${index}`], getStdio(index, getTypeofGenerator(true)));
+	t.deepEqual(stdio[index], ['[object String]']);
+};
+
+test('The first generator with result.stdout does not receive an object argument even in objectMode', testFirstOutputGeneratorArgument, 1);
+test('The first generator with result.stderr does not receive an object argument even in objectMode', testFirstOutputGeneratorArgument, 2);
+test('The first generator with result.stdio[*] does not receive an object argument even in objectMode', testFirstOutputGeneratorArgument, 3);
+
+// eslint-disable-next-line max-params
+const testGeneratorReturnType = async (t, input, encoding, reject, objectMode) => {
+	const fixtureName = reject ? 'noop-fd.js' : 'noop-fail.js';
+	const {stdout} = await execa(fixtureName, ['1', 'other'], {
+		stdout: getOutputGenerator(input, objectMode),
+		encoding,
+		reject,
+	});
+	const typeofChunk = Array.isArray(stdout) ? stdout[0] : stdout;
+	const output = Buffer.from(typeofChunk, encoding === 'buffer' ? undefined : encoding).toString();
 	t.is(output, foobarString);
 };
 
-test('Generator can return string with default encoding', testGeneratorReturnType, foobarString, 'utf8');
-test('Generator can return Uint8Array with default encoding', testGeneratorReturnType, foobarUint8Array, 'utf8');
-test('Generator can return string with encoding "buffer"', testGeneratorReturnType, foobarString, 'buffer');
-test('Generator can return Uint8Array with encoding "buffer"', testGeneratorReturnType, foobarUint8Array, 'buffer');
-test('Generator can return string with encoding "hex"', testGeneratorReturnType, foobarString, 'hex');
-test('Generator can return Uint8Array with encoding "hex"', testGeneratorReturnType, foobarUint8Array, 'hex');
+test('Generator can return string with default encoding', testGeneratorReturnType, foobarString, 'utf8', true, false);
+test('Generator can return Uint8Array with default encoding', testGeneratorReturnType, foobarUint8Array, 'utf8', true, false);
+test('Generator can return string with encoding "buffer"', testGeneratorReturnType, foobarString, 'buffer', true, false);
+test('Generator can return Uint8Array with encoding "buffer"', testGeneratorReturnType, foobarUint8Array, 'buffer', true, false);
+test('Generator can return string with encoding "hex"', testGeneratorReturnType, foobarString, 'hex', true, false);
+test('Generator can return Uint8Array with encoding "hex"', testGeneratorReturnType, foobarUint8Array, 'hex', true, false);
+test('Generator can return string with default encoding, failure', testGeneratorReturnType, foobarString, 'utf8', false, false);
+test('Generator can return Uint8Array with default encoding, failure', testGeneratorReturnType, foobarUint8Array, 'utf8', false, false);
+test('Generator can return string with encoding "buffer", failure', testGeneratorReturnType, foobarString, 'buffer', false, false);
+test('Generator can return Uint8Array with encoding "buffer", failure', testGeneratorReturnType, foobarUint8Array, 'buffer', false, false);
+test('Generator can return string with encoding "hex", failure', testGeneratorReturnType, foobarString, 'hex', false, false);
+test('Generator can return Uint8Array with encoding "hex", failure', testGeneratorReturnType, foobarUint8Array, 'hex', false, false);
+test('Generator can return string with default encoding, objectMode', testGeneratorReturnType, foobarString, 'utf8', true, true);
+test('Generator can return Uint8Array with default encoding, objectMode', testGeneratorReturnType, foobarUint8Array, 'utf8', true, true);
+test('Generator can return string with encoding "buffer", objectMode', testGeneratorReturnType, foobarString, 'buffer', true, true);
+test('Generator can return Uint8Array with encoding "buffer", objectMode', testGeneratorReturnType, foobarUint8Array, 'buffer', true, true);
+test('Generator can return string with encoding "hex", objectMode', testGeneratorReturnType, foobarString, 'hex', true, true);
+test('Generator can return Uint8Array with encoding "hex", objectMode', testGeneratorReturnType, foobarUint8Array, 'hex', true, true);
+test('Generator can return string with default encoding, objectMode, failure', testGeneratorReturnType, foobarString, 'utf8', false, true);
+test('Generator can return Uint8Array with default encoding, objectMode, failure', testGeneratorReturnType, foobarUint8Array, 'utf8', false, true);
+test('Generator can return string with encoding "buffer", objectMode, failure', testGeneratorReturnType, foobarString, 'buffer', false, true);
+test('Generator can return Uint8Array with encoding "buffer", objectMode, failure', testGeneratorReturnType, foobarUint8Array, 'buffer', false, true);
+test('Generator can return string with encoding "hex", objectMode, failure', testGeneratorReturnType, foobarString, 'hex', false, true);
+test('Generator can return Uint8Array with encoding "hex", objectMode, failure', testGeneratorReturnType, foobarUint8Array, 'hex', false, true);
 
 const multibyteChar = '\u{1F984}';
 const multibyteString = `${multibyteChar}${multibyteChar}`;
-const multibyteUint8Array = new TextEncoder().encode(multibyteString);
+const multibyteUint8Array = textEncoder.encode(multibyteString);
 const breakingLength = multibyteUint8Array.length * 0.75;
 const brokenSymbol = '\uFFFD';
 
-const noopGenerator = async function * (lines) {
-	yield * lines;
-};
-
-test('Generator handles multibyte characters with Uint8Array', async t => {
-	const childProcess = execa('stdin.js', {stdin: noopGenerator});
+const testMultibyte = async (t, objectMode) => {
+	const childProcess = execa('stdin.js', {stdin: noopGenerator(objectMode)});
 	childProcess.stdin.write(multibyteUint8Array.slice(0, breakingLength));
 	await setTimeout(0);
 	childProcess.stdin.end(multibyteUint8Array.slice(breakingLength));
 	const {stdout} = await childProcess;
 	t.is(stdout, multibyteString);
-});
+};
 
-test('Generator handles partial multibyte characters with Uint8Array', async t => {
-	const {stdout} = await execa('stdin.js', {stdin: [multibyteUint8Array.slice(0, breakingLength), noopGenerator]});
+test('Generator handles multibyte characters with Uint8Array', testMultibyte, false);
+test('Generator handles multibyte characters with Uint8Array, objectMode', testMultibyte, true);
+
+const testMultibytePartial = async (t, objectMode) => {
+	const {stdout} = await execa('stdin.js', {stdin: [multibyteUint8Array.slice(0, breakingLength), noopGenerator(objectMode)]});
 	t.is(stdout, `${multibyteChar}${brokenSymbol}`);
-});
+};
+
+test('Generator handles partial multibyte characters with Uint8Array', testMultibytePartial, false);
+test('Generator handles partial multibyte characters with Uint8Array, objectMode', testMultibytePartial, true);
 
 // eslint-disable-next-line require-yield
 const noYieldGenerator = async function * (lines) {
@@ -265,10 +473,13 @@ const noYieldGenerator = async function * (lines) {
 	for await (const line of lines) {}
 };
 
-test('Generator can filter by not calling yield', async t => {
-	const {stdout} = await execa('noop.js', {stdout: noYieldGenerator});
-	t.is(stdout, '');
-});
+const testNoYield = async (t, objectMode, output) => {
+	const {stdout} = await execa('noop.js', {stdout: {transform: noYieldGenerator, objectMode}});
+	t.deepEqual(stdout, output);
+};
+
+test('Generator can filter by not calling yield', testNoYield, false, '');
+test('Generator can filter by not calling yield, objectMode', testNoYield, true, []);
 
 const prefix = '> ';
 const suffix = ' <';
@@ -377,10 +588,18 @@ const maxBuffer = 10;
 
 test('Generators take "maxBuffer" into account', async t => {
 	const bigString = '.'.repeat(maxBuffer);
-	const {stdout} = await execa('noop.js', {maxBuffer, stdout: outputGenerator.bind(undefined, bigString)});
+	const {stdout} = await execa('noop.js', {maxBuffer, stdout: getOutputGenerator(bigString, false)});
 	t.is(stdout, bigString);
 
-	await t.throwsAsync(execa('noop.js', {maxBuffer, stdout: outputGenerator.bind(undefined, `${bigString}.`)}));
+	await t.throwsAsync(execa('noop.js', {maxBuffer, stdout: getOutputGenerator(`${bigString}.`, false)}));
+});
+
+test('Generators take "maxBuffer" into account, objectMode', async t => {
+	const bigArray = Array.from({length: maxBuffer});
+	const {stdout} = await execa('noop.js', {maxBuffer, stdout: getOutputsGenerator(bigArray, true)});
+	t.is(stdout.length, maxBuffer);
+
+	await t.throwsAsync(execa('noop.js', {maxBuffer, stdout: getOutputsGenerator([...bigArray, ''], true)}));
 });
 
 const timeoutGenerator = async function * (timeout, lines) {

--- a/test/stdio/input.js
+++ b/test/stdio/input.js
@@ -1,18 +1,11 @@
-import {Buffer} from 'node:buffer';
 import {Writable} from 'node:stream';
 import test from 'ava';
 import {execa, execaSync} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {runExeca, runExecaSync, runScript, runScriptSync} from '../helpers/run.js';
+import {foobarUint8Array, foobarBuffer, foobarArrayBuffer, foobarUint16Array, foobarDataView} from '../helpers/input.js';
 
 setFixtureDir();
-
-const textEncoder = new TextEncoder();
-const binaryFoobar = textEncoder.encode('foobar');
-const bufferFoobar = Buffer.from(binaryFoobar);
-const arrayBufferFoobar = binaryFoobar.buffer;
-const dataViewFoobar = new DataView(arrayBufferFoobar);
-const uint16ArrayFoobar = new Uint16Array(arrayBufferFoobar);
 
 const testInput = async (t, input, execaMethod) => {
 	const {stdout} = await execaMethod('stdin.js', {input});
@@ -20,9 +13,9 @@ const testInput = async (t, input, execaMethod) => {
 };
 
 test('input option can be a String', testInput, 'foobar', runExeca);
-test('input option can be a Uint8Array', testInput, binaryFoobar, runExeca);
+test('input option can be a Uint8Array', testInput, foobarUint8Array, runExeca);
 test('input option can be a String - sync', testInput, 'foobar', runExecaSync);
-test('input option can be a Uint8Array - sync', testInput, binaryFoobar, runExecaSync);
+test('input option can be a Uint8Array - sync', testInput, foobarUint8Array, runExecaSync);
 test('input option can be used with $', testInput, 'foobar', runScript);
 test('input option can be used with $.sync', testInput, 'foobar', runScriptSync);
 
@@ -32,18 +25,18 @@ const testInvalidInput = async (t, input, execaMethod) => {
 	}, {message: /a string, a Uint8Array/});
 };
 
-test('input option cannot be a Buffer', testInvalidInput, bufferFoobar, execa);
-test('input option cannot be an ArrayBuffer', testInvalidInput, arrayBufferFoobar, execa);
-test('input option cannot be a DataView', testInvalidInput, dataViewFoobar, execa);
-test('input option cannot be a Uint16Array', testInvalidInput, uint16ArrayFoobar, execa);
+test('input option cannot be a Buffer', testInvalidInput, foobarBuffer, execa);
+test('input option cannot be an ArrayBuffer', testInvalidInput, foobarArrayBuffer, execa);
+test('input option cannot be a DataView', testInvalidInput, foobarDataView, execa);
+test('input option cannot be a Uint16Array', testInvalidInput, foobarUint16Array, execa);
 test('input option cannot be 0', testInvalidInput, 0, execa);
 test('input option cannot be false', testInvalidInput, false, execa);
 test('input option cannot be null', testInvalidInput, null, execa);
 test('input option cannot be a non-Readable stream', testInvalidInput, new Writable(), execa);
-test('input option cannot be a Buffer - sync', testInvalidInput, bufferFoobar, execaSync);
-test('input option cannot be an ArrayBuffer - sync', testInvalidInput, arrayBufferFoobar, execaSync);
-test('input option cannot be a DataView - sync', testInvalidInput, dataViewFoobar, execaSync);
-test('input option cannot be a Uint16Array - sync', testInvalidInput, uint16ArrayFoobar, execaSync);
+test('input option cannot be a Buffer - sync', testInvalidInput, foobarBuffer, execaSync);
+test('input option cannot be an ArrayBuffer - sync', testInvalidInput, foobarArrayBuffer, execaSync);
+test('input option cannot be a DataView - sync', testInvalidInput, foobarDataView, execaSync);
+test('input option cannot be a Uint16Array - sync', testInvalidInput, foobarUint16Array, execaSync);
 test('input option cannot be 0 - sync', testInvalidInput, 0, execaSync);
 test('input option cannot be false - sync', testInvalidInput, false, execaSync);
 test('input option cannot be null - sync', testInvalidInput, null, execaSync);

--- a/test/stdio/iterable.js
+++ b/test/stdio/iterable.js
@@ -1,9 +1,31 @@
 import {once} from 'node:events';
+import {setTimeout} from 'node:timers/promises';
 import test from 'ava';
 import {execa, execaSync} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {getStdio} from '../helpers/stdio.js';
-import {stringGenerator, binaryGenerator, asyncGenerator, throwingGenerator, infiniteGenerator} from '../helpers/generator.js';
+import {foobarObject, foobarObjectString} from '../helpers/input.js';
+import {serializeGenerator} from '../helpers/generator.js';
+
+const stringArray = ['foo', 'bar'];
+
+const stringGenerator = function * () {
+	yield * stringArray;
+};
+
+const textEncoder = new TextEncoder();
+const binaryFoo = textEncoder.encode('foo');
+const binaryBar = textEncoder.encode('bar');
+const binaryArray = [binaryFoo, binaryBar];
+
+const binaryGenerator = function * () {
+	yield * binaryArray;
+};
+
+const asyncGenerator = async function * () {
+	await setTimeout(0);
+	yield * stringArray;
+};
 
 setFixtureDir();
 
@@ -12,6 +34,10 @@ const testIterable = async (t, stdioOption, index) => {
 	t.is(stdout, 'foobar');
 };
 
+test('stdin option can be an array of strings', testIterable, [stringArray], 0);
+test('stdio[*] option can be an array of strings', testIterable, [stringArray], 3);
+test('stdin option can be an array of Uint8Arrays', testIterable, [binaryArray], 0);
+test('stdio[*] option can be an array of Uint8Arrays', testIterable, [binaryArray], 3);
 test('stdin option can be an iterable of strings', testIterable, stringGenerator(), 0);
 test('stdio[*] option can be an iterable of strings', testIterable, stringGenerator(), 3);
 test('stdin option can be an iterable of Uint8Arrays', testIterable, binaryGenerator(), 0);
@@ -19,16 +45,43 @@ test('stdio[*] option can be an iterable of Uint8Arrays', testIterable, binaryGe
 test('stdin option can be an async iterable', testIterable, asyncGenerator(), 0);
 test('stdio[*] option can be an async iterable', testIterable, asyncGenerator(), 3);
 
+const foobarObjectGenerator = function * () {
+	yield foobarObject;
+};
+
+const foobarAsyncObjectGenerator = function * () {
+	yield foobarObject;
+};
+
+const testObjectIterable = async (t, stdioOption, index) => {
+	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [stdioOption, serializeGenerator]));
+	t.is(stdout, foobarObjectString);
+};
+
+test('stdin option can be an array of objects', testObjectIterable, [foobarObject], 0);
+test('stdio[*] option can be an array of objects', testObjectIterable, [foobarObject], 3);
+test('stdin option can be an iterable of objects', testObjectIterable, foobarObjectGenerator(), 0);
+test('stdio[*] option can be an iterable of objects', testObjectIterable, foobarObjectGenerator(), 3);
+test('stdin option can be an async iterable of objects', testObjectIterable, foobarAsyncObjectGenerator(), 0);
+test('stdio[*] option can be an async iterable of objects', testObjectIterable, foobarAsyncObjectGenerator(), 3);
+
 const testIterableSync = (t, stdioOption, index) => {
 	t.throws(() => {
 		execaSync('empty.js', getStdio(index, stdioOption));
 	}, {message: /an iterable in sync mode/});
 };
 
+test('stdin option cannot be an array of strings - sync', testIterableSync, [stringArray], 0);
+test('stdio[*] option cannot be an array of strings - sync', testIterableSync, [stringArray], 3);
 test('stdin option cannot be a sync iterable - sync', testIterableSync, stringGenerator(), 0);
 test('stdio[*] option cannot be a sync iterable - sync', testIterableSync, stringGenerator(), 3);
 test('stdin option cannot be an async iterable - sync', testIterableSync, asyncGenerator(), 0);
 test('stdio[*] option cannot be an async iterable - sync', testIterableSync, asyncGenerator(), 3);
+
+// eslint-disable-next-line require-yield
+const throwingGenerator = function * () {
+	throw new Error('generator error');
+};
 
 const testIterableError = async (t, index) => {
 	const {originalMessage} = await t.throwsAsync(execa('stdin-fd.js', [`${index}`], getStdio(index, throwingGenerator())));
@@ -38,16 +91,31 @@ const testIterableError = async (t, index) => {
 test('stdin option handles errors in iterables', testIterableError, 0);
 test('stdio[*] option handles errors in iterables', testIterableError, 3);
 
-const testNoIterableOutput = (t, index, execaMethod) => {
+const testNoIterableOutput = (t, stdioOption, index, execaMethod) => {
 	t.throws(() => {
-		execaMethod('empty.js', getStdio(index, stringGenerator()));
+		execaMethod('empty.js', getStdio(index, stdioOption));
 	}, {message: /cannot be an iterable/});
 };
 
-test('stdout option cannot be an iterable', testNoIterableOutput, 1, execa);
-test('stderr option cannot be an iterable', testNoIterableOutput, 2, execa);
-test('stdout option cannot be an iterable - sync', testNoIterableOutput, 1, execaSync);
-test('stderr option cannot be an iterable - sync', testNoIterableOutput, 2, execaSync);
+test('stdout option cannot be an array of strings', testNoIterableOutput, [stringArray], 1, execa);
+test('stderr option cannot be an array of strings', testNoIterableOutput, [stringArray], 2, execa);
+test('stdout option cannot be an array of strings - sync', testNoIterableOutput, [stringArray], 1, execaSync);
+test('stderr option cannot be an array of strings - sync', testNoIterableOutput, [stringArray], 2, execaSync);
+test('stdout option cannot be an iterable', testNoIterableOutput, stringGenerator(), 1, execa);
+test('stderr option cannot be an iterable', testNoIterableOutput, stringGenerator(), 2, execa);
+test('stdout option cannot be an iterable - sync', testNoIterableOutput, stringGenerator(), 1, execaSync);
+test('stderr option cannot be an iterable - sync', testNoIterableOutput, stringGenerator(), 2, execaSync);
+
+const infiniteGenerator = () => {
+	const controller = new AbortController();
+
+	const generator = async function * () {
+		yield 'foo';
+		await setTimeout(1e7, undefined, {signal: controller.signal});
+	};
+
+	return {iterable: generator(), abort: controller.abort.bind(controller)};
+};
 
 test('stdin option can be an infinite iterable', async t => {
 	const {iterable, abort} = infiniteGenerator();

--- a/test/stdio/lines.js
+++ b/test/stdio/lines.js
@@ -33,62 +33,99 @@ const textDecoder = new TextDecoder();
 const stringsToUint8Arrays = (strings, isUint8Array) => isUint8Array
 	? strings.map(string => textEncoder.encode(string))
 	: strings;
-const uint8ArrayToString = (result, isUint8Array) => isUint8Array ? textDecoder.decode(result) : result;
+
+const serializeResult = (result, isUint8Array, objectMode) => objectMode
+	? result.map(resultItem => serializeResultItem(resultItem, isUint8Array)).join('')
+	: serializeResultItem(result, isUint8Array);
+
+const serializeResultItem = (resultItem, isUint8Array) => isUint8Array
+	? textDecoder.decode(resultItem)
+	: resultItem;
 
 // eslint-disable-next-line max-params
-const testLines = async (t, index, input, expectedLines, isUint8Array) => {
+const testLines = async (t, index, input, expectedLines, isUint8Array, objectMode) => {
 	const lines = [];
 	const {stdio} = await execa('noop-fd.js', [`${index}`], {
 		...getStdio(index, [
-			inputGenerator.bind(undefined, stringsToUint8Arrays(input, isUint8Array)),
-			resultGenerator.bind(undefined, lines),
+			{transform: inputGenerator.bind(undefined, stringsToUint8Arrays(input, isUint8Array)), objectMode},
+			{transform: resultGenerator.bind(undefined, lines), objectMode},
 		]),
 		encoding: isUint8Array ? 'buffer' : 'utf8',
 		stripFinalNewline: false,
 	});
-	t.is(uint8ArrayToString(stdio[index], isUint8Array), input.join(''));
+	t.is(input.join(''), serializeResult(stdio[index], isUint8Array, objectMode));
 	t.deepEqual(lines, stringsToUint8Arrays(expectedLines, isUint8Array));
 };
 
-test('Split string stdout - n newlines, 1 chunk', testLines, 1, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false);
-test('Split string stderr - n newlines, 1 chunk', testLines, 2, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false);
-test('Split string stdio[*] - n newlines, 1 chunk', testLines, 3, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false);
-test('Split string stdout - no newline, n chunks', testLines, 1, ['aaa', 'bbb', 'ccc'], ['aaabbbccc'], false);
-test('Split string stdout - 0 newlines, 1 chunk', testLines, 1, ['aaa'], ['aaa'], false);
-test('Split string stdout - Windows newlines', testLines, 1, ['aaa\r\nbbb\r\nccc'], ['aaa\r\n', 'bbb\r\n', 'ccc'], false);
-test('Split string stdout - chunk ends with newline', testLines, 1, ['aaa\nbbb\nccc\n'], ['aaa\n', 'bbb\n', 'ccc\n'], false);
-test('Split string stdout - single newline', testLines, 1, ['\n'], ['\n'], false);
-test('Split string stdout - only newlines', testLines, 1, ['\n\n\n'], ['\n', '\n', '\n'], false);
-test('Split string stdout - only Windows newlines', testLines, 1, ['\r\n\r\n\r\n'], ['\r\n', '\r\n', '\r\n'], false);
-test('Split string stdout - line split over multiple chunks', testLines, 1, ['aaa\nb', 'b', 'b\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false);
-test('Split string stdout - 0 newlines, big line', testLines, 1, [bigLine], [bigLine], false);
-test('Split string stdout - 0 newlines, many chunks', testLines, 1, manyChunks, [manyChunks.join('')], false);
-test('Split Uint8Array stdout - n newlines, 1 chunk', testLines, 1, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true);
-test('Split Uint8Array stderr - n newlines, 1 chunk', testLines, 2, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true);
-test('Split Uint8Array stdio[*] - n newlines, 1 chunk', testLines, 3, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true);
-test('Split Uint8Array stdout - no newline, n chunks', testLines, 1, ['aaa', 'bbb', 'ccc'], ['aaabbbccc'], true);
-test('Split Uint8Array stdout - 0 newlines, 1 chunk', testLines, 1, ['aaa'], ['aaa'], true);
-test('Split Uint8Array stdout - Windows newlines', testLines, 1, ['aaa\r\nbbb\r\nccc'], ['aaa\r\n', 'bbb\r\n', 'ccc'], true);
-test('Split Uint8Array stdout - chunk ends with newline', testLines, 1, ['aaa\nbbb\nccc\n'], ['aaa\n', 'bbb\n', 'ccc\n'], true);
-test('Split Uint8Array stdout - single newline', testLines, 1, ['\n'], ['\n'], true);
-test('Split Uint8Array stdout - only newlines', testLines, 1, ['\n\n\n'], ['\n', '\n', '\n'], true);
-test('Split Uint8Array stdout - only Windows newlines', testLines, 1, ['\r\n\r\n\r\n'], ['\r\n', '\r\n', '\r\n'], true);
-test('Split Uint8Array stdout - line split over multiple chunks', testLines, 1, ['aaa\nb', 'b', 'b\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true);
-test('Split Uint8Array stdout - 0 newlines, big line', testLines, 1, [bigLine], [bigLine], true);
-test('Split Uint8Array stdout - 0 newlines, many chunks', testLines, 1, manyChunks, [manyChunks.join('')], true);
+test('Split string stdout - n newlines, 1 chunk', testLines, 1, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false, false);
+test('Split string stderr - n newlines, 1 chunk', testLines, 2, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false, false);
+test('Split string stdio[*] - n newlines, 1 chunk', testLines, 3, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false, false);
+test('Split string stdout - no newline, n chunks', testLines, 1, ['aaa', 'bbb', 'ccc'], ['aaabbbccc'], false, false);
+test('Split string stdout - 0 newlines, 1 chunk', testLines, 1, ['aaa'], ['aaa'], false, false);
+test('Split string stdout - Windows newlines', testLines, 1, ['aaa\r\nbbb\r\nccc'], ['aaa\r\n', 'bbb\r\n', 'ccc'], false, false);
+test('Split string stdout - chunk ends with newline', testLines, 1, ['aaa\nbbb\nccc\n'], ['aaa\n', 'bbb\n', 'ccc\n'], false, false);
+test('Split string stdout - single newline', testLines, 1, ['\n'], ['\n'], false, false);
+test('Split string stdout - only newlines', testLines, 1, ['\n\n\n'], ['\n', '\n', '\n'], false, false);
+test('Split string stdout - only Windows newlines', testLines, 1, ['\r\n\r\n\r\n'], ['\r\n', '\r\n', '\r\n'], false, false);
+test('Split string stdout - line split over multiple chunks', testLines, 1, ['aaa\nb', 'b', 'b\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false, false);
+test('Split string stdout - 0 newlines, big line', testLines, 1, [bigLine], [bigLine], false, false);
+test('Split string stdout - 0 newlines, many chunks', testLines, 1, manyChunks, [manyChunks.join('')], false, false);
+test('Split Uint8Array stdout - n newlines, 1 chunk', testLines, 1, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true, false);
+test('Split Uint8Array stderr - n newlines, 1 chunk', testLines, 2, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true, false);
+test('Split Uint8Array stdio[*] - n newlines, 1 chunk', testLines, 3, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true, false);
+test('Split Uint8Array stdout - no newline, n chunks', testLines, 1, ['aaa', 'bbb', 'ccc'], ['aaabbbccc'], true, false);
+test('Split Uint8Array stdout - 0 newlines, 1 chunk', testLines, 1, ['aaa'], ['aaa'], true, false);
+test('Split Uint8Array stdout - Windows newlines', testLines, 1, ['aaa\r\nbbb\r\nccc'], ['aaa\r\n', 'bbb\r\n', 'ccc'], true, false);
+test('Split Uint8Array stdout - chunk ends with newline', testLines, 1, ['aaa\nbbb\nccc\n'], ['aaa\n', 'bbb\n', 'ccc\n'], true, false);
+test('Split Uint8Array stdout - single newline', testLines, 1, ['\n'], ['\n'], true, false);
+test('Split Uint8Array stdout - only newlines', testLines, 1, ['\n\n\n'], ['\n', '\n', '\n'], true, false);
+test('Split Uint8Array stdout - only Windows newlines', testLines, 1, ['\r\n\r\n\r\n'], ['\r\n', '\r\n', '\r\n'], true, false);
+test('Split Uint8Array stdout - line split over multiple chunks', testLines, 1, ['aaa\nb', 'b', 'b\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true, false);
+test('Split Uint8Array stdout - 0 newlines, big line', testLines, 1, [bigLine], [bigLine], true, false);
+test('Split Uint8Array stdout - 0 newlines, many chunks', testLines, 1, manyChunks, [manyChunks.join('')], true, false);
+test('Split string stdout - n newlines, 1 chunk, objectMode', testLines, 1, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false, true);
+test('Split string stderr - n newlines, 1 chunk, objectMode', testLines, 2, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false, true);
+test('Split string stdio[*] - n newlines, 1 chunk, objectMode', testLines, 3, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false, true);
+test('Split string stdout - no newline, n chunks, objectMode', testLines, 1, ['aaa', 'bbb', 'ccc'], ['aaabbbccc'], false, true);
+test('Split string stdout - 0 newlines, 1 chunk, objectMode', testLines, 1, ['aaa'], ['aaa'], false, true);
+test('Split string stdout - Windows newlines, objectMode', testLines, 1, ['aaa\r\nbbb\r\nccc'], ['aaa\r\n', 'bbb\r\n', 'ccc'], false, true);
+test('Split string stdout - chunk ends with newline, objectMode', testLines, 1, ['aaa\nbbb\nccc\n'], ['aaa\n', 'bbb\n', 'ccc\n'], false, true);
+test('Split string stdout - single newline, objectMode', testLines, 1, ['\n'], ['\n'], false, true);
+test('Split string stdout - only newlines, objectMode', testLines, 1, ['\n\n\n'], ['\n', '\n', '\n'], false, true);
+test('Split string stdout - only Windows newlines, objectMode', testLines, 1, ['\r\n\r\n\r\n'], ['\r\n', '\r\n', '\r\n'], false, true);
+test('Split string stdout - line split over multiple chunks, objectMode', testLines, 1, ['aaa\nb', 'b', 'b\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false, true);
+test('Split string stdout - 0 newlines, big line, objectMode', testLines, 1, [bigLine], [bigLine], false, true);
+test('Split string stdout - 0 newlines, many chunks, objectMode', testLines, 1, manyChunks, [manyChunks.join('')], false, true);
+test('Split Uint8Array stdout - n newlines, 1 chunk, objectMode', testLines, 1, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true, true);
+test('Split Uint8Array stderr - n newlines, 1 chunk, objectMode', testLines, 2, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true, true);
+test('Split Uint8Array stdio[*] - n newlines, 1 chunk, objectMode', testLines, 3, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true, true);
+test('Split Uint8Array stdout - no newline, n chunks, objectMode', testLines, 1, ['aaa', 'bbb', 'ccc'], ['aaabbbccc'], true, true);
+test('Split Uint8Array stdout - 0 newlines, 1 chunk, objectMode', testLines, 1, ['aaa'], ['aaa'], true, true);
+test('Split Uint8Array stdout - Windows newlines, objectMode', testLines, 1, ['aaa\r\nbbb\r\nccc'], ['aaa\r\n', 'bbb\r\n', 'ccc'], true, true);
+test('Split Uint8Array stdout - chunk ends with newline, objectMode', testLines, 1, ['aaa\nbbb\nccc\n'], ['aaa\n', 'bbb\n', 'ccc\n'], true, true);
+test('Split Uint8Array stdout - single newline, objectMode', testLines, 1, ['\n'], ['\n'], true, true);
+test('Split Uint8Array stdout - only newlines, objectMode', testLines, 1, ['\n\n\n'], ['\n', '\n', '\n'], true, true);
+test('Split Uint8Array stdout - only Windows newlines, objectMode', testLines, 1, ['\r\n\r\n\r\n'], ['\r\n', '\r\n', '\r\n'], true, true);
+test('Split Uint8Array stdout - line split over multiple chunks, objectMode', testLines, 1, ['aaa\nb', 'b', 'b\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true, true);
+test('Split Uint8Array stdout - 0 newlines, big line, objectMode', testLines, 1, [bigLine], [bigLine], true, true);
+test('Split Uint8Array stdout - 0 newlines, many chunks, objectMode', testLines, 1, manyChunks, [manyChunks.join('')], true, true);
 
-const testBinaryOption = async (t, binary, input, expectedLines) => {
+// eslint-disable-next-line max-params
+const testBinaryOption = async (t, binary, input, expectedLines, objectMode) => {
 	const lines = [];
 	const {stdout} = await execa('noop-fd.js', ['1'], {
 		stdout: [
-			inputGenerator.bind(undefined, input),
-			{transform: resultGenerator.bind(undefined, lines), binary},
+			{transform: inputGenerator.bind(undefined, input), objectMode},
+			{transform: resultGenerator.bind(undefined, lines), objectMode, binary},
 		],
 	});
-	t.is(stdout, input.join(''));
+	t.is(input.join(''), objectMode ? stdout.join('') : stdout);
 	t.deepEqual(lines, expectedLines);
 };
 
-test('Does not split lines when "binary" is true', testBinaryOption, true, ['aaa\nbbb\nccc'], ['aaa\nbbb\nccc']);
-test('Splits lines when "binary" is false', testBinaryOption, false, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc']);
-test('Splits lines when "binary" is undefined', testBinaryOption, undefined, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc']);
+test('Does not split lines when "binary" is true', testBinaryOption, true, ['aaa\nbbb\nccc'], ['aaa\nbbb\nccc'], false);
+test('Splits lines when "binary" is false', testBinaryOption, false, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false);
+test('Splits lines when "binary" is undefined', testBinaryOption, undefined, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], false);
+test('Does not split lines when "binary" is true, objectMode', testBinaryOption, true, ['aaa\nbbb\nccc'], ['aaa\nbbb\nccc'], true);
+test('Splits lines when "binary" is false, objectMode', testBinaryOption, false, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true);
+test('Splits lines when "binary" is undefined, objectMode', testBinaryOption, undefined, ['aaa\nbbb\nccc'], ['aaa\n', 'bbb\n', 'ccc'], true);

--- a/test/stdio/typed-array.js
+++ b/test/stdio/typed-array.js
@@ -2,13 +2,12 @@ import test from 'ava';
 import {execa, execaSync} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {getStdio} from '../helpers/stdio.js';
+import {foobarUint8Array} from '../helpers/input.js';
 
 setFixtureDir();
 
-const uint8ArrayFoobar = new TextEncoder().encode('foobar');
-
 const testUint8Array = async (t, index) => {
-	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, uint8ArrayFoobar));
+	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, foobarUint8Array));
 	t.is(stdout, 'foobar');
 };
 
@@ -19,7 +18,7 @@ test('stdio[*] option can be a Uint8Array - sync', testUint8Array, 3);
 
 const testNoUint8ArrayOutput = (t, index, execaMethod) => {
 	t.throws(() => {
-		execaMethod('empty.js', getStdio(index, uint8ArrayFoobar));
+		execaMethod('empty.js', getStdio(index, foobarUint8Array));
 	}, {message: /cannot be a Uint8Array/});
 };
 


### PR DESCRIPTION
Fixes #21. That's our oldest open issue (almost 8 years old)!
This is also a requirement towards fixing #706.

This allows using any type with transforms by using `{transform, objectMode: true}`. The process' return `stdout`/`stderr` will be an array. Typically, this is an array of objects, but this can be any type, including strings (which is very useful for #706).

```js
const transform = async function * (lines) {
	for await (const line of lines) {
		yield JSON.parse(line)
	}
}

const {stdout} = await execa('./jsonlines-output.js', {stdout: {transform, objectMode: true}});
for (const data of stdout) {
	console.log(stdout) // {...}
}
```

This also works for `stdin`. Users can pass objects to `stdin` with `childProcess.stdin.write()`. They can also directly pass an iterable of objects to the `stdin` option.

```js
const transform = async function * (lines) {
	for await (const line of lines) {
		yield JSON.stringify(line)
	}
}

const input = [{event: 'example'}, {event: 'otherExample'}]
await execa('./jsonlines-input.js', {stdin: [input, {transform, objectMode: true}]});
```

While this is a big PR, most of it are code quality related (tests, types, documentation). The runtime part is actually not as big. 

When it comes to the tests, they mostly repeat existing tests, but using object mode instead. I tried to make sure every edge case was tested.

This PR only has runtime changes for users of transforms with `objectMode: true`. I.e. it has no behavior changes for current users.