### PR TITLE
Simplify transforms syntax

### DIFF
--- a/docs/transform.md
+++ b/docs/transform.md
@@ -98,7 +98,7 @@ const transform = function * (line) {
 To create additional lines after the last one, a `final` generator function can be used by passing a `{transform, final}` plain object.
 
 ```js
-let count = 0
+let count = 0;
 
 const transform = function * (line) {
 	count += 1;

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,10 +20,12 @@ type BaseStdioOption =
 
 // @todo Use `string`, `Uint8Array` or `unknown` for both the argument and the return type, based on whether `encoding: 'buffer'` and `objectMode: true` are used.
 // See https://github.com/sindresorhus/execa/issues/694
-type StdioTransform = ((chunks: Iterable<unknown>) => AsyncGenerator<unknown, void, void>);
+type StdioTransform = (chunk: unknown) => AsyncGenerator<unknown, void, void> | Generator<unknown, void, void>;
+type StdioFinal = () => AsyncGenerator<unknown, void, void> | Generator<unknown, void, void>;
 
 type StdioTransformFull = {
 	transform: StdioTransform;
+	final?: StdioFinal;
 	binary?: boolean;
 	objectMode?: boolean;
 };
@@ -319,7 +321,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-	This can also be an async generator function to transform the input. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
+	This can also be a generator function to transform the input. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
 
 	@default `inherit` with `$`, `pipe` otherwise
 	*/
@@ -340,7 +342,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-	This can also be an async generator function to transform the output. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
+	This can also be a generator function to transform the output. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
 
 	@default 'pipe'
 	*/
@@ -361,7 +363,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-	This can also be an async generator function to transform the output. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
+	This can also be a generator function to transform the output. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
 
 	@default 'pipe'
 	*/

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -34,44 +34,46 @@ expectType<AnySyncChunk>({} as ExecaSyncReturnValue['stdout']);
 expectType<AnySyncChunk>({} as ExecaSyncReturnValue['stderr']);
 expectType<[undefined, AnySyncChunk, AnySyncChunk]>({} as ExecaSyncReturnValue['stdio']);
 
-const objectGenerator = async function * (lines: Iterable<unknown>) {
-	for await (const line of lines) {
-		yield JSON.parse(line as string) as object;
-	}
+const objectGenerator = function * (line: unknown) {
+	yield JSON.parse(line as string) as object;
 };
 
-const unknownArrayGenerator = async function * (lines: Iterable<unknown>) {
-	for await (const line of lines) {
-		yield line;
-	}
+const objectFinal = function * () {
+	yield {};
 };
 
-const booleanGenerator = async function * (lines: Iterable<boolean>) {
-	for await (const line of lines) {
-		yield line;
-	}
+const unknownGenerator = function * (line: unknown) {
+	yield line;
 };
 
-const arrayGenerator = async function * (lines: string[]) {
-	for await (const line of lines) {
-		yield line;
-	}
+const unknownFinal = function * () {
+	yield {} as unknown;
 };
 
-const invalidReturnGenerator = async function * (lines: Iterable<string>) {
-	for await (const line of lines) {
-		yield line;
-	}
+const booleanGenerator = function * (line: boolean) {
+	yield line;
+};
 
+const stringGenerator = function * (line: string) {
+	yield line;
+};
+
+const invalidReturnGenerator = function * (line: unknown) {
+	yield line;
 	return false;
 };
 
-const syncGenerator = function * (lines: Iterable<string>) {
-	for (const line of lines) {
-		yield line;
-	}
-
+const invalidReturnFinal = function * () {
+	yield {} as unknown;
 	return false;
+};
+
+const asyncGenerator = async function * (line: unknown) {
+	yield line;
+};
+
+const asyncFinal = async function * () {
+	yield {} as unknown;
 };
 
 try {
@@ -347,65 +349,65 @@ try {
 	const ignoreFd3Result = await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', 'ignore']});
 	expectType<undefined>(ignoreFd3Result.stdio[3]);
 
-	const objectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: true}});
+	const objectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}});
 	expectType<unknown[]>(objectTransformStdoutResult.stdout);
 	expectType<[undefined, unknown[], string]>(objectTransformStdoutResult.stdio);
 
-	const objectTransformStderrResult = await execa('unicorns', {stderr: {transform: objectGenerator, objectMode: true}});
+	const objectTransformStderrResult = await execa('unicorns', {stderr: {transform: objectGenerator, final: objectFinal, objectMode: true}});
 	expectType<unknown[]>(objectTransformStderrResult.stderr);
 	expectType<[undefined, string, unknown[]]>(objectTransformStderrResult.stdio);
 
-	const objectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, objectMode: true}]});
+	const objectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, final: objectFinal, objectMode: true}]});
 	expectType<unknown[]>(objectTransformStdioResult.stderr);
 	expectType<[undefined, string, unknown[]]>(objectTransformStdioResult.stdio);
 
-	const singleObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, objectMode: true}]});
+	const singleObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, final: objectFinal, objectMode: true}]});
 	expectType<unknown[]>(singleObjectTransformStdoutResult.stdout);
 	expectType<[undefined, unknown[], string]>(singleObjectTransformStdoutResult.stdio);
 
-	const manyObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, objectMode: true}, {transform: objectGenerator, objectMode: true}]});
+	const manyObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, final: objectFinal, objectMode: true}, {transform: objectGenerator, final: objectFinal, objectMode: true}]});
 	expectType<unknown[]>(manyObjectTransformStdoutResult.stdout);
 	expectType<[undefined, unknown[], string]>(manyObjectTransformStdoutResult.stdio);
 
-	const falseObjectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: false}});
+	const falseObjectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: false}});
 	expectType<string>(falseObjectTransformStdoutResult.stdout);
 	expectType<[undefined, string, string]>(falseObjectTransformStdoutResult.stdio);
 
-	const falseObjectTransformStderrResult = await execa('unicorns', {stderr: {transform: objectGenerator, objectMode: false}});
+	const falseObjectTransformStderrResult = await execa('unicorns', {stderr: {transform: objectGenerator, final: objectFinal, objectMode: false}});
 	expectType<string>(falseObjectTransformStderrResult.stderr);
 	expectType<[undefined, string, string]>(falseObjectTransformStderrResult.stdio);
 
-	const falseObjectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, objectMode: false}]});
+	const falseObjectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, final: objectFinal, objectMode: false}]});
 	expectType<string>(falseObjectTransformStdioResult.stderr);
 	expectType<[undefined, string, string]>(falseObjectTransformStdioResult.stdio);
 
-	const undefinedObjectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator}});
+	const undefinedObjectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal}});
 	expectType<string>(undefinedObjectTransformStdoutResult.stdout);
 	expectType<[undefined, string, string]>(undefinedObjectTransformStdoutResult.stdio);
 
-	const noObjectTransformStdoutResult = await execa('unicorns', {stdout: objectGenerator});
+	const noObjectTransformStdoutResult = await execa('unicorns', {stdout: objectGenerator, final: objectFinal});
 	expectType<string>(noObjectTransformStdoutResult.stdout);
 	expectType<[undefined, string, string]>(noObjectTransformStdoutResult.stdio);
 
-	const trueTrueObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: true}, stderr: {transform: objectGenerator, objectMode: true}, all: true});
+	const trueTrueObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}, stderr: {transform: objectGenerator, final: objectFinal, objectMode: true}, all: true});
 	expectType<unknown[]>(trueTrueObjectTransformResult.stdout);
 	expectType<unknown[]>(trueTrueObjectTransformResult.stderr);
 	expectType<unknown[]>(trueTrueObjectTransformResult.all);
 	expectType<[undefined, unknown[], unknown[]]>(trueTrueObjectTransformResult.stdio);
 
-	const trueFalseObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: true}, stderr: {transform: objectGenerator, objectMode: false}, all: true});
+	const trueFalseObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}, stderr: {transform: objectGenerator, final: objectFinal, objectMode: false}, all: true});
 	expectType<unknown[]>(trueFalseObjectTransformResult.stdout);
 	expectType<string>(trueFalseObjectTransformResult.stderr);
 	expectType<unknown[]>(trueFalseObjectTransformResult.all);
 	expectType<[undefined, unknown[], string]>(trueFalseObjectTransformResult.stdio);
 
-	const falseTrueObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: false}, stderr: {transform: objectGenerator, objectMode: true}, all: true});
+	const falseTrueObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: false}, stderr: {transform: objectGenerator, final: objectFinal, objectMode: true}, all: true});
 	expectType<string>(falseTrueObjectTransformResult.stdout);
 	expectType<unknown[]>(falseTrueObjectTransformResult.stderr);
 	expectType<unknown[]>(falseTrueObjectTransformResult.all);
 	expectType<[undefined, string, unknown[]]>(falseTrueObjectTransformResult.stdio);
 
-	const falseFalseObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, objectMode: false}, stderr: {transform: objectGenerator, objectMode: false}, all: true});
+	const falseFalseObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: false}, stderr: {transform: objectGenerator, final: objectFinal, objectMode: false}, all: true});
 	expectType<string>(falseFalseObjectTransformResult.stdout);
 	expectType<string>(falseFalseObjectTransformResult.stderr);
 	expectType<string>(falseFalseObjectTransformResult.all);
@@ -517,27 +519,27 @@ try {
 	expectType<undefined>(streamStderrError.stderr);
 	expectType<string>(streamStderrError.all);
 
-	const objectTransformStdoutError = error as ExecaError<{stdout: {transform: typeof objectGenerator; objectMode: true}}>;
+	const objectTransformStdoutError = error as ExecaError<{stdout: {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: true}}>;
 	expectType<unknown[]>(objectTransformStdoutError.stdout);
 	expectType<[undefined, unknown[], string]>(objectTransformStdoutError.stdio);
 
-	const objectTransformStderrError = error as ExecaError<{stderr: {transform: typeof objectGenerator; objectMode: true}}>;
+	const objectTransformStderrError = error as ExecaError<{stderr: {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: true}}>;
 	expectType<unknown[]>(objectTransformStderrError.stderr);
 	expectType<[undefined, string, unknown[]]>(objectTransformStderrError.stdio);
 
-	const objectTransformStdioError = error as ExecaError<{stdio: ['pipe', 'pipe', {transform: typeof objectGenerator; objectMode: true}]}>;
+	const objectTransformStdioError = error as ExecaError<{stdio: ['pipe', 'pipe', {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: true}]}>;
 	expectType<unknown[]>(objectTransformStdioError.stderr);
 	expectType<[undefined, string, unknown[]]>(objectTransformStdioError.stdio);
 
-	const falseObjectTransformStdoutError = error as ExecaError<{stdout: {transform: typeof objectGenerator; objectMode: false}}>;
+	const falseObjectTransformStdoutError = error as ExecaError<{stdout: {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: false}}>;
 	expectType<string>(falseObjectTransformStdoutError.stdout);
 	expectType<[undefined, string, string]>(falseObjectTransformStdoutError.stdio);
 
-	const falseObjectTransformStderrError = error as ExecaError<{stderr: {transform: typeof objectGenerator; objectMode: false}}>;
+	const falseObjectTransformStderrError = error as ExecaError<{stderr: {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: false}}>;
 	expectType<string>(falseObjectTransformStderrError.stderr);
 	expectType<[undefined, string, string]>(falseObjectTransformStderrError.stdio);
 
-	const falseObjectTransformStdioError = error as ExecaError<{stdio: ['pipe', 'pipe', {transform: typeof objectGenerator; objectMode: false}]}>;
+	const falseObjectTransformStdioError = error as ExecaError<{stdio: ['pipe', 'pipe', {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: false}]}>;
 	expectType<string>(falseObjectTransformStdioError.stderr);
 	expectType<[undefined, string, string]>(falseObjectTransformStdioError.stdio);
 }
@@ -831,29 +833,46 @@ execa('unicorns', {stdin: 1});
 execaSync('unicorns', {stdin: 1});
 execa('unicorns', {stdin: [1]});
 execaSync('unicorns', {stdin: [1]});
-execa('unicorns', {stdin: unknownArrayGenerator});
-expectError(execaSync('unicorns', {stdin: unknownArrayGenerator}));
-execa('unicorns', {stdin: [unknownArrayGenerator]});
-expectError(execaSync('unicorns', {stdin: [unknownArrayGenerator]}));
+execa('unicorns', {stdin: unknownGenerator});
+expectError(execaSync('unicorns', {stdin: unknownGenerator}));
+execa('unicorns', {stdin: [unknownGenerator]});
+expectError(execaSync('unicorns', {stdin: [unknownGenerator]}));
 expectError(execa('unicorns', {stdin: booleanGenerator}));
-expectError(execa('unicorns', {stdin: arrayGenerator}));
+expectError(execaSync('unicorns', {stdin: booleanGenerator}));
+expectError(execa('unicorns', {stdin: stringGenerator}));
+expectError(execaSync('unicorns', {stdin: stringGenerator}));
 expectError(execa('unicorns', {stdin: invalidReturnGenerator}));
-expectError(execa('unicorns', {stdin: syncGenerator}));
-execa('unicorns', {stdin: {transform: unknownArrayGenerator}});
-expectError(execaSync('unicorns', {stdin: {transform: unknownArrayGenerator}}));
-execa('unicorns', {stdin: [{transform: unknownArrayGenerator}]});
-expectError(execaSync('unicorns', {stdin: [{transform: unknownArrayGenerator}]}));
+expectError(execaSync('unicorns', {stdin: invalidReturnGenerator}));
+execa('unicorns', {stdin: asyncGenerator});
+expectError(execaSync('unicorns', {stdin: asyncGenerator}));
+execa('unicorns', {stdin: {transform: unknownGenerator}});
+expectError(execaSync('unicorns', {stdin: {transform: unknownGenerator}}));
+execa('unicorns', {stdin: [{transform: unknownGenerator}]});
+expectError(execaSync('unicorns', {stdin: [{transform: unknownGenerator}]}));
 expectError(execa('unicorns', {stdin: {transform: booleanGenerator}}));
-expectError(execa('unicorns', {stdin: {transform: arrayGenerator}}));
+expectError(execaSync('unicorns', {stdin: {transform: booleanGenerator}}));
+expectError(execa('unicorns', {stdin: {transform: stringGenerator}}));
+expectError(execaSync('unicorns', {stdin: {transform: stringGenerator}}));
 expectError(execa('unicorns', {stdin: {transform: invalidReturnGenerator}}));
-expectError(execa('unicorns', {stdin: {transform: syncGenerator}}));
+expectError(execaSync('unicorns', {stdin: {transform: invalidReturnGenerator}}));
+execa('unicorns', {stdin: {transform: asyncGenerator}});
+expectError(execaSync('unicorns', {stdin: {transform: asyncGenerator}}));
+execa('unicorns', {stdin: {transform: unknownGenerator, final: unknownFinal}});
+expectError(execaSync('unicorns', {stdin: {transform: unknownGenerator, final: unknownFinal}}));
+execa('unicorns', {stdin: [{transform: unknownGenerator, final: unknownFinal}]});
+expectError(execaSync('unicorns', {stdin: [{transform: unknownGenerator, final: unknownFinal}]}));
+expectError(execa('unicorns', {stdin: {transform: unknownGenerator, final: invalidReturnFinal}}));
+expectError(execaSync('unicorns', {stdin: {transform: unknownGenerator, final: invalidReturnFinal}}));
+execa('unicorns', {stdin: {transform: unknownGenerator, final: asyncFinal}});
+expectError(execaSync('unicorns', {stdin: {transform: unknownGenerator, final: asyncFinal}}));
 expectError(execa('unicorns', {stdin: {}}));
 expectError(execa('unicorns', {stdin: {binary: true}}));
 expectError(execa('unicorns', {stdin: {objectMode: true}}));
-execa('unicorns', {stdin: {transform: unknownArrayGenerator, binary: true}});
-expectError(execa('unicorns', {stdin: {transform: unknownArrayGenerator, binary: 'true'}}));
-execa('unicorns', {stdin: {transform: unknownArrayGenerator, objectMode: true}});
-expectError(execa('unicorns', {stdin: {transform: unknownArrayGenerator, objectMode: 'true'}}));
+expectError(execa('unicorns', {stdin: {final: unknownFinal}}));
+execa('unicorns', {stdin: {transform: unknownGenerator, binary: true}});
+expectError(execa('unicorns', {stdin: {transform: unknownGenerator, binary: 'true'}}));
+execa('unicorns', {stdin: {transform: unknownGenerator, objectMode: true}});
+expectError(execa('unicorns', {stdin: {transform: unknownGenerator, objectMode: 'true'}}));
 execa('unicorns', {stdin: undefined});
 execaSync('unicorns', {stdin: undefined});
 execa('unicorns', {stdin: [undefined]});
@@ -912,29 +931,46 @@ execa('unicorns', {stdout: 1});
 execaSync('unicorns', {stdout: 1});
 execa('unicorns', {stdout: [1]});
 execaSync('unicorns', {stdout: [1]});
-execa('unicorns', {stdout: unknownArrayGenerator});
-expectError(execaSync('unicorns', {stdout: unknownArrayGenerator}));
-execa('unicorns', {stdout: [unknownArrayGenerator]});
-expectError(execaSync('unicorns', {stdout: [unknownArrayGenerator]}));
+execa('unicorns', {stdout: unknownGenerator});
+expectError(execaSync('unicorns', {stdout: unknownGenerator}));
+execa('unicorns', {stdout: [unknownGenerator]});
+expectError(execaSync('unicorns', {stdout: [unknownGenerator]}));
 expectError(execa('unicorns', {stdout: booleanGenerator}));
-expectError(execa('unicorns', {stdout: arrayGenerator}));
+expectError(execaSync('unicorns', {stdout: booleanGenerator}));
+expectError(execa('unicorns', {stdout: stringGenerator}));
+expectError(execaSync('unicorns', {stdout: stringGenerator}));
 expectError(execa('unicorns', {stdout: invalidReturnGenerator}));
-expectError(execa('unicorns', {stdout: syncGenerator}));
-execa('unicorns', {stdout: {transform: unknownArrayGenerator}});
-expectError(execaSync('unicorns', {stdout: {transform: unknownArrayGenerator}}));
-execa('unicorns', {stdout: [{transform: unknownArrayGenerator}]});
-expectError(execaSync('unicorns', {stdout: [{transform: unknownArrayGenerator}]}));
+expectError(execaSync('unicorns', {stdout: invalidReturnGenerator}));
+execa('unicorns', {stdout: asyncGenerator});
+expectError(execaSync('unicorns', {stdout: asyncGenerator}));
+execa('unicorns', {stdout: {transform: unknownGenerator}});
+expectError(execaSync('unicorns', {stdout: {transform: unknownGenerator}}));
+execa('unicorns', {stdout: [{transform: unknownGenerator}]});
+expectError(execaSync('unicorns', {stdout: [{transform: unknownGenerator}]}));
 expectError(execa('unicorns', {stdout: {transform: booleanGenerator}}));
-expectError(execa('unicorns', {stdout: {transform: arrayGenerator}}));
+expectError(execaSync('unicorns', {stdout: {transform: booleanGenerator}}));
+expectError(execa('unicorns', {stdout: {transform: stringGenerator}}));
+expectError(execaSync('unicorns', {stdout: {transform: stringGenerator}}));
 expectError(execa('unicorns', {stdout: {transform: invalidReturnGenerator}}));
-expectError(execa('unicorns', {stdout: {transform: syncGenerator}}));
+expectError(execaSync('unicorns', {stdout: {transform: invalidReturnGenerator}}));
+execa('unicorns', {stdout: {transform: asyncGenerator}});
+expectError(execaSync('unicorns', {stdout: {transform: asyncGenerator}}));
+execa('unicorns', {stdout: {transform: unknownGenerator, final: unknownFinal}});
+expectError(execaSync('unicorns', {stdout: {transform: unknownGenerator, final: unknownFinal}}));
+execa('unicorns', {stdout: [{transform: unknownGenerator, final: unknownFinal}]});
+expectError(execaSync('unicorns', {stdout: [{transform: unknownGenerator, final: unknownFinal}]}));
+expectError(execa('unicorns', {stdout: {transform: unknownGenerator, final: invalidReturnFinal}}));
+expectError(execaSync('unicorns', {stdout: {transform: unknownGenerator, final: invalidReturnFinal}}));
+execa('unicorns', {stdout: {transform: unknownGenerator, final: asyncFinal}});
+expectError(execaSync('unicorns', {stdout: {transform: unknownGenerator, final: asyncFinal}}));
 expectError(execa('unicorns', {stdout: {}}));
 expectError(execa('unicorns', {stdout: {binary: true}}));
 expectError(execa('unicorns', {stdout: {objectMode: true}}));
-execa('unicorns', {stdout: {transform: unknownArrayGenerator, binary: true}});
-expectError(execa('unicorns', {stdout: {transform: unknownArrayGenerator, binary: 'true'}}));
-execa('unicorns', {stdout: {transform: unknownArrayGenerator, objectMode: true}});
-expectError(execa('unicorns', {stdout: {transform: unknownArrayGenerator, objectMode: 'true'}}));
+expectError(execa('unicorns', {stdout: {final: unknownFinal}}));
+execa('unicorns', {stdout: {transform: unknownGenerator, binary: true}});
+expectError(execa('unicorns', {stdout: {transform: unknownGenerator, binary: 'true'}}));
+execa('unicorns', {stdout: {transform: unknownGenerator, objectMode: true}});
+expectError(execa('unicorns', {stdout: {transform: unknownGenerator, objectMode: 'true'}}));
 execa('unicorns', {stdout: undefined});
 execaSync('unicorns', {stdout: undefined});
 execa('unicorns', {stdout: [undefined]});
@@ -993,29 +1029,46 @@ execa('unicorns', {stderr: 1});
 execaSync('unicorns', {stderr: 1});
 execa('unicorns', {stderr: [1]});
 execaSync('unicorns', {stderr: [1]});
-execa('unicorns', {stderr: unknownArrayGenerator});
-expectError(execaSync('unicorns', {stderr: unknownArrayGenerator}));
-execa('unicorns', {stderr: [unknownArrayGenerator]});
-expectError(execaSync('unicorns', {stderr: [unknownArrayGenerator]}));
+execa('unicorns', {stderr: unknownGenerator});
+expectError(execaSync('unicorns', {stderr: unknownGenerator}));
+execa('unicorns', {stderr: [unknownGenerator]});
+expectError(execaSync('unicorns', {stderr: [unknownGenerator]}));
 expectError(execa('unicorns', {stderr: booleanGenerator}));
-expectError(execa('unicorns', {stderr: arrayGenerator}));
+expectError(execaSync('unicorns', {stderr: booleanGenerator}));
+expectError(execa('unicorns', {stderr: stringGenerator}));
+expectError(execaSync('unicorns', {stderr: stringGenerator}));
 expectError(execa('unicorns', {stderr: invalidReturnGenerator}));
-expectError(execa('unicorns', {stderr: syncGenerator}));
-execa('unicorns', {stderr: {transform: unknownArrayGenerator}});
-expectError(execaSync('unicorns', {stderr: {transform: unknownArrayGenerator}}));
-execa('unicorns', {stderr: [{transform: unknownArrayGenerator}]});
-expectError(execaSync('unicorns', {stderr: [{transform: unknownArrayGenerator}]}));
+expectError(execaSync('unicorns', {stderr: invalidReturnGenerator}));
+execa('unicorns', {stderr: asyncGenerator});
+expectError(execaSync('unicorns', {stderr: asyncGenerator}));
+execa('unicorns', {stderr: {transform: unknownGenerator}});
+expectError(execaSync('unicorns', {stderr: {transform: unknownGenerator}}));
+execa('unicorns', {stderr: [{transform: unknownGenerator}]});
+expectError(execaSync('unicorns', {stderr: [{transform: unknownGenerator}]}));
 expectError(execa('unicorns', {stderr: {transform: booleanGenerator}}));
-expectError(execa('unicorns', {stderr: {transform: arrayGenerator}}));
+expectError(execaSync('unicorns', {stderr: {transform: booleanGenerator}}));
+expectError(execa('unicorns', {stderr: {transform: stringGenerator}}));
+expectError(execaSync('unicorns', {stderr: {transform: stringGenerator}}));
 expectError(execa('unicorns', {stderr: {transform: invalidReturnGenerator}}));
-expectError(execa('unicorns', {stderr: {transform: syncGenerator}}));
+expectError(execaSync('unicorns', {stderr: {transform: invalidReturnGenerator}}));
+execa('unicorns', {stderr: {transform: asyncGenerator}});
+expectError(execaSync('unicorns', {stderr: {transform: asyncGenerator}}));
+execa('unicorns', {stderr: {transform: unknownGenerator, final: unknownFinal}});
+expectError(execaSync('unicorns', {stderr: {transform: unknownGenerator, final: unknownFinal}}));
+execa('unicorns', {stderr: [{transform: unknownGenerator, final: unknownFinal}]});
+expectError(execaSync('unicorns', {stderr: [{transform: unknownGenerator, final: unknownFinal}]}));
+expectError(execa('unicorns', {stderr: {transform: unknownGenerator, final: invalidReturnFinal}}));
+expectError(execaSync('unicorns', {stderr: {transform: unknownGenerator, final: invalidReturnFinal}}));
+execa('unicorns', {stderr: {transform: unknownGenerator, final: asyncFinal}});
+expectError(execaSync('unicorns', {stderr: {transform: unknownGenerator, final: asyncFinal}}));
 expectError(execa('unicorns', {stderr: {}}));
 expectError(execa('unicorns', {stderr: {binary: true}}));
 expectError(execa('unicorns', {stderr: {objectMode: true}}));
-execa('unicorns', {stderr: {transform: unknownArrayGenerator, binary: true}});
-expectError(execa('unicorns', {stderr: {transform: unknownArrayGenerator, binary: 'true'}}));
-execa('unicorns', {stderr: {transform: unknownArrayGenerator, objectMode: true}});
-expectError(execa('unicorns', {stderr: {transform: unknownArrayGenerator, objectMode: 'true'}}));
+expectError(execa('unicorns', {stderr: {final: unknownFinal}}));
+execa('unicorns', {stderr: {transform: unknownGenerator, binary: true}});
+expectError(execa('unicorns', {stderr: {transform: unknownGenerator, binary: 'true'}}));
+execa('unicorns', {stderr: {transform: unknownGenerator, objectMode: true}});
+expectError(execa('unicorns', {stderr: {transform: unknownGenerator, objectMode: 'true'}}));
 execa('unicorns', {stderr: undefined});
 execaSync('unicorns', {stderr: undefined});
 execa('unicorns', {stderr: [undefined]});
@@ -1052,10 +1105,10 @@ expectError(execa('unicorns', {stdio: 'ipc'}));
 expectError(execaSync('unicorns', {stdio: 'ipc'}));
 expectError(execa('unicorns', {stdio: 1}));
 expectError(execaSync('unicorns', {stdio: 1}));
-expectError(execa('unicorns', {stdio: unknownArrayGenerator}));
-expectError(execaSync('unicorns', {stdio: unknownArrayGenerator}));
-expectError(execa('unicorns', {stdio: {transform: unknownArrayGenerator}}));
-expectError(execaSync('unicorns', {stdio: {transform: unknownArrayGenerator}}));
+expectError(execa('unicorns', {stdio: unknownGenerator}));
+expectError(execaSync('unicorns', {stdio: unknownGenerator}));
+expectError(execa('unicorns', {stdio: {transform: unknownGenerator}}));
+expectError(execaSync('unicorns', {stdio: {transform: unknownGenerator}}));
 expectError(execa('unicorns', {stdio: fileUrl}));
 expectError(execaSync('unicorns', {stdio: fileUrl}));
 expectError(execa('unicorns', {stdio: {file: './test'}}));
@@ -1106,10 +1159,11 @@ execa('unicorns', {
 		'inherit',
 		process.stdin,
 		1,
-		unknownArrayGenerator,
-		{transform: unknownArrayGenerator},
-		{transform: unknownArrayGenerator, binary: true},
-		{transform: unknownArrayGenerator, objectMode: true},
+		unknownGenerator,
+		{transform: unknownGenerator},
+		{transform: unknownGenerator, binary: true},
+		{transform: unknownGenerator, objectMode: true},
+		{transform: unknownGenerator, final: unknownFinal},
 		undefined,
 		fileUrl,
 		{file: './test'},
@@ -1139,8 +1193,8 @@ execaSync('unicorns', {
 		new Uint8Array(),
 	],
 });
-expectError(execaSync('unicorns', {stdio: [unknownArrayGenerator]}));
-expectError(execaSync('unicorns', {stdio: [{transform: unknownArrayGenerator}]}));
+expectError(execaSync('unicorns', {stdio: [unknownGenerator]}));
+expectError(execaSync('unicorns', {stdio: [{transform: unknownGenerator}]}));
 expectError(execaSync('unicorns', {stdio: [new WritableStream()]}));
 expectError(execaSync('unicorns', {stdio: [new ReadableStream()]}));
 expectError(execaSync('unicorns', {stdio: [emptyStringGenerator()]}));
@@ -1155,10 +1209,11 @@ execa('unicorns', {
 		['inherit'],
 		[process.stdin],
 		[1],
-		[unknownArrayGenerator],
-		[{transform: unknownArrayGenerator}],
-		[{transform: unknownArrayGenerator, binary: true}],
-		[{transform: unknownArrayGenerator, objectMode: true}],
+		[unknownGenerator],
+		[{transform: unknownGenerator}],
+		[{transform: unknownGenerator, binary: true}],
+		[{transform: unknownGenerator, objectMode: true}],
+		[{transform: unknownGenerator, final: unknownFinal}],
 		[undefined],
 		[fileUrl],
 		[{file: './test'}],
@@ -1192,8 +1247,8 @@ execaSync('unicorns', {
 		[new Uint8Array()],
 	],
 });
-expectError(execaSync('unicorns', {stdio: [[unknownArrayGenerator]]}));
-expectError(execaSync('unicorns', {stdio: [[{transform: unknownArrayGenerator}]]}));
+expectError(execaSync('unicorns', {stdio: [[unknownGenerator]]}));
+expectError(execaSync('unicorns', {stdio: [[{transform: unknownGenerator}]]}));
 expectError(execaSync('unicorns', {stdio: [[new WritableStream()]]}));
 expectError(execaSync('unicorns', {stdio: [[new ReadableStream()]]}));
 expectError(execaSync('unicorns', {stdio: [[['foo', 'bar']]]}));

--- a/lib/stdio/duplex.js
+++ b/lib/stdio/duplex.js
@@ -20,7 +20,7 @@ export const generatorsToDuplex = (generators, {writableObjectMode, readableObje
 	let iterable = passThrough.iterator();
 
 	for (const generator of generators) {
-		iterable = generator(iterable);
+		iterable = applyGenerator(generator, iterable);
 	}
 
 	const readableStream = Readable.from(iterable, {
@@ -29,6 +29,16 @@ export const generatorsToDuplex = (generators, {writableObjectMode, readableObje
 	});
 	const duplexStream = Duplex.from({writable: passThrough, readable: readableStream});
 	return duplexStream;
+};
+
+const applyGenerator = async function * ({transform, final}, chunks) {
+	for await (const chunk of chunks) {
+		yield * transform(chunk);
+	}
+
+	if (final !== undefined) {
+		yield * final();
+	}
 };
 
 /*

--- a/lib/stdio/encoding.js
+++ b/lib/stdio/encoding.js
@@ -12,14 +12,21 @@ export const handleStreamsEncoding = (stdioStreams, {encoding}, isSync) => {
 	}
 
 	const objectMode = newStdioStreams.findLast(({type}) => type === 'generator')?.value.objectMode === true;
-	const encodingEndGenerator = objectMode ? encodingEndObjectGenerator : encodingEndStringGenerator;
-	const transform = encodingEndGenerator.bind(undefined, encoding);
+	const stringDecoder = new StringDecoder(encoding);
+	const generator = objectMode
+		? {
+			transform: encodingEndObjectGenerator.bind(undefined, stringDecoder),
+		}
+		: {
+			transform: encodingEndStringGenerator.bind(undefined, stringDecoder),
+			final: encodingEndStringFinal.bind(undefined, stringDecoder),
+		};
 	return [
 		...newStdioStreams,
 		{
 			...newStdioStreams[0],
 			type: 'generator',
-			value: {transform, binary: true, objectMode},
+			value: {...generator, binary: true, objectMode},
 			encoding: 'buffer',
 		},
 	];
@@ -33,25 +40,19 @@ const shouldEncodeOutput = (stdioStreams, encoding, isSync) => stdioStreams[0].d
 // eslint-disable-next-line unicorn/text-encoding-identifier-case
 const IGNORED_ENCODINGS = new Set(['utf8', 'utf-8', 'buffer']);
 
-const encodingEndStringGenerator = async function * (encoding, chunks) {
-	const stringDecoder = new StringDecoder(encoding);
+const encodingEndStringGenerator = function * (stringDecoder, chunk) {
+	yield stringDecoder.write(chunk);
+};
 
-	for await (const chunk of chunks) {
-		yield stringDecoder.write(chunk);
-	}
-
+const encodingEndStringFinal = function * (stringDecoder) {
 	const lastChunk = stringDecoder.end();
 	if (lastChunk !== '') {
 		yield lastChunk;
 	}
 };
 
-const encodingEndObjectGenerator = async function * (encoding, chunks) {
-	const stringDecoder = new StringDecoder(encoding);
-
-	for await (const chunk of chunks) {
-		yield isUint8Array(chunk) ? stringDecoder.end(chunk) : chunk;
-	}
+const encodingEndObjectGenerator = function * (stringDecoder, chunk) {
+	yield isUint8Array(chunk) ? stringDecoder.end(chunk) : chunk;
 };
 
 /*
@@ -66,33 +67,35 @@ However, those are converted to Buffer:
 - on writes: `Duplex.writable` `decodeStrings: true` default option
 - on reads: `Duplex.readable` `readableEncoding: null` default option
 */
-export const getEncodingStartGenerator = encoding => encoding === 'buffer'
-	? encodingStartBufferGenerator
-	: encodingStartStringGenerator;
+export const getEncodingStartGenerator = encoding => {
+	if (encoding === 'buffer') {
+		return {transform: encodingStartBufferGenerator.bind(undefined, new TextEncoder())};
+	}
 
-const encodingStartBufferGenerator = async function * (chunks) {
-	const textEncoder = new TextEncoder();
+	const textDecoder = new TextDecoder();
+	return {
+		transform: encodingStartStringGenerator.bind(undefined, textDecoder),
+		final: encodingStartStringFinal.bind(undefined, textDecoder),
+	};
+};
 
-	for await (const chunk of chunks) {
-		if (Buffer.isBuffer(chunk)) {
-			yield new Uint8Array(chunk);
-		} else if (typeof chunk === 'string') {
-			yield textEncoder.encode(chunk);
-		} else {
-			yield chunk;
-		}
+const encodingStartBufferGenerator = function * (textEncoder, chunk) {
+	if (Buffer.isBuffer(chunk)) {
+		yield new Uint8Array(chunk);
+	} else if (typeof chunk === 'string') {
+		yield textEncoder.encode(chunk);
+	} else {
+		yield chunk;
 	}
 };
 
-const encodingStartStringGenerator = async function * (chunks) {
-	const textDecoder = new TextDecoder();
+const encodingStartStringGenerator = function * (textDecoder, chunk) {
+	yield Buffer.isBuffer(chunk) || isUint8Array(chunk)
+		? textDecoder.decode(chunk, {stream: true})
+		: chunk;
+};
 
-	for await (const chunk of chunks) {
-		yield Buffer.isBuffer(chunk) || isUint8Array(chunk)
-			? textDecoder.decode(chunk, {stream: true})
-			: chunk;
-	}
-
+const encodingStartStringFinal = function * (textDecoder) {
 	const lastChunk = textDecoder.decode();
 	if (lastChunk !== '') {
 		yield lastChunk;

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -18,11 +18,11 @@ export const normalizeGenerators = stdioStreams => {
 };
 
 const normalizeGenerator = ({value, ...stdioStream}, index, newGenerators) => {
-	const {transform, binary = false, objectMode = false} = isGeneratorOptions(value) ? value : {transform: value};
+	const {transform, final, binary = false, objectMode = false} = isGeneratorOptions(value) ? value : {transform: value};
 	const objectModes = stdioStream.direction === 'output'
 		? getOutputObjectModes(objectMode, index, newGenerators)
 		: getInputObjectModes(objectMode, index, newGenerators);
-	return {...stdioStream, value: {transform, binary, ...objectModes}};
+	return {...stdioStream, value: {transform, final, binary, ...objectModes}};
 };
 
 /*
@@ -54,8 +54,8 @@ const sortGenerators = newGenerators => newGenerators[0]?.direction === 'input' 
 Generators can be used to transform/filter standard streams.
 
 Generators have a simple syntax, yet allows all of the following:
-- Sharing state between chunks, by using logic before the `for` loop
-- Flushing logic, by using logic after the `for` loop
+- Sharing `state` between chunks
+- Flushing logic, by using a `final` function
 - Asynchronous logic
 - Emitting multiple chunks from a single source chunk, even if spaced in time, by using multiple `yield`
 - Filtering, by using no `yield`
@@ -67,15 +67,15 @@ The `highWaterMark` is kept as the default value, since this is what `childProce
 Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
 */
 export const generatorToDuplexStream = ({
-	value: {transform, binary, writableObjectMode, readableObjectMode},
+	value: {transform, final, binary, writableObjectMode, readableObjectMode},
 	encoding,
 	optionName,
 }) => {
 	const generators = [
 		getEncodingStartGenerator(encoding),
 		getLinesGenerator(encoding, binary),
-		transform,
-		getValidateTransformReturn(readableObjectMode, optionName),
+		{transform, final},
+		{transform: getValidateTransformReturn(readableObjectMode, optionName)},
 	].filter(Boolean);
 	const duplexStream = generatorsToDuplex(generators, {writableObjectMode, readableObjectMode});
 	return {value: duplexStream};
@@ -85,24 +85,20 @@ const getValidateTransformReturn = (readableObjectMode, optionName) => readableO
 	? validateObjectTransformReturn.bind(undefined, optionName)
 	: validateStringTransformReturn.bind(undefined, optionName);
 
-const validateObjectTransformReturn = async function * (optionName, chunks) {
-	for await (const chunk of chunks) {
-		if (chunk === null) {
-			throw new Error(`The \`${optionName}\` option's function must not return null.`);
-		}
-
-		yield chunk;
+const validateObjectTransformReturn = function * (optionName, chunk) {
+	if (chunk === null) {
+		throw new TypeError(`The \`${optionName}\` option's function must not return null.`);
 	}
+
+	yield chunk;
 };
 
-const validateStringTransformReturn = async function * (optionName, chunks) {
-	for await (const chunk of chunks) {
-		if (typeof chunk !== 'string' && !isBinary(chunk)) {
-			throw new Error(`The \`${optionName}\` option's function must return a string or an Uint8Array, not ${typeof chunk}.`);
-		}
-
-		yield chunk;
+const validateStringTransformReturn = function * (optionName, chunk) {
+	if (typeof chunk !== 'string' && !isBinary(chunk)) {
+		throw new TypeError(`The \`${optionName}\` option's function must return a string or an Uint8Array, not ${typeof chunk}.`);
 	}
+
+	yield chunk;
 };
 
 // `childProcess.stdin|stdout|stderr|stdio` is directly mutated.

--- a/lib/stdio/lines.js
+++ b/lib/stdio/lines.js
@@ -19,8 +19,8 @@ const shouldSplitLines = (stdioStreams, lines, isSync) => stdioStreams[0].direct
 	&& !isSync
 	&& willPipeStreams(stdioStreams);
 
-const linesEndGenerator = async function * (chunks) {
-	yield * chunks;
+const linesEndGenerator = function * (chunk) {
+	yield chunk;
 };
 
 // Split chunks line-wise for generators passed to the `std*` options
@@ -29,17 +29,12 @@ export const getLinesGenerator = (encoding, binary) => {
 		return;
 	}
 
-	return encoding === 'buffer' ? linesUint8ArrayGenerator : linesStringGenerator;
-};
-
-const linesUint8ArrayGenerator = async function * (chunks) {
-	yield * linesGenerator({
-		chunks,
-		emptyValue: new Uint8Array(0),
-		newline: 0x0A,
-		concat: concatUint8Array,
-		isValidType: isUint8Array,
-	});
+	const info = encoding === 'buffer' ? linesUint8ArrayInfo : linesStringInfo;
+	const state = {previousChunks: info.emptyValue};
+	return {
+		transform: linesGenerator.bind(undefined, state, info),
+		final: linesFinal.bind(undefined, state),
+	};
 };
 
 const concatUint8Array = (firstChunk, secondChunk) => {
@@ -49,51 +44,56 @@ const concatUint8Array = (firstChunk, secondChunk) => {
 	return chunk;
 };
 
-const linesStringGenerator = async function * (chunks) {
-	yield * linesGenerator({
-		chunks,
-		emptyValue: '',
-		newline: '\n',
-		concat: concatString,
-		isValidType: isString,
-	});
+const linesUint8ArrayInfo = {
+	emptyValue: new Uint8Array(0),
+	newline: 0x0A,
+	concat: concatUint8Array,
+	isValidType: isUint8Array,
 };
 
 const concatString = (firstChunk, secondChunk) => `${firstChunk}${secondChunk}`;
 const isString = chunk => typeof chunk === 'string';
 
+const linesStringInfo = {
+	emptyValue: '',
+	newline: '\n',
+	concat: concatString,
+	isValidType: isString,
+};
+
 // This imperative logic is much faster than using `String.split()` and uses very low memory.
 // Also, it allows sharing it with `Uint8Array`.
-const linesGenerator = async function * ({chunks, emptyValue, newline, concat, isValidType}) {
-	let previousChunks = emptyValue;
+const linesGenerator = function * (state, {emptyValue, newline, concat, isValidType}, chunk) {
+	if (!isValidType(chunk)) {
+		yield chunk;
+		return;
+	}
 
-	for await (const chunk of chunks) {
-		if (!isValidType(chunk)) {
-			yield chunk;
-			continue;
-		}
+	let {previousChunks} = state;
+	let start = -1;
 
-		let start = -1;
+	for (let end = 0; end < chunk.length; end += 1) {
+		if (chunk[end] === newline) {
+			let line = chunk.slice(start + 1, end + 1);
 
-		for (let end = 0; end < chunk.length; end += 1) {
-			if (chunk[end] === newline) {
-				let line = chunk.slice(start + 1, end + 1);
-
-				if (previousChunks.length > 0) {
-					line = concat(previousChunks, line);
-					previousChunks = emptyValue;
-				}
-
-				yield line;
-				start = end;
+			if (previousChunks.length > 0) {
+				line = concat(previousChunks, line);
+				previousChunks = emptyValue;
 			}
-		}
 
-		if (start !== chunk.length - 1) {
-			previousChunks = concat(previousChunks, chunk.slice(start + 1));
+			yield line;
+			start = end;
 		}
 	}
 
+	if (start !== chunk.length - 1) {
+		previousChunks = concat(previousChunks, chunk.slice(start + 1));
+	}
+
+	state.previousChunks = previousChunks;
+};
+
+const linesFinal = function * ({previousChunks}) {
 	if (previousChunks.length > 0) {
 		yield previousChunks;
 	}

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -3,12 +3,8 @@ import {isUint8Array} from './utils.js';
 
 // The `stdin`/`stdout`/`stderr` option can be of many types. This detects it.
 export const getStdioOptionType = (stdioOption, optionName) => {
-	if (isAsyncGenerator(stdioOption)) {
+	if (isGenerator(stdioOption)) {
 		return 'generator';
-	}
-
-	if (isSyncGenerator(stdioOption)) {
-		throw new TypeError(`The \`${optionName}\` option must use an asynchronous generator, not a synchronous one.`);
 	}
 
 	if (isUrl(stdioOption)) {
@@ -42,9 +38,13 @@ export const getStdioOptionType = (stdioOption, optionName) => {
 	return 'native';
 };
 
-const getGeneratorObjectType = ({transform, binary, objectMode}, optionName) => {
-	if (!isAsyncGenerator(transform)) {
-		throw new TypeError(`The \`${optionName}.transform\` option must use an asynchronous generator.`);
+const getGeneratorObjectType = ({transform, final, binary, objectMode}, optionName) => {
+	if (!isGenerator(transform)) {
+		throw new TypeError(`The \`${optionName}.transform\` option must be a generator.`);
+	}
+
+	if (final !== undefined && !isGenerator(final)) {
+		throw new TypeError(`The \`${optionName}.final\` option must be a generator.`);
 	}
 
 	checkBooleanOption(binary, `${optionName}.binary`);
@@ -59,8 +59,8 @@ const checkBooleanOption = (value, optionName) => {
 	}
 };
 
-const isAsyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object AsyncGeneratorFunction]';
-const isSyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object GeneratorFunction]';
+const isGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object AsyncGeneratorFunction]'
+	|| Object.prototype.toString.call(stdioOption) === '[object GeneratorFunction]';
 export const isGeneratorOptions = stdioOption => typeof stdioOption === 'object'
 	&& stdioOption !== null
 	&& stdioOption.transform !== undefined;

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -57,8 +57,8 @@ const getAllStream = ({all, stdout, stderr}, encoding) => all && stdout && stder
 	: all;
 
 const allStreamGenerator = {
-	async * transform(chunks) {
-		yield * chunks;
+	* transform(chunk) {
+		yield chunk;
 	},
 	binary: true,
 	writableObjectMode: true,

--- a/readme.md
+++ b/readme.md
@@ -556,7 +556,7 @@ See also the [`input`](#input) and [`stdin`](#stdin) options.
 
 #### stdin
 
-Type: `string | number | stream.Readable | ReadableStream | URL | Uint8Array | Iterable<string> | Iterable<Uint8Array> | Iterable<unknown> | AsyncIterable<string> | AsyncIterable<Uint8Array> | AsyncIterable<unknown> | AsyncGeneratorFunction<string> | AsyncGeneratorFunction<Uint8Array> | AsyncGeneratorFunction<unknown>` (or a tuple of those types)\
+Type: `string | number | stream.Readable | ReadableStream | URL | Uint8Array | Iterable<string> | Iterable<Uint8Array> | Iterable<unknown> | AsyncIterable<string> | AsyncIterable<Uint8Array> | AsyncIterable<unknown> | GeneratorFunction<string> | GeneratorFunction<Uint8Array> | GeneratorFunction<unknown>| AsyncGeneratorFunction<string> | AsyncGeneratorFunction<Uint8Array> | AsyncGeneratorFunction<unknown>` (or a tuple of those types)\
 Default: `inherit` with [`$`](#command), `pipe` otherwise
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard input. This can be:
@@ -575,11 +575,11 @@ Default: `inherit` with [`$`](#command), `pipe` otherwise
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-This can also be an async generator function to transform the input. [Learn more.](docs/transform.md)
+This can also be a generator function to transform the input. [Learn more.](docs/transform.md)
 
 #### stdout
 
-Type: `string | number | stream.Writable | WritableStream | URL | AsyncGeneratorFunction<string> | AsyncGeneratorFunction<Uint8Array> | AsyncGeneratorFunction<unknown>` (or a tuple of those types)\
+Type: `string | number | stream.Writable | WritableStream | URL | GeneratorFunction<string> | GeneratorFunction<Uint8Array> | GeneratorFunction<unknown>| AsyncGeneratorFunction<string> | AsyncGeneratorFunction<Uint8Array> | AsyncGeneratorFunction<unknown>` (or a tuple of those types)\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard output. This can be:
@@ -596,11 +596,11 @@ Default: `pipe`
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-This can also be an async generator function to transform the output. [Learn more.](docs/transform.md)
+This can also be a generator function to transform the output. [Learn more.](docs/transform.md)
 
 #### stderr
 
-Type: `string | number | stream.Writable | WritableStream | URL | AsyncGeneratorFunction<string> | AsyncGeneratorFunction<Uint8Array> | AsyncGeneratorFunction<unknown>` (or a tuple of those types)`\
+Type: `string | number | stream.Writable | WritableStream | URL | GeneratorFunction<string> | GeneratorFunction<Uint8Array> | GeneratorFunction<unknown>| AsyncGeneratorFunction<string> | AsyncGeneratorFunction<Uint8Array> | AsyncGeneratorFunction<unknown>` (or a tuple of those types)\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard error. This can be:
@@ -617,11 +617,11 @@ Default: `pipe`
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-This can also be an async generator function to transform the output. [Learn more.](docs/transform.md)
+This can also be a generator function to transform the output. [Learn more.](docs/transform.md)
 
 #### stdio
 
-Type: `string | Array<string | number | stream.Readable | stream.Writable | ReadableStream | WritableStream | URL | Uint8Array | Iterable<string> | Iterable<Uint8Array> | Iterable<unknown> | AsyncIterable<string> | AsyncIterable<Uint8Array> | AsyncIterable<unknown> | AsyncGeneratorFunction<string> | AsyncGeneratorFunction<Uint8Array> | AsyncGeneratorFunction<unknown>>` (or a tuple of those types)\
+Type: `string | Array<string | number | stream.Readable | stream.Writable | ReadableStream | WritableStream | URL | Uint8Array | Iterable<string> | Iterable<Uint8Array> | Iterable<unknown> | AsyncIterable<string> | AsyncIterable<Uint8Array> | AsyncIterable<unknown> | GeneratorFunction<string> | GeneratorFunction<Uint8Array> | GeneratorFunction<unknown>| AsyncGeneratorFunction<string> | AsyncGeneratorFunction<Uint8Array> | AsyncGeneratorFunction<unknown>>` (or a tuple of those types)\
 Default: `pipe`
 
 Like the [`stdin`](#stdin), [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options but for all file descriptors at once. For example, `{stdio: ['ignore', 'pipe', 'pipe']}` is the same as `{stdin: 'ignore', stdout: 'pipe', stderr: 'pipe'}`.

--- a/test/fixtures/nested-inherit.js
+++ b/test/fixtures/nested-inherit.js
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 import {execa} from '../../index.js';
 
-const uppercaseGenerator = async function * (lines) {
-	for await (const line of lines) {
-		yield line.toUpperCase();
-	}
+const uppercaseGenerator = function * (line) {
+	yield line.toUpperCase();
 };
 
 await execa('noop-fd.js', ['1'], {stdout: ['inherit', uppercaseGenerator]});

--- a/test/stdio/encoding.js
+++ b/test/stdio/encoding.js
@@ -128,8 +128,10 @@ test('can pass encoding "base64" to stdio[*] - sync', checkEncoding, 'base64', 3
 test('can pass encoding "base64url" to stdio[*] - sync', checkEncoding, 'base64url', 3, execaSync);
 /* eslint-enable unicorn/text-encoding-identifier-case */
 
-test('validate unknown encodings', async t => {
-	await t.throwsAsync(execa('noop.js', {encoding: 'unknownEncoding'}), {code: 'ERR_UNKNOWN_ENCODING'});
+test('validate unknown encodings', t => {
+	t.throws(() => {
+		execa('noop.js', {encoding: 'unknownEncoding'});
+	}, {code: 'ERR_UNKNOWN_ENCODING'});
 });
 
 const foobarArray = ['fo', 'ob', 'ar', '..'];

--- a/test/stdio/lines.js
+++ b/test/stdio/lines.js
@@ -29,22 +29,17 @@ const runOverChunks = ['aaa\nb', 'b', 'b\nccc'];
 const bigLine = '.'.repeat(1e5);
 const manyChunks = Array.from({length: 1e3}).fill('.');
 
-const inputGenerator = async function * (input, chunks) {
-	// eslint-disable-next-line no-unused-vars
-	for await (const chunk of chunks) {
-		for (const inputItem of input) {
-			yield inputItem;
-			// eslint-disable-next-line no-await-in-loop
-			await scheduler.yield();
-		}
+const inputGenerator = async function * (input) {
+	for (const inputItem of input) {
+		yield inputItem;
+		// eslint-disable-next-line no-await-in-loop
+		await scheduler.yield();
 	}
 };
 
-const resultGenerator = async function * (lines, chunks) {
-	for await (const chunk of chunks) {
-		lines.push(chunk);
-		yield chunk;
-	}
+const resultGenerator = function * (lines, chunk) {
+	lines.push(chunk);
+	yield chunk;
 };
 
 const textEncoder = new TextEncoder();


### PR DESCRIPTION
This PR simplifies the transforms' syntax.
The assumption is that most transforms will simply map or filter lines, so the syntax should be optimized for this use case.

### Simple mapping

#### Before

```js
const transform = async function * (lines) {
  for await (const line of lines) {
    yield line.toUpperCase();
  }
};
```

#### After

```js
const transform = function * (line) {
  yield line.toUpperCase();
};
```

### Filtering

#### Before

```js
const transform = async function * (lines) {
  for await (const line of lines) {
    if (!line.includes('secret')) {
      yield line;
    }
  }
};
```

#### After

```js
const transform = function * (line) {
  if (!line.includes('secret')) {
    yield line.toUpperCase();
  }
};
```

### Sharing state

#### Before

```js
const transform = async function * (lines) {
  let count = 0; 

  for await (const line of lines) {
    yield `[${count++}] ${line}`;
  }
};
```

#### After

```js
let count = 0;

const transform = function * (line) {
  yield `[${count++}] ${line}`;
};
```

### Final lines

Not sure whether this one results in a simpler syntax, but this is more of an edge case.

#### Before

```js
const transform = async function * (lines) {
  let count = 0; 

  for await (const line of lines) {
    count += 1;
    yield line;
  }

  yield `Number of lines: ${count}`; 
};

await execa('...', {stdout: transform});
```

#### After

```js
let count = 0;

const transform = function * (line) {
  count += 1
  yield line;
};

const final = function * () {
  yield `Number of lines: ${count}`; 
}

await execa('...', {stdout: {transform, final}});
```

### Additional pros

Beyond the simplified syntax, this brings the following pros.

#### Implementation simplicity

The implementation can be moved to using a single, simpler `Transform` stream. As opposed to what we currently use: a `Duplex.from()` + `PassThrough` + `Readable.iterator()` + `Readable.from()` setup. Using a more straightforward `Transform` will be more efficient and result in fewer bugs.

I can implement this in a follow-up PR. 

#### Synchronous transforms

Allows the transform to be synchronous, which results in better performance in that case by avoiding repeatedly calling `await`. 

The transforms we use internally for the `lines` option, the `encoding` option, the transform line-wise logic and the transform encoding logic are all synchronous. Therefore, that's important not to run them asynchronously unnecessarily.