### PR TITLE
Improve `.pipe()` validation error message

### DIFF
--- a/lib/pipe.js
+++ b/lib/pipe.js
@@ -1,11 +1,13 @@
 import {ChildProcess} from 'node:child_process';
 import {isWritableStream} from 'is-stream';
+import {STANDARD_STREAMS_ALIASES} from './stdio/utils.js';
 
-export const pipeToProcess = ({spawned, stdioStreamsGroups, options}, targetProcess, streamName = 'stdout') => {
+export const pipeToProcess = ({spawned, stdioStreamsGroups, options}, targetProcess, streamName) => {
 	validateTargetProcess(targetProcess);
 
-	const inputStream = getInputStream(spawned, streamName, stdioStreamsGroups);
-	validateStdioOption(inputStream, spawned, streamName, options);
+	const streamIndex = getStreamIndex(streamName);
+	const inputStream = getInputStream(spawned, streamIndex, stdioStreamsGroups);
+	validateStdioOption(inputStream, streamIndex, streamName, options);
 
 	inputStream.pipe(targetProcess.stdin);
 	return targetProcess;
@@ -23,57 +25,71 @@ const validateTargetProcess = targetProcess => {
 
 const isExecaChildProcess = target => target instanceof ChildProcess && typeof target.then === 'function';
 
-const getInputStream = (spawned, streamName, stdioStreamsGroups) => {
-	if (VALID_STREAM_NAMES.has(streamName)) {
-		return spawned[streamName];
+const getStreamIndex = (streamName = 'stdout') => STANDARD_STREAMS_ALIASES.includes(streamName)
+	? STANDARD_STREAMS_ALIASES.indexOf(streamName)
+	: streamName;
+
+const getInputStream = (spawned, streamIndex, stdioStreamsGroups) => {
+	if (streamIndex === 'all') {
+		return spawned.all;
 	}
 
-	if (streamName === 'stdin') {
+	if (streamIndex === 0) {
 		throw new TypeError('The second argument must not be "stdin".');
 	}
 
-	if (!Number.isInteger(streamName) || streamName < 0) {
-		throw new TypeError(`The second argument must not be "${streamName}".
+	if (!Number.isInteger(streamIndex) || streamIndex < 0) {
+		throw new TypeError(`The second argument must not be "${streamIndex}".
 It must be "stdout", "stderr", "all" or a file descriptor integer.
 It is optional and defaults to "stdout".`);
 	}
 
-	const stdioStreams = stdioStreamsGroups[streamName];
+	const stdioStreams = stdioStreamsGroups[streamIndex];
 	if (stdioStreams === undefined) {
-		throw new TypeError(`The second argument must not be ${streamName}: that file descriptor does not exist.
+		throw new TypeError(`The second argument must not be ${streamIndex}: that file descriptor does not exist.
 Please set the "stdio" option to ensure that file descriptor exists.`);
 	}
 
 	if (stdioStreams[0].direction === 'input') {
-		throw new TypeError(`The second argument must not be ${streamName}: it must be a readable stream, not writable.`);
+		throw new TypeError(`The second argument must not be ${streamIndex}: it must be a readable stream, not writable.`);
 	}
 
-	return spawned.stdio[streamName];
+	return spawned.stdio[streamIndex];
 };
 
-const VALID_STREAM_NAMES = new Set(['stdout', 'stderr', 'all']);
-
-const validateStdioOption = (inputStream, spawned, streamName, options) => {
+const validateStdioOption = (inputStream, streamIndex, streamName, options) => {
 	if (inputStream !== null && inputStream !== undefined) {
 		return;
 	}
 
-	if (streamName === 'all' && !options.all) {
+	if (streamIndex === 'all' && !options.all) {
 		throw new TypeError('The "all" option must be true to use `childProcess.pipe(targetProcess, "all")`.');
 	}
 
-	throw new TypeError(`The "${getInvalidStdioOption(inputStream, spawned, options)}" option's value is incompatible with using \`childProcess.pipe(targetProcess)\`.
+	const {optionName, optionValue} = getInvalidStdioOption(streamIndex, options);
+	const pipeArgument = streamName === undefined ? '' : `, ${streamName}`;
+	throw new TypeError(`The \`${optionName}: ${serializeOptionValue(optionValue)}\` option is incompatible with using \`childProcess.pipe(targetProcess${pipeArgument})\`.
 Please set this option with "pipe" instead.`);
 };
 
-const getInvalidStdioOption = (inputStream, spawned, options) => {
-	if (inputStream === spawned.stdout && options.stdout !== undefined) {
-		return 'stdout';
+const getInvalidStdioOption = (streamIndex, {stdout, stderr, stdio}) => {
+	const usedIndex = streamIndex === 'all' ? 1 : streamIndex;
+
+	if (usedIndex === 1 && stdout !== undefined) {
+		return {optionName: 'stdout', optionValue: stdout};
 	}
 
-	if (inputStream === spawned.stderr && options.stderr !== undefined) {
-		return 'stderr';
+	if (usedIndex === 2 && stderr !== undefined) {
+		return {optionName: 'stderr', optionValue: stderr};
 	}
 
-	return 'stdio';
+	return {optionName: `stdio[${usedIndex}]`, optionValue: stdio[usedIndex]};
+};
+
+const serializeOptionValue = optionValue => {
+	if (typeof optionValue === 'string') {
+		return `"${optionValue}"`;
+	}
+
+	return typeof optionValue === 'number' ? `${optionValue}` : 'Stream';
 };

--- a/lib/stdio/normalize.js
+++ b/lib/stdio/normalize.js
@@ -1,3 +1,5 @@
+import {STANDARD_STREAMS_ALIASES} from './utils.js';
+
 // Add support for `stdin`/`stdout`/`stderr` as an alias for `stdio`
 export const normalizeStdio = options => {
 	if (!options) {
@@ -7,11 +9,11 @@ export const normalizeStdio = options => {
 	const {stdio} = options;
 
 	if (stdio === undefined) {
-		return aliases.map(alias => options[alias]);
+		return STANDARD_STREAMS_ALIASES.map(alias => options[alias]);
 	}
 
 	if (hasAlias(options)) {
-		throw new Error(`It's not possible to provide \`stdio\` in combination with one of ${aliases.map(alias => `\`${alias}\``).join(', ')}`);
+		throw new Error(`It's not possible to provide \`stdio\` in combination with one of ${STANDARD_STREAMS_ALIASES.map(alias => `\`${alias}\``).join(', ')}`);
 	}
 
 	if (typeof stdio === 'string') {
@@ -22,13 +24,11 @@ export const normalizeStdio = options => {
 		throw new TypeError(`Expected \`stdio\` to be of type \`string\` or \`Array\`, got \`${typeof stdio}\``);
 	}
 
-	const length = Math.max(stdio.length, aliases.length);
+	const length = Math.max(stdio.length, STANDARD_STREAMS_ALIASES.length);
 	return Array.from({length}, (value, index) => stdio[index]);
 };
 
-const hasAlias = options => aliases.some(alias => options[alias] !== undefined);
-
-const aliases = ['stdin', 'stdout', 'stderr'];
+const hasAlias = options => STANDARD_STREAMS_ALIASES.some(alias => options[alias] !== undefined);
 
 // Same but for `execaNode()`, i.e. push `ipc` unless already present
 export const normalizeStdioNode = options => {

--- a/lib/stdio/utils.js
+++ b/lib/stdio/utils.js
@@ -25,3 +25,4 @@ export const pipeStreams = async (source, destination) => {
 
 export const isStandardStream = stream => STANDARD_STREAMS.includes(stream);
 export const STANDARD_STREAMS = [process.stdin, process.stdout, process.stderr];
+export const STANDARD_STREAMS_ALIASES = ['stdin', 'stdout', 'stderr'];

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -79,17 +79,32 @@ test('Must set target "stdin" option to "pipe" to use pipe()', t => {
 	}, {message: /stdin must be available/});
 });
 
-const invalidSource = (t, optionName, streamName, options) => {
+// eslint-disable-next-line max-params
+const invalidSource = (t, optionName, optionValue, streamName, options) => {
 	t.throws(() => {
 		execa('empty.js', options).pipe(execa('empty.js'), streamName);
-	}, {message: new RegExp(`"${optionName}" option's value is incompatible`)});
+	}, {message: new RegExp(`\`${optionName}: ${optionValue}\` option is incompatible`)});
 };
 
-test('Cannot set "stdout" option to "ignore" to use pipe()', invalidSource, 'stdout', 1, {stdout: 'ignore'});
-test('Cannot set "stderr" option to "ignore" to use pipe()', invalidSource, 'stderr', 2, {stderr: 'ignore'});
-test('Cannot set "stdio[*]" option to "ignore" to use pipe()', invalidSource, 'stdio', 3, {stdio: ['pipe', 'pipe', 'pipe', 'ignore']});
-test('Cannot set "stdout" + "stderr" option to "ignore" to use pipe() with "all"', invalidSource, 'stdout', 1, {stdout: 'ignore', stderr: 'ignore', all: true});
-test('Cannot set "stdout" option to "inherit" to use pipe()', invalidSource, 'stdout', 1, {stdout: 'inherit'});
-test('Cannot set "stdout" option to "ipc" to use pipe()', invalidSource, 'stdout', 1, {stdout: 'ipc'});
-test('Cannot set "stdout" option to file descriptors to use pipe()', invalidSource, 'stdout', 1, {stdout: 1});
-test('Cannot set "stdout" option to Node.js streams to use pipe()', invalidSource, 'stdout', 1, {stdout: process.stdout});
+test('Cannot set "stdout" option to "ignore" to use pipe(...)', invalidSource, 'stdout', '"ignore"', undefined, {stdout: 'ignore'});
+test('Cannot set "stdout" option to "ignore" to use pipe(..., 1)', invalidSource, 'stdout', '"ignore"', 1, {stdout: 'ignore'});
+test('Cannot set "stdout" option to "ignore" to use pipe(..., "stdout")', invalidSource, 'stdout', '"ignore"', 'stdout', {stdout: 'ignore'});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use pipe(...)', invalidSource, 'stdout', '"ignore"', undefined, {stdout: 'ignore', stderr: 'ignore'});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use pipe(..., 1)', invalidSource, 'stdout', '"ignore"', 1, {stdout: 'ignore', stderr: 'ignore'});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use pipe(..., "stdout")', invalidSource, 'stdout', '"ignore"', 'stdout', {stdout: 'ignore', stderr: 'ignore'});
+test('Cannot set "stdio[1]" option to "ignore" to use pipe(...)', invalidSource, 'stdio\\[1\\]', '"ignore"', undefined, {stdio: ['pipe', 'ignore', 'pipe']});
+test('Cannot set "stdio[1]" option to "ignore" to use pipe(..., 1)', invalidSource, 'stdio\\[1\\]', '"ignore"', 1, {stdio: ['pipe', 'ignore', 'pipe']});
+test('Cannot set "stdio[1]" option to "ignore" to use pipe(..., "stdout")', invalidSource, 'stdio\\[1\\]', '"ignore"', 'stdout', {stdio: ['pipe', 'ignore', 'pipe']});
+test('Cannot set "stderr" option to "ignore" to use pipe(..., 2)', invalidSource, 'stderr', '"ignore"', 2, {stderr: 'ignore'});
+test('Cannot set "stderr" option to "ignore" to use pipe(..., "stderr")', invalidSource, 'stderr', '"ignore"', 'stderr', {stderr: 'ignore'});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use pipe(..., 2)', invalidSource, 'stderr', '"ignore"', 2, {stdout: 'ignore', stderr: 'ignore'});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use pipe(..., "stderr")', invalidSource, 'stderr', '"ignore"', 'stderr', {stdout: 'ignore', stderr: 'ignore'});
+test('Cannot set "stdio[2]" option to "ignore" to use pipe(..., 2)', invalidSource, 'stdio\\[2\\]', '"ignore"', 2, {stdio: ['pipe', 'pipe', 'ignore']});
+test('Cannot set "stdio[2]" option to "ignore" to use pipe(..., "stderr")', invalidSource, 'stdio\\[2\\]', '"ignore"', 'stderr', {stdio: ['pipe', 'pipe', 'ignore']});
+test('Cannot set "stdio[3]" option to "ignore" to use pipe(..., 3)', invalidSource, 'stdio\\[3\\]', '"ignore"', 3, {stdio: ['pipe', 'pipe', 'pipe', 'ignore']});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use pipe(..., "all")', invalidSource, 'stdout', '"ignore"', 'all', {stdout: 'ignore', stderr: 'ignore', all: true});
+test('Cannot set "stdio[1]" + "stdio[2]" option to "ignore" to use pipe(..., "all")', invalidSource, 'stdio\\[1\\]', '"ignore"', 'all', {stdio: ['pipe', 'ignore', 'ignore'], all: true});
+test('Cannot set "stdout" option to "inherit" to use pipe()', invalidSource, 'stdout', '"inherit"', 1, {stdout: 'inherit'});
+test('Cannot set "stdout" option to "ipc" to use pipe()', invalidSource, 'stdout', '"ipc"', 1, {stdout: 'ipc'});
+test('Cannot set "stdout" option to file descriptors to use pipe()', invalidSource, 'stdout', '1', 1, {stdout: 1});
+test('Cannot set "stdout" option to Node.js streams to use pipe()', invalidSource, 'stdout', 'Stream', 1, {stdout: process.stdout});


### PR DESCRIPTION
When using the `.pipe()` method, the user must make sure not to use options like `stdout: "ignore"`, `stderr: "inherit"`, etc. We validate this and throw an error when the wrong option is used.

This PR fixes the error message, which was not showing the correct option under some specific conditions.
This PR also improves the error message by showing not only the option's name but also its value.
Finally, it adds more tests related to that error message.