### PR TITLE
Fix `error.stack` with `stream.destroy(error)`

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -50,6 +50,8 @@ const COPIED_ERROR_PROPERTIES = [
 
 // Sets `error.message`.
 // Fixes `error.stack` not being updated when it has been already accessed, since it is memoized by V8.
+// For example, this happens when calling `stream.destroy(error)`.
+// See https://github.com/nodejs/node/issues/51715
 const setErrorMessage = (error, newMessage) => {
 	const {name, message, stack} = error;
 	error.message = newMessage;

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -1,0 +1,68 @@
+export const getFinalError = (initialError, message) => {
+	const error = createFinalError(initialError, message);
+	previousErrors.add(error);
+	return error;
+};
+
+const createFinalError = (error, message) => {
+	if (!isErrorInstance(error)) {
+		return new Error(message);
+	}
+
+	return previousErrors.has(error)
+		? cloneError(error, message)
+		: setErrorMessage(error, message);
+};
+
+export const isErrorInstance = value => Object.prototype.toString.call(value) === '[object Error]';
+
+const cloneError = (oldError, newMessage) => {
+	const {name, message, stack} = oldError;
+	const error = new Error(newMessage);
+	error.stack = fixStack(name, stack, message, newMessage);
+	Object.defineProperty(error, 'name', {value: name, enumerable: false, configurable: true, writable: true});
+	copyErrorProperties(error, oldError);
+	return error;
+};
+
+const copyErrorProperties = (newError, previousError) => {
+	for (const propertyName of COPIED_ERROR_PROPERTIES) {
+		const descriptor = Object.getOwnPropertyDescriptor(previousError, propertyName);
+		if (descriptor !== undefined) {
+			Object.defineProperty(newError, propertyName, descriptor);
+		}
+	}
+};
+
+// Known error properties
+const COPIED_ERROR_PROPERTIES = [
+	'cause',
+	'errors',
+	'code',
+	'errno',
+	'syscall',
+	'path',
+	'dest',
+	'address',
+	'port',
+	'info',
+];
+
+// Sets `error.message`.
+// Fixes `error.stack` not being updated when it has been already accessed, since it is memoized by V8.
+const setErrorMessage = (error, newMessage) => {
+	const {name, message, stack} = error;
+	error.message = newMessage;
+	error.stack = fixStack(name, stack, message, newMessage);
+	return error;
+};
+
+const fixStack = (name, stack, message, newMessage) => stack.includes(newMessage)
+	? stack
+	: stack.replace(`${name}: ${message}`, `${name}: ${newMessage}`);
+
+// Two `execa()` calls might return the same error.
+// So we must close those before directly mutating them.
+export const isPreviousError = error => previousErrors.has(error);
+
+const previousErrors = new WeakSet();

--- a/lib/error.js
+++ b/lib/error.js
@@ -2,6 +2,33 @@ import {signalsByName} from 'human-signals';
 import stripFinalNewline from 'strip-final-newline';
 import {isBinary, binaryToString} from './stdio/utils.js';
 import {fixCwdError} from './cwd.js';
+import {getFinalError, isPreviousError} from './clone.js';
+
+const createMessages = ({
+	stdio,
+	all,
+	error,
+	signal,
+	signalDescription,
+	exitCode,
+	command,
+	timedOut,
+	isCanceled,
+	timeout,
+	cwd,
+}) => {
+	const errorCode = error?.code;
+	const prefix = getErrorPrefix({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled});
+	const originalMessage = getOriginalMessage(error, cwd);
+	const newline = originalMessage === '' ? '' : '\n';
+	const shortMessage = `${prefix}: ${command}${newline}${originalMessage}`;
+	const messageStdio = all === undefined ? [stdio[2], stdio[1]] : [all];
+	const message = [shortMessage, ...messageStdio, ...stdio.slice(3)]
+		.map(messagePart => stripFinalNewline(serializeMessagePart(messagePart)))
+		.filter(Boolean)
+		.join('\n\n');
+	return {originalMessage, shortMessage, message};
+};
 
 export const getErrorPrefix = ({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled}) => {
 	if (timedOut) {
@@ -27,24 +54,13 @@ export const getErrorPrefix = ({timedOut, timeout, errorCode, signal, signalDesc
 	return 'Command failed';
 };
 
-const getErrorSuffix = (error, cwd) => {
+const getOriginalMessage = (error, cwd) => {
 	if (error === undefined) {
-		return {originalMessage: '', suffix: ''};
+		return '';
 	}
 
-	const originalErrorMessage = previousErrors.has(error) ? error.originalMessage : String(error?.message ?? error);
-	const originalMessage = fixCwdError(originalErrorMessage, cwd);
-	const suffix = `\n${originalMessage}`;
-	return {originalMessage, suffix};
-};
-
-// `signal` and `exitCode` emitted on `spawned.on('exit')` event can be `null`.
-// We normalize them to `undefined`
-export const normalizeExitPayload = (rawExitCode, rawSignal) => {
-	const exitCode = rawExitCode === null ? undefined : rawExitCode;
-	const signal = rawSignal === null ? undefined : rawSignal;
-	const signalDescription = signal === undefined ? undefined : signalsByName[rawSignal].description;
-	return {exitCode, signal, signalDescription};
+	const originalErrorMessage = isPreviousError(error) ? error.originalMessage : String(error?.message ?? error);
+	return fixCwdError(originalErrorMessage, cwd);
 };
 
 const serializeMessagePart = messagePart => Array.isArray(messagePart)
@@ -63,6 +79,15 @@ const serializeMessageItem = messageItem => {
 	return '';
 };
 
+// `signal` and `exitCode` emitted on `spawned.on('exit')` event can be `null`.
+// We normalize them to `undefined`
+export const normalizeExitPayload = (rawExitCode, rawSignal) => {
+	const exitCode = rawExitCode === null ? undefined : rawExitCode;
+	const signal = rawSignal === null ? undefined : rawSignal;
+	const signalDescription = signal === undefined ? undefined : signalsByName[rawSignal].description;
+	return {exitCode, signal, signalDescription};
+};
+
 export const makeError = ({
 	stdio,
 	all,
@@ -75,29 +100,22 @@ export const makeError = ({
 	isCanceled,
 	options: {timeoutDuration, timeout = timeoutDuration, cwd},
 }) => {
-	let error = rawError?.discarded ? undefined : rawError;
+	const initialError = rawError?.discarded ? undefined : rawError;
 	const {exitCode, signal, signalDescription} = normalizeExitPayload(rawExitCode, rawSignal);
-	const errorCode = error?.code;
-	const prefix = getErrorPrefix({timedOut, timeout, errorCode, signal, signalDescription, exitCode, isCanceled});
-	const {originalMessage, suffix} = getErrorSuffix(error, cwd);
-	const shortMessage = `${prefix}: ${command}${suffix}`;
-	const messageStdio = all === undefined ? [stdio[2], stdio[1]] : [all];
-	const message = [shortMessage, ...messageStdio, ...stdio.slice(3)]
-		.map(messagePart => stripFinalNewline(serializeMessagePart(messagePart)))
-		.filter(Boolean)
-		.join('\n\n');
-
-	if (!isErrorInstance(error)) {
-		error = new Error(message);
-	} else if (previousErrors.has(error)) {
-		const newError = new Error(message);
-		copyErrorProperties(newError, error);
-		error = newError;
-	} else {
-		error.message = message;
-	}
-
-	previousErrors.add(error);
+	const {originalMessage, shortMessage, message} = createMessages({
+		stdio,
+		all,
+		error: initialError,
+		signal,
+		signalDescription,
+		exitCode,
+		command,
+		timedOut,
+		isCanceled,
+		timeout,
+		cwd,
+	});
+	const error = getFinalError(initialError, message);
 
 	error.shortMessage = shortMessage;
 	error.originalMessage = originalMessage;
@@ -128,28 +146,3 @@ export const makeError = ({
 
 	return error;
 };
-
-export const isErrorInstance = value => Object.prototype.toString.call(value) === '[object Error]';
-
-const copyErrorProperties = (newError, previousError) => {
-	for (const propertyName of COPIED_ERROR_PROPERTIES) {
-		const descriptor = Object.getOwnPropertyDescriptor(previousError, propertyName);
-		if (descriptor !== undefined) {
-			Object.defineProperty(newError, propertyName, descriptor);
-		}
-	}
-};
-
-// Known Node.js-specific error properties
-const COPIED_ERROR_PROPERTIES = [
-	'code',
-	'errno',
-	'syscall',
-	'path',
-	'dest',
-	'address',
-	'port',
-	'info',
-];
-
-const previousErrors = new WeakSet();

--- a/lib/kill.js
+++ b/lib/kill.js
@@ -2,7 +2,8 @@ import {addAbortListener} from 'node:events';
 import os from 'node:os';
 import {setTimeout} from 'node:timers/promises';
 import {onExit} from 'signal-exit';
-import {normalizeExitPayload, getErrorPrefix, isErrorInstance} from './error.js';
+import {normalizeExitPayload, getErrorPrefix} from './error.js';
+import {isErrorInstance} from './clone.js';
 
 const DEFAULT_FORCE_KILL_TIMEOUT = 1000 * 5;
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
 	},
 	"ava": {
 		"workerThreads": false,
+		"concurrency": 1,
 		"timeout": "60s"
 	},
 	"xo": {

--- a/test/clone.js
+++ b/test/clone.js
@@ -1,0 +1,142 @@
+import test from 'ava';
+import {execa} from '../index.js';
+import {setFixtureDir} from './helpers/fixtures-dir.js';
+import {foobarString} from './helpers/input.js';
+
+setFixtureDir();
+
+const testUnusualError = async (t, error, expectedOriginalMessage = String(error)) => {
+	const childProcess = execa('empty.js');
+	childProcess.emit('error', error);
+	const {originalMessage, shortMessage, message} = await t.throwsAsync(childProcess);
+	t.is(originalMessage, expectedOriginalMessage);
+	t.true(shortMessage.includes(expectedOriginalMessage));
+	t.is(message, shortMessage);
+};
+
+test('error instance can be null', testUnusualError, null);
+test('error instance can be false', testUnusualError, false);
+test('error instance can be a string', testUnusualError, 'test');
+test('error instance can be a number', testUnusualError, 0);
+test('error instance can be a BigInt', testUnusualError, 0n);
+test('error instance can be a symbol', testUnusualError, Symbol('test'));
+test('error instance can be a function', testUnusualError, () => {});
+test('error instance can be an array', testUnusualError, ['test', 'test']);
+// eslint-disable-next-line unicorn/error-message
+test('error instance can be an error with an empty message', testUnusualError, new Error(''), '');
+test('error instance can be undefined', testUnusualError, undefined, '');
+
+test('error instance can be a plain object', async t => {
+	const childProcess = execa('empty.js');
+	childProcess.emit('error', {message: foobarString});
+	await t.throwsAsync(childProcess, {message: new RegExp(foobarString)});
+});
+
+const runAndFail = (t, fixtureName, argument, error) => {
+	const childProcess = execa(fixtureName, [argument]);
+	childProcess.emit('error', error);
+	return t.throwsAsync(childProcess);
+};
+
+const runAndClone = async (t, initialError) => {
+	const previousError = await runAndFail(t, 'empty.js', 'foo', initialError);
+	t.is(previousError, initialError);
+
+	return runAndFail(t, 'empty.js', 'bar', previousError);
+};
+
+const testErrorCopy = async (t, getPreviousArgument, argument = 'two') => {
+	const fixtureName = 'empty.js';
+	const firstArgument = 'foo';
+
+	const previousArgument = await getPreviousArgument(t, fixtureName);
+	const previousError = await runAndFail(t, fixtureName, firstArgument, previousArgument);
+	const error = await runAndFail(t, fixtureName, argument, previousError);
+	const message = `Command failed: ${fixtureName} ${argument}\n${foobarString}`;
+
+	t.not(error, previousError);
+	t.is(error.command, `${fixtureName} ${argument}`);
+	t.is(error.message, message);
+	t.true(error.stack.includes(message));
+	t.is(error.stack, previousError.stack.replace(firstArgument, argument));
+	t.is(error.shortMessage, message);
+	t.is(error.originalMessage, foobarString);
+};
+
+test('error instance can be shared', testErrorCopy, () => new Error(foobarString));
+test('error TypeError can be shared', testErrorCopy, () => new TypeError(foobarString));
+test('error string can be shared', testErrorCopy, () => foobarString);
+test('error copy can be shared', testErrorCopy, (t, fixtureName) => runAndFail(t, fixtureName, 'bar', new Error(foobarString)));
+test('error with same message can be shared', testErrorCopy, () => new Error(foobarString), 'foo');
+
+const testErrorCopyProperty = async (t, propertyName, isCopied) => {
+	const propertyValue = 'test';
+	const initialError = new Error(foobarString);
+	initialError[propertyName] = propertyValue;
+
+	const error = await runAndClone(t, initialError);
+	t.is(error[propertyName] === propertyValue, isCopied);
+};
+
+test('error.code can be copied', testErrorCopyProperty, 'code', true);
+test('error.errno can be copied', testErrorCopyProperty, 'errno', true);
+test('error.syscall can be copied', testErrorCopyProperty, 'syscall', true);
+test('error.path can be copied', testErrorCopyProperty, 'path', true);
+test('error.dest can be copied', testErrorCopyProperty, 'dest', true);
+test('error.address can be copied', testErrorCopyProperty, 'address', true);
+test('error.port can be copied', testErrorCopyProperty, 'port', true);
+test('error.info can be copied', testErrorCopyProperty, 'info', true);
+test('error.other cannot be copied', testErrorCopyProperty, 'other', false);
+
+test('error.name can be copied', async t => {
+	const initialError = new TypeError('test');
+	const error = await runAndClone(t, initialError);
+	t.deepEqual(Object.getOwnPropertyDescriptor(Object.getPrototypeOf(initialError), 'name'), Object.getOwnPropertyDescriptor(error, 'name'));
+});
+
+test('error.cause can be copied', async t => {
+	const initialError = new Error('test', {cause: new Error('innerTest')});
+	const error = await runAndClone(t, initialError);
+	t.deepEqual(Object.getOwnPropertyDescriptor(initialError, 'cause'), Object.getOwnPropertyDescriptor(error, 'cause'));
+});
+
+test('error.errors can be copied', async t => {
+	const initialError = new AggregateError([], 'test');
+	const error = await runAndClone(t, initialError);
+	t.deepEqual(Object.getOwnPropertyDescriptor(initialError, 'errors'), Object.getOwnPropertyDescriptor(error, 'errors'));
+});
+
+test('error.stack is set even if memoized', async t => {
+	const message = 'test';
+	const error = new Error(message);
+	t.is(typeof error.stack, 'string');
+
+	const newMessage = 'newTest';
+	error.message = newMessage;
+	t.false(error.stack.includes(newMessage));
+	error.message = message;
+
+	const childProcess = execa('empty.js');
+	childProcess.emit('error', error);
+	t.is(await t.throwsAsync(childProcess), error);
+	t.is(error.message, `Command failed: empty.js\n${message}`);
+	t.true(error.stack.startsWith(`Error: Command failed: empty.js\n${message}`));
+});
+
+test('Cloned errors keep the stack trace', async t => {
+	const message = 'test';
+	const error = new Error(message);
+	const stack = error.stack.split('\n').filter(line => line.trim().startsWith('at ')).join('\n');
+
+	const childProcess = execa('empty.js');
+	childProcess.emit('error', error);
+	t.is(await t.throwsAsync(childProcess), error);
+
+	const secondChildProcess = execa('empty.js');
+	secondChildProcess.emit('error', error);
+	const secondError = await t.throwsAsync(secondChildProcess);
+	t.not(secondError, error);
+	t.is(secondError.message, `Command failed: empty.js\n${message}`);
+	t.is(secondError.stack, `Error: Command failed: empty.js\n${message}\n${stack}`);
+});
+


### PR DESCRIPTION
Fixes #813.

This PR works around [a bug in Node.js](https://github.com/nodejs/node/issues/51715) which makes `stream.destroy(error)` create Execa errors without a proper error message.

This PR also improves how errors are cloned. When `execa()` returns twice the same error instance, it clones it to avoid directly mutating the first return value. This PR enhances that error cloning so that `error.name`, `error.stack`, `error.cause` and `error.errors` are kept. Previously, they were not kept.

Finally, this PR does some minor refactoring of the error logic, mostly moving lines of code around.