### PR TITLE
Fix passing `undefined` options

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,25 +49,8 @@ const handleArguments = (rawFile, rawArgs, rawOptions = {}) => {
 
 	const {command: file, args, options: initialOptions} = crossSpawn._parse(filePath, rawArgs, rawOptions);
 
-	const options = {
-		maxBuffer: DEFAULT_MAX_BUFFER,
-		buffer: true,
-		stripFinalNewline: true,
-		extendEnv: true,
-		preferLocal: false,
-		localDir: initialOptions.cwd || process.cwd(),
-		execPath: process.execPath,
-		encoding: 'utf8',
-		reject: true,
-		cleanup: true,
-		all: false,
-		windowsHide: true,
-		verbose: verboseDefault,
-		killSignal: 'SIGTERM',
-		...initialOptions,
-		shell: normalizeFileUrl(initialOptions.shell),
-	};
-
+	const options = addDefaultOptions(initialOptions);
+	options.shell = normalizeFileUrl(options.shell);
 	options.env = getEnv(options);
 
 	if (process.platform === 'win32' && path.basename(file, '.exe') === 'cmd') {
@@ -79,6 +62,42 @@ const handleArguments = (rawFile, rawArgs, rawOptions = {}) => {
 
 	return {file, args, command, escapedCommand, options};
 };
+
+const addDefaultOptions = ({
+	maxBuffer = DEFAULT_MAX_BUFFER,
+	buffer = true,
+	stripFinalNewline = true,
+	extendEnv = true,
+	preferLocal = false,
+	cwd = process.cwd(),
+	localDir = cwd,
+	execPath = process.execPath,
+	encoding = 'utf8',
+	reject = true,
+	cleanup = true,
+	all = false,
+	windowsHide = true,
+	verbose = verboseDefault,
+	killSignal = 'SIGTERM',
+	...options
+}) => ({
+	...options,
+	maxBuffer,
+	buffer,
+	stripFinalNewline,
+	extendEnv,
+	preferLocal,
+	cwd,
+	localDir,
+	execPath,
+	encoding,
+	reject,
+	cleanup,
+	all,
+	windowsHide,
+	verbose,
+	killSignal,
+});
 
 const handleOutput = (options, value) => {
 	if (value === undefined || value === null) {

--- a/test/test.js
+++ b/test/test.js
@@ -76,20 +76,26 @@ test('skip throwing when using reject option in sync mode', t => {
 
 const testStripFinalNewline = async (t, index, stripFinalNewline, execaCommand) => {
 	const {stdio} = await execaCommand('noop-fd.js', [`${index}`, 'foobar\n'], {...fullStdio, stripFinalNewline});
-	t.is(stdio[index], `foobar${stripFinalNewline ? '' : '\n'}`);
+	t.is(stdio[index], `foobar${stripFinalNewline === false ? '\n' : ''}`);
 };
 
-test('stripFinalNewline: true with stdout', testStripFinalNewline, 1, undefined, execa);
+test('stripFinalNewline: undefined with stdout', testStripFinalNewline, 1, undefined, execa);
+test('stripFinalNewline: true with stdout', testStripFinalNewline, 1, true, execa);
 test('stripFinalNewline: false with stdout', testStripFinalNewline, 1, false, execa);
-test('stripFinalNewline: true with stderr', testStripFinalNewline, 2, undefined, execa);
+test('stripFinalNewline: undefined with stderr', testStripFinalNewline, 2, undefined, execa);
+test('stripFinalNewline: true with stderr', testStripFinalNewline, 2, true, execa);
 test('stripFinalNewline: false with stderr', testStripFinalNewline, 2, false, execa);
-test('stripFinalNewline: true with stdio[*]', testStripFinalNewline, 3, undefined, execa);
+test('stripFinalNewline: undefined with stdio[*]', testStripFinalNewline, 3, undefined, execa);
+test('stripFinalNewline: true with stdio[*]', testStripFinalNewline, 3, true, execa);
 test('stripFinalNewline: false with stdio[*]', testStripFinalNewline, 3, false, execa);
-test('stripFinalNewline: true with stdout - sync', testStripFinalNewline, 1, undefined, execaSync);
+test('stripFinalNewline: undefined with stdout - sync', testStripFinalNewline, 1, undefined, execaSync);
+test('stripFinalNewline: true with stdout - sync', testStripFinalNewline, 1, true, execaSync);
 test('stripFinalNewline: false with stdout - sync', testStripFinalNewline, 1, false, execaSync);
-test('stripFinalNewline: true with stderr - sync', testStripFinalNewline, 2, undefined, execaSync);
+test('stripFinalNewline: undefined with stderr - sync', testStripFinalNewline, 2, undefined, execaSync);
+test('stripFinalNewline: true with stderr - sync', testStripFinalNewline, 2, true, execaSync);
 test('stripFinalNewline: false with stderr - sync', testStripFinalNewline, 2, false, execaSync);
-test('stripFinalNewline: true with stdio[*] - sync', testStripFinalNewline, 3, undefined, execaSync);
+test('stripFinalNewline: undefined with stdio[*] - sync', testStripFinalNewline, 3, undefined, execaSync);
+test('stripFinalNewline: true with stdio[*] - sync', testStripFinalNewline, 3, true, execaSync);
 test('stripFinalNewline: false with stdio[*] - sync', testStripFinalNewline, 3, false, execaSync);
 
 const getPathWithoutLocalDir = () => {


### PR DESCRIPTION
Right now, if options are passed with an `undefined` value, it overrides the default value. The default value should be used instead.