### PR TITLE
Improve transform speed

### DIFF
--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -1,7 +1,7 @@
 import {generatorsToTransform} from './transform.js';
 import {getEncodingStartGenerator} from './encoding.js';
 import {getLinesGenerator} from './lines.js';
-import {isGeneratorOptions} from './type.js';
+import {isGeneratorOptions, isAsyncGenerator} from './type.js';
 import {isBinary, pipeStreams} from './utils.js';
 
 export const normalizeGenerators = stdioStreams => {
@@ -77,7 +77,9 @@ export const generatorToDuplexStream = ({
 		{transform, final},
 		{transform: getValidateTransformReturn(readableObjectMode, optionName)},
 	].filter(Boolean);
-	const duplexStream = generatorsToTransform(generators, {writableObjectMode, readableObjectMode});
+	const transformAsync = isAsyncGenerator(transform);
+	const finalAsync = isAsyncGenerator(final);
+	const duplexStream = generatorsToTransform(generators, {transformAsync, finalAsync, writableObjectMode, readableObjectMode});
 	return {value: duplexStream};
 };
 

--- a/lib/stdio/transform.js
+++ b/lib/stdio/transform.js
@@ -3,21 +3,30 @@ import {callbackify} from 'node:util';
 
 // Transform an array of generator functions into a `Transform` stream.
 // `Duplex.from(generator)` cannot be used because it does not allow setting the `objectMode` and `highWaterMark`.
-export const generatorsToTransform = (generators, {writableObjectMode, readableObjectMode}) => new Transform({
-	writableObjectMode,
-	writableHighWaterMark: getDefaultHighWaterMark(writableObjectMode),
-	readableObjectMode,
-	readableHighWaterMark: getDefaultHighWaterMark(readableObjectMode),
-	transform(chunk, encoding, done) {
-		pushChunks(transformChunk.bind(undefined, chunk, generators, 0), this, done);
-	},
-	flush(done) {
-		pushChunks(finalChunks.bind(undefined, generators), this, done);
-	},
-});
+export const generatorsToTransform = (generators, {transformAsync, finalAsync, writableObjectMode, readableObjectMode}) => {
+	const transformMethod = transformAsync
+		? pushChunks.bind(undefined, transformChunk)
+		: pushChunksSync.bind(undefined, transformChunkSync);
+	const finalMethod = transformAsync || finalAsync
+		? pushChunks.bind(undefined, finalChunks)
+		: pushChunksSync.bind(undefined, finalChunksSync);
 
-const pushChunks = callbackify(async (getChunks, transformStream) => {
-	for await (const chunk of getChunks()) {
+	return new Transform({
+		writableObjectMode,
+		writableHighWaterMark: getDefaultHighWaterMark(writableObjectMode),
+		readableObjectMode,
+		readableHighWaterMark: getDefaultHighWaterMark(readableObjectMode),
+		transform(chunk, encoding, done) {
+			transformMethod([chunk, generators, 0], this, done);
+		},
+		flush(done) {
+			finalMethod([generators], this, done);
+		},
+	});
+};
+
+const pushChunks = callbackify(async (getChunks, args, transformStream) => {
+	for await (const chunk of getChunks(...args)) {
 		transformStream.push(chunk);
 	}
 });
@@ -49,5 +58,47 @@ const generatorFinalChunks = async function * (final, index, generators) {
 
 	for await (const finalChunk of final()) {
 		yield * transformChunk(finalChunk, generators, index + 1);
+	}
+};
+
+// Duplicate the code above but as synchronous functions.
+// This is a performance optimization when the `transform`/`flush` function is synchronous, which is the common case.
+const pushChunksSync = (getChunksSync, args, transformStream, done) => {
+	try {
+		for (const chunk of getChunksSync(...args)) {
+			transformStream.push(chunk);
+		}
+
+		done();
+	} catch (error) {
+		done(error);
+	}
+};
+
+const transformChunkSync = function * (chunk, generators, index) {
+	if (index === generators.length) {
+		yield chunk;
+		return;
+	}
+
+	const {transform} = generators[index];
+	for (const transformedChunk of transform(chunk)) {
+		yield * transformChunkSync(transformedChunk, generators, index + 1);
+	}
+};
+
+const finalChunksSync = function * (generators) {
+	for (const [index, {final}] of Object.entries(generators)) {
+		yield * generatorFinalChunksSync(final, Number(index), generators);
+	}
+};
+
+const generatorFinalChunksSync = function * (final, index, generators) {
+	if (final === undefined) {
+		return;
+	}
+
+	for (const finalChunk of final()) {
+		yield * transformChunkSync(finalChunk, generators, index + 1);
 	}
 };

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -59,8 +59,9 @@ const checkBooleanOption = (value, optionName) => {
 	}
 };
 
-const isGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object AsyncGeneratorFunction]'
-	|| Object.prototype.toString.call(stdioOption) === '[object GeneratorFunction]';
+const isGenerator = stdioOption => isAsyncGenerator(stdioOption) || isSyncGenerator(stdioOption);
+export const isAsyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object AsyncGeneratorFunction]';
+const isSyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object GeneratorFunction]';
 export const isGeneratorOptions = stdioOption => typeof stdioOption === 'object'
 	&& stdioOption !== null
 	&& stdioOption.transform !== undefined;


### PR DESCRIPTION
This improves the speed of transforms when the `transform` function is synchronous, which I am assuming should be the vast majority of the cases.

The performance improvement is quite big. On my machine, using a child process with some big output (1MB), the transform runs 4x faster.