### PR TITLE
Make tests more stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,9 @@
 		]
 	},
 	"ava": {
-		"workerThreads": false
+		"workerThreads": false,
+		"concurrency": 1,
+		"timeout": "60s"
 	},
 	"xo": {
 		"rules": {


### PR DESCRIPTION
Our tests are spawning lots of processes all at once.
This often crashes test files randomly when I run them on my machine.
It also fails randomly in CI, although CI uses a lower value of [2 test files at once](https://github.com/avajs/ava/blob/2e0c2b1cef779e1c092eb60f0a9558bb9cf4c848/lib/api.js#L255).

This PR tries to fix this by both:
  - running only 1 test file
  - increasing test timeout from 10s to 60s