### PR TITLE
Do not allow returning `null` from transforms

### DIFF
--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -82,10 +82,20 @@ export const generatorToDuplexStream = ({
 };
 
 const getValidateTransformReturn = (readableObjectMode, optionName) => readableObjectMode
-	? undefined
-	: validateTransformReturn.bind(undefined, optionName);
+	? validateObjectTransformReturn.bind(undefined, optionName)
+	: validateStringTransformReturn.bind(undefined, optionName);
 
-const validateTransformReturn = async function * (optionName, chunks) {
+const validateObjectTransformReturn = async function * (optionName, chunks) {
+	for await (const chunk of chunks) {
+		if (chunk === null) {
+			throw new Error(`The \`${optionName}\` option's function must not return null.`);
+		}
+
+		yield chunk;
+	}
+};
+
+const validateStringTransformReturn = async function * (optionName, chunks) {
 	for await (const chunk of chunks) {
 		if (typeof chunk !== 'string' && !isBinary(chunk)) {
 			throw new Error(`The \`${optionName}\` option's function must return a string or an Uint8Array, not ${typeof chunk}.`);


### PR DESCRIPTION
The `null` values have a special value in Node.js streams. With a readable stream, it ends it. With a writable stream, it is not allowed and throws.

This PR adds some better validation to ensure users do not return `null` with transforms.