### PR TITLE
Avoid code duplication with return value's logic

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -92,15 +92,15 @@ const normalizeExitPayload = (rawExitCode, rawSignal) => {
 };
 
 export const makeError = ({
-	stdio,
-	all,
 	error: rawError,
-	signal: rawSignal,
-	exitCode: rawExitCode,
 	command,
 	escapedCommand,
 	timedOut,
 	isCanceled,
+	exitCode: rawExitCode,
+	signal: rawSignal,
+	stdio,
+	all,
 	options: {timeoutDuration, timeout = timeoutDuration, cwd},
 }) => {
 	const initialError = rawError instanceof DiscardedError ? undefined : rawError;
@@ -149,3 +149,40 @@ export const makeError = ({
 
 	return error;
 };
+
+export const makeEarlyError = ({
+	error,
+	command,
+	escapedCommand,
+	stdioStreamsGroups,
+	options,
+}) => makeError({
+	error,
+	command,
+	escapedCommand,
+	timedOut: false,
+	isCanceled: false,
+	stdio: Array.from({length: stdioStreamsGroups.length}),
+	options,
+});
+
+export const makeSuccessResult = ({
+	command,
+	escapedCommand,
+	stdio,
+	all,
+	options: {cwd},
+}) => ({
+	command,
+	escapedCommand,
+	cwd,
+	failed: false,
+	timedOut: false,
+	isCanceled: false,
+	isTerminated: false,
+	exitCode: 0,
+	stdout: stdio[1],
+	stderr: stdio[2],
+	all,
+	stdio,
+});


### PR DESCRIPTION
This removes some code duplication in the logic related to the value returned by Execa. 
This is refactoring-only and does not change the behavior.