### PR TITLE
`.pipe()` shortcut for `$`

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -6,7 +6,7 @@ With Execa, you can write scripts with Node.js instead of a shell language. It i
 import {$} from 'execa';
 
 const {stdout: name} = await $`cat package.json`
-  .pipe($({stdin: 'pipe'})`grep name`);
+  .pipe`grep name`;
 console.log(name);
 
 const branch = await $`git branch --show-current`;
@@ -599,8 +599,8 @@ await $`npm run build | sort | head -n2`;
 ```js
 // Execa
 await $`npm run build`
-	.pipe($({stdin: 'pipe'})`sort`)
-	.pipe($({stdin: 'pipe'})`head -n2`);
+	.pipe`sort`
+	.pipe`head -n2`;
 ```
 
 ### Piping stdout and stderr to another command
@@ -621,7 +621,8 @@ await Promise.all([echo, cat]);
 
 ```js
 // Execa
-await $({all: true})`echo example`.pipe($({from: 'all', stdin: 'pipe'})`cat`);
+await $({all: true})`echo example`
+	.pipe({from: 'all'})`cat`;
 ```
 
 ### Piping stdout to a file

--- a/index.d.ts
+++ b/index.d.ts
@@ -845,7 +845,10 @@ type PipableProcess = {
 	When using `$`, the following simpler syntax can be used instead.
 
 	```js
+ 	import {$} from 'execa';
+
 	await $`command`.pipe`secondCommand`;
+
 	// To pass either child process options or pipe options
 	await $`command`.pipe(options)`secondCommand`;
 	```

--- a/index.d.ts
+++ b/index.d.ts
@@ -841,8 +841,38 @@ type PipableProcess = {
 	This can be called multiple times to chain a series of processes.
 
 	Multiple child processes can be piped to the same process. Conversely, the same child process can be piped to multiple other processes.
+
+	When using `$`, the following simpler syntax can be used instead.
+
+	```js
+	await $`command`.pipe`secondCommand`;
+	// To pass either child process options or pipe options
+	await $`command`.pipe(options)`secondCommand`;
+	```
 	*/
 	pipe<Destination extends ExecaChildProcess>(destination: Destination, options?: PipeOptions): Promise<Awaited<Destination>> & PipableProcess;
+};
+
+type ScriptPipableProcess = PipableProcess & {
+	/**
+	[Pipe](https://nodejs.org/api/stream.html#readablepipedestination-options) the child process' `stdout` to a second Execa child process' `stdin`. This resolves with that second process' result. If either process is rejected, this is rejected with that process' error instead.
+
+	This can be called multiple times to chain a series of processes.
+
+	Multiple child processes can be piped to the same process. Conversely, the same child process can be piped to multiple other processes.
+
+	When using `$`, the following simpler syntax can be used instead.
+
+	```js
+	await $`command`.pipe`secondCommand`;
+	// To pass either child process options or pipe options
+	await $`command`.pipe(options)`secondCommand`;
+	```
+	*/
+	pipe(templates: TemplateStringsArray, ...expressions: TemplateExpression[]): Promise<ExecaReturnValue<{}>> & ScriptPipableProcess;
+	pipe<OptionsType extends Options & PipeOptions = {}>(options: OptionsType):
+	(templates: TemplateStringsArray, ...expressions: TemplateExpression[])
+	=> Promise<ExecaReturnValue<OptionsType>> & ScriptPipableProcess;
 };
 
 export type ExecaChildPromise<OptionsType extends Options = Options> = {
@@ -1146,11 +1176,10 @@ type Execa$<OptionsType extends CommonOptions = {}> = {
 	```
 	*/
 	<NewOptionsType extends CommonOptions = {}>
-	(options: NewOptionsType):
-	Execa$<OptionsType & NewOptionsType>;
+	(options: NewOptionsType): Execa$<OptionsType & NewOptionsType>;
 
 	(templates: TemplateStringsArray, ...expressions: TemplateExpression[]):
-	ExecaChildProcess<StricterOptions<OptionsType, Options>>;
+	ExecaChildProcess<StricterOptions<OptionsType, Options>> & ScriptPipableProcess;
 
 	/**
 	Same as $\`command\` but synchronous.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -84,22 +84,60 @@ try {
 	const execaBufferPromise = execa('unicorns', {encoding: 'buffer', all: true});
 	const bufferResult = await execaBufferPromise;
 
+	const scriptPromise = $`unicorns`;
+
 	expectType<typeof bufferResult>(await execaPromise.pipe(execaBufferPromise));
+	expectType<typeof bufferResult>(await scriptPromise.pipe(execaBufferPromise));
 	expectNotType<typeof bufferResult>(await execaPromise.pipe(execaPromise));
+	expectNotType<typeof bufferResult>(await scriptPromise.pipe(execaPromise));
+	expectType<ExecaReturnValue<{}>>(await scriptPromise.pipe`stdin`);
 	expectType<typeof bufferResult>(await execaPromise.pipe(execaPromise).pipe(execaBufferPromise));
+	expectType<typeof bufferResult>(await scriptPromise.pipe(execaPromise).pipe(execaBufferPromise));
+	expectType <ExecaReturnValue<{}>>(await scriptPromise.pipe`stdin`.pipe`stdin`);
 	await execaPromise.pipe(execaPromise).pipe(execaBufferPromise, {from: 'stdout'});
+	await scriptPromise.pipe(execaPromise).pipe(execaBufferPromise, {from: 'stdout'});
+	await scriptPromise.pipe`stdin`.pipe({from: 'stdout'})`stdin`;
 	expectError(execaPromise.pipe(execaBufferPromise).stdout);
+	expectError(scriptPromise.pipe(execaBufferPromise).stdout);
+	expectError(scriptPromise.pipe`stdin`.stdout);
 	expectError(execaPromise.pipe(createWriteStream('output.txt')));
+	expectError(scriptPromise.pipe(createWriteStream('output.txt')));
 	expectError(execaPromise.pipe('output.txt'));
+	expectError(scriptPromise.pipe('output.txt'));
 	await execaPromise.pipe(execaBufferPromise, {});
+	await scriptPromise.pipe(execaBufferPromise, {});
+	await scriptPromise.pipe({})`stdin`;
 	expectError(execaPromise.pipe(execaBufferPromise, 'stdout'));
+	expectError(scriptPromise.pipe(execaBufferPromise, 'stdout'));
+	expectError(scriptPromise.pipe('stdout')`stdin`);
 	await execaPromise.pipe(execaBufferPromise, {from: 'stdout'});
+	await scriptPromise.pipe(execaBufferPromise, {from: 'stdout'});
+	await scriptPromise.pipe({from: 'stdout'})`stdin`;
 	await execaPromise.pipe(execaBufferPromise, {from: 'stderr'});
+	await scriptPromise.pipe(execaBufferPromise, {from: 'stderr'});
+	await scriptPromise.pipe({from: 'stderr'})`stdin`;
 	await execaPromise.pipe(execaBufferPromise, {from: 'all'});
+	await scriptPromise.pipe(execaBufferPromise, {from: 'all'});
+	await scriptPromise.pipe({from: 'all'})`stdin`;
 	await execaPromise.pipe(execaBufferPromise, {from: 3});
+	await scriptPromise.pipe(execaBufferPromise, {from: 3});
+	await scriptPromise.pipe({from: 3})`stdin`;
 	expectError(execaPromise.pipe(execaBufferPromise, {from: 'other'}));
+	expectError(scriptPromise.pipe(execaBufferPromise, {from: 'other'}));
+	expectError(scriptPromise.pipe({from: 'other'})`stdin`);
 	await execaPromise.pipe(execaBufferPromise, {signal: new AbortController().signal});
+	await scriptPromise.pipe(execaBufferPromise, {signal: new AbortController().signal});
+	await scriptPromise.pipe({signal: new AbortController().signal})`stdin`;
 	expectError(await execaPromise.pipe(execaBufferPromise, {signal: true}));
+	expectError(await scriptPromise.pipe(execaBufferPromise, {signal: true}));
+	expectError(await scriptPromise.pipe({signal: true})`stdin`);
+	expectError(await scriptPromise.pipe({})({}));
+	expectError(await scriptPromise.pipe({})(execaPromise));
+
+	const pipeResult = await scriptPromise.pipe`stdin`;
+	expectType<string>(pipeResult.stdout);
+	const ignorePipeResult = await scriptPromise.pipe({stdout: 'ignore'})`stdin`;
+	expectType<undefined>(ignorePipeResult.stdout);
 
 	expectType<Readable>(execaPromise.all);
 	const noAllPromise = execa('unicorns');
@@ -1322,8 +1360,8 @@ expectError(execa('unicorns').kill('SIGKILL', {}));
 expectError(execa('unicorns').kill(null, new Error('test')));
 
 expectError(execa(['unicorns', 'arg']));
-expectType<ExecaChildProcess>(execa('unicorns'));
-expectType<ExecaChildProcess>(execa(fileUrl));
+expectAssignable<ExecaChildProcess>(execa('unicorns'));
+expectAssignable<ExecaChildProcess>(execa(fileUrl));
 expectType<ExecaReturnValue>(await execa('unicorns'));
 expectAssignable<{stdout: string}>(await execa('unicorns'));
 expectAssignable<{stdout: Uint8Array}>(await execa('unicorns', {encoding: 'buffer'}));
@@ -1338,7 +1376,7 @@ expectAssignable<{stdout: Uint8Array}>(execaSync('unicorns', {encoding: 'buffer'
 expectAssignable<{stdout: string}>(execaSync('unicorns', ['foo']));
 expectAssignable<{stdout: Uint8Array}>(execaSync('unicorns', ['foo'], {encoding: 'buffer'}));
 
-expectType<ExecaChildProcess>(execaCommand('unicorns'));
+expectAssignable<ExecaChildProcess>(execaCommand('unicorns'));
 expectType<ExecaReturnValue>(await execaCommand('unicorns'));
 expectAssignable<{stdout: string}>(await execaCommand('unicorns'));
 expectAssignable<{stdout: Uint8Array}>(await execaCommand('unicorns', {encoding: 'buffer'}));
@@ -1352,7 +1390,7 @@ expectAssignable<{stdout: string}>(execaCommandSync('unicorns foo'));
 expectAssignable<{stdout: Uint8Array}>(execaCommandSync('unicorns foo', {encoding: 'buffer'}));
 
 expectError(execaNode(['unicorns', 'arg']));
-expectType<ExecaChildProcess>(execaNode('unicorns'));
+expectAssignable<ExecaChildProcess>(execaNode('unicorns'));
 expectType<ExecaReturnValue>(await execaNode('unicorns'));
 expectType<ExecaReturnValue>(await execaNode(fileUrl));
 expectAssignable<{stdout: string}>(await execaNode('unicorns'));

--- a/lib/pipe/validate.js
+++ b/lib/pipe/validate.js
@@ -1,5 +1,4 @@
-import {ChildProcess} from 'node:child_process';
-import {STANDARD_STREAMS_ALIASES} from '../utils.js';
+import {STANDARD_STREAMS_ALIASES, isExecaChildProcess} from '../utils.js';
 import {makeEarlyError} from '../return/error.js';
 import {abortSourceStream, endDestinationStream} from './streaming.js';
 
@@ -26,10 +25,6 @@ const getDestinationStream = destination => {
 		return {destinationError: error};
 	}
 };
-
-const isExecaChildProcess = destination => destination instanceof ChildProcess
-	&& typeof destination.then === 'function'
-	&& typeof destination.pipe === 'function';
 
 const getSourceStream = (source, stdioStreamsGroups, from, options) => {
 	try {

--- a/lib/script.js
+++ b/lib/script.js
@@ -1,6 +1,5 @@
-import {ChildProcess} from 'node:child_process';
 import isPlainObject from 'is-plain-obj';
-import {isBinary, binaryToString} from './utils.js';
+import {isBinary, binaryToString, isChildProcess, isExecaChildProcess} from './utils.js';
 import {execa} from './async.js';
 import {execaSync} from './sync.js';
 
@@ -15,7 +14,9 @@ const create$ = options => {
 		}
 
 		const [file, ...args] = parseTemplates(templatesOrOptions, expressions);
-		return execa(file, args, normalizeScriptOptions(options));
+		const childProcess = execa(file, args, normalizeScriptOptions(options));
+		childProcess.pipe = scriptPipe.bind(undefined, childProcess.pipe.bind(childProcess), {});
+		return childProcess;
 	}
 
 	$.sync = (templates, ...expressions) => {
@@ -37,6 +38,27 @@ const create$ = options => {
 };
 
 export const $ = create$();
+
+const scriptPipe = (originalPipe, options, firstArgument, ...args) => {
+	if (isExecaChildProcess(firstArgument)) {
+		if (Object.keys(options).length > 0) {
+			throw new TypeError('Please use .pipe(options)`command` or .pipe($(options)`command`) instead of .pipe(options)($`command`).');
+		}
+
+		return originalPipe(firstArgument, ...args);
+	}
+
+	if (isPlainObject(firstArgument)) {
+		return scriptPipe.bind(undefined, originalPipe, {...options, ...firstArgument});
+	}
+
+	if (!Array.isArray(firstArgument)) {
+		throw new TypeError('The first argument must be a template string, an options object or an Execa child process.');
+	}
+
+	const childProcess = create$({...options, stdin: 'pipe'})(firstArgument, ...args);
+	return originalPipe(childProcess, options);
+};
 
 const parseTemplates = (templates, expressions) => {
 	let tokens = [];
@@ -96,7 +118,7 @@ const parseExpression = expression => {
 	if (
 		typeOfExpression === 'object'
 		&& expression !== null
-		&& !(expression instanceof ChildProcess)
+		&& !isChildProcess(expression)
 		&& 'stdout' in expression
 	) {
 		const typeOfStdout = typeof expression.stdout;

--- a/lib/script.js
+++ b/lib/script.js
@@ -53,7 +53,7 @@ const scriptPipe = (originalPipe, options, firstArgument, ...args) => {
 	}
 
 	if (!Array.isArray(firstArgument)) {
-		throw new TypeError('The first argument must be a template string, an options object or an Execa child process.');
+		throw new TypeError('The first argument must be a template string, an options object, or an Execa child process.');
 	}
 
 	const childProcess = create$({...options, stdin: 'pipe'})(firstArgument, ...args);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 import {Buffer} from 'node:buffer';
+import {ChildProcess} from 'node:child_process';
 import {addAbortListener} from 'node:events';
 import process from 'node:process';
 
@@ -25,3 +26,9 @@ export const incrementMaxListeners = (eventEmitter, maxListenersIncrement, signa
 		eventEmitter.setMaxListeners(eventEmitter.getMaxListeners() - maxListenersIncrement);
 	});
 };
+
+export const isExecaChildProcess = value => isChildProcess(value)
+	&& typeof value.then === 'function'
+	&& typeof value.pipe === 'function';
+
+export const isChildProcess = value => value instanceof ChildProcess;

--- a/readme.md
+++ b/readme.md
@@ -340,7 +340,10 @@ Multiple child processes can be piped to the same process. Conversely, the same 
 When using [`$`](#command), the following [simpler syntax](docs/scripts.md#piping-stdout-to-another-command) can be used instead.
 
 ```js
+import {$} from 'execa';
+
 await $`command`.pipe`secondCommand`;
+
 // To pass either child process options or pipe options
 await $`command`.pipe(options)`secondCommand`;
 ```

--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,16 @@ await $$`echo rainbows`;
 //=> 'rainbows'
 ```
 
+#### Piping
+
+```js
+import {$} from 'execa';
+
+await $`npm run build`
+	.pipe`sort`
+	.pipe`head -n2`;
+```
+
 #### Verbose mode
 
 ```sh
@@ -326,6 +336,14 @@ _Returns_: [`Promise<ChildProcessResult>`](#childprocessresult)
 This can be called multiple times to chain a series of processes.
 
 Multiple child processes can be piped to the same process. Conversely, the same child process can be piped to multiple other processes.
+
+When using [`$`](#command), the following [simpler syntax](docs/scripts.md#piping-stdout-to-another-command) can be used instead.
+
+```js
+await $`command`.pipe`secondCommand`;
+// To pass either child process options or pipe options
+await $`command`.pipe(options)`secondCommand`;
+```
 
 ##### pipeOptions
 

--- a/test/script.js
+++ b/test/script.js
@@ -1,8 +1,10 @@
+import {spawn} from 'node:child_process';
 import {inspect} from 'node:util';
 import test from 'ava';
 import {isStream} from 'is-stream';
 import {$} from '../index.js';
 import {setFixtureDir} from './helpers/fixtures-dir.js';
+import {foobarString} from './helpers/input.js';
 
 setFixtureDir();
 
@@ -264,3 +266,53 @@ test('$.sync stdin defaults to "inherit"', t => {
 test('$ stdin has no default value when stdio is set', t => {
 	t.true(isStream($({stdio: 'pipe'})`noop.js`.stdin));
 });
+
+test('$.pipe(childProcess)', async t => {
+	const {stdout} = await $`noop.js ${foobarString}`.pipe($({stdin: 'pipe'})`stdin.js`);
+	t.is(stdout, foobarString);
+});
+
+test('$.pipe`command`', async t => {
+	const {stdout} = await $`noop.js ${foobarString}`.pipe`stdin.js`;
+	t.is(stdout, foobarString);
+});
+
+test('$.pipe(childProcess, pipeOptions)', async t => {
+	const {stdout} = await $`noop-fd.js 2 ${foobarString}`.pipe($({stdin: 'pipe'})`stdin.js`, {from: 'stderr'});
+	t.is(stdout, foobarString);
+});
+
+test('$.pipe(pipeOptions)`command`', async t => {
+	const {stdout} = await $`noop-fd.js 2 ${foobarString}`.pipe({from: 'stderr'})`stdin.js`;
+	t.is(stdout, foobarString);
+});
+
+test('$.pipe(options)`command`', async t => {
+	const {stdout} = await $`noop.js ${foobarString}`.pipe({stripFinalNewline: false})`stdin.js`;
+	t.is(stdout, `${foobarString}\n`);
+});
+
+test('$.pipe(pipeAndProcessOptions)`command`', async t => {
+	const {stdout} = await $`noop-fd.js 2 ${foobarString}\n`.pipe({from: 'stderr', stripFinalNewline: false})`stdin.js`;
+	t.is(stdout, `${foobarString}\n`);
+});
+
+test('$.pipe(options)(secondOptions)`command`', async t => {
+	const {stdout} = await $`noop.js ${foobarString}`.pipe({stripFinalNewline: false})({stripFinalNewline: true})`stdin.js`;
+	t.is(stdout, foobarString);
+});
+
+test('$.pipe(options)(childProcess) fails', t => {
+	t.throws(() => {
+		$`empty.js`.pipe({stdout: 'pipe'})($`empty.js`);
+	}, {message: /Please use \.pipe/});
+});
+
+const testInvalidPipe = (t, ...args) => {
+	t.throws(() => {
+		$`empty.js`.pipe(...args);
+	}, {message: /must be a template string/});
+};
+
+test('$.pipe(nonExecaChildProcess) fails', testInvalidPipe, spawn('node', ['--version']));
+test('$.pipe(false) fails', testInvalidPipe, false);


### PR DESCRIPTION
Fixes #797.

This adds a shortcut syntax so that users can turn this:

```js
const {stdout} = await $({preferLocal: true})`npm run docs`
  .pipe($({stdin: 'pipe'})($`grep ${message}`))
  .pipe($({stdin: 'pipe'})($`sort`))
  .pipe($({stdin: 'pipe', lines: true})($`head -n ${count}`), {signal});
```

Into this instead:

```js
const {stdout} = await $({preferLocal: true})`npm run docs`
  .pipe`grep ${message}`
  .pipe`sort`
  .pipe({lines: true, signal})`head -n ${count}`;
```