### PR TITLE
Fix return value being re-used between multiple calls 

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -61,23 +61,24 @@ export const makeError = ({
 	signal = signal === null ? undefined : signal;
 	const signalDescription = signal === undefined ? undefined : signalsByName[signal].description;
 
-	const errorCode = error && error.code;
-
+	const errorCode = error?.code;
 	const prefix = getErrorPrefix({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled});
 	const execaMessage = `Command ${prefix}: ${command}`;
-	const isError = Object.prototype.toString.call(error) === '[object Error]';
-	const shortMessage = isError ? `${execaMessage}\n${error.message}` : execaMessage;
+	const originalMessage = previousErrors.has(error) ? error.originalMessage : String(error?.message ?? error);
+	const shortMessage = error === undefined ? execaMessage : `${execaMessage}\n${originalMessage}`;
 	const messageStdio = all === undefined ? [stdio[2], stdio[1]] : [all];
 	const message = [shortMessage, ...messageStdio, ...stdio.slice(3)]
 		.map(messagePart => stripFinalNewline(serializeMessagePart(messagePart)))
 		.filter(Boolean)
 		.join('\n\n');
 
-	if (isError) {
-		error.originalMessage = error.message;
-		error.message = message;
-	} else {
+	if (Object.prototype.toString.call(error) !== '[object Error]' || previousErrors.has(error)) {
 		error = new Error(message);
+		error.originalMessage = originalMessage;
+	} else {
+		previousErrors.add(error);
+		error.message = message;
+		error.originalMessage = originalMessage;
 	}
 
 	error.shortMessage = shortMessage;
@@ -106,3 +107,5 @@ export const makeError = ({
 
 	return error;
 };
+
+const previousErrors = new WeakSet();


### PR DESCRIPTION
Fixes #795.

### TLDR

Cloning an error is tricky, and this solves an edge case for Execa, so this PR does the bare minimum.

### Details

By cloning the error, we are losing the `stack`, `name`, `cause`, `errors`, and any user-set properties. Unfortunately, setting those is not straight-forward. Some time ago, I have created the [`set-error-message`](https://github.com/ehmicky/set-error-message), [`wrap-error-message`](https://github.com/ehmicky/wrap-error-message), [`set-error-class`](https://github.com/ehmicky/set-error-class), [`set-error-stack`](https://github.com/ehmicky/set-error-stack) and [`set-error-props`](https://github.com/ehmicky/set-error-props) libraries for this specific problem. 

For example, on V8, `error.stack` is memoized after being accessed first. So when updating `error.message`, `error.stack` might remain unchanged, even though its first lines include the error message. One can set `error.stack` manually, but it can get tricky since Node.js source maps prepends it, which makes string replacement difficult.

Also, one must be careful after setting the non-enumerability of `error.*` correctly since this results in errors being printed weirdly otherwise.

Setting `error.name` has the same issue as setting `error.message` since `error.name` is included (usually) in the beginning of `error.stack`. Also, it is actually incorrect to set `error.name`: `ErrorClass.prototype.name` should be used instead, otherwise the error gets printed weirdly as well. In other words, it should be an inherited property, not an own property. However, this requires changing an error's prototype, which has its own pitfalls.

Then, the error itself might have a wide range of abnormal shapes and problems. I have created a library [`normalize-exception`](https://github.com/ehmicky/normalize-exception) which fixes it. It has a long list of [potential issues](https://github.com/ehmicky/normalize-exception?tab=readme-ov-file#features).

Finally, the cloning logic itself has its own caveats. I also have created a library for it ([`error-serializer`](https://github.com/ehmicky/error-serializer)). It enables some good cloning behavior, handling many edge cases. It includes the libraries above, so cloning is just:

```js
import { serialize, parse } from 'error-serializer'

const error = new TypeError('example')
const newError = parse(serialize(error)) // Error instance: 'TypeError: example ...'
```

### Implementation in this PR

However, to avoid introducing a new dependency, or re-implementing it (which is a rabbit hole), I have kept the logic in this PR very simple. We only keep the `error.message` and do not handle any potential issue with the exception being handled.

On the plus side:
  - In the vast majority of cases, exceptions thrown inside Execa are done by the `child_process` core module, which creates individual error instances.
  - When processes are run individually or serially (which is the main usage), they tend not to share exceptions being thrown.    
  - Even if this cloning does happen, it means another Execa call previously failed with the full original error instance. So users will still have access to it, just not on each failing Execa call.