### PR TITLE
Fix Codecov setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,6 @@ jobs:
       - run: npm install
       - run: npm test
       - uses: codecov/codecov-action@v3
-        if: matrix.node-version == 20
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 20
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
#839 added code coverage in CI for Windows and macOS.

However, Codecov does not seem to work properly and keep showing one specific line of code that is only covered by Windows as not covered at all. This makes PRs show a red tick even when the test coverage does not change.

![Screenshot from 2024-02-26 01-21-50](https://github.com/sindresorhus/execa/assets/8136211/70e69e65-491b-4739-b7be-3e64ca5f12d0)

This PR reverts #839 to fix this.