### PR TITLE
Improve default value of the `stdin` option with `$`

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -6,7 +6,7 @@ With Execa, you can write scripts with Node.js instead of a shell language. It i
 import {$} from 'execa';
 
 const {stdout: name} = await $`cat package.json`
-  .pipe($({stdin: 'pipe'})`grep name`);
+  .pipe($`grep name`);
 console.log(name);
 
 const branch = await $`git branch --show-current`;
@@ -598,7 +598,7 @@ await $`echo example | cat`;
 
 ```js
 // Execa
-await $`echo example`.pipe($({stdin: 'pipe'})`cat`);
+await $`echo example`.pipe($`cat`);
 ```
 
 ### Piping stdout and stderr to another command
@@ -619,7 +619,7 @@ await Promise.all([echo, cat]);
 
 ```js
 // Execa
-await $({all: true})`echo example`.pipe($({stdin: 'pipe'})`cat`, 'all');
+await $({all: true})`echo example`.pipe($`cat`, 'all');
 ```
 
 ### Piping stdout to a file
@@ -656,6 +656,15 @@ await cat
 ```js
 // Execa
 await $({inputFile: 'file.txt'})`cat`
+```
+
+### Interactive stdin
+
+By default, the command can use the user's interactive input.\
+If you encounter any issues receiving it, the following can help.
+
+```js
+await $({stdin: 'inherit'})`interactive-command`
 ```
 
 ### Silent stderr

--- a/index.d.ts
+++ b/index.d.ts
@@ -1100,6 +1100,8 @@ type Execa$<OptionsType extends CommonOptions = {}> = {
 
 	Cannot use the following options: `all`, `cleanup`, `buffer`, `detached`, `serialization`, `signal` and `lines`. Also, the `stdin`, `stdout`, `stderr`, `stdio` and `input` options cannot be an array, an iterable or a web stream. Node.js streams must have a file descriptor unless the `input` option is used.
 
+	Unlike $\`command\`, the `stdin` option defaults to `"inherit"`, not `["pipe", "inherit"]`.
+
 	Returns or throws a `childProcessResult`. The `childProcess` is not returned: its methods and properties are not available. This includes [`.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`.pid`](https://nodejs.org/api/child_process.html#subprocesspid), `.pipe()` and the [`.stdin`/`.stdout`/`.stderr`](https://nodejs.org/api/child_process.html#subprocessstdout) streams.
 
 	@returns A `childProcessResult` object

--- a/index.js
+++ b/index.js
@@ -284,13 +284,16 @@ export function execaSync(rawFile, rawArgs, rawOptions) {
 	};
 }
 
-const normalizeScriptStdin = ({input, inputFile, stdio}) => input === undefined && inputFile === undefined && stdio === undefined
-	? {stdin: 'inherit'}
+const normalizeScriptStdin = (defaultStdin, {input, inputFile, stdio}) => input === undefined && inputFile === undefined && stdio === undefined
+	? defaultStdin
 	: {};
 
-const normalizeScriptOptions = (options = {}) => ({
+const defaultScriptStdin = {stdin: ['pipe', 'inherit']};
+const defaultScriptStdinSync = {stdin: 'inherit'};
+
+const normalizeScriptOptions = (defaultStdin, options = {}) => ({
 	preferLocal: true,
-	...normalizeScriptStdin(options),
+	...normalizeScriptStdin(defaultStdin, options),
 	...options,
 });
 
@@ -301,7 +304,7 @@ function create$(options) {
 		}
 
 		const [file, ...args] = parseTemplates(templatesOrOptions, expressions);
-		return execa(file, args, normalizeScriptOptions(options));
+		return execa(file, args, normalizeScriptOptions(defaultScriptStdin, options));
 	}
 
 	$.sync = (templates, ...expressions) => {
@@ -310,7 +313,7 @@ function create$(options) {
 		}
 
 		const [file, ...args] = parseTemplates(templates, expressions);
-		return execaSync(file, args, normalizeScriptOptions(options));
+		return execaSync(file, args, normalizeScriptOptions(defaultScriptStdinSync, options));
 	};
 
 	$.s = $.sync;

--- a/readme.md
+++ b/readme.md
@@ -289,6 +289,8 @@ Same as [$\`command\`](#command) but synchronous.
 
 Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`serialization`](#serialization), [`signal`](#signal) and [`lines`](#lines). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio-1) and [`input`](#input) options cannot be an array, an iterable or a web stream. Node.js streams [must have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr) unless the `input` option is used.
 
+Unlike $\`command\`, the [`stdin`](#stdin) option defaults to `"inherit"`, not `["pipe", "inherit"]`.
+
 Returns or throws a [`childProcessResult`](#childProcessResult). The [`childProcess`](#childprocess) is not returned: its methods and properties are not available. This includes [`.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`.pid`](https://nodejs.org/api/child_process.html#subprocesspid), [`.pipe()`](#pipeexecachildprocess-streamname) and the [`.stdin`/`.stdout`/`.stderr`](https://nodejs.org/api/child_process.html#subprocessstdout) streams.
 
 ### execaCommandSync(command, options?)
@@ -549,7 +551,7 @@ See also the [`input`](#input) and [`stdin`](#stdin) options.
 #### stdin
 
 Type: `string | number | stream.Readable | ReadableStream | URL | Uint8Array | Iterable<string> | Iterable<Uint8Array> | Iterable<unknown> | AsyncIterable<string> | AsyncIterable<Uint8Array> | AsyncIterable<unknown> | GeneratorFunction<string> | GeneratorFunction<Uint8Array> | GeneratorFunction<unknown>| AsyncGeneratorFunction<string> | AsyncGeneratorFunction<Uint8Array> | AsyncGeneratorFunction<unknown>` (or a tuple of those types)\
-Default: `inherit` with [`$`](#command), `pipe` otherwise
+Default: `["pipe", "inherit"]` with [`$`](#command), `"inherit"` with [`$.sync`](#synccommand), `"pipe"` otherwise
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the child process' standard input. This can be:
 - `'pipe'`: Sets [`childProcess.stdin`](https://nodejs.org/api/child_process.html#subprocessstdin) stream.

--- a/test/command.js
+++ b/test/command.js
@@ -330,6 +330,11 @@ test('$ stdin defaults to "inherit"', async t => {
 	t.is(stdout, 'foo');
 });
 
+test('$ stdin also defaults to "pipe"', async t => {
+	const {stdout} = await $`noop.js foo`.pipe($`stdin.js`);
+	t.is(stdout, 'foo');
+});
+
 test('$.sync stdin defaults to "inherit"', t => {
 	const {stdout} = $({input: 'foo'}).sync`stdin-script.js`;
 	t.is(stdout, 'foo');


### PR DESCRIPTION
Fixes #742.

Currently in draft: Windows tests are failing in CI. The underlying issue requires fixes by other PRs, so I'm pausing this one.