### PR TITLE
Allow newlines in `$`

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -121,6 +121,30 @@ await $`echo example`;
 await $`echo example`;
 ```
 
+### Multiline commands
+
+```sh
+# Bash
+npm run build \
+  --example-flag-one \
+  --example-flag-two
+```
+
+```js
+// zx
+await $`npm run build ${[
+	'--example-flag-one',
+	'--example-flag-two',
+]}`;
+```
+
+```js
+// Execa
+await $`npm run build
+	--example-flag-one
+	--example-flag-two`
+```
+
 ### Subcommands
 
 ```sh

--- a/lib/script.js
+++ b/lib/script.js
@@ -67,17 +67,20 @@ const parseTemplates = (templates, expressions) => {
 		tokens = parseTemplate({templates, expressions, tokens, index, template});
 	}
 
+	if (tokens.length === 0) {
+		throw new TypeError('Template script must not be empty');
+	}
+
 	return tokens;
 };
 
 const parseTemplate = ({templates, expressions, tokens, index, template}) => {
-	const templateString = template ?? templates.raw[index];
-	const templateTokens = templateString.split(SPACES_REGEXP).filter(Boolean);
-	const newTokens = concatTokens(
-		tokens,
-		templateTokens,
-		templateString.startsWith(' '),
-	);
+	if (template === undefined) {
+		throw new TypeError(`Invalid backslash sequence: ${templates.raw[index]}`);
+	}
+
+	const {nextTokens, leadingWhitespaces, trailingWhitespaces} = splitByWhitespaces(template, templates.raw[index]);
+	const newTokens = concatTokens(tokens, nextTokens, leadingWhitespaces);
 
 	if (index === expressions.length) {
 		return newTokens;
@@ -87,16 +90,64 @@ const parseTemplate = ({templates, expressions, tokens, index, template}) => {
 	const expressionTokens = Array.isArray(expression)
 		? expression.map(expression => parseExpression(expression))
 		: [parseExpression(expression)];
-	return concatTokens(
-		newTokens,
-		expressionTokens,
-		templateString.endsWith(' '),
-	);
+	return concatTokens(newTokens, expressionTokens, trailingWhitespaces);
 };
 
-const SPACES_REGEXP = / +/g;
+// Like `string.split(/[ \t\r\n]+/)` except newlines and tabs are:
+//  - ignored when input as a backslash sequence like: `echo foo\n bar`
+//  - not ignored when input directly
+// The only way to distinguish those in JavaScript is to use a tagged template and compare:
+//  - the first array argument, which does not escape backslash sequences
+//  - its `raw` property, which escapes them
+const splitByWhitespaces = (template, rawTemplate) => {
+	if (rawTemplate.length === 0) {
+		return {nextTokens: [], leadingWhitespaces: false, trailingWhitespaces: false};
+	}
 
-const concatTokens = (tokens, nextTokens, isNew) => isNew || tokens.length === 0 || nextTokens.length === 0
+	const nextTokens = [];
+	let templateStart = 0;
+	const leadingWhitespaces = DELIMITERS.has(rawTemplate[0]);
+
+	for (
+		let templateIndex = 0, rawIndex = 0;
+		templateIndex < template.length;
+		templateIndex += 1, rawIndex += 1
+	) {
+		const rawCharacter = rawTemplate[rawIndex];
+		if (DELIMITERS.has(rawCharacter)) {
+			if (templateStart !== templateIndex) {
+				nextTokens.push(template.slice(templateStart, templateIndex));
+			}
+
+			templateStart = templateIndex + 1;
+		} else if (rawCharacter === '\\') {
+			const nextRawCharacter = rawTemplate[rawIndex + 1];
+			if (nextRawCharacter === 'u' && rawTemplate[rawIndex + 2] === '{') {
+				rawIndex = rawTemplate.indexOf('}', rawIndex + 3);
+			} else {
+				rawIndex += ESCAPE_LENGTH[nextRawCharacter] ?? 1;
+			}
+		}
+	}
+
+	const trailingWhitespaces = templateStart === template.length;
+	if (!trailingWhitespaces) {
+		nextTokens.push(template.slice(templateStart));
+	}
+
+	return {nextTokens, leadingWhitespaces, trailingWhitespaces};
+};
+
+const DELIMITERS = new Set([' ', '\t', '\r', '\n']);
+
+// Number of characters in backslash escape sequences: \0 \xXX or \uXXXX
+// \cX is allowed in RegExps but not in strings
+// Octal sequences are not allowed in strict mode
+const ESCAPE_LENGTH = {x: 3, u: 5};
+
+const concatTokens = (tokens, nextTokens, isSeparated) => isSeparated
+	|| tokens.length === 0
+	|| nextTokens.length === 0
 	? [...tokens, ...nextTokens]
 	: [
 		...tokens.slice(0, -1),

--- a/readme.md
+++ b/readme.md
@@ -256,6 +256,8 @@ This is the preferred method when executing multiple commands in a script file.
 
 The `command` string can inject any `${value}` with the following types: string, number, [`childProcess`](#childprocess) or an array of those types. For example: `` $`echo one ${'two'} ${3} ${['four', 'five']}` ``. For `${childProcess}`, the process's `stdout` is used.
 
+The `command` string can use [multiple lines and indentation](docs/scripts.md#multiline-commands).
+
 For more information, please see [this section](#scripts-interface) and [this page](docs/scripts.md).
 
 #### $(options)

--- a/test/script.js
+++ b/test/script.js
@@ -1,5 +1,4 @@
 import {spawn} from 'node:child_process';
-import {inspect} from 'node:util';
 import test from 'ava';
 import {isStream} from 'is-stream';
 import {$} from '../index.js';
@@ -8,250 +7,342 @@ import {foobarString} from './helpers/input.js';
 
 setFixtureDir();
 
-test('$', async t => {
-	const {stdout} = await $`echo.js foo bar`;
-	t.is(stdout, 'foo\nbar');
-});
+// Workaround since some text editors or IDEs do not allow inputting \r directly
+const escapedCall = string => {
+	const templates = [string];
+	templates.raw = [string];
+	return $(templates);
+};
 
-test('$ accepts options', async t => {
-	const {stdout} = await $({stripFinalNewline: true})`noop.js foo`;
-	t.is(stdout, 'foo');
-});
+const testScriptStdout = async (t, getChildProcess, expectedStdout) => {
+	const {stdout} = await getChildProcess();
+	t.is(stdout, expectedStdout);
+};
 
-test('$ allows string interpolation', async t => {
-	const {stdout} = await $`echo.js foo ${'bar'}`;
-	t.is(stdout, 'foo\nbar');
-});
+test('$ executes command', testScriptStdout, () => $`echo.js foo bar`, 'foo\nbar');
+test('$ accepts options', testScriptStdout, () => $({stripFinalNewline: true})`noop.js foo`, 'foo');
+test('$ allows number interpolation', testScriptStdout, () => $`echo.js 1 ${2}`, '1\n2');
+test('$ can concatenate multiple tokens', testScriptStdout, () => $`echo.js ${'foo'}bar${'foo'}`, 'foobarfoo');
+test('$ can use newlines and tab indentations', testScriptStdout, () => $`echo.js foo
+	bar`, 'foo\nbar');
+test('$ can use newlines and space indentations', testScriptStdout, () => $`echo.js foo
+  bar`, 'foo\nbar');
+test('$ can use Windows newlines and tab indentations', testScriptStdout, () => escapedCall('echo.js foo\r\n\tbar'), 'foo\nbar');
+test('$ can use Windows newlines and space indentations', testScriptStdout, () => escapedCall('echo.js foo\r\n  bar'), 'foo\nbar');
+test('$ does not ignore comments in expressions', testScriptStdout, () => $`echo.js foo
+	${/* This is a comment */''}
+	bar
+	${/* This is another comment */''}
+	baz
+`, 'foo\n\nbar\n\nbaz');
+test('$ allows escaping spaces with interpolation', testScriptStdout, () => $`echo.js ${'foo bar'}`, 'foo bar');
+test('$ allows escaping spaces in commands with interpolation', testScriptStdout, () => $`${'command with space.js'} foo bar`, 'foo\nbar');
+test('$ trims', testScriptStdout, () => $`  echo.js foo bar  `, 'foo\nbar');
+test('$ allows array interpolation', testScriptStdout, () => $`echo.js ${['foo', 'bar']}`, 'foo\nbar');
+test('$ allows empty array interpolation', testScriptStdout, () => $`echo.js foo ${[]} bar`, 'foo\nbar');
+test('$ allows space escaped values in array interpolation', testScriptStdout, () => $`echo.js ${['foo', 'bar baz']}`, 'foo\nbar baz');
+test('$ can concatenate at the end of tokens followed by an array', testScriptStdout, () => $`echo.js foo${['bar', 'foo']}`, 'foobar\nfoo');
+test('$ can concatenate at the start of tokens followed by an array', testScriptStdout, () => $`echo.js ${['foo', 'bar']}foo`, 'foo\nbarfoo');
+test('$ can concatenate at the start and end of tokens followed by an array', testScriptStdout, () => $`echo.js foo${['bar', 'foo']}bar`, 'foobar\nfoobar');
+test('$ handles escaped newlines', testScriptStdout, () => $`echo.js a\
+b`, 'ab');
+test('$ handles backslashes at end of lines', testScriptStdout, () => $`echo.js a\\
+ b`, 'a\\\nb');
+test('$ handles double backslashes at end of lines', testScriptStdout, () => $`echo.js a\\\\
+ b`, 'a\\\\\nb');
+test('$ handles tokens - a', testScriptStdout, () => $`echo.js a`, 'a');
+test('$ handles expressions - a', testScriptStdout, () => $`echo.js ${'a'}`, 'a');
+test('$ handles tokens - abc', testScriptStdout, () => $`echo.js abc`, 'abc');
+test('$ handles expressions - abc', testScriptStdout, () => $`echo.js ${'abc'}`, 'abc');
+test('$ handles tokens - ""', testScriptStdout, () => $`echo.js`, '');
+test('$ handles expressions - ""', testScriptStdout, () => $`echo.js a ${''} b`, 'a\n\nb');
+test('$ splits tokens - ""', testScriptStdout, () => $`echo.js ab`, 'ab');
+test('$ splits expressions - ""', testScriptStdout, () => $`echo.js ${'a'}${'b'}`, 'ab');
+test('$ concatenates expressions - ""', testScriptStdout, () => $`echo.js a${'b'}c`, 'abc');
+test('$ handles tokens - " "', testScriptStdout, () => $`echo.js `, '');
+test('$ handles expressions - " "', testScriptStdout, () => $`echo.js ${' '}`, ' ');
+test('$ splits tokens - " "', testScriptStdout, () => $`echo.js a b`, 'a\nb');
+test('$ splits expressions - " "', testScriptStdout, () => $`echo.js ${'a'} ${'b'}`, 'a\nb');
+test('$ concatenates tokens - " "', testScriptStdout, () => $`echo.js  a `, 'a');
+test('$ concatenates expressions - " "', testScriptStdout, () => $`echo.js  ${'a'} `, 'a');
+test('$ handles tokens - "  " (2 spaces)', testScriptStdout, () => $`echo.js  `, '');
+test('$ handles expressions - "  " (2 spaces)', testScriptStdout, () => $`echo.js ${'  '}`, '  ');
+test('$ splits tokens - "  " (2 spaces)', testScriptStdout, () => $`echo.js a  b`, 'a\nb');
+test('$ splits expressions - "  " (2 spaces)', testScriptStdout, () => $`echo.js ${'a'}  ${'b'}`, 'a\nb');
+test('$ concatenates tokens - "  " (2 spaces)', testScriptStdout, () => $`echo.js   a  `, 'a');
+test('$ concatenates expressions - "  " (2 spaces)', testScriptStdout, () => $`echo.js   ${'a'}  `, 'a');
+test('$ handles tokens - "   " (3 spaces)', testScriptStdout, () => $`echo.js   `, '');
+test('$ handles expressions - "   " (3 spaces)', testScriptStdout, () => $`echo.js ${'   '}`, '   ');
+test('$ splits tokens - "  " (3 spaces)', testScriptStdout, () => $`echo.js a   b`, 'a\nb');
+test('$ splits expressions - "   " (3 spaces)', testScriptStdout, () => $`echo.js ${'a'}   ${'b'}`, 'a\nb');
+test('$ concatenates tokens - "   " (3 spaces)', testScriptStdout, () => $`echo.js    a   `, 'a');
+test('$ concatenates expressions - "   " (3 spaces)', testScriptStdout, () => $`echo.js    ${'a'}   `, 'a');
+test('$ handles tokens - \\t (no escape)', testScriptStdout, () => $`echo.js 	`, '');
+test('$ handles expressions - \\t (no escape)', testScriptStdout, () => $`echo.js ${'	'}`, '\t');
+test('$ splits tokens - \\t (no escape)', testScriptStdout, () => $`echo.js a	b`, 'a\nb');
+test('$ splits expressions - \\t (no escape)', testScriptStdout, () => $`echo.js ${'a'}	${'b'}`, 'a\nb');
+test('$ concatenates tokens - \\t (no escape)', testScriptStdout, () => $`echo.js 	a	 b`, 'a\nb');
+test('$ concatenates expressions - \\t (no escape)', testScriptStdout, () => $`echo.js 	${'a'}	 b`, 'a\nb');
+test('$ handles tokens - \\t (escape)', testScriptStdout, () => $`echo.js \t`, '\t');
+test('$ handles expressions - \\t (escape)', testScriptStdout, () => $`echo.js ${'\t'}`, '\t');
+test('$ splits tokens - \\t (escape)', testScriptStdout, () => $`echo.js a\tb`, 'a\tb');
+test('$ splits expressions - \\t (escape)', testScriptStdout, () => $`echo.js ${'a'}\t${'b'}`, 'a\tb');
+test('$ concatenates tokens - \\t (escape)', testScriptStdout, () => $`echo.js \ta\t b`, '\ta\t\nb');
+test('$ concatenates expressions - \\t (escape)', testScriptStdout, () => $`echo.js \t${'a'}\t b`, '\ta\t\nb');
+test('$ handles tokens - \\n (no escape)', testScriptStdout, () => $`echo.js
+ `, '');
+test('$ handles expressions - \\n (no escape)', testScriptStdout, () => $`echo.js ${`
+`} `, '\n');
+test('$ splits tokens - \\n (no escape)', testScriptStdout, () => $`echo.js a
+ b`, 'a\nb');
+test('$ splits expressions - \\n (no escape)', testScriptStdout, () => $`echo.js ${'a'}
+ ${'b'}`, 'a\nb');
+test('$ concatenates tokens - \\n (no escape)', testScriptStdout, () => $`echo.js
+a
+ b`, 'a\nb');
+test('$ concatenates expressions - \\n (no escape)', testScriptStdout, () => $`echo.js
+${'a'}
+ b`, 'a\nb');
+test('$ handles tokens - \\n (escape)', testScriptStdout, () => $`echo.js \n `, '\n');
+test('$ handles expressions - \\n (escape)', testScriptStdout, () => $`echo.js ${'\n'} `, '\n');
+test('$ splits tokens - \\n (escape)', testScriptStdout, () => $`echo.js a\n b`, 'a\n\nb');
+test('$ splits expressions - \\n (escape)', testScriptStdout, () => $`echo.js ${'a'}\n ${'b'}`, 'a\n\nb');
+test('$ concatenates tokens - \\n (escape)', testScriptStdout, () => $`echo.js \na\n b`, '\na\n\nb');
+test('$ concatenates expressions - \\n (escape)', testScriptStdout, () => $`echo.js \n${'a'}\n b`, '\na\n\nb');
+test('$ handles tokens - \\r (no escape)', testScriptStdout, () => escapedCall('echo.js \r '), '');
+test('$ splits tokens - \\r (no escape)', testScriptStdout, () => escapedCall('echo.js a\rb'), 'a\nb');
+test('$ splits expressions - \\r (no escape)', testScriptStdout, () => escapedCall(`echo.js ${'a'}\r${'b'}`), 'a\nb');
+test('$ concatenates tokens - \\r (no escape)', testScriptStdout, () => escapedCall('echo.js \ra\r b'), 'a\nb');
+test('$ concatenates expressions - \\r (no escape)', testScriptStdout, () => escapedCall(`echo.js \r${'a'}\r b`), 'a\nb');
+test('$ splits tokens - \\r (escape)', testScriptStdout, () => $`echo.js a\r b`, 'a\r\nb');
+test('$ splits expressions - \\r (escape)', testScriptStdout, () => $`echo.js ${'a'}\r ${'b'}`, 'a\r\nb');
+test('$ concatenates tokens - \\r (escape)', testScriptStdout, () => $`echo.js \ra\r b`, '\ra\r\nb');
+test('$ concatenates expressions - \\r (escape)', testScriptStdout, () => $`echo.js \r${'a'}\r b`, '\ra\r\nb');
+test('$ handles tokens - \\r\\n (no escape)', testScriptStdout, () => escapedCall('echo.js \r\n '), '');
+test('$ splits tokens - \\r\\n (no escape)', testScriptStdout, () => escapedCall('echo.js a\r\nb'), 'a\nb');
+test('$ splits expressions - \\r\\n (no escape)', testScriptStdout, () => escapedCall(`echo.js ${'a'}\r\n${'b'}`), 'a\nb');
+test('$ concatenates tokens - \\r\\n (no escape)', testScriptStdout, () => escapedCall('echo.js \r\na\r\n b'), 'a\nb');
+test('$ concatenates expressions - \\r\\n (no escape)', testScriptStdout, () => escapedCall(`echo.js \r\n${'a'}\r\n b`), 'a\nb');
+test('$ handles tokens - \\r\\n (escape)', testScriptStdout, () => $`echo.js \r\n `, '\r\n');
+test('$ handles expressions - \\r\\n (escape)', testScriptStdout, () => $`echo.js ${'\r\n'} `, '\r\n');
+test('$ splits tokens - \\r\\n (escape)', testScriptStdout, () => $`echo.js a\r\n b`, 'a\r\n\nb');
+test('$ splits expressions - \\r\\n (escape)', testScriptStdout, () => $`echo.js ${'a'}\r\n ${'b'}`, 'a\r\n\nb');
+test('$ concatenates tokens - \\r\\n (escape)', testScriptStdout, () => $`echo.js \r\na\r\n b`, '\r\na\r\n\nb');
+test('$ concatenates expressions - \\r\\n (escape)', testScriptStdout, () => $`echo.js \r\n${'a'}\r\n b`, '\r\na\r\n\nb');
+/* eslint-disable no-irregular-whitespace */
+test('$ handles expressions - \\f (no escape)', testScriptStdout, () => $`echo.js ${''}`, '\f');
+test('$ splits tokens - \\f (no escape)', testScriptStdout, () => $`echo.js ab`, 'a\fb');
+test('$ splits expressions - \\f (no escape)', testScriptStdout, () => $`echo.js ${'a'}${'b'}`, 'a\fb');
+test('$ concatenates tokens - \\f (no escape)', testScriptStdout, () => $`echo.js a b`, '\fa\f\nb');
+test('$ concatenates expressions - \\f (no escape)', testScriptStdout, () => $`echo.js ${'a'} b`, '\fa\f\nb');
+/* eslint-enable no-irregular-whitespace */
+test('$ handles tokens - \\f (escape)', testScriptStdout, () => $`echo.js \f`, '\f');
+test('$ handles expressions - \\f (escape)', testScriptStdout, () => $`echo.js ${'\f'}`, '\f');
+test('$ splits tokens - \\f (escape)', testScriptStdout, () => $`echo.js a\fb`, 'a\fb');
+test('$ splits expressions - \\f (escape)', testScriptStdout, () => $`echo.js ${'a'}\f${'b'}`, 'a\fb');
+test('$ concatenates tokens - \\f (escape)', testScriptStdout, () => $`echo.js \fa\f b`, '\fa\f\nb');
+test('$ concatenates expressions - \\f (escape)', testScriptStdout, () => $`echo.js \f${'a'}\f b`, '\fa\f\nb');
+test('$ handles tokens - \\', testScriptStdout, () => $`echo.js \\`, '\\');
+test('$ handles expressions - \\', testScriptStdout, () => $`echo.js ${'\\'}`, '\\');
+test('$ splits tokens - \\', testScriptStdout, () => $`echo.js a\\b`, 'a\\b');
+test('$ splits expressions - \\', testScriptStdout, () => $`echo.js ${'a'}\\${'b'}`, 'a\\b');
+test('$ concatenates tokens - \\', testScriptStdout, () => $`echo.js \\a\\ b`, '\\a\\\nb');
+test('$ concatenates expressions - \\', testScriptStdout, () => $`echo.js \\${'a'}\\ b`, '\\a\\\nb');
+test('$ handles tokens - \\\\', testScriptStdout, () => $`echo.js \\\\`, '\\\\');
+test('$ handles expressions - \\\\', testScriptStdout, () => $`echo.js ${'\\\\'}`, '\\\\');
+test('$ splits tokens - \\\\', testScriptStdout, () => $`echo.js a\\\\b`, 'a\\\\b');
+test('$ splits expressions - \\\\', testScriptStdout, () => $`echo.js ${'a'}\\\\${'b'}`, 'a\\\\b');
+test('$ concatenates tokens - \\\\', testScriptStdout, () => $`echo.js \\\\a\\\\ b`, '\\\\a\\\\\nb');
+test('$ concatenates expressions - \\\\', testScriptStdout, () => $`echo.js \\\\${'a'}\\\\ b`, '\\\\a\\\\\nb');
+test('$ handles tokens - `', testScriptStdout, () => $`echo.js \``, '`');
+test('$ handles expressions - `', testScriptStdout, () => $`echo.js ${'`'}`, '`');
+test('$ splits tokens - `', testScriptStdout, () => $`echo.js a\`b`, 'a`b');
+test('$ splits expressions - `', testScriptStdout, () => $`echo.js ${'a'}\`${'b'}`, 'a`b');
+test('$ concatenates tokens - `', testScriptStdout, () => $`echo.js \`a\` b`, '`a`\nb');
+test('$ concatenates expressions - `', testScriptStdout, () => $`echo.js \`${'a'}\` b`, '`a`\nb');
+test('$ handles tokens - \\v', testScriptStdout, () => $`echo.js \v`, '\v');
+test('$ handles expressions - \\v', testScriptStdout, () => $`echo.js ${'\v'}`, '\v');
+test('$ splits tokens - \\v', testScriptStdout, () => $`echo.js a\vb`, 'a\vb');
+test('$ splits expressions - \\v', testScriptStdout, () => $`echo.js ${'a'}\v${'b'}`, 'a\vb');
+test('$ concatenates tokens - \\v', testScriptStdout, () => $`echo.js \va\v b`, '\va\v\nb');
+test('$ concatenates expressions - \\v', testScriptStdout, () => $`echo.js \v${'a'}\v b`, '\va\v\nb');
+test('$ handles tokens - \\u2028', testScriptStdout, () => $`echo.js \u2028`, '\u2028');
+test('$ handles expressions - \\u2028', testScriptStdout, () => $`echo.js ${'\u2028'}`, '\u2028');
+test('$ splits tokens - \\u2028', testScriptStdout, () => $`echo.js a\u2028b`, 'a\u2028b');
+test('$ splits expressions - \\u2028', testScriptStdout, () => $`echo.js ${'a'}\u2028${'b'}`, 'a\u2028b');
+test('$ concatenates tokens - \\u2028', testScriptStdout, () => $`echo.js \u2028a\u2028 b`, '\u2028a\u2028\nb');
+test('$ concatenates expressions - \\u2028', testScriptStdout, () => $`echo.js \u2028${'a'}\u2028 b`, '\u2028a\u2028\nb');
+test('$ handles tokens - \\a', testScriptStdout, () => $`echo.js \a`, 'a');
+test('$ splits tokens - \\a', testScriptStdout, () => $`echo.js a\ab`, 'aab');
+test('$ splits expressions - \\a', testScriptStdout, () => $`echo.js ${'a'}\a${'b'}`, 'aab');
+test('$ concatenates tokens - \\a', testScriptStdout, () => $`echo.js \aa\a b`, 'aaa\nb');
+test('$ concatenates expressions - \\a', testScriptStdout, () => $`echo.js \a${'a'}\a b`, 'aaa\nb');
+test('$ handles tokens - \\cJ', testScriptStdout, () => $`echo.js \cJ`, 'cJ');
+test('$ splits tokens - \\cJ', testScriptStdout, () => $`echo.js a\cJb`, 'acJb');
+test('$ splits expressions - \\cJ', testScriptStdout, () => $`echo.js ${'a'}\cJ${'b'}`, 'acJb');
+test('$ concatenates tokens - \\cJ', testScriptStdout, () => $`echo.js \cJa\cJ b`, 'cJacJ\nb');
+test('$ concatenates expressions - \\cJ', testScriptStdout, () => $`echo.js \cJ${'a'}\cJ b`, 'cJacJ\nb');
+test('$ handles tokens - \\.', testScriptStdout, () => $`echo.js \.`, '.');
+test('$ splits tokens - \\.', testScriptStdout, () => $`echo.js a\.b`, 'a.b');
+test('$ splits expressions - \\.', testScriptStdout, () => $`echo.js ${'a'}\.${'b'}`, 'a.b');
+test('$ concatenates tokens - \\.', testScriptStdout, () => $`echo.js \.a\. b`, '.a.\nb');
+test('$ concatenates expressions - \\.', testScriptStdout, () => $`echo.js \.${'a'}\. b`, '.a.\nb');
+/* eslint-disable unicorn/no-hex-escape */
+test('$ handles tokens - \\x63', testScriptStdout, () => $`echo.js \x63`, 'c');
+test('$ splits tokens - \\x63', testScriptStdout, () => $`echo.js a\x63b`, 'acb');
+test('$ splits expressions - \\x63', testScriptStdout, () => $`echo.js ${'a'}\x63${'b'}`, 'acb');
+test('$ concatenates tokens - \\x63', testScriptStdout, () => $`echo.js \x63a\x63 b`, 'cac\nb');
+test('$ concatenates expressions - \\x63', testScriptStdout, () => $`echo.js \x63${'a'}\x63 b`, 'cac\nb');
+/* eslint-enable unicorn/no-hex-escape */
+test('$ handles tokens - \\u0063', testScriptStdout, () => $`echo.js \u0063`, 'c');
+test('$ splits tokens - \\u0063', testScriptStdout, () => $`echo.js a\u0063b`, 'acb');
+test('$ splits expressions - \\u0063', testScriptStdout, () => $`echo.js ${'a'}\u0063${'b'}`, 'acb');
+test('$ concatenates tokens - \\u0063', testScriptStdout, () => $`echo.js \u0063a\u0063 b`, 'cac\nb');
+test('$ concatenates expressions - \\u0063', testScriptStdout, () => $`echo.js \u0063${'a'}\u0063 b`, 'cac\nb');
+test('$ handles tokens - \\u{1}', testScriptStdout, () => $`echo.js \u{1}`, '\u0001');
+test('$ splits tokens - \\u{1}', testScriptStdout, () => $`echo.js a\u{1}b`, 'a\u0001b');
+test('$ splits expressions - \\u{1}', testScriptStdout, () => $`echo.js ${'a'}\u{1}${'b'}`, 'a\u0001b');
+test('$ concatenates tokens - \\u{1}', testScriptStdout, () => $`echo.js \u{1}a\u{1} b`, '\u0001a\u0001\nb');
+test('$ concatenates expressions - \\u{1}', testScriptStdout, () => $`echo.js \u{1}${'a'}\u{1} b`, '\u0001a\u0001\nb');
+test('$ handles tokens - \\u{63}', testScriptStdout, () => $`echo.js \u{63}`, 'c');
+test('$ splits tokens - \\u{63}', testScriptStdout, () => $`echo.js a\u{63}b`, 'acb');
+test('$ splits expressions - \\u{63}', testScriptStdout, () => $`echo.js ${'a'}\u{63}${'b'}`, 'acb');
+test('$ concatenates tokens - \\u{63}', testScriptStdout, () => $`echo.js \u{63}a\u{63} b`, 'cac\nb');
+test('$ concatenates expressions - \\u{63}', testScriptStdout, () => $`echo.js \u{63}${'a'}\u{63} b`, 'cac\nb');
+test('$ handles tokens - \\u{063}', testScriptStdout, () => $`echo.js \u{063}`, 'c');
+test('$ splits tokens - \\u{063}', testScriptStdout, () => $`echo.js a\u{063}b`, 'acb');
+test('$ splits expressions - \\u{063}', testScriptStdout, () => $`echo.js ${'a'}\u{063}${'b'}`, 'acb');
+test('$ concatenates tokens - \\u{063}', testScriptStdout, () => $`echo.js \u{063}a\u{063} b`, 'cac\nb');
+test('$ concatenates expressions - \\u{063}', testScriptStdout, () => $`echo.js \u{063}${'a'}\u{063} b`, 'cac\nb');
+test('$ handles tokens - \\u{0063}', testScriptStdout, () => $`echo.js \u{0063}`, 'c');
+test('$ splits tokens - \\u{0063}', testScriptStdout, () => $`echo.js a\u{0063}b`, 'acb');
+test('$ splits expressions - \\u{0063}', testScriptStdout, () => $`echo.js ${'a'}\u{0063}${'b'}`, 'acb');
+test('$ concatenates tokens - \\u{0063}', testScriptStdout, () => $`echo.js \u{0063}a\u{0063} b`, 'cac\nb');
+test('$ concatenates expressions - \\u{0063}', testScriptStdout, () => $`echo.js \u{0063}${'a'}\u{0063} b`, 'cac\nb');
+test('$ handles tokens - \\u{00063}', testScriptStdout, () => $`echo.js \u{00063}`, 'c');
+test('$ splits tokens - \\u{00063}', testScriptStdout, () => $`echo.js a\u{00063}b`, 'acb');
+test('$ splits expressions - \\u{00063}', testScriptStdout, () => $`echo.js ${'a'}\u{00063}${'b'}`, 'acb');
+test('$ concatenates tokens - \\u{00063}', testScriptStdout, () => $`echo.js \u{00063}a\u{00063} b`, 'cac\nb');
+test('$ concatenates expressions - \\u{00063}', testScriptStdout, () => $`echo.js \u{00063}${'a'}\u{00063} b`, 'cac\nb');
+test('$ handles tokens - \\u{000063}', testScriptStdout, () => $`echo.js \u{000063}`, 'c');
+test('$ splits tokens - \\u{000063}', testScriptStdout, () => $`echo.js a\u{000063}b`, 'acb');
+test('$ splits expressions - \\u{000063}', testScriptStdout, () => $`echo.js ${'a'}\u{000063}${'b'}`, 'acb');
+test('$ concatenates tokens - \\u{000063}', testScriptStdout, () => $`echo.js \u{000063}a\u{000063} b`, 'cac\nb');
+test('$ concatenates expressions - \\u{000063}', testScriptStdout, () => $`echo.js \u{000063}${'a'}\u{000063} b`, 'cac\nb');
+test('$ handles tokens - \\u{0000063}', testScriptStdout, () => $`echo.js \u{0000063}`, 'c');
+test('$ splits tokens - \\u{0000063}', testScriptStdout, () => $`echo.js a\u{0000063}b`, 'acb');
+test('$ splits expressions - \\u{0000063}', testScriptStdout, () => $`echo.js ${'a'}\u{0000063}${'b'}`, 'acb');
+test('$ concatenates tokens - \\u{0000063}', testScriptStdout, () => $`echo.js \u{0000063}a\u{0000063} b`, 'cac\nb');
+test('$ concatenates expressions - \\u{0000063}', testScriptStdout, () => $`echo.js \u{0000063}${'a'}\u{0000063} b`, 'cac\nb');
+test('$ handles tokens - \\u{0063}}', testScriptStdout, () => $`echo.js \u{0063}}`, 'c}');
+test('$ splits tokens - \\u{0063}}', testScriptStdout, () => $`echo.js a\u{0063}}b`, 'ac}b');
+test('$ splits expressions - \\u{0063}}', testScriptStdout, () => $`echo.js ${'a'}\u{0063}}${'b'}`, 'ac}b');
+test('$ concatenates tokens - \\u{0063}}', testScriptStdout, () => $`echo.js \u{0063}}a\u{0063}} b`, 'c}ac}\nb');
+test('$ concatenates expressions - \\u{0063}}', testScriptStdout, () => $`echo.js \u{0063}}${'a'}\u{0063}} b`, 'c}ac}\nb');
 
-test('$ allows number interpolation', async t => {
-	const {stdout} = await $`echo.js 1 ${2}`;
-	t.is(stdout, '1\n2');
-});
+const testScriptStdoutSync = (t, getChildProcess, expectedStdout) => {
+	const {stdout} = getChildProcess();
+	t.is(stdout, expectedStdout);
+};
 
-test('$ allows array interpolation', async t => {
-	const {stdout} = await $`echo.js ${['foo', 'bar']}`;
-	t.is(stdout, 'foo\nbar');
-});
+test('$.sync', testScriptStdoutSync, () => $.sync`echo.js foo bar`, 'foo\nbar');
+test('$.sync can be called $.s', testScriptStdoutSync, () => $.s`echo.js foo bar`, 'foo\nbar');
+test('$.sync accepts options', testScriptStdoutSync, () => $({stripFinalNewline: true}).sync`noop.js foo`, 'foo');
 
-test('$ allows empty array interpolation', async t => {
-	const {stdout} = await $`echo.js foo ${[]} bar`;
-	t.is(stdout, 'foo\nbar');
-});
+const testReturnInterpolate = async (t, getChildProcess, expectedStdout, options = {}) => {
+	const foo = await $(options)`echo.js foo`;
+	const {stdout} = await getChildProcess(foo);
+	t.is(stdout, expectedStdout);
+};
 
-test('$ allows execa return value interpolation', async t => {
-	const foo = await $`echo.js foo`;
-	const {stdout} = await $`echo.js ${foo} bar`;
-	t.is(stdout, 'foo\nbar');
-});
+test('$ allows execa return value interpolation', testReturnInterpolate, foo => $`echo.js ${foo} bar`, 'foo\nbar');
+test('$ allows execa return value buffer interpolation', testReturnInterpolate, foo => $`echo.js ${foo} bar`, 'foo\nbar', {encoding: 'buffer'});
+test('$ allows execa return value array interpolation', testReturnInterpolate, foo => $`echo.js ${[foo, 'bar']}`, 'foo\nbar');
+test('$ allows execa return value buffer array interpolation', testReturnInterpolate, foo => $`echo.js ${[foo, 'bar']}`, 'foo\nbar', {encoding: 'buffer'});
 
-test('$ allows execa return value array interpolation', async t => {
-	const foo = await $`echo.js foo`;
-	const {stdout} = await $`echo.js ${[foo, 'bar']}`;
-	t.is(stdout, 'foo\nbar');
-});
+const testReturnInterpolateSync = (t, getChildProcess, expectedStdout, options = {}) => {
+	const foo = $(options).sync`echo.js foo`;
+	const {stdout} = getChildProcess(foo);
+	t.is(stdout, expectedStdout);
+};
 
-test('$ allows execa return value buffer interpolation', async t => {
-	const foo = await $({encoding: 'buffer'})`echo.js foo`;
-	const {stdout} = await $`echo.js ${foo} bar`;
-	t.is(stdout, 'foo\nbar');
-});
+test('$.sync allows execa return value interpolation', testReturnInterpolateSync, foo => $.sync`echo.js ${foo} bar`, 'foo\nbar');
+test('$.sync allows execa return value buffer interpolation', testReturnInterpolateSync, foo => $.sync`echo.js ${foo} bar`, 'foo\nbar', {encoding: 'buffer'});
+test('$.sync allows execa return value array interpolation', testReturnInterpolateSync, foo => $.sync`echo.js ${[foo, 'bar']}`, 'foo\nbar');
+test('$.sync allows execa return value buffer array interpolation', testReturnInterpolateSync, foo => $.sync`echo.js ${[foo, 'bar']}`, 'foo\nbar', {encoding: 'buffer'});
 
-test('$ allows execa return value buffer array interpolation', async t => {
-	const foo = await $({encoding: 'buffer'})`echo.js foo`;
-	const {stdout} = await $`echo.js ${[foo, 'bar']}`;
-	t.is(stdout, 'foo\nbar');
-});
+const testInvalidSequence = (t, getChildProcess) => {
+	t.throws(getChildProcess, {message: /Invalid backslash sequence/});
+};
 
-test('$ ignores consecutive spaces', async t => {
-	const {stdout} = await $`echo.js foo    bar`;
-	t.is(stdout, 'foo\nbar');
-});
+test('$ handles invalid escape sequence - \\1', testInvalidSequence, () => $`echo.js \1`);
+test('$ handles invalid escape sequence - \\u', testInvalidSequence, () => $`echo.js \u`);
+test('$ handles invalid escape sequence - \\u0', testInvalidSequence, () => $`echo.js \u0`);
+test('$ handles invalid escape sequence - \\u00', testInvalidSequence, () => $`echo.js \u00`);
+test('$ handles invalid escape sequence - \\u000', testInvalidSequence, () => $`echo.js \u000`);
+test('$ handles invalid escape sequence - \\ug', testInvalidSequence, () => $`echo.js \ug`);
+test('$ handles invalid escape sequence - \\u{', testInvalidSequence, () => $`echo.js \u{`);
+test('$ handles invalid escape sequence - \\u{0000', testInvalidSequence, () => $`echo.js \u{0000`);
+test('$ handles invalid escape sequence - \\u{g}', testInvalidSequence, () => $`echo.js \u{g}`);
+/* eslint-disable unicorn/no-hex-escape */
+test('$ handles invalid escape sequence - \\x', testInvalidSequence, () => $`echo.js \x`);
+test('$ handles invalid escape sequence - \\x0', testInvalidSequence, () => $`echo.js \x0`);
+test('$ handles invalid escape sequence - \\xgg', testInvalidSequence, () => $`echo.js \xgg`);
+/* eslint-enable unicorn/no-hex-escape */
 
-test('$ allows escaping spaces with interpolation', async t => {
-	const {stdout} = await $`echo.js ${'foo bar'}`;
-	t.is(stdout, 'foo bar');
-});
+const testEmptyScript = (t, getChildProcess) => {
+	t.throws(getChildProcess, {message: /Template script must not be empty/});
+};
 
-test('$ disallows escaping spaces with backslashes', async t => {
-	const {stdout} = await $`echo.js foo\\ bar`;
-	t.is(stdout, 'foo\\\nbar');
-});
+test('$``', testEmptyScript, () => $``);
+test('$` `', testEmptyScript, () => $` `);
+test('$`  ` (2 spaces)', testEmptyScript, () => $`  `);
+test('$`\\t`', testEmptyScript, () => $`	`);
+test('$`\\n`', testEmptyScript, () => $`
+`);
 
-test('$ allows space escaped values in array interpolation', async t => {
-	const {stdout} = await $`echo.js ${['foo', 'bar baz']}`;
-	t.is(stdout, 'foo\nbar baz');
-});
-
-test('$ passes newline escape sequence as one argument', async t => {
-	const {stdout} = await $`echo.js \n`;
-	t.is(stdout, '\n');
-});
-
-test('$ passes newline escape sequence in interpolation as one argument', async t => {
-	const {stdout} = await $`echo.js ${'\n'}`;
-	t.is(stdout, '\n');
-});
-
-test('$ handles invalid escape sequence', async t => {
-	const {stdout} = await $`echo.js \u`;
-	t.is(stdout, '\\u');
-});
-
-test('$ can concatenate at the end of tokens', async t => {
-	const {stdout} = await $`echo.js foo${'bar'}`;
-	t.is(stdout, 'foobar');
-});
-
-test('$ does not concatenate at the end of tokens with a space', async t => {
-	const {stdout} = await $`echo.js foo ${'bar'}`;
-	t.is(stdout, 'foo\nbar');
-});
-
-test('$ can concatenate at the end of tokens followed by an array', async t => {
-	const {stdout} = await $`echo.js foo${['bar', 'foo']}`;
-	t.is(stdout, 'foobar\nfoo');
-});
-
-test('$ can concatenate at the start of tokens', async t => {
-	const {stdout} = await $`echo.js ${'foo'}bar`;
-	t.is(stdout, 'foobar');
-});
-
-test('$ does not concatenate at the start of tokens with a space', async t => {
-	const {stdout} = await $`echo.js ${'foo'} bar`;
-	t.is(stdout, 'foo\nbar');
-});
-
-test('$ can concatenate at the start of tokens followed by an array', async t => {
-	const {stdout} = await $`echo.js ${['foo', 'bar']}foo`;
-	t.is(stdout, 'foo\nbarfoo');
-});
-
-test('$ can concatenate at the start and end of tokens followed by an array', async t => {
-	const {stdout} = await $`echo.js foo${['bar', 'foo']}bar`;
-	t.is(stdout, 'foobar\nfoobar');
-});
-
-test('$ can concatenate multiple tokens', async t => {
-	const {stdout} = await $`echo.js ${'foo'}bar${'foo'}`;
-	t.is(stdout, 'foobarfoo');
-});
-
-test('$ allows escaping spaces in commands with interpolation', async t => {
-	const {stdout} = await $`${'command with space.js'} foo bar`;
-	t.is(stdout, 'foo\nbar');
-});
-
-test('$ escapes other whitespaces', async t => {
-	const {stdout} = await $`echo.js foo\tbar`;
-	t.is(stdout, 'foo\tbar');
-});
-
-test('$ trims', async t => {
-	const {stdout} = await $`  echo.js foo bar  `;
-	t.is(stdout, 'foo\nbar');
+test('$.sync must be used after options binding, not before', t => {
+	t.throws(() => $.sync({})`noop.js`, {message: /Please use/});
 });
 
 test('$ must only use options or templates', t => {
 	t.throws(() => $(true)`noop.js`, {message: /Please use either/});
 });
 
-test('$.sync', t => {
-	const {stdout} = $.sync`echo.js foo bar`;
-	t.is(stdout, 'foo\nbar');
-});
-
-test('$.sync can be called $.s', t => {
-	const {stdout} = $.s`echo.js foo bar`;
-	t.is(stdout, 'foo\nbar');
-});
-
-test('$.sync accepts options', t => {
-	const {stdout} = $({stripFinalNewline: true}).sync`noop.js foo`;
-	t.is(stdout, 'foo');
-});
-
-test('$.sync must be used after options binding, not before', t => {
-	t.throws(() => $.sync({})`noop.js`, {message: /Please use/});
-});
-
-test('$.sync allows execa return value interpolation', t => {
-	const foo = $.sync`echo.js foo`;
-	const {stdout} = $.sync`echo.js ${foo} bar`;
-	t.is(stdout, 'foo\nbar');
-});
-
-test('$.sync allows execa return value array interpolation', t => {
-	const foo = $.sync`echo.js foo`;
-	const {stdout} = $.sync`echo.js ${[foo, 'bar']}`;
-	t.is(stdout, 'foo\nbar');
-});
-
-test('$.sync allows execa return value buffer interpolation', t => {
-	const foo = $({encoding: 'buffer'}).sync`echo.js foo`;
-	const {stdout} = $.sync`echo.js ${foo} bar`;
-	t.is(stdout, 'foo\nbar');
-});
-
-test('$.sync allows execa return value buffer array interpolation', t => {
-	const foo = $({encoding: 'buffer'}).sync`echo.js foo`;
-	const {stdout} = $.sync`echo.js ${[foo, 'bar']}`;
-	t.is(stdout, 'foo\nbar');
-});
-
 test('$.sync must only templates', t => {
 	t.throws(() => $.sync(true)`noop.js`, {message: /A template string must be used/});
 });
 
-const invalidExpression = test.macro({
-	async exec(t, input, expected) {
-		await t.throwsAsync(
-			async () => $`echo.js ${input}`,
-			{instanceOf: TypeError, message: expected},
-		);
+const testInvalidExpression = (t, invalidExpression, execaMethod) => {
+	const expression = typeof invalidExpression === 'function' ? invalidExpression() : invalidExpression;
+	t.throws(
+		() => execaMethod`echo.js ${expression}`,
+		{message: /in template expression/},
+	);
+};
 
-		t.throws(
-			() => $.sync`echo.js ${input}`,
-			{instanceOf: TypeError, message: expected},
-		);
-	},
-	title(prettyInput, input, expected) {
-		return `$ APIs throw on invalid '${prettyInput ?? inspect(input)}' expression with '${expected}'`;
-	},
-});
-
-test(invalidExpression, undefined, 'Unexpected "undefined" in template expression');
-test(invalidExpression, [undefined], 'Unexpected "undefined" in template expression');
-
-test(invalidExpression, null, 'Unexpected "object" in template expression');
-test(invalidExpression, [null], 'Unexpected "object" in template expression');
-
-test(invalidExpression, true, 'Unexpected "boolean" in template expression');
-test(invalidExpression, [true], 'Unexpected "boolean" in template expression');
-
-test(invalidExpression, {}, 'Unexpected "object" in template expression');
-test(invalidExpression, [{}], 'Unexpected "object" in template expression');
-
-test(invalidExpression, {foo: 'bar'}, 'Unexpected "object" in template expression');
-test(invalidExpression, [{foo: 'bar'}], 'Unexpected "object" in template expression');
-
-test(invalidExpression, {stdout: undefined}, 'Unexpected "undefined" stdout in template expression');
-test(invalidExpression, [{stdout: undefined}], 'Unexpected "undefined" stdout in template expression');
-
-test(invalidExpression, {stdout: 1}, 'Unexpected "number" stdout in template expression');
-test(invalidExpression, [{stdout: 1}], 'Unexpected "number" stdout in template expression');
-
-test(invalidExpression, Promise.resolve(), 'Unexpected "object" in template expression');
-test(invalidExpression, [Promise.resolve()], 'Unexpected "object" in template expression');
-
-test(invalidExpression, Promise.resolve({stdout: 'foo'}), 'Unexpected "object" in template expression');
-test(invalidExpression, [Promise.resolve({stdout: 'foo'})], 'Unexpected "object" in template expression');
-
-test('$`noop.js`', invalidExpression, $`noop.js`, 'Unexpected "object" in template expression');
-test('[ $`noop.js` ]', invalidExpression, [$`noop.js`], 'Unexpected "object" in template expression');
-
-test('$({stdio: \'ignore\'}).sync`noop.js`', invalidExpression, $({stdio: 'ignore'}).sync`noop.js`, 'Unexpected "undefined" stdout in template expression');
-test('[ $({stdio: \'ignore\'}).sync`noop.js` ]', invalidExpression, [$({stdio: 'ignore'}).sync`noop.js`], 'Unexpected "undefined" stdout in template expression');
+test('$ throws on invalid expression - undefined', testInvalidExpression, undefined, $);
+test('$ throws on invalid expression - null', testInvalidExpression, null, $);
+test('$ throws on invalid expression - true', testInvalidExpression, true, $);
+test('$ throws on invalid expression - {}', testInvalidExpression, {}, $);
+test('$ throws on invalid expression - {foo: "bar"}', testInvalidExpression, {foo: 'bar'}, $);
+test('$ throws on invalid expression - {stdout: undefined}', testInvalidExpression, {stdout: undefined}, $);
+test('$ throws on invalid expression - {stdout: 1}', testInvalidExpression, {stdout: 1}, $);
+test('$ throws on invalid expression - Promise.resolve()', testInvalidExpression, Promise.resolve(), $);
+test('$ throws on invalid expression - Promise.resolve({stdout: "foo"})', testInvalidExpression, Promise.resolve({foo: 'bar'}), $);
+test('$ throws on invalid expression - $', testInvalidExpression, () => $`noop.js`, $);
+test('$ throws on invalid expression - $(options).sync', testInvalidExpression, () => $({stdio: 'ignore'}).sync`noop.js`, $);
+test('$ throws on invalid expression - [undefined]', testInvalidExpression, [undefined], $);
+test('$ throws on invalid expression - [null]', testInvalidExpression, [null], $);
+test('$ throws on invalid expression - [true]', testInvalidExpression, [true], $);
+test('$ throws on invalid expression - [{}]', testInvalidExpression, [{}], $);
+test('$ throws on invalid expression - [{foo: "bar"}]', testInvalidExpression, [{foo: 'bar'}], $);
+test('$ throws on invalid expression - [{stdout: undefined}]', testInvalidExpression, [{stdout: undefined}], $);
+test('$ throws on invalid expression - [{stdout: 1}]', testInvalidExpression, [{stdout: 1}], $);
+test('$ throws on invalid expression - [Promise.resolve()]', testInvalidExpression, [Promise.resolve()], $);
+test('$ throws on invalid expression - [Promise.resolve({stdout: "foo"})]', testInvalidExpression, [Promise.resolve({stdout: 'foo'})], $);
+test('$ throws on invalid expression - [$]', testInvalidExpression, () => [$`noop.js`], $);
+test('$ throws on invalid expression - [$(options).sync]', testInvalidExpression, () => [$({stdio: 'ignore'}).sync`noop.js`], $);
 
 test('$ stdin defaults to "inherit"', async t => {
 	const {stdout} = await $({input: 'foo'})`stdin-script.js`;


### PR DESCRIPTION
Fixes #721.
Fixes #842.

Note: Codecov seems confused. It is reporting one line not covered in this PR, but when clicking on the Codecov report, it shows it as covered. :thinking: 