### PR TITLE
Fix error handling of transforms

### DIFF
--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -5,7 +5,7 @@ import mergeStreams from '@sindresorhus/merge-streams';
 import {handleInput} from './handle.js';
 import {TYPE_TO_MESSAGE} from './type.js';
 import {generatorToDuplexStream, pipeGenerator} from './generator.js';
-import {pipeline} from './utils.js';
+import {pipeStreams} from './utils.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async mode
 export const handleInputAsync = options => handleInput(addPropertiesAsync, options, false);
@@ -51,7 +51,7 @@ export const pipeOutputAsync = (spawned, stdioStreamsGroups) => {
 
 	for (const [index, inputStreams] of Object.entries(inputStreamsGroups)) {
 		const value = inputStreams.length === 1 ? inputStreams[0] : mergeStreams(inputStreams);
-		pipeline(value, spawned.stdio[index]);
+		pipeStreams(value, spawned.stdio[index]);
 	}
 };
 
@@ -61,7 +61,7 @@ const pipeStdioOption = (spawned, {type, value, direction, index}, inputStreamsG
 	}
 
 	if (direction === 'output') {
-		pipeline(spawned.stdio[index], value);
+		pipeStreams(spawned.stdio[index], value);
 	} else {
 		inputStreamsGroups[index] = [...(inputStreamsGroups[index] ?? []), value];
 	}

--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -5,6 +5,7 @@ import mergeStreams from '@sindresorhus/merge-streams';
 import {handleInput} from './handle.js';
 import {TYPE_TO_MESSAGE} from './type.js';
 import {generatorToDuplexStream, pipeGenerator} from './generator.js';
+import {pipeline} from './utils.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async mode
 export const handleInputAsync = options => handleInput(addPropertiesAsync, options, false);
@@ -50,7 +51,7 @@ export const pipeOutputAsync = (spawned, stdioStreamsGroups) => {
 
 	for (const [index, inputStreams] of Object.entries(inputStreamsGroups)) {
 		const value = inputStreams.length === 1 ? inputStreams[0] : mergeStreams(inputStreams);
-		value.pipe(spawned.stdio[index]);
+		pipeline(value, spawned.stdio[index]);
 	}
 };
 
@@ -60,7 +61,7 @@ const pipeStdioOption = (spawned, {type, value, direction, index}, inputStreamsG
 	}
 
 	if (direction === 'output') {
-		spawned.stdio[index].pipe(value);
+		pipeline(spawned.stdio[index], value);
 	} else {
 		inputStreamsGroups[index] = [...(inputStreamsGroups[index] ?? []), value];
 	}

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -2,7 +2,7 @@ import {generatorsToDuplex} from './duplex.js';
 import {getEncodingStartGenerator} from './encoding.js';
 import {getLinesGenerator} from './lines.js';
 import {isGeneratorOptions} from './type.js';
-import {isBinary} from './utils.js';
+import {isBinary, pipeline} from './utils.js';
 
 export const normalizeGenerators = stdioStreams => {
 	const nonGenerators = stdioStreams.filter(({type}) => type !== 'generator');
@@ -98,9 +98,9 @@ const validateTransformReturn = async function * (optionName, chunks) {
 // `childProcess.stdin|stdout|stderr|stdio` is directly mutated.
 export const pipeGenerator = (spawned, {value, direction, index}) => {
 	if (direction === 'output') {
-		spawned.stdio[index].pipe(value);
-	}	else {
-		value.pipe(spawned.stdio[index]);
+		pipeline(spawned.stdio[index], value);
+	} else {
+		pipeline(value, spawned.stdio[index]);
 	}
 
 	const streamProperty = PROCESS_STREAM_PROPERTIES[index];

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -2,7 +2,7 @@ import {generatorsToDuplex} from './duplex.js';
 import {getEncodingStartGenerator} from './encoding.js';
 import {getLinesGenerator} from './lines.js';
 import {isGeneratorOptions} from './type.js';
-import {isBinary, pipeline} from './utils.js';
+import {isBinary, pipeStreams} from './utils.js';
 
 export const normalizeGenerators = stdioStreams => {
 	const nonGenerators = stdioStreams.filter(({type}) => type !== 'generator');
@@ -98,9 +98,9 @@ const validateTransformReturn = async function * (optionName, chunks) {
 // `childProcess.stdin|stdout|stderr|stdio` is directly mutated.
 export const pipeGenerator = (spawned, {value, direction, index}) => {
 	if (direction === 'output') {
-		pipeline(spawned.stdio[index], value);
+		pipeStreams(spawned.stdio[index], value);
 	} else {
-		pipeline(value, spawned.stdio[index]);
+		pipeStreams(value, spawned.stdio[index]);
 	}
 
 	const streamProperty = PROCESS_STREAM_PROPERTIES[index];

--- a/lib/stdio/utils.js
+++ b/lib/stdio/utils.js
@@ -10,7 +10,7 @@ const textDecoder = new TextDecoder();
 export const binaryToString = uint8ArrayOrBuffer => textDecoder.decode(uint8ArrayOrBuffer);
 
 // Like `source.pipe(destination)`, if `source` ends, `destination` ends.
-// Like `stream.pipeline(source, destination)`, if `source` aborts/errors, `destination` aborts.
+// Like `Stream.pipeline(source, destination)`, if `source` aborts/errors, `destination` aborts.
 // Unlike `stream.pipeline(source, destination)`, `destination` behavior does not propagate to `source`.
 export const pipeline = async (source, destination) => {
 	source.pipe(destination);

--- a/lib/stdio/utils.js
+++ b/lib/stdio/utils.js
@@ -12,7 +12,7 @@ export const binaryToString = uint8ArrayOrBuffer => textDecoder.decode(uint8Arra
 // Like `source.pipe(destination)`, if `source` ends, `destination` ends.
 // Like `Stream.pipeline(source, destination)`, if `source` aborts/errors, `destination` aborts.
 // Unlike `Stream.pipeline(source, destination)`, `destination` behavior does not propagate to `source`.
-export const pipeline = async (source, destination) => {
+export const pipeStreams = async (source, destination) => {
 	source.pipe(destination);
 
 	try {

--- a/lib/stdio/utils.js
+++ b/lib/stdio/utils.js
@@ -11,7 +11,7 @@ export const binaryToString = uint8ArrayOrBuffer => textDecoder.decode(uint8Arra
 
 // Like `source.pipe(destination)`, if `source` ends, `destination` ends.
 // Like `Stream.pipeline(source, destination)`, if `source` aborts/errors, `destination` aborts.
-// Unlike `stream.pipeline(source, destination)`, `destination` behavior does not propagate to `source`.
+// Unlike `Stream.pipeline(source, destination)`, `destination` behavior does not propagate to `source`.
 export const pipeline = async (source, destination) => {
 	source.pipe(destination);
 

--- a/lib/stdio/utils.js
+++ b/lib/stdio/utils.js
@@ -1,4 +1,5 @@
 import {Buffer} from 'node:buffer';
+import {finished} from 'node:stream/promises';
 
 export const bufferToUint8Array = buffer => new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 
@@ -7,3 +8,16 @@ export const isBinary = value => isUint8Array(value) || Buffer.isBuffer(value);
 
 const textDecoder = new TextDecoder();
 export const binaryToString = uint8ArrayOrBuffer => textDecoder.decode(uint8ArrayOrBuffer);
+
+// Like `src.pipe(dest)`, if `src` ends, `dest` ends.
+// Like `stream.pipeline(src, dest)`, if `src` aborts/errors, `dest` aborts.
+// Unlike `stream.pipeline(src, dest)`, `dest` behavior does not propagate to `src`.
+export const pipeline = async (source, destination) => {
+	source.pipe(destination);
+
+	try {
+		await finished(source);
+	} catch {
+		destination.destroy();
+	}
+};

--- a/lib/stdio/utils.js
+++ b/lib/stdio/utils.js
@@ -11,7 +11,7 @@ export const binaryToString = uint8ArrayOrBuffer => textDecoder.decode(uint8Arra
 
 // Like `source.pipe(destination)`, if `source` ends, `destination` ends.
 // Like `Stream.pipeline(source, destination)`, if `source` aborts/errors, `destination` aborts.
-// Unlike `Stream.pipeline(source, destination)`, `destination` behavior does not propagate to `source`.
+// Unlike `Stream.pipeline(source, destination)`, if `destination` ends/aborts/errors, `source` does not end/abort/error.
 export const pipeStreams = async (source, destination) => {
 	source.pipe(destination);
 

--- a/lib/stdio/utils.js
+++ b/lib/stdio/utils.js
@@ -9,9 +9,9 @@ export const isBinary = value => isUint8Array(value) || Buffer.isBuffer(value);
 const textDecoder = new TextDecoder();
 export const binaryToString = uint8ArrayOrBuffer => textDecoder.decode(uint8ArrayOrBuffer);
 
-// Like `src.pipe(dest)`, if `src` ends, `dest` ends.
-// Like `stream.pipeline(src, dest)`, if `src` aborts/errors, `dest` aborts.
-// Unlike `stream.pipeline(src, dest)`, `dest` behavior does not propagate to `src`.
+// Like `source.pipe(destination)`, if `source` ends, `destination` ends.
+// Like `stream.pipeline(source, destination)`, if `source` aborts/errors, `destination` aborts.
+// Unlike `stream.pipeline(source, destination)`, `destination` behavior does not propagate to `source`.
 export const pipeline = async (source, destination) => {
 	source.pipe(destination);
 

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -115,17 +115,6 @@ const throwOnStreamError = async stream => {
 	throw error;
 };
 
-// The streams created by the `std*` options are automatically ended by `.pipe()`.
-// However `.pipe()` only does so when the source stream ended, not when it errored.
-// Therefore, when `childProcess.stdin|stdout|stderr` errors, those streams must be manually destroyed.
-const cleanupStdioStreams = (customStreams, error) => {
-	for (const {value} of customStreams) {
-		if (!STANDARD_STREAMS.includes(value)) {
-			value.destroy(error);
-		}
-	}
-};
-
 // Like `once()` except it never rejects, especially not on `error` event.
 const pEvent = (eventEmitter, eventName) => new Promise(resolve => {
 	eventEmitter.once(eventName, (...payload) => {
@@ -191,7 +180,6 @@ export const getSpawnedResult = async ({
 			Promise.all(stdioPromises.map(stdioPromise => getBufferedData(stdioPromise, encoding))),
 			getBufferedData(allPromise, encoding),
 		]);
-		cleanupStdioStreams(customStreams, error);
 		await Promise.allSettled(customStreamsEndPromises);
 		return results;
 	} finally {

--- a/test/stdio/generator.js
+++ b/test/stdio/generator.js
@@ -629,6 +629,19 @@ test('Generators errors make process fail', async t => {
 	);
 });
 
+test('Generators errors make process fail even when other output generators do not throw', async t => {
+	await t.throwsAsync(
+		execa('noop-fd.js', ['1', foobarString], {stdout: [noopGenerator(false), throwingGenerator, noopGenerator(false)]}),
+		{message: /Generator error foobar/},
+	);
+});
+
+test('Generators errors make process fail even when other input generators do not throw', async t => {
+	const childProcess = execa('stdin-fd.js', ['0'], {stdin: [noopGenerator(false), throwingGenerator, noopGenerator(false)]});
+	childProcess.stdin.write('foobar\n');
+	await t.throwsAsync(childProcess, {message: /Generator error foobar/});
+});
+
 // eslint-disable-next-line require-yield
 const errorHandlerGenerator = async function * (state, lines) {
 	try {
@@ -641,7 +654,7 @@ const errorHandlerGenerator = async function * (state, lines) {
 	}
 };
 
-test.serial('Process streams failures make generators throw', async t => {
+test('Process streams failures make generators throw', async t => {
 	const state = {};
 	const childProcess = execa('noop-fail.js', ['1'], {stdout: errorHandlerGenerator.bind(undefined, state)});
 	const error = new Error('test');


### PR DESCRIPTION
When using multiple transforms and one of them throws, the other transforms are currently not always properly destroyed. This makes the promise returned by Execa hang forever.

This PR fixes this.