### PR TITLE
Improve tests related to passing Node.js streams

### DIFF
--- a/test/stdio/node-stream.js
+++ b/test/stdio/node-stream.js
@@ -1,7 +1,8 @@
 import {once} from 'node:events';
 import {createReadStream, createWriteStream} from 'node:fs';
 import {readFile, writeFile, rm} from 'node:fs/promises';
-import {Readable, Writable, PassThrough} from 'node:stream';
+import {Readable, Writable, Duplex, PassThrough} from 'node:stream';
+import {text} from 'node:stream/consumers';
 import {setImmediate} from 'node:timers/promises';
 import {callbackify} from 'node:util';
 import test from 'ava';
@@ -9,48 +10,55 @@ import tempfile from 'tempfile';
 import {execa, execaSync} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {getStdio} from '../helpers/stdio.js';
+import {foobarString} from '../helpers/input.js';
 
 setFixtureDir();
 
-const createNoFileReadable = value => {
-	const stream = new PassThrough();
-	stream.write(value);
-	stream.end();
-	return stream;
-};
+const noopReadable = () => new Readable({read() {}});
+const noopWritable = () => new Writable({write() {}});
+const noopDuplex = () => new Duplex({read() {}, write() {}});
+const simpleReadable = () => Readable.from([foobarString]);
 
-const testNoFileStreamSync = async (t, index, StreamClass) => {
+const testNoFileStreamSync = async (t, index, stream) => {
 	t.throws(() => {
-		execaSync('empty.js', getStdio(index, new StreamClass()));
+		execaSync('empty.js', getStdio(index, stream));
 	}, {code: 'ERR_INVALID_ARG_VALUE'});
 };
 
-test('stdin cannot be a Node.js Readable without a file descriptor - sync', testNoFileStreamSync, 0, Readable);
-test('stdout cannot be a Node.js Writable without a file descriptor - sync', testNoFileStreamSync, 1, Writable);
-test('stderr cannot be a Node.js Writable without a file descriptor - sync', testNoFileStreamSync, 2, Writable);
-test('stdio[*] cannot be a Node.js Readable without a file descriptor - sync', testNoFileStreamSync, 3, Readable);
-test('stdio[*] cannot be a Node.js Writable without a file descriptor - sync', testNoFileStreamSync, 3, Writable);
+test('stdin cannot be a Node.js Readable without a file descriptor - sync', testNoFileStreamSync, 0, noopReadable());
+test('stdin cannot be a Node.js Duplex without a file descriptor - sync', testNoFileStreamSync, 0, noopDuplex());
+test('stdout cannot be a Node.js Writable without a file descriptor - sync', testNoFileStreamSync, 1, noopWritable());
+test('stdout cannot be a Node.js Duplex without a file descriptor - sync', testNoFileStreamSync, 1, noopDuplex());
+test('stderr cannot be a Node.js Writable without a file descriptor - sync', testNoFileStreamSync, 2, noopWritable());
+test('stderr cannot be a Node.js Duplex without a file descriptor - sync', testNoFileStreamSync, 2, noopDuplex());
+test('stdio[*] cannot be a Node.js Readable without a file descriptor - sync', testNoFileStreamSync, 3, noopReadable());
+test('stdio[*] cannot be a Node.js Writable without a file descriptor - sync', testNoFileStreamSync, 3, noopWritable());
+test('stdio[*] cannot be a Node.js Duplex without a file descriptor - sync', testNoFileStreamSync, 3, noopDuplex());
 
 test('input can be a Node.js Readable without a file descriptor', async t => {
-	const {stdout} = await execa('stdin.js', {input: createNoFileReadable('foobar')});
-	t.is(stdout, 'foobar');
+	const {stdout} = await execa('stdin.js', {input: simpleReadable()});
+	t.is(stdout, foobarString);
 });
 
 test('input cannot be a Node.js Readable without a file descriptor - sync', t => {
 	t.throws(() => {
-		execaSync('empty.js', {input: createNoFileReadable('foobar')});
+		execaSync('empty.js', {input: simpleReadable()});
 	}, {message: 'The `input` option cannot be a Node.js stream in sync mode.'});
 });
 
-const testNoFileStream = async (t, index, StreamClass) => {
-	await t.throwsAsync(execa('empty.js', getStdio(index, new StreamClass())), {code: 'ERR_INVALID_ARG_VALUE'});
+const testNoFileStream = async (t, index, stream) => {
+	await t.throwsAsync(execa('empty.js', getStdio(index, stream)), {code: 'ERR_INVALID_ARG_VALUE'});
 };
 
-test('stdin cannot be a Node.js Readable without a file descriptor', testNoFileStream, 0, Readable);
-test('stdout cannot be a Node.js Writable without a file descriptor', testNoFileStream, 1, Writable);
-test('stderr cannot be a Node.js Writable without a file descriptor', testNoFileStream, 2, Writable);
-test('stdio[*] cannot be a Node.js Readable without a file descriptor', testNoFileStream, 3, Readable);
-test('stdio[*] cannot be a Node.js Writable without a file descriptor', testNoFileStream, 3, Writable);
+test('stdin cannot be a Node.js Readable without a file descriptor', testNoFileStream, 0, noopReadable());
+test('stdin cannot be a Node.js Duplex without a file descriptor', testNoFileStream, 0, noopDuplex());
+test('stdout cannot be a Node.js Writable without a file descriptor', testNoFileStream, 1, noopWritable());
+test('stdout cannot be a Node.js Duplex without a file descriptor', testNoFileStream, 1, noopDuplex());
+test('stderr cannot be a Node.js Writable without a file descriptor', testNoFileStream, 2, noopWritable());
+test('stderr cannot be a Node.js Duplex without a file descriptor', testNoFileStream, 2, noopDuplex());
+test('stdio[*] cannot be a Node.js Readable without a file descriptor', testNoFileStream, 3, noopReadable());
+test('stdio[*] cannot be a Node.js Writable without a file descriptor', testNoFileStream, 3, noopWritable());
+test('stdio[*] cannot be a Node.js Duplex without a file descriptor', testNoFileStream, 3, noopDuplex());
 
 const testFileReadable = async (t, index, execaMethod) => {
 	const filePath = tempfile();
@@ -132,9 +140,6 @@ test('Waits for custom streams destroy on process errors', async t => {
 	t.true(waitedForDestroy);
 });
 
-const noopReadable = () => new Readable({read() {}});
-const noopWritable = () => new Writable({write() {}});
-
 const testStreamEarlyExit = async (t, stream, streamName) => {
 	await t.throwsAsync(execa('noop.js', {[streamName]: [stream, 'pipe'], uid: -1}));
 	t.true(stream.destroyed);
@@ -142,6 +147,29 @@ const testStreamEarlyExit = async (t, stream, streamName) => {
 
 test('Input streams are canceled on early process exit', testStreamEarlyExit, noopReadable(), 'stdin');
 test('Output streams are canceled on early process exit', testStreamEarlyExit, noopWritable(), 'stdout');
+
+const testInputDuplexStream = async (t, index) => {
+	const stream = new PassThrough();
+	stream.end(foobarString);
+	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [stream, 'pipe']));
+	t.is(stdout, foobarString);
+};
+
+test('Can pass Duplex streams to stdin', testInputDuplexStream, 0);
+test('Can pass Duplex streams to input stdio[*]', testInputDuplexStream, 3);
+
+const testOutputDuplexStream = async (t, index) => {
+	const stream = new PassThrough();
+	const [output] = await Promise.all([
+		text(stream),
+		execa('noop-fd.js', [`${index}`], getStdio(index, [stream, 'pipe'])),
+	]);
+	t.is(output, foobarString);
+};
+
+test('Can pass Duplex streams to stdout', testOutputDuplexStream, 1);
+test('Can pass Duplex streams to stderr', testOutputDuplexStream, 2);
+test('Can pass Duplex streams to output stdio[*]', testOutputDuplexStream, 3);
 
 test('Handles output streams ends', async t => {
 	const stream = noopWritable();
@@ -161,7 +189,9 @@ const testStreamAbort = async (t, stream, streamName) => {
 };
 
 test('Handles input streams aborts', testStreamAbort, noopReadable(), 'stdin');
+test('Handles input Duplex streams aborts', testStreamAbort, noopDuplex(), 'stdin');
 test('Handles output streams aborts', testStreamAbort, noopWritable(), 'stdout');
+test('Handles output Duplex streams aborts', testStreamAbort, noopDuplex(), 'stdout');
 
 const testStreamError = async (t, stream, streamName) => {
 	const error = new Error('test');
@@ -173,15 +203,19 @@ const testStreamError = async (t, stream, streamName) => {
 };
 
 test('Handles input streams errors', testStreamError, noopReadable(), 'stdin');
+test('Handles input Duplex streams errors', testStreamError, noopDuplex(), 'stdin');
 test('Handles output streams errors', testStreamError, noopWritable(), 'stdout');
+test('Handles output Duplex streams errors', testStreamError, noopDuplex(), 'stdout');
 
-test('Handles childProcess.stdin end', async t => {
-	const stream = noopReadable();
+const testChildStreamEnd = async (t, stream) => {
 	const childProcess = execa('forever.js', {stdin: [stream, 'pipe']});
 	childProcess.stdin.end();
 	await t.throwsAsync(childProcess, {code: 'ERR_STREAM_PREMATURE_CLOSE'});
 	t.true(stream.destroyed);
-});
+};
+
+test('Handles childProcess.stdin end', testChildStreamEnd, noopReadable());
+test('Handles childProcess.stdin Duplex end', testChildStreamEnd, noopDuplex());
 
 const testChildStreamAbort = async (t, stream, streamName) => {
 	const childProcess = execa('forever.js', {[streamName]: [stream, 'pipe']});
@@ -191,7 +225,9 @@ const testChildStreamAbort = async (t, stream, streamName) => {
 };
 
 test('Handles childProcess.stdin aborts', testChildStreamAbort, noopReadable(), 'stdin');
+test('Handles childProcess.stdin Duplex aborts', testChildStreamAbort, noopDuplex(), 'stdin');
 test('Handles childProcess.stdout aborts', testChildStreamAbort, noopWritable(), 'stdout');
+test('Handles childProcess.stdout Duplex aborts', testChildStreamAbort, noopDuplex(), 'stdout');
 
 const testChildStreamError = async (t, stream, streamName) => {
 	const childProcess = execa('forever.js', {[streamName]: [stream, 'pipe']});
@@ -202,4 +238,6 @@ const testChildStreamError = async (t, stream, streamName) => {
 };
 
 test('Handles childProcess.stdin errors', testChildStreamError, noopReadable(), 'stdin');
+test('Handles childProcess.stdin Duplex errors', testChildStreamError, noopDuplex(), 'stdin');
 test('Handles childProcess.stdout errors', testChildStreamError, noopWritable(), 'stdout');
+test('Handles childProcess.stdout Duplex errors', testChildStreamError, noopDuplex(), 'stdout');


### PR DESCRIPTION
This adds more tests related to passing Node.js streams to the `stdin`/`stdout`/`stderr` options.
More specifically, passing Duplex streams.