### PR TITLE
Fix `maxListeners` warning when running multiple processes in parallel

### DIFF
--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -1,3 +1,4 @@
+import {addAbortListener} from 'node:events';
 import {createReadStream, createWriteStream} from 'node:fs';
 import {Buffer} from 'node:buffer';
 import {Readable, Writable} from 'node:stream';
@@ -59,12 +60,38 @@ const pipeStdioOption = (spawned, {type, value, direction, index}, inputStreamsG
 		return;
 	}
 
+	setStandardStreamMaxListeners(value, controller);
+
 	if (direction === 'output') {
 		pipeStreams([spawned.stdio[index]], value, controller);
 	} else {
 		inputStreamsGroups[index] = [...(inputStreamsGroups[index] ?? []), value];
 	}
 };
+
+// Multiple processes might be piping from/to `process.std*` at the same time.
+// This is not necessarily an error and should not print a `maxListeners` warning.
+const setStandardStreamMaxListeners = (stream, {signal}) => {
+	if (!isStandardStream(stream)) {
+		return;
+	}
+
+	const maxListeners = stream.getMaxListeners();
+	if (maxListeners === 0 || maxListeners === Number.POSITIVE_INFINITY) {
+		return;
+	}
+
+	stream.setMaxListeners(maxListeners + maxListenersIncrement);
+	addAbortListener(signal, () => {
+		stream.setMaxListeners(stream.getMaxListeners() - maxListenersIncrement);
+	});
+};
+
+// `source.pipe(destination)` adds at most 1 listener for each event.
+// We also listen for the stream's completion using `finished()`, which adds 1 more listener.
+// If `stdin` option is an array, the values might be combined with `merge-streams`.
+// That library also listens for `source` end, which adds 1 more listener.
+const maxListenersIncrement = 3;
 
 // The stream error handling is performed by the piping logic above, which cannot be performed before process spawning.
 // If the process spawning fails (e.g. due to an invalid command), the streams need to be manually destroyed.

--- a/test/stdio/async.js
+++ b/test/stdio/async.js
@@ -1,0 +1,88 @@
+import {once, defaultMaxListeners} from 'node:events';
+import process from 'node:process';
+import {setTimeout} from 'node:timers/promises';
+import test from 'ava';
+import {execa} from '../../index.js';
+import {STANDARD_STREAMS} from '../helpers/stdio.js';
+import {foobarString} from '../helpers/input.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+
+setFixtureDir();
+
+const getStandardStreamListeners = stream => Object.fromEntries(stream.eventNames().map(eventName => [eventName, stream.listeners(eventName)]));
+const getStandardStreamsListeners = () => STANDARD_STREAMS.map(stream => getStandardStreamListeners(stream));
+
+const getComplexStdio = isMultiple => ({
+	stdin: ['pipe', 'inherit', ...(isMultiple ? [0, process.stdin] : [])],
+	stdout: ['pipe', 'inherit', ...(isMultiple ? [1, process.stdout] : [])],
+	stderr: ['pipe', 'inherit', ...(isMultiple ? [2, process.stderr] : [])],
+});
+
+const testListenersCleanup = async (t, isMultiple) => {
+	const streamsPreviousListeners = getStandardStreamsListeners();
+	const childProcess = execa('empty.js', getComplexStdio(isMultiple));
+	t.notDeepEqual(getStandardStreamsListeners(), streamsPreviousListeners);
+	await Promise.all([
+		childProcess,
+		once(childProcess.stdin, 'unpipe'),
+		once(process.stdout, 'unpipe'),
+		once(process.stderr, 'unpipe'),
+	]);
+
+	for (const [index, streamNewListeners] of Object.entries(getStandardStreamsListeners())) {
+		const defaultListeners = Object.fromEntries(Reflect.ownKeys(streamNewListeners).map(eventName => [eventName, []]));
+		t.deepEqual(streamNewListeners, {...defaultListeners, ...streamsPreviousListeners[index]});
+	}
+};
+
+test.serial('process.std* listeners are cleaned up on success with a single input', testListenersCleanup, false);
+test.serial('process.std* listeners are cleaned up on success with multiple inputs', testListenersCleanup, true);
+
+const processesCount = 100;
+
+test.serial('Can spawn many processes in parallel', async t => {
+	const results = await Promise.all(
+		Array.from({length: processesCount}, () => execa('noop.js', [foobarString])),
+	);
+	t.true(results.every(({stdout}) => stdout === foobarString));
+});
+
+const testMaxListeners = async (t, isMultiple, maxListenersCount) => {
+	let warning;
+	const captureWarning = warningArgument => {
+		warning = warningArgument;
+	};
+
+	process.on('warning', captureWarning);
+
+	for (const standardStream of STANDARD_STREAMS) {
+		standardStream.setMaxListeners(maxListenersCount);
+	}
+
+	try {
+		const results = await Promise.all(
+			Array.from({length: processesCount}, () => execa('empty.js', getComplexStdio(isMultiple))),
+		);
+		await setTimeout(0);
+		t.true(results.every(({exitCode}) => exitCode === 0));
+		t.is(warning, undefined);
+	} finally {
+		for (const standardStream of STANDARD_STREAMS) {
+			t.is(standardStream.getMaxListeners(), maxListenersCount);
+			standardStream.setMaxListeners(defaultMaxListeners);
+		}
+
+		process.off('warning', captureWarning);
+	}
+};
+
+test.serial('No warning with maxListeners 1 and ["pipe", "inherit"]', testMaxListeners, false, 1);
+test.serial('No warning with maxListeners default and ["pipe", "inherit"]', testMaxListeners, false, defaultMaxListeners);
+test.serial('No warning with maxListeners 100 and ["pipe", "inherit"]', testMaxListeners, false, 100);
+test.serial('No warning with maxListeners Infinity and ["pipe", "inherit"]', testMaxListeners, false, Number.POSITIVE_INFINITY);
+test.serial('No warning with maxListeners 0 and ["pipe", "inherit"]', testMaxListeners, false, 0);
+test.serial('No warning with maxListeners 1 and ["pipe", "inherit"], multiple inputs', testMaxListeners, true, 1);
+test.serial('No warning with maxListeners default and ["pipe", "inherit"], multiple inputs', testMaxListeners, true, defaultMaxListeners);
+test.serial('No warning with maxListeners 100 and ["pipe", "inherit"], multiple inputs', testMaxListeners, true, 100);
+test.serial('No warning with maxListeners Infinity and ["pipe", "inherit"], multiple inputs', testMaxListeners, true, Number.POSITIVE_INFINITY);
+test.serial('No warning with maxListeners 0 and ["pipe", "inherit"], multiple inputs', testMaxListeners, true, 0);

--- a/test/stream.js
+++ b/test/stream.js
@@ -7,10 +7,9 @@ import getStream from 'get-stream';
 import {execa, execaSync} from '../index.js';
 import {setFixtureDir} from './helpers/fixtures-dir.js';
 import {fullStdio, getStdio} from './helpers/stdio.js';
+import {foobarString} from './helpers/input.js';
 
 setFixtureDir();
-
-const foobarString = 'foobar';
 
 test.serial('result.all shows both `stdout` and `stderr` intermixed', async t => {
 	const {all} = await execa('noop-132.js', {all: true});


### PR DESCRIPTION
Fixes #765.