### PR TITLE
Fix using both `objectMode` and `encoding` options

### DIFF
--- a/lib/stdio/encoding.js
+++ b/lib/stdio/encoding.js
@@ -10,8 +10,9 @@ export const handleStreamsEncoding = (stdioStreams, {encoding}, isSync) => {
 		return newStdioStreams;
 	}
 
-	const transform = encodingEndGenerator.bind(undefined, encoding);
 	const objectMode = newStdioStreams.findLast(({type}) => type === 'generator')?.value.objectMode === true;
+	const encodingEndGenerator = objectMode ? encodingEndObjectGenerator : encodingEndStringGenerator;
+	const transform = encodingEndGenerator.bind(undefined, encoding);
 	return [
 		...newStdioStreams,
 		{
@@ -26,7 +27,7 @@ export const handleStreamsEncoding = (stdioStreams, {encoding}, isSync) => {
 // eslint-disable-next-line unicorn/text-encoding-identifier-case
 const IGNORED_ENCODINGS = new Set(['utf8', 'utf-8', 'buffer']);
 
-const encodingEndGenerator = async function * (encoding, chunks) {
+const encodingEndStringGenerator = async function * (encoding, chunks) {
 	const stringDecoder = new StringDecoder(encoding);
 
 	for await (const chunk of chunks) {
@@ -36,6 +37,14 @@ const encodingEndGenerator = async function * (encoding, chunks) {
 	const lastChunk = stringDecoder.end();
 	if (lastChunk !== '') {
 		yield lastChunk;
+	}
+};
+
+const encodingEndObjectGenerator = async function * (encoding, chunks) {
+	const stringDecoder = new StringDecoder(encoding);
+
+	for await (const chunk of chunks) {
+		yield isUint8Array(chunk) ? stringDecoder.end(chunk) : chunk;
 	}
 };
 

--- a/test/helpers/generator.js
+++ b/test/helpers/generator.js
@@ -1,3 +1,4 @@
+import {setImmediate} from 'node:timers/promises';
 import {foobarObject} from './input.js';
 
 export const noopGenerator = objectMode => ({
@@ -37,3 +38,17 @@ export const getOutputGenerator = (input, objectMode) => ({
 });
 
 export const outputObjectGenerator = getOutputGenerator(foobarObject, true);
+
+export const getChunksGenerator = (chunks, objectMode) => ({
+	async * transform(lines) {
+	// eslint-disable-next-line no-unused-vars
+		for await (const line of lines) {
+			for (const chunk of chunks) {
+				yield chunk;
+				// eslint-disable-next-line no-await-in-loop
+				await setImmediate();
+			}
+		}
+	},
+	objectMode,
+});


### PR DESCRIPTION
This fixes using both: 
  - Transforms in `objectMode`
  - The `encoding` option with values like `hex` or `base64`

When a transform in `objectMode` returns an object, `encoding: 'base64'` should be a noop.

When a transform in `objectMode` returns a string or an `Uint8Array`, `encoding: base64` can work. However, it must operate chunk-wise instead of line-wise, since consumers of streams in `objectMode` might assume for emitted chunks to be independent from each other. For example, we will make that assumption with #706: we will emit one line at a time in `objectMode`, and would assume to be encoded separately from the next one.