### PR TITLE
Improve copying previous Execa errors

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -73,16 +73,20 @@ export const makeError = ({
 		.filter(Boolean)
 		.join('\n\n');
 
-	if (Object.prototype.toString.call(error) !== '[object Error]' || previousErrors.has(error)) {
+	if (Object.prototype.toString.call(error) !== '[object Error]') {
 		error = new Error(message);
-		error.originalMessage = originalMessage;
+	} else if (previousErrors.has(error)) {
+		const newError = new Error(message);
+		copyErrorProperties(newError, error);
+		error = newError;
 	} else {
-		previousErrors.add(error);
 		error.message = message;
-		error.originalMessage = originalMessage;
 	}
 
+	previousErrors.add(error);
+
 	error.shortMessage = shortMessage;
+	error.originalMessage = originalMessage;
 	error.command = command;
 	error.escapedCommand = escapedCommand;
 	error.cwd = cwd;
@@ -110,5 +114,26 @@ export const makeError = ({
 
 	return error;
 };
+
+const copyErrorProperties = (newError, previousError) => {
+	for (const propertyName of COPIED_ERROR_PROPERTIES) {
+		const descriptor = Object.getOwnPropertyDescriptor(previousError, propertyName);
+		if (descriptor !== undefined) {
+			Object.defineProperty(newError, propertyName, descriptor);
+		}
+	}
+};
+
+// Known Node.js-specific error properties
+const COPIED_ERROR_PROPERTIES = [
+	'code',
+	'errno',
+	'syscall',
+	'path',
+	'dest',
+	'address',
+	'port',
+	'info',
+];
 
 const previousErrors = new WeakSet();


### PR DESCRIPTION
This is an improvement upon #796, which was dealing with multiple Execa calls returning the same error instance.

The previous PR intentionally left out copying error properties except for `message`.
However, I was working on another PR (for #753) where this feature is being needed.

This PR improves how error instances are being copied: it now copies known error properties such as `error.code` and `error.errno`.