### PR TITLE
Refactor `encoding` option

### DIFF
--- a/lib/stdio/encoding.js
+++ b/lib/stdio/encoding.js
@@ -5,18 +5,19 @@ import {isUint8Array} from './utils.js';
 // Apply the `encoding` option using an implicit generator.
 // This encodes the final output of `stdout`/`stderr`.
 export const handleStreamsEncoding = (stdioStreams, {encoding}, isSync) => {
-	if (stdioStreams[0].direction === 'input' || IGNORED_ENCODINGS.has(encoding) || isSync) {
-		return stdioStreams.map(stdioStream => ({...stdioStream, encoding}));
+	const newStdioStreams = stdioStreams.map(stdioStream => ({...stdioStream, encoding}));
+	if (newStdioStreams[0].direction === 'input' || IGNORED_ENCODINGS.has(encoding) || isSync) {
+		return newStdioStreams;
 	}
 
 	const transform = encodingEndGenerator.bind(undefined, encoding);
-	const objectMode = stdioStreams.findLast(({type}) => type === 'generator')?.value.readableObjectMode === true;
+	const objectMode = newStdioStreams.findLast(({type}) => type === 'generator')?.value.objectMode === true;
 	return [
-		...stdioStreams,
+		...newStdioStreams,
 		{
-			...stdioStreams[0],
+			...newStdioStreams[0],
 			type: 'generator',
-			value: {transform, binary: true, readableObjectMode: objectMode, writableObjectMode: objectMode},
+			value: {transform, binary: true, objectMode},
 			encoding: 'buffer',
 		},
 	];

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -13,8 +13,8 @@ export const handleInput = (addProperties, options, isSync) => {
 	const stdioStreamsGroups = [[...stdinStreams, ...handleInputOptions(options)], ...otherStreamsGroups]
 		.map(stdioStreams => validateStreams(stdioStreams))
 		.map(stdioStreams => addStreamDirection(stdioStreams))
-		.map(stdioStreams => normalizeGenerators(stdioStreams))
 		.map(stdioStreams => handleStreamsEncoding(stdioStreams, options, isSync))
+		.map(stdioStreams => normalizeGenerators(stdioStreams))
 		.map(stdioStreams => addStreamsProperties(stdioStreams, addProperties));
 	options.stdio = transformStdio(stdioStreamsGroups);
 	return stdioStreamsGroups;


### PR DESCRIPTION
This refactors the `encoding` option. This does not change the behavior, just simplify the implementation.