### PR TITLE
Re-order return value properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,15 +210,15 @@ const handlePromise = async ({spawned, options, stdioStreamsGroups, originalStre
 	return {
 		command,
 		escapedCommand,
-		exitCode: 0,
-		stdio,
-		stdout: stdio[1],
-		stderr: stdio[2],
-		all,
 		failed: false,
 		timedOut: false,
 		isCanceled: false,
 		isTerminated: false,
+		exitCode: 0,
+		stdout: stdio[1],
+		stderr: stdio[2],
+		all,
+		stdio,
 	};
 };
 
@@ -277,14 +277,14 @@ export function execaSync(rawFile, rawArgs, rawOptions) {
 	return {
 		command,
 		escapedCommand,
-		exitCode: 0,
-		stdio,
-		stdout: stdio[1],
-		stderr: stdio[2],
 		failed: false,
 		timedOut: false,
 		isCanceled: false,
 		isTerminated: false,
+		exitCode: 0,
+		stdout: stdio[1],
+		stderr: stdio[2],
+		stdio,
 	};
 }
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -84,26 +84,28 @@ export const makeError = ({
 	error.shortMessage = shortMessage;
 	error.command = command;
 	error.escapedCommand = escapedCommand;
-	error.exitCode = exitCode;
-	error.signal = signal;
-	error.signalDescription = signalDescription;
-	error.stdio = stdio;
-	error.stdout = stdio[1];
-	error.stderr = stdio[2];
 	error.cwd = cwd;
-
-	if (all !== undefined) {
-		error.all = all;
-	}
-
-	if ('bufferedData' in error) {
-		delete error.bufferedData;
-	}
 
 	error.failed = true;
 	error.timedOut = Boolean(timedOut);
 	error.isCanceled = isCanceled;
 	error.isTerminated = signal !== undefined;
+	error.exitCode = exitCode;
+	error.signal = signal;
+	error.signalDescription = signalDescription;
+
+	error.stdout = stdio[1];
+	error.stderr = stdio[2];
+
+	if (all !== undefined) {
+		error.all = all;
+	}
+
+	error.stdio = stdio;
+
+	if ('bufferedData' in error) {
+		delete error.bufferedData;
+	}
 
 	return error;
 };

--- a/readme.md
+++ b/readme.md
@@ -362,13 +362,11 @@ Same as [`command`](#command-1) but escaped.
 This is meant to be copied and pasted into a shell, for debugging purposes.
 Since the escaping is fairly basic, this should not be executed directly as a process, including using [`execa()`](#execafile-arguments-options) or [`execaCommand()`](#execacommandcommand-options).
 
-#### exitCode
+#### cwd
 
-Type: `number | undefined`
+Type: `string`
 
-The numeric exit code of the process that was run.
-
-This is `undefined` when the process could not be spawned or was terminated by a [signal](#signal-1).
+The `cwd` of the command if provided in the [command options](#cwd-1). Otherwise it is `process.cwd()`.
 
 #### stdout
 
@@ -406,6 +404,28 @@ The output of the process on [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`
 
 Items are `undefined` when their corresponding [`stdio`](#stdio-1) option is set to [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio). Items are arrays when their corresponding `stdio` option is a [transform in object mode](docs/transform.md#object-mode).
 
+#### message
+
+Type: `string`
+
+Error message when the child process failed to run. In addition to the [underlying error message](#originalMessage), it also contains some information related to why the child process errored.
+
+The child process [`stderr`](#stderr), [`stdout`](#stdout) and other [file descriptors' output](#stdio) are appended to the end, separated with newlines and not interleaved.
+
+#### shortMessage
+
+Type: `string`
+
+This is the same as the [`message` property](#message) except it does not include the child process [`stdout`](#stdout)/[`stderr`](#stderr)/[`stdio`](#stdio).
+
+#### originalMessage
+
+Type: `string | undefined`
+
+Original error message. This is the same as the `message` property excluding the child process [`stdout`](#stdout)/[`stderr`](#stderr)/[`stdio`](#stdio) and some additional information added by Execa.
+
+This is `undefined` unless the child process exited due to an `error` event or a timeout.
+
 #### failed
 
 Type: `boolean`
@@ -432,6 +452,14 @@ Whether the process was terminated by a signal (like `SIGTERM`) sent by either:
 - The current process.
 - Another process. This case is [not supported on Windows](https://nodejs.org/api/process.html#signal-events).
 
+#### exitCode
+
+Type: `number | undefined`
+
+The numeric exit code of the process that was run.
+
+This is `undefined` when the process could not be spawned or was terminated by a [signal](#signal-1).
+
 #### signal
 
 Type: `string | undefined`
@@ -449,34 +477,6 @@ Type: `string | undefined`
 A human-friendly description of the signal that was used to terminate the process. For example, `Floating point arithmetic error`.
 
 If a signal terminated the process, this property is defined and included in the error message. Otherwise it is `undefined`. It is also `undefined` when the signal is very uncommon which should seldomly happen.
-
-#### cwd
-
-Type: `string`
-
-The `cwd` of the command if provided in the [command options](#cwd-1). Otherwise it is `process.cwd()`.
-
-#### message
-
-Type: `string`
-
-Error message when the child process failed to run. In addition to the [underlying error message](#originalMessage), it also contains some information related to why the child process errored.
-
-The child process [`stderr`](#stderr), [`stdout`](#stdout) and other [file descriptors' output](#stdio) are appended to the end, separated with newlines and not interleaved.
-
-#### shortMessage
-
-Type: `string`
-
-This is the same as the [`message` property](#message) except it does not include the child process [`stdout`](#stdout)/[`stderr`](#stderr)/[`stdio`](#stdio).
-
-#### originalMessage
-
-Type: `string | undefined`
-
-Original error message. This is the same as the `message` property excluding the child process [`stdout`](#stdout)/[`stderr`](#stderr)/[`stdio`](#stdio) and some additional information added by Execa.
-
-This is `undefined` unless the child process exited due to an `error` event or a timeout.
 
 ### options
 

--- a/test/error.js
+++ b/test/error.js
@@ -12,6 +12,47 @@ setFixtureDir();
 
 const TIMEOUT_REGEXP = /timed out after/;
 
+test('Return value properties are not missing and are ordered', async t => {
+	const result = await execa('empty.js', {...fullStdio, all: true});
+	t.deepEqual(Reflect.ownKeys(result), [
+		'command',
+		'escapedCommand',
+		'failed',
+		'timedOut',
+		'isCanceled',
+		'isTerminated',
+		'exitCode',
+		'stdout',
+		'stderr',
+		'all',
+		'stdio',
+	]);
+});
+
+test('Error properties are not missing and are ordered', async t => {
+	const error = await t.throwsAsync(execa('fail.js', {...fullStdio, all: true}));
+	t.deepEqual(Reflect.ownKeys(error), [
+		'stack',
+		'message',
+		'originalMessage',
+		'shortMessage',
+		'command',
+		'escapedCommand',
+		'cwd',
+		'failed',
+		'timedOut',
+		'isCanceled',
+		'isTerminated',
+		'exitCode',
+		'signal',
+		'signalDescription',
+		'stdout',
+		'stderr',
+		'all',
+		'stdio',
+	]);
+});
+
 const testEmptyErrorStdio = async (t, execaMethod) => {
 	const {failed, stdout, stderr, stdio} = await execaMethod('fail.js', {reject: false});
 	t.true(failed);


### PR DESCRIPTION
This re-orders the properties of the Execa return value (on success or error). When the result is printed, that order is preserved, so this PR makes them follow a logical order.

Also, this adds a test to make sure we are not missing properties, which avoids bugs like https://github.com/sindresorhus/execa/issues/798.