### PR TITLE
Handle stream errors even with `buffer: false`

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -11,6 +11,23 @@ export const makeAllStream = ({stdout, stderr}, {all}) => all && (stdout || stde
 	? mergeStreams([stdout, stderr].filter(Boolean))
 	: undefined;
 
+// `childProcess.stdout|stderr` do not end until they have been consumed by `childProcess.all`.
+// `childProcess.all` does not end until `childProcess.stdout|stderr` have ended.
+// That's a good thing, since it ensures those streams are fully read and destroyed, even on errors.
+// However, this creates a deadlock if `childProcess.all` is not being read.
+// Doing so prevents the process from exiting, even when it failed.
+// It also prevents those streams from being properly destroyed.
+// This can only happen when:
+//  - `all` is `true`
+//  - `buffer` is `false`
+//  - `childProcess.all` is not read by the user
+// Therefore, we forcefully resume `childProcess.all` flow on errors.
+const resumeAll = all => {
+	if (all?.readableFlowing === null) {
+		all.resume();
+	}
+};
+
 // On failure, `result.stdout|stderr|all` should contain the currently buffered stream
 // They are automatically closed and flushed by Node.js when the child process exits
 // We guarantee this by calling `childProcess.kill()`
@@ -49,8 +66,12 @@ const allStreamGenerator = {
 };
 
 const getStreamPromise = async ({stream, encoding, buffer, maxBuffer}) => {
-	if (!stream || !buffer) {
+	if (!stream) {
 		return;
+	}
+
+	if (!buffer) {
+		return finished(stream);
 	}
 
 	if (stream.readableObjectMode) {
@@ -163,6 +184,7 @@ export const getSpawnedResult = async ({
 		]);
 	} catch (error) {
 		spawned.kill();
+		resumeAll(spawned.all);
 		const results = await Promise.all([
 			error,
 			waitForFailedProcess(processSpawnPromise, processErrorPromise, processExitPromise),


### PR DESCRIPTION
Fixes #716.