### PR TITLE
Improve input validation

### DIFF
--- a/lib/arguments/node.js
+++ b/lib/arguments/node.js
@@ -1,11 +1,11 @@
 import {execPath, execArgv} from 'node:process';
 import {basename, resolve} from 'node:path';
 import {execa} from '../async.js';
-import {handleOptionalArguments} from './options.js';
+import {normalizeArguments} from './options.js';
 import {safeNormalizeFileUrl} from './cwd.js';
 
 export function execaNode(file, args, options) {
-	[args, options] = handleOptionalArguments(args, options);
+	[file, args, options] = normalizeArguments(file, args, options);
 
 	if (options.node === false) {
 		throw new TypeError('The "node" option cannot be false with `execaNode()`.');

--- a/lib/arguments/options.js
+++ b/lib/arguments/options.js
@@ -2,6 +2,7 @@ import {basename} from 'node:path';
 import process from 'node:process';
 import crossSpawn from 'cross-spawn';
 import {npmRunPathEnv} from 'npm-run-path';
+import isPlainObject from 'is-plain-obj';
 import {normalizeForceKillAfterDelay} from '../exit/kill.js';
 import {validateTimeout} from '../exit/timeout.js';
 import {handleNodeOption} from './node.js';
@@ -9,12 +10,24 @@ import {logCommand, verboseDefault} from './verbose.js';
 import {joinCommand} from './escape.js';
 import {normalizeCwd, safeNormalizeFileUrl, normalizeFileUrl} from './cwd.js';
 
-export const handleOptionalArguments = (args = [], options = {}) => Array.isArray(args)
-	? [args, options]
-	: [[], args];
-
-export const handleArguments = (rawFile, rawArgs, rawOptions) => {
+export const normalizeArguments = (rawFile, rawArgs = [], rawOptions = {}) => {
 	const filePath = safeNormalizeFileUrl(rawFile, 'First argument');
+	const [args, options] = isPlainObject(rawArgs)
+		? [[], rawArgs]
+		: [rawArgs, rawOptions];
+
+	if (!Array.isArray(args)) {
+		throw new TypeError(`Second argument must be either an array of arguments or an options object: ${args}`);
+	}
+
+	if (!isPlainObject(options)) {
+		throw new TypeError(`Last argument must be an options object: ${options}`);
+	}
+
+	return [filePath, args, options];
+};
+
+export const handleArguments = (filePath, rawArgs, rawOptions) => {
 	const {command, escapedCommand} = joinCommand(filePath, rawArgs);
 
 	rawOptions.cwd = normalizeCwd(rawOptions.cwd);

--- a/lib/async.js
+++ b/lib/async.js
@@ -1,6 +1,6 @@
 import {setMaxListeners} from 'node:events';
 import childProcess from 'node:child_process';
-import {handleOptionalArguments, handleArguments} from './arguments/options.js';
+import {normalizeArguments, handleArguments} from './arguments/options.js';
 import {makeError, makeEarlyError, makeSuccessResult} from './return/error.js';
 import {handleOutput} from './return/output.js';
 import {handleInputAsync, pipeOutputAsync, cleanupStdioStreams} from './stdio/async.js';
@@ -45,7 +45,7 @@ export const execa = (rawFile, rawArgs, rawOptions) => {
 };
 
 const handleAsyncArguments = (rawFile, rawArgs, rawOptions) => {
-	[rawArgs, rawOptions] = handleOptionalArguments(rawArgs, rawOptions);
+	[rawFile, rawArgs, rawOptions] = normalizeArguments(rawFile, rawArgs, rawOptions);
 	const {file, args, command, escapedCommand, options: normalizedOptions} = handleArguments(rawFile, rawArgs, rawOptions);
 	const options = handleAsyncOptions(normalizedOptions);
 	return {file, args, command, escapedCommand, options};

--- a/lib/command.js
+++ b/lib/command.js
@@ -12,6 +12,10 @@ export function execaCommandSync(command, options) {
 }
 
 const parseCommand = command => {
+	if (typeof command !== 'string') {
+		throw new TypeError(`First argument must be a string: ${command}.`);
+	}
+
 	const tokens = [];
 	for (const token of command.trim().split(SPACES_REGEXP)) {
 		// Allow spaces to be escaped by a backslash if not meant as a delimiter

--- a/lib/script.js
+++ b/lib/script.js
@@ -1,12 +1,17 @@
 import {ChildProcess} from 'node:child_process';
+import isPlainObject from 'is-plain-obj';
 import {isBinary, binaryToString} from './utils.js';
 import {execa} from './async.js';
 import {execaSync} from './sync.js';
 
 const create$ = options => {
 	function $(templatesOrOptions, ...expressions) {
-		if (!Array.isArray(templatesOrOptions)) {
+		if (isPlainObject(templatesOrOptions)) {
 			return create$({...options, ...templatesOrOptions});
+		}
+
+		if (!Array.isArray(templatesOrOptions)) {
+			throw new TypeError('Please use either $(option) or $`command`.');
 		}
 
 		const [file, ...args] = parseTemplates(templatesOrOptions, expressions);
@@ -14,8 +19,12 @@ const create$ = options => {
 	}
 
 	$.sync = (templates, ...expressions) => {
-		if (!Array.isArray(templates)) {
+		if (isPlainObject(templates)) {
 			throw new TypeError('Please use $(options).sync`command` instead of $.sync(options)`command`.');
+		}
+
+		if (!Array.isArray(templates)) {
+			throw new TypeError('A template string must be used: $.sync`command`.');
 		}
 
 		const [file, ...args] = parseTemplates(templates, expressions);

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,5 +1,5 @@
 import childProcess from 'node:child_process';
-import {handleOptionalArguments, handleArguments} from './arguments/options.js';
+import {normalizeArguments, handleArguments} from './arguments/options.js';
 import {makeError, makeEarlyError, makeSuccessResult} from './return/error.js';
 import {handleOutput} from './return/output.js';
 import {handleInputSync, pipeOutputSync} from './stdio/sync.js';
@@ -51,7 +51,7 @@ export const execaSync = (rawFile, rawArgs, rawOptions) => {
 };
 
 const handleSyncArguments = (rawFile, rawArgs, rawOptions) => {
-	[rawArgs, rawOptions] = handleOptionalArguments(rawArgs, rawOptions);
+	[rawFile, rawArgs, rawOptions] = normalizeArguments(rawFile, rawArgs, rawOptions);
 	const syncOptions = normalizeSyncOptions(rawOptions);
 	const {file, args, command, escapedCommand, options} = handleArguments(rawFile, rawArgs, syncOptions);
 	validateSyncOptions(options);

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"cross-spawn": "^7.0.3",
 		"get-stream": "^8.0.1",
 		"human-signals": "^6.0.0",
+		"is-plain-obj": "^4.1.0",
 		"is-stream": "^4.0.1",
 		"npm-run-path": "^5.2.0",
 		"signal-exit": "^4.1.0",

--- a/test/arguments/options.js
+++ b/test/arguments/options.js
@@ -123,6 +123,26 @@ test('execa()\'s command argument must be a string or file URL', testInvalidComm
 test('execaSync()\'s command argument must be a string or file URL', testInvalidCommand, execaSync);
 test('execaNode()\'s command argument must be a string or file URL', testInvalidCommand, execaNode);
 
+const testInvalidArgs = async (t, execaMethod) => {
+	t.throws(() => {
+		execaMethod('echo', true);
+	}, {message: /Second argument must be either/});
+};
+
+test('execa()\'s second argument must be an array', testInvalidArgs, execa);
+test('execaSync()\'s second argument must be an array', testInvalidArgs, execaSync);
+test('execaNode()\'s second argument must be an array', testInvalidArgs, execaNode);
+
+const testInvalidOptions = async (t, execaMethod) => {
+	t.throws(() => {
+		execaMethod('echo', [], new Map());
+	}, {message: /Last argument must be an options object/});
+};
+
+test('execa()\'s third argument must be a plain object', testInvalidOptions, execa);
+test('execaSync()\'s third argument must be a plain object', testInvalidOptions, execaSync);
+test('execaNode()\'s third argument must be a plain object', testInvalidOptions, execaNode);
+
 test('use relative path with \'..\' chars', async t => {
 	const pathViaParentDir = join('..', basename(fileURLToPath(new URL('../..', import.meta.url))), 'test', 'fixtures', 'noop.js');
 	const {stdout} = await execa(pathViaParentDir, ['foo']);

--- a/test/command.js
+++ b/test/command.js
@@ -38,3 +38,23 @@ test('execaCommandSync()', t => {
 	const {stdout} = execaCommandSync('echo.js foo bar');
 	t.is(stdout, 'foo\nbar');
 });
+
+const testInvalidCommand = (t, execaCommand, invalidArgument) => {
+	t.throws(() => {
+		execaCommand(invalidArgument);
+	}, {message: /First argument must be a string/});
+};
+
+test('execaCommand() must use a string', testInvalidCommand, execaCommand, true);
+test('execaCommandSync() must use a string', testInvalidCommand, execaCommandSync, true);
+test('execaCommand() must have an argument', testInvalidCommand, execaCommand, undefined);
+test('execaCommandSync() must have an argument', testInvalidCommand, execaCommandSync, undefined);
+
+const testInvalidArgs = (t, execaCommand) => {
+	t.throws(() => {
+		execaCommand('echo', ['']);
+	}, {message: /Last argument must be an options object/});
+};
+
+test('execaCommand() must not pass an array of arguments', testInvalidArgs, execaCommand);
+test('execaCommandSync() must not pass an array of arguments', testInvalidArgs, execaCommandSync);

--- a/test/script.js
+++ b/test/script.js
@@ -150,6 +150,10 @@ test('$ trims', async t => {
 	t.is(stdout, 'foo\nbar');
 });
 
+test('$ must only use options or templates', t => {
+	t.throws(() => $(true)`noop.js`, {message: /Please use either/});
+});
+
 test('$.sync', t => {
 	const {stdout} = $.sync`echo.js foo bar`;
 	t.is(stdout, 'foo\nbar');
@@ -191,6 +195,10 @@ test('$.sync allows execa return value buffer array interpolation', t => {
 	const foo = $({encoding: 'buffer'}).sync`echo.js foo`;
 	const {stdout} = $.sync`echo.js ${[foo, 'bar']}`;
 	t.is(stdout, 'foo\nbar');
+});
+
+test('$.sync must only templates', t => {
+	t.throws(() => $.sync(true)`noop.js`, {message: /A template string must be used/});
 });
 
 const invalidExpression = test.macro({


### PR DESCRIPTION
This PR throws better error messages when the user passes unexpected types as arguments to `execa()`, `execaSync()`, `execaCommand()`, `execaCommandSync()`, `execaNode()` or `$`. For example, when calling `execaCommand('command', ['arg'])`.