### PR TITLE
Improve process failure logic

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -3,28 +3,48 @@ import stripFinalNewline from 'strip-final-newline';
 import {isBinary, binaryToString} from './stdio/utils.js';
 import {fixCwdError} from './cwd.js';
 
-const getErrorPrefix = ({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled}) => {
+export const getErrorPrefix = ({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled}) => {
 	if (timedOut) {
-		return `timed out after ${timeout} milliseconds`;
+		return `Command timed out after ${timeout} milliseconds`;
 	}
 
 	if (isCanceled) {
-		return 'was canceled';
+		return 'Command was canceled';
 	}
 
 	if (errorCode !== undefined) {
-		return `failed with ${errorCode}`;
+		return `Command failed with ${errorCode}`;
 	}
 
 	if (signal !== undefined) {
-		return `was killed with ${signal} (${signalDescription})`;
+		return `Command was killed with ${signal} (${signalDescription})`;
 	}
 
 	if (exitCode !== undefined) {
-		return `failed with exit code ${exitCode}`;
+		return `Command failed with exit code ${exitCode}`;
 	}
 
-	return 'failed';
+	return 'Command failed';
+};
+
+const getErrorSuffix = (error, cwd) => {
+	if (error === undefined) {
+		return {originalMessage: '', suffix: ''};
+	}
+
+	const originalErrorMessage = previousErrors.has(error) ? error.originalMessage : String(error?.message ?? error);
+	const originalMessage = fixCwdError(originalErrorMessage, cwd);
+	const suffix = `\n${originalMessage}`;
+	return {originalMessage, suffix};
+};
+
+// `signal` and `exitCode` emitted on `spawned.on('exit')` event can be `null`.
+// We normalize them to `undefined`
+export const normalizeExitPayload = (rawExitCode, rawSignal) => {
+	const exitCode = rawExitCode === null ? undefined : rawExitCode;
+	const signal = rawSignal === null ? undefined : rawSignal;
+	const signalDescription = signal === undefined ? undefined : signalsByName[rawSignal].description;
+	return {exitCode, signal, signalDescription};
 };
 
 const serializeMessagePart = messagePart => Array.isArray(messagePart)
@@ -46,27 +66,21 @@ const serializeMessageItem = messageItem => {
 export const makeError = ({
 	stdio,
 	all,
-	error,
-	signal,
-	exitCode,
+	error: rawError,
+	signal: rawSignal,
+	exitCode: rawExitCode,
 	command,
 	escapedCommand,
 	timedOut,
 	isCanceled,
-	options: {timeoutDuration: timeout, cwd},
+	options: {timeoutDuration, timeout = timeoutDuration, cwd},
 }) => {
-	// `signal` and `exitCode` emitted on `spawned.on('exit')` event can be `null`.
-	// We normalize them to `undefined`
-	exitCode = exitCode === null ? undefined : exitCode;
-	signal = signal === null ? undefined : signal;
-	const signalDescription = signal === undefined ? undefined : signalsByName[signal].description;
-
+	let error = rawError?.discarded ? undefined : rawError;
+	const {exitCode, signal, signalDescription} = normalizeExitPayload(rawExitCode, rawSignal);
 	const errorCode = error?.code;
 	const prefix = getErrorPrefix({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled});
-	const execaMessage = `Command ${prefix}: ${command}`;
-	const originalErrorMessage = previousErrors.has(error) ? error.originalMessage : String(error?.message ?? error);
-	const originalMessage = fixCwdError(originalErrorMessage, cwd);
-	const shortMessage = error === undefined ? execaMessage : `${execaMessage}\n${originalMessage}`;
+	const {originalMessage, suffix} = getErrorSuffix(error, cwd);
+	const shortMessage = `${prefix}: ${command}${suffix}`;
 	const messageStdio = all === undefined ? [stdio[2], stdio[1]] : [all];
 	const message = [shortMessage, ...messageStdio, ...stdio.slice(3)]
 		.map(messagePart => stripFinalNewline(serializeMessagePart(messagePart)))

--- a/lib/kill.js
+++ b/lib/kill.js
@@ -2,6 +2,7 @@ import {addAbortListener} from 'node:events';
 import os from 'node:os';
 import {setTimeout} from 'node:timers/promises';
 import {onExit} from 'signal-exit';
+import {normalizeExitPayload, getErrorPrefix} from './error.js';
 
 const DEFAULT_FORCE_KILL_TIMEOUT = 1000 * 5;
 
@@ -48,10 +49,25 @@ export const normalizeForceKillAfterDelay = forceKillAfterDelay => {
 	return forceKillAfterDelay;
 };
 
+export const waitForSuccessfulExit = async exitPromise => {
+	const [exitCode, signal] = await exitPromise;
+
+	if (!isProcessErrorExit(exitCode, signal) && isFailedExit(exitCode, signal)) {
+		const message = getErrorPrefix(normalizeExitPayload(exitCode, signal));
+		throw setDiscardedError(new Error(message));
+	}
+
+	return [exitCode, signal];
+};
+
+const isProcessErrorExit = (exitCode, signal) => exitCode === undefined && signal === undefined;
+export const isFailedExit = (exitCode, signal) => exitCode !== 0 || signal !== null;
+
 const killAfterTimeout = async (timeout, context, {signal}) => {
 	await setTimeout(timeout, undefined, {signal});
 	context.timedOut = true;
-	throw new Error('Timed out');
+	const message = getErrorPrefix({timedOut: true, timeout});
+	throw setDiscardedError(new Error(message));
 };
 
 // `timeout` option handling
@@ -64,6 +80,9 @@ export const validateTimeout = ({timeout}) => {
 		throw new TypeError(`Expected the \`timeout\` option to be a non-negative integer, got \`${timeout}\` (${typeof timeout})`);
 	}
 };
+
+// Indicates that the error is used only to interrupt control flow, but not in the return value
+const setDiscardedError = error => Object.assign(error, {discarded: true});
 
 // `cleanup` option handling
 export const cleanupOnExit = (spawned, {cleanup, detached}, {signal}) => {

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -3,7 +3,7 @@ import {finished} from 'node:stream/promises';
 import {setImmediate} from 'node:timers/promises';
 import getStream, {getStreamAsArrayBuffer, getStreamAsArray} from 'get-stream';
 import mergeStreams from '@sindresorhus/merge-streams';
-import {throwOnTimeout} from './kill.js';
+import {waitForSuccessfulExit, throwOnTimeout} from './kill.js';
 import {isStandardStream} from './stdio/utils.js';
 import {generatorToDuplexStream} from './stdio/generator.js';
 
@@ -180,8 +180,8 @@ export const getSpawnedResult = async ({
 	try {
 		return await Promise.race([
 			Promise.all([
-				undefined,
-				exitPromise,
+				{},
+				waitForSuccessfulExit(exitPromise),
 				Promise.all(stdioPromises),
 				allPromise,
 				...originalPromises,
@@ -193,7 +193,7 @@ export const getSpawnedResult = async ({
 	} catch (error) {
 		spawned.kill();
 		return Promise.all([
-			error,
+			{error},
 			exitPromise,
 			Promise.all(stdioPromises.map(stdioPromise => getBufferedData(stdioPromise, encoding))),
 			getBufferedData(allPromise, encoding),

--- a/test/stdio/node-stream.js
+++ b/test/stdio/node-stream.js
@@ -134,10 +134,20 @@ test('Waits for custom streams destroy on process errors', async t => {
 			return error;
 		}),
 	});
-	const childProcess = execa('forever.js', {stdout: [stream, 'pipe'], timeout: 1});
-	const {timedOut} = await t.throwsAsync(childProcess);
+	const {timedOut} = await t.throwsAsync(execa('forever.js', {stdout: [stream, 'pipe'], timeout: 1}));
 	t.true(timedOut);
 	t.true(waitedForDestroy);
+});
+
+test('Handles custom streams destroy errors on process success', async t => {
+	const error = new Error('test');
+	const stream = new Writable({
+		destroy(destroyError, done) {
+			done(destroyError ?? error);
+		},
+	});
+	const thrownError = await t.throwsAsync(execa('empty.js', {stdout: [stream, 'pipe']}));
+	t.is(thrownError, error);
 });
 
 const testStreamEarlyExit = async (t, stream, streamName) => {


### PR DESCRIPTION
This PR refactors some logic related to process failure.

Processes fail due to either:
  1. a process `error` event, timeout, a stream failure, or a transform error
  2. a non-0 exit code or a signal termination

Right now, those lead to different code paths. This PR ensures that all types of process failures end up in the same `catch` block.

This does not change behavior, except for some small bug fixes highlighted in the comments below. The main purpose is to make it easier to add logic which handles any type of process failure. This is something I am currently needing as part of implementing #753 and #745.