### PR TITLE
Avoid code duplication with logic related to `maxListeners`

### DIFF
--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -1,4 +1,3 @@
-import {addAbortListener} from 'node:events';
 import {createReadStream, createWriteStream} from 'node:fs';
 import {Buffer} from 'node:buffer';
 import {Readable, Writable} from 'node:stream';
@@ -6,7 +5,7 @@ import {handleInput} from './handle.js';
 import {pipeStreams} from './pipeline.js';
 import {TYPE_TO_MESSAGE} from './type.js';
 import {generatorToDuplexStream, pipeGenerator} from './generator.js';
-import {isStandardStream} from './utils.js';
+import {isStandardStream, incrementMaxListeners} from './utils.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async mode
 export const handleInputAsync = options => handleInput(addPropertiesAsync, options, false);
@@ -72,25 +71,15 @@ const pipeStdioOption = (spawned, {type, value, direction, index}, inputStreamsG
 // Multiple processes might be piping from/to `process.std*` at the same time.
 // This is not necessarily an error and should not print a `maxListeners` warning.
 const setStandardStreamMaxListeners = (stream, {signal}) => {
-	if (!isStandardStream(stream)) {
-		return;
+	if (isStandardStream(stream)) {
+		incrementMaxListeners(stream, MAX_LISTENERS_INCREMENT, signal);
 	}
-
-	const maxListeners = stream.getMaxListeners();
-	if (maxListeners === 0 || maxListeners === Number.POSITIVE_INFINITY) {
-		return;
-	}
-
-	stream.setMaxListeners(maxListeners + maxListenersIncrement);
-	addAbortListener(signal, () => {
-		stream.setMaxListeners(stream.getMaxListeners() - maxListenersIncrement);
-	});
 };
 
 // `source.pipe(destination)` adds at most 1 listener for each event.
 // If `stdin` option is an array, the values might be combined with `merge-streams`.
 // That library also listens for `source` end, which adds 1 more listener.
-const maxListenersIncrement = 2;
+const MAX_LISTENERS_INCREMENT = 2;
 
 // The stream error handling is performed by the piping logic above, which cannot be performed before process spawning.
 // If the process spawning fails (e.g. due to an invalid command), the streams need to be manually destroyed.

--- a/lib/stdio/utils.js
+++ b/lib/stdio/utils.js
@@ -1,4 +1,5 @@
 import {Buffer} from 'node:buffer';
+import {addAbortListener} from 'node:events';
 import process from 'node:process';
 
 export const bufferToUint8Array = buffer => new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
@@ -12,3 +13,15 @@ export const binaryToString = uint8ArrayOrBuffer => textDecoder.decode(uint8Arra
 export const isStandardStream = stream => STANDARD_STREAMS.includes(stream);
 export const STANDARD_STREAMS = [process.stdin, process.stdout, process.stderr];
 export const STANDARD_STREAMS_ALIASES = ['stdin', 'stdout', 'stderr'];
+
+export const incrementMaxListeners = (eventEmitter, maxListenersIncrement, signal) => {
+	const maxListeners = eventEmitter.getMaxListeners();
+	if (maxListeners === 0 || maxListeners === Number.POSITIVE_INFINITY) {
+		return;
+	}
+
+	eventEmitter.setMaxListeners(maxListeners + maxListenersIncrement);
+	addAbortListener(signal, () => {
+		eventEmitter.setMaxListeners(eventEmitter.getMaxListeners() - maxListenersIncrement);
+	});
+};

--- a/test/helpers/listeners.js
+++ b/test/helpers/listeners.js
@@ -1,0 +1,14 @@
+import process from 'node:process';
+
+export const assertMaxListeners = t => {
+	let warning;
+	const captureWarning = warningArgument => {
+		warning = warningArgument;
+	};
+
+	process.once('warning', captureWarning);
+	return () => {
+		t.is(warning, undefined);
+		process.removeListener('warning', captureWarning);
+	};
+};

--- a/test/kill.js
+++ b/test/kill.js
@@ -7,6 +7,7 @@ import {pEvent} from 'p-event';
 import isRunning from 'is-running';
 import {execa, execaSync} from '../index.js';
 import {setFixtureDir, FIXTURES_DIR} from './helpers/fixtures-dir.js';
+import {assertMaxListeners} from './helpers/listeners.js';
 
 setFixtureDir();
 
@@ -122,12 +123,7 @@ if (isWindows) {
 	});
 
 	test.serial('Can call `.kill()` with `forceKillAfterDelay` many times without triggering the maxListeners warning', async t => {
-		let warning;
-		const captureWarning = warningArgument => {
-			warning = warningArgument;
-		};
-
-		process.once('warning', captureWarning);
+		const checkMaxListeners = assertMaxListeners(t);
 
 		const subprocess = spawnNoKillableSimple();
 		for (let index = 0; index < defaultMaxListeners + 1; index += 1) {
@@ -138,8 +134,7 @@ if (isWindows) {
 		t.true(isTerminated);
 		t.is(signal, 'SIGKILL');
 
-		t.is(warning, undefined);
-		process.off('warning', captureWarning);
+		checkMaxListeners();
 	});
 
 	test('Can call `.kill()` with `forceKillAfterDelay` multiple times', async t => {


### PR DESCRIPTION
This removes some code duplication in the logic related to avoiding the `maxListeners` warning. 
This is refactoring-only and does not change the behavior.