### PR TITLE
Improve `timeout` option validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ const handleArguments = (rawFile, rawArgs, rawOptions = {}) => {
 	const {command: file, args, options: initialOptions} = crossSpawn._parse(filePath, rawArgs, rawOptions);
 
 	const options = addDefaultOptions(initialOptions);
+	validateTimeout(options);
 	options.shell = normalizeFileUrl(options.shell);
 	options.env = getEnv(options);
 
@@ -117,7 +118,6 @@ const handleOutput = (options, value) => {
 
 export function execa(rawFile, rawArgs, rawOptions) {
 	const {file, args, command, escapedCommand, options} = handleArguments(rawFile, rawArgs, rawOptions);
-	validateTimeout(options);
 
 	const stdioStreamsGroups = handleInputAsync(options);
 

--- a/test/error.js
+++ b/test/error.js
@@ -236,7 +236,7 @@ if (!isWindows) {
 	});
 
 	test('custom error.signal', async t => {
-		const {signal} = await t.throwsAsync(execa('noop.js', {killSignal: 'SIGHUP', timeout: 1, message: TIMEOUT_REGEXP}));
+		const {signal} = await t.throwsAsync(execa('forever.js', {killSignal: 'SIGHUP', timeout: 1, message: TIMEOUT_REGEXP}));
 		t.is(signal, 'SIGHUP');
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -175,7 +175,7 @@ test('child_process.spawn() errors are propagated', async t => {
 
 test('child_process.spawnSync() errors are propagated with a correct shape', t => {
 	const {failed} = t.throws(() => {
-		execaSync('noop.js', {timeout: -1});
+		execaSync('noop.js', {uid: -1});
 	});
 	t.true(failed);
 });


### PR DESCRIPTION
The `timeout` option is currently only validated with `execa()`. This PR validates it with `execaSync()` too, since our error message is better than the one provided by `child_process.spawnSync()`.

This PR also improves a few tests related to the `timeout` option.