### PR TITLE
Use `process.exitCode` instead of `process.exit()` in tests

### DIFF
--- a/test/fixtures/all-fail.js
+++ b/test/fixtures/all-fail.js
@@ -3,4 +3,4 @@ import process from 'node:process';
 
 console.log('stdout');
 console.error('stderr');
-process.exit(1);
+process.exitCode = 1;

--- a/test/fixtures/echo-fail.js
+++ b/test/fixtures/echo-fail.js
@@ -5,4 +5,4 @@ import {writeSync} from 'node:fs';
 console.log('stdout');
 console.error('stderr');
 writeSync(3, 'fd3');
-process.exit(1);
+process.exitCode = 1;

--- a/test/fixtures/exit.js
+++ b/test/fixtures/exit.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 import process from 'node:process';
 
-process.exit(Number(process.argv[2]));
+process.exitCode = Number(process.argv[2]);

--- a/test/fixtures/fail.js
+++ b/test/fixtures/fail.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 import process from 'node:process';
 
-process.exit(2);
+process.exitCode = 2;

--- a/test/fixtures/noop-both-fail.js
+++ b/test/fixtures/noop-both-fail.js
@@ -3,4 +3,4 @@ import process from 'node:process';
 
 process.stdout.write(process.argv[2]);
 process.stderr.write(process.argv[3]);
-process.exit(1);
+process.exitCode = 1;

--- a/test/fixtures/noop-fail.js
+++ b/test/fixtures/noop-fail.js
@@ -3,4 +3,4 @@ import process from 'node:process';
 import {writeSync} from 'node:fs';
 
 writeSync(Number(process.argv[2]), process.argv[3] || 'foobar');
-process.exit(2);
+process.exitCode = 2;


### PR DESCRIPTION
Use `process.exitCode` instead of [`process.exit()` in tests](https://nodejs.org/api/process.html#processexitcode).

> Calling `process.exit()` will force the process to exit as quickly as possible even if there are still asynchronous operations pending that have not yet completed fully, including I/O operations to `process.stdout` and `process.stderr`.

> In most situations, it is not actually necessary to call `process.exit()` explicitly. The Node.js process will exit on its own if there is no additional work pending in the event loop. The `process.exitCode` property can be set to tell the process which exit code to use when the process exits gracefully.