### PR TITLE
Rename `index` to `fdNumber`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,17 +104,17 @@ type BufferEncodingOption = 'buffer';
 
 // Whether `result.stdout|stderr|all` is an array of values due to `objectMode: true`
 type IsObjectStream<
-	StreamIndex extends string,
+	FdNumber extends string,
 	OptionsType extends CommonOptions = CommonOptions,
-> = IsObjectModeStream<StreamIndex, IsObjectOutputOptions<StreamOption<StreamIndex, OptionsType>>, OptionsType>;
+> = IsObjectModeStream<FdNumber, IsObjectOutputOptions<StreamOption<FdNumber, OptionsType>>, OptionsType>;
 
 type IsObjectModeStream<
-	StreamIndex extends string,
+	FdNumber extends string,
 	IsObjectModeStreamOption extends boolean,
 	OptionsType extends CommonOptions = CommonOptions,
 > = IsObjectModeStreamOption extends true
 	? true
-	: IsObjectOutputOptions<StdioProperty<StreamIndex, OptionsType>>;
+	: IsObjectOutputOptions<StdioProperty<FdNumber, OptionsType>>;
 
 type IsObjectOutputOptions<OutputOptions extends StdioOption> = IsObjectOutputOption<OutputOptions extends StdioSingleOption[]
 	? OutputOptions[number]
@@ -129,40 +129,40 @@ type BooleanObjectMode<ObjectModeOption extends StdioTransformFull['objectMode']
 
 // Whether `result.stdout|stderr|all` is `undefined`, excluding the `buffer` option
 type IgnoresStreamResult<
-	StreamIndex extends string,
+	FdNumber extends string,
 	OptionsType extends CommonOptions = CommonOptions,
-> = IgnoresStreamReturn<StreamIndex, IgnoresStdioResult<StreamOption<StreamIndex, OptionsType>>, OptionsType>;
+> = IgnoresStreamReturn<FdNumber, IgnoresStdioResult<StreamOption<FdNumber, OptionsType>>, OptionsType>;
 
 type IgnoresStreamReturn<
-	StreamIndex extends string,
+	FdNumber extends string,
 	IsIgnoredStreamOption extends boolean,
 	OptionsType extends CommonOptions = CommonOptions,
 > = IsIgnoredStreamOption extends true
 	? true
-	: IgnoresStdioResult<StdioProperty<StreamIndex, OptionsType>>;
+	: IgnoresStdioResult<StdioProperty<FdNumber, OptionsType>>;
 
 // Whether `result.stdio[*]` is `undefined`
 type IgnoresStdioResult<StdioOptionType extends StdioOption> = StdioOptionType extends NoStreamStdioOption ? true : false;
 
 // Whether `result.stdout|stderr|all` is `undefined`
 type IgnoresStreamOutput<
-	StreamIndex extends string,
+	FdNumber extends string,
 	OptionsType extends CommonOptions = CommonOptions,
 > = LacksBuffer<OptionsType['buffer']> extends true
 	? true
-	: IsInputStdioIndex<StreamIndex, OptionsType> extends true
+	: IsInputStdioDescriptor<FdNumber, OptionsType> extends true
 		? true
-		: IgnoresStreamResult<StreamIndex, OptionsType>;
+		: IgnoresStreamResult<FdNumber, OptionsType>;
 
 type LacksBuffer<BufferOption extends Options['buffer']> = BufferOption extends false ? true : false;
 
-// Whether `result.stdio[StreamIndex]` is an input stream
-type IsInputStdioIndex<
-	StreamIndex extends string,
+// Whether `result.stdio[FdNumber]` is an input stream
+type IsInputStdioDescriptor<
+	FdNumber extends string,
 	OptionsType extends CommonOptions = CommonOptions,
-> = StreamIndex extends '0'
+> = FdNumber extends '0'
 	? true
-	: IsInputStdio<StdioProperty<StreamIndex, OptionsType>>;
+	: IsInputStdio<StdioProperty<FdNumber, OptionsType>>;
 
 // Whether `result.stdio[3+]` is an input stream
 type IsInputStdio<StdioOptionType extends StdioOption> = StdioOptionType extends StdinOption
@@ -173,44 +173,44 @@ type IsInputStdio<StdioOptionType extends StdioOption> = StdioOptionType extends
 
 // `options.stdin|stdout|stderr`
 type StreamOption<
-	StreamIndex extends string,
+	FdNumber extends string,
 	OptionsType extends CommonOptions = CommonOptions,
-> = string extends StreamIndex ? StdioOption
-	: StreamIndex extends '0' ? OptionsType['stdin']
-		: StreamIndex extends '1' ? OptionsType['stdout']
-			: StreamIndex extends '2' ? OptionsType['stderr']
+> = string extends FdNumber ? StdioOption
+	: FdNumber extends '0' ? OptionsType['stdin']
+		: FdNumber extends '1' ? OptionsType['stdout']
+			: FdNumber extends '2' ? OptionsType['stderr']
 				: undefined;
 
-// `options.stdio[StreamIndex]`
+// `options.stdio[FdNumber]`
 type StdioProperty<
-	StreamIndex extends string,
+	FdNumber extends string,
 	OptionsType extends CommonOptions = CommonOptions,
-> = StdioOptionProperty<StreamIndex, StdioArrayOption<OptionsType>>;
+> = StdioOptionProperty<FdNumber, StdioArrayOption<OptionsType>>;
 
 type StdioOptionProperty<
-	StreamIndex extends string,
+	FdNumber extends string,
 	StdioOptionsType extends StdioOptions,
-> = string extends StreamIndex
+> = string extends FdNumber
 	? StdioOption | undefined
 	: StdioOptionsType extends StdioOptionsArray
-		? StreamIndex extends keyof StdioOptionsType
-			? StdioOptionsType[StreamIndex]
+		? FdNumber extends keyof StdioOptionsType
+			? StdioOptionsType[FdNumber]
 			: undefined
 		: undefined;
 
 // Type of `result.stdout|stderr`
 type StdioOutput<
-	StreamIndex extends string,
+	FdNumber extends string,
 	OptionsType extends CommonOptions = CommonOptions,
-> = StdioOutputResult<StreamIndex, IgnoresStreamOutput<StreamIndex, OptionsType>, OptionsType>;
+> = StdioOutputResult<FdNumber, IgnoresStreamOutput<FdNumber, OptionsType>, OptionsType>;
 
 type StdioOutputResult<
-	StreamIndex extends string,
+	FdNumber extends string,
 	StreamOutputIgnored extends boolean,
 	OptionsType extends CommonOptions = CommonOptions,
 > = StreamOutputIgnored extends true
 	? undefined
-	: StreamEncoding<IsObjectStream<StreamIndex, OptionsType>, OptionsType['lines'], OptionsType['encoding']>;
+	: StreamEncoding<IsObjectStream<FdNumber, OptionsType>, OptionsType['lines'], OptionsType['encoding']>;
 
 type StreamEncoding<
 	IsObjectResult extends boolean,
@@ -246,8 +246,8 @@ type MapStdioOptions<
 	StdioOptionsArrayType extends StdioOptionsArray,
 	OptionsType extends CommonOptions = CommonOptions,
 > = {
-	[StreamIndex in keyof StdioOptionsArrayType]: StdioOutput<
-	StreamIndex extends string ? StreamIndex : string,
+	[FdNumber in keyof StdioOptionsArrayType]: StdioOutput<
+	FdNumber extends string ? FdNumber : string,
 	OptionsType
 	>
 };
@@ -782,17 +782,17 @@ export type ExecaError<OptionsType extends Options = Options> = ExecaCommonRetur
 export type ExecaSyncError<OptionsType extends SyncOptions = SyncOptions> = ExecaCommonReturnValue<true, OptionsType> & ExecaCommonError;
 
 type StreamUnlessIgnored<
-	StreamIndex extends string,
+	FdNumber extends string,
 	OptionsType extends Options = Options,
-> = ChildProcessStream<StreamIndex, IgnoresStreamResult<StreamIndex, OptionsType>, OptionsType>;
+> = ChildProcessStream<FdNumber, IgnoresStreamResult<FdNumber, OptionsType>, OptionsType>;
 
 type ChildProcessStream<
-	StreamIndex extends string,
+	FdNumber extends string,
 	StreamResultIgnored extends boolean,
 	OptionsType extends Options = Options,
 > = StreamResultIgnored extends true
 	? null
-	: InputOutputStream<IsInputStdioIndex<StreamIndex, OptionsType>>;
+	: InputOutputStream<IsInputStdioDescriptor<FdNumber, OptionsType>>;
 
 type InputOutputStream<IsInput extends boolean> = IsInput extends true
 	? Writable

--- a/lib/pipe/validate.js
+++ b/lib/pipe/validate.js
@@ -48,11 +48,11 @@ export const PROCESS_OPTIONS = new WeakMap();
 
 const getSourceStream = (source, stdioStreamsGroups, from, sourceOptions) => {
 	try {
-		const streamIndex = getStreamIndex(stdioStreamsGroups, from);
-		const sourceStream = streamIndex === 'all' ? source.all : source.stdio[streamIndex];
+		const fdNumber = getFdNumber(stdioStreamsGroups, from);
+		const sourceStream = fdNumber === 'all' ? source.all : source.stdio[fdNumber];
 
 		if (sourceStream === null || sourceStream === undefined) {
-			throw new TypeError(getInvalidStdioOptionMessage(streamIndex, from, sourceOptions));
+			throw new TypeError(getInvalidStdioOptionMessage(fdNumber, from, sourceOptions));
 		}
 
 		return {sourceStream};
@@ -61,61 +61,61 @@ const getSourceStream = (source, stdioStreamsGroups, from, sourceOptions) => {
 	}
 };
 
-const getStreamIndex = (stdioStreamsGroups, from = 'stdout') => {
-	const streamIndex = STANDARD_STREAMS_ALIASES.includes(from)
+const getFdNumber = (stdioStreamsGroups, from = 'stdout') => {
+	const fdNumber = STANDARD_STREAMS_ALIASES.includes(from)
 		? STANDARD_STREAMS_ALIASES.indexOf(from)
 		: from;
 
-	if (streamIndex === 'all') {
-		return streamIndex;
+	if (fdNumber === 'all') {
+		return fdNumber;
 	}
 
-	if (streamIndex === 0) {
+	if (fdNumber === 0) {
 		throw new TypeError('The "from" option must not be "stdin".');
 	}
 
-	if (!Number.isInteger(streamIndex) || streamIndex < 0) {
-		throw new TypeError(`The "from" option must not be "${streamIndex}".
+	if (!Number.isInteger(fdNumber) || fdNumber < 0) {
+		throw new TypeError(`The "from" option must not be "${fdNumber}".
 It must be "stdout", "stderr", "all" or a file descriptor integer.
 It is optional and defaults to "stdout".`);
 	}
 
-	const stdioStreams = stdioStreamsGroups[streamIndex];
+	const stdioStreams = stdioStreamsGroups[fdNumber];
 	if (stdioStreams === undefined) {
-		throw new TypeError(`The "from" option must not be ${streamIndex}. That file descriptor does not exist.
+		throw new TypeError(`The "from" option must not be ${fdNumber}. That file descriptor does not exist.
 Please set the "stdio" option to ensure that file descriptor exists.`);
 	}
 
 	if (stdioStreams[0].direction === 'input') {
-		throw new TypeError(`The "from" option must not be ${streamIndex}. It must be a readable stream, not writable.`);
+		throw new TypeError(`The "from" option must not be ${fdNumber}. It must be a readable stream, not writable.`);
 	}
 
-	return streamIndex;
+	return fdNumber;
 };
 
-const getInvalidStdioOptionMessage = (streamIndex, from, sourceOptions) => {
-	if (streamIndex === 'all' && !sourceOptions.all) {
+const getInvalidStdioOptionMessage = (fdNumber, from, sourceOptions) => {
+	if (fdNumber === 'all' && !sourceOptions.all) {
 		return 'The "all" option must be true to use `childProcess.pipe(destinationProcess, {from: "all"})`.';
 	}
 
-	const {optionName, optionValue} = getInvalidStdioOption(streamIndex, sourceOptions);
+	const {optionName, optionValue} = getInvalidStdioOption(fdNumber, sourceOptions);
 	const pipeOptions = from === undefined ? '' : `, {from: ${serializeOptionValue(from)}}`;
 	return `The \`${optionName}: ${serializeOptionValue(optionValue)}\` option is incompatible with using \`childProcess.pipe(destinationProcess${pipeOptions})\`.
 Please set this option with "pipe" instead.`;
 };
 
-const getInvalidStdioOption = (streamIndex, {stdout, stderr, stdio}) => {
-	const usedIndex = streamIndex === 'all' ? 1 : streamIndex;
+const getInvalidStdioOption = (fdNumber, {stdout, stderr, stdio}) => {
+	const usedDescriptor = fdNumber === 'all' ? 1 : fdNumber;
 
-	if (usedIndex === 1 && stdout !== undefined) {
+	if (usedDescriptor === 1 && stdout !== undefined) {
 		return {optionName: 'stdout', optionValue: stdout};
 	}
 
-	if (usedIndex === 2 && stderr !== undefined) {
+	if (usedDescriptor === 2 && stderr !== undefined) {
 		return {optionName: 'stderr', optionValue: stderr};
 	}
 
-	return {optionName: `stdio[${usedIndex}]`, optionValue: stdio[usedIndex]};
+	return {optionName: `stdio[${usedDescriptor}]`, optionValue: stdio[usedDescriptor]};
 };
 
 const serializeOptionValue = optionValue => {

--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -49,12 +49,12 @@ export const pipeOutputAsync = (spawned, stdioStreamsGroups, controller) => {
 		}
 	}
 
-	for (const [index, inputStreams] of Object.entries(inputStreamsGroups)) {
-		pipeStreams(inputStreams, spawned.stdio[index]);
+	for (const [fdNumber, inputStreams] of Object.entries(inputStreamsGroups)) {
+		pipeStreams(inputStreams, spawned.stdio[fdNumber]);
 	}
 };
 
-const pipeStdioOption = (spawned, {type, value, direction, index}, inputStreamsGroups, controller) => {
+const pipeStdioOption = (spawned, {type, value, direction, fdNumber}, inputStreamsGroups, controller) => {
 	if (type === 'native') {
 		return;
 	}
@@ -62,9 +62,9 @@ const pipeStdioOption = (spawned, {type, value, direction, index}, inputStreamsG
 	setStandardStreamMaxListeners(value, controller);
 
 	if (direction === 'output') {
-		pipeStreams([spawned.stdio[index]], value);
+		pipeStreams([spawned.stdio[fdNumber]], value);
 	} else {
-		inputStreamsGroups[index] = [...(inputStreamsGroups[index] ?? []), value];
+		inputStreamsGroups[fdNumber] = [...(inputStreamsGroups[fdNumber] ?? []), value];
 	}
 };
 

--- a/lib/stdio/direction.js
+++ b/lib/stdio/direction.js
@@ -6,9 +6,9 @@ import {
 } from 'is-stream';
 import {isWritableStream} from './type.js';
 
-// For `stdio[index]` beyond stdin/stdout/stderr, we need to guess whether the value passed is intended for inputs or outputs.
+// For `stdio[fdNumber]` beyond stdin/stdout/stderr, we need to guess whether the value passed is intended for inputs or outputs.
 // This allows us to know whether to pipe _into_ or _from_ the stream.
-// When `stdio[index]` is a single value, this guess is fairly straightforward.
+// When `stdio[fdNumber]` is a single value, this guess is fairly straightforward.
 // However, when it is an array instead, we also need to make sure the different values are not incompatible with each other.
 export const addStreamDirection = stdioStreams => {
 	const directions = stdioStreams.map(stdioStream => getStreamDirection(stdioStream));
@@ -21,7 +21,7 @@ export const addStreamDirection = stdioStreams => {
 	return stdioStreams.map(stdioStream => addDirection(stdioStream, direction));
 };
 
-const getStreamDirection = stdioStream => KNOWN_DIRECTIONS[stdioStream.index] ?? guessStreamDirection[stdioStream.type](stdioStream.value);
+const getStreamDirection = stdioStream => KNOWN_DIRECTIONS[stdioStream.fdNumber] ?? guessStreamDirection[stdioStream.type](stdioStream.value);
 
 // `stdin`/`stdout`/`stderr` have a known direction
 const KNOWN_DIRECTIONS = ['input', 'output', 'output'];

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -85,19 +85,19 @@ export const generatorToDuplexStream = ({
 };
 
 // `childProcess.stdin|stdout|stderr|stdio` is directly mutated.
-export const pipeGenerator = (spawned, {value, direction, index}) => {
+export const pipeGenerator = (spawned, {value, direction, fdNumber}) => {
 	if (direction === 'output') {
-		pipeStreams([spawned.stdio[index]], value);
+		pipeStreams([spawned.stdio[fdNumber]], value);
 	} else {
-		pipeStreams([value], spawned.stdio[index]);
+		pipeStreams([value], spawned.stdio[fdNumber]);
 	}
 
-	const streamProperty = PROCESS_STREAM_PROPERTIES[index];
+	const streamProperty = PROCESS_STREAM_PROPERTIES[fdNumber];
 	if (streamProperty !== undefined) {
 		spawned[streamProperty] = value;
 	}
 
-	spawned.stdio[index] = value;
+	spawned.stdio[fdNumber] = value;
 };
 
 const PROCESS_STREAM_PROPERTIES = ['stdin', 'stdout', 'stderr'];

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -11,7 +11,7 @@ import {forwardStdio} from './forward.js';
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async/sync mode
 export const handleInput = (addProperties, options, isSync) => {
 	const stdio = normalizeStdio(options);
-	const [stdinStreams, ...otherStreamsGroups] = stdio.map((stdioOption, index) => getStdioStreams(stdioOption, index));
+	const [stdinStreams, ...otherStreamsGroups] = stdio.map((stdioOption, fdNumber) => getStdioStreams(stdioOption, fdNumber));
 	const stdioStreamsGroups = [[...stdinStreams, ...handleInputOptions(options)], ...otherStreamsGroups]
 		.map(stdioStreams => validateStreams(stdioStreams))
 		.map(stdioStreams => addStreamDirection(stdioStreams))
@@ -26,22 +26,22 @@ export const handleInput = (addProperties, options, isSync) => {
 // We make sure passing an array with a single item behaves the same as passing that item without an array.
 // This is what users would expect.
 // For example, `stdout: ['ignore']` behaves the same as `stdout: 'ignore'`.
-const getStdioStreams = (stdioOption, index) => {
-	const optionName = getOptionName(index);
+const getStdioStreams = (stdioOption, fdNumber) => {
+	const optionName = getOptionName(fdNumber);
 	const stdioOptions = Array.isArray(stdioOption) ? stdioOption : [stdioOption];
-	const rawStdioStreams = stdioOptions.map(stdioOption => getStdioStream(stdioOption, optionName, index));
+	const rawStdioStreams = stdioOptions.map(stdioOption => getStdioStream(stdioOption, optionName, fdNumber));
 	const stdioStreams = filterDuplicates(rawStdioStreams);
 	const isStdioArray = stdioStreams.length > 1;
 	validateStdioArray(stdioStreams, isStdioArray, optionName);
 	return stdioStreams.map(stdioStream => handleNativeStream(stdioStream, isStdioArray));
 };
 
-const getOptionName = index => KNOWN_OPTION_NAMES[index] ?? `stdio[${index}]`;
+const getOptionName = fdNumber => KNOWN_OPTION_NAMES[fdNumber] ?? `stdio[${fdNumber}]`;
 const KNOWN_OPTION_NAMES = ['stdin', 'stdout', 'stderr'];
 
-const getStdioStream = (stdioOption, optionName, index) => {
+const getStdioStream = (stdioOption, optionName, fdNumber) => {
 	const type = getStdioOptionType(stdioOption, optionName);
-	return {type, value: stdioOption, optionName, index};
+	return {type, value: stdioOption, optionName, fdNumber};
 };
 
 const filterDuplicates = stdioStreams => stdioStreams.filter((stdioStreamOne, indexOne) =>

--- a/lib/stdio/input.js
+++ b/lib/stdio/input.js
@@ -12,7 +12,7 @@ const handleInputOption = input => input === undefined ? undefined : {
 	type: getInputType(input),
 	value: input,
 	optionName: 'input',
-	index: 0,
+	fdNumber: 0,
 };
 
 const getInputType = input => {
@@ -34,7 +34,7 @@ const getInputType = input => {
 const handleInputFileOption = inputFile => inputFile === undefined ? undefined : {
 	...getInputFileType(inputFile),
 	optionName: 'inputFile',
-	index: 0,
+	fdNumber: 0,
 };
 
 const getInputFileType = inputFile => {

--- a/lib/stdio/native.js
+++ b/lib/stdio/native.js
@@ -6,17 +6,17 @@ import {STANDARD_STREAMS} from '../utils.js';
 // To do so, we transform the following values:
 //  - Node.js streams are marked as `type: nodeStream`
 //  - 'inherit' becomes `process.stdin|stdout|stderr`
-//  - any file descriptor integer becomes `process.stdio[index]`
+//  - any file descriptor integer becomes `process.stdio[fdNumber]`
 // All of the above transformations tell Execa to perform manual piping.
 export const handleNativeStream = (stdioStream, isStdioArray) => {
-	const {type, value, index, optionName} = stdioStream;
+	const {type, value, fdNumber, optionName} = stdioStream;
 
 	if (!isStdioArray || type !== 'native') {
 		return stdioStream;
 	}
 
 	if (value === 'inherit') {
-		return {...stdioStream, type: 'nodeStream', value: getStandardStream(index, value, optionName)};
+		return {...stdioStream, type: 'nodeStream', value: getStandardStream(fdNumber, value, optionName)};
 	}
 
 	if (typeof value === 'number') {
@@ -35,8 +35,8 @@ export const handleNativeStream = (stdioStream, isStdioArray) => {
 //  - Using a TCP `Socket` would work but be rather complex to implement.
 // Since this is an edge case, we simply throw an error message.
 // See https://github.com/sindresorhus/execa/pull/643#discussion_r1435905707
-const getStandardStream = (index, value, optionName) => {
-	const standardStream = STANDARD_STREAMS[index];
+const getStandardStream = (fdNumber, value, optionName) => {
+	const standardStream = STANDARD_STREAMS[fdNumber];
 
 	if (standardStream === undefined) {
 		throw new TypeError(`The \`${optionName}: ${value}\` option is invalid: no such standard stream.`);

--- a/lib/stdio/option.js
+++ b/lib/stdio/option.js
@@ -26,7 +26,7 @@ const getStdioArray = (stdio, options) => {
 	}
 
 	const length = Math.max(stdio.length, STANDARD_STREAMS_ALIASES.length);
-	return Array.from({length}, (value, index) => stdio[index]);
+	return Array.from({length}, (value, fdNumber) => stdio[fdNumber]);
 };
 
 const hasAlias = options => STANDARD_STREAMS_ALIASES.some(alias => options[alias] !== undefined);

--- a/lib/stdio/sync.js
+++ b/lib/stdio/sync.js
@@ -54,7 +54,7 @@ export const pipeOutputSync = (stdioStreamsGroups, result) => {
 
 	for (const stdioStreams of stdioStreamsGroups) {
 		for (const stdioStream of stdioStreams) {
-			pipeStdioOptionSync(result.output[stdioStream.index], stdioStream);
+			pipeStdioOptionSync(result.output[stdioStream.fdNumber], stdioStream);
 		}
 	}
 };

--- a/lib/stream/all.js
+++ b/lib/stream/all.js
@@ -11,7 +11,7 @@ export const makeAllStream = ({stdout, stderr}, {all}) => all && (stdout || stde
 export const waitForAllStream = ({spawned, encoding, buffer, maxBuffer, streamInfo}) => waitForChildStream({
 	stream: getAllStream(spawned, encoding),
 	spawned,
-	index: 1,
+	fdNumber: 1,
 	encoding,
 	buffer,
 	maxBuffer: maxBuffer * 2,

--- a/lib/stream/child.js
+++ b/lib/stream/child.js
@@ -2,19 +2,19 @@ import {setImmediate} from 'node:timers/promises';
 import getStream, {getStreamAsArrayBuffer, getStreamAsArray, MaxBufferError} from 'get-stream';
 import {waitForStream, handleStreamError, isInputFileDescriptor} from './wait.js';
 
-export const waitForChildStream = async ({stream, spawned, index, encoding, buffer, maxBuffer, streamInfo}) => {
+export const waitForChildStream = async ({stream, spawned, fdNumber, encoding, buffer, maxBuffer, streamInfo}) => {
 	if (!stream) {
 		return;
 	}
 
-	if (isInputFileDescriptor(index, streamInfo.stdioStreamsGroups)) {
-		await waitForStream(stream, index, streamInfo);
+	if (isInputFileDescriptor(fdNumber, streamInfo.stdioStreamsGroups)) {
+		await waitForStream(stream, fdNumber, streamInfo);
 		return;
 	}
 
 	if (!buffer) {
 		await Promise.all([
-			waitForStream(stream, index, streamInfo),
+			waitForStream(stream, fdNumber, streamInfo),
 			resumeStream(stream),
 		]);
 		return;
@@ -27,7 +27,7 @@ export const waitForChildStream = async ({stream, spawned, index, encoding, buff
 			spawned.kill();
 		}
 
-		handleStreamError(error, index, streamInfo);
+		handleStreamError(error, fdNumber, streamInfo);
 		return handleBufferedData(error, encoding);
 	}
 };

--- a/lib/stream/resolve.js
+++ b/lib/stream/resolve.js
@@ -54,21 +54,21 @@ export const getSpawnedResult = async ({
 
 // Read the contents of `childProcess.std*` and|or wait for its completion
 const waitForChildStreams = ({spawned, encoding, buffer, maxBuffer, streamInfo}) =>
-	spawned.stdio.map((stream, index) => waitForChildStream({stream, spawned, index, encoding, buffer, maxBuffer, streamInfo}));
+	spawned.stdio.map((stream, fdNumber) => waitForChildStream({stream, spawned, fdNumber, encoding, buffer, maxBuffer, streamInfo}));
 
 // Transforms replace `childProcess.std*`, which means they are not exposed to users.
 // However, we still want to wait for their completion.
 const waitForOriginalStreams = (originalStreams, spawned, streamInfo) =>
-	originalStreams.map((stream, index) => stream === spawned.stdio[index]
+	originalStreams.map((stream, fdNumber) => stream === spawned.stdio[fdNumber]
 		? undefined
-		: waitForStream(stream, index, streamInfo));
+		: waitForStream(stream, fdNumber, streamInfo));
 
 // Some `stdin`/`stdout`/`stderr` options create a stream, e.g. when passing a file path.
 // The `.pipe()` method automatically ends that stream when `childProcess` ends.
 // This makes sure we wait for the completion of those streams, in order to catch any error.
-const waitForCustomStreamsEnd = (stdioStreamsGroups, streamInfo) => stdioStreamsGroups.flatMap((stdioStreams, index) => stdioStreams
+const waitForCustomStreamsEnd = (stdioStreamsGroups, streamInfo) => stdioStreamsGroups.flatMap((stdioStreams, fdNumber) => stdioStreams
 	.filter(({value}) => isStream(value, {checkOpen: false}) && !isStandardStream(value))
-	.map(({type, value}) => waitForStream(value, index, streamInfo, {
+	.map(({type, value}) => waitForStream(value, fdNumber, streamInfo, {
 		isSameDirection: type === 'generator',
 		stopOnExit: type === 'native',
 	})));

--- a/lib/stream/wait.js
+++ b/lib/stream/wait.js
@@ -3,7 +3,7 @@ import {finished} from 'node:stream/promises';
 // Wraps `finished(stream)` to handle the following case:
 //  - When the child process exits, Node.js automatically calls `childProcess.stdin.destroy()`, which we need to ignore.
 //  - However, we still need to throw if `childProcess.stdin.destroy()` is called before child process exit.
-export const waitForStream = async (stream, index, streamInfo, {isSameDirection, stopOnExit = false} = {}) => {
+export const waitForStream = async (stream, fdNumber, streamInfo, {isSameDirection, stopOnExit = false} = {}) => {
 	const {originalStreams: [originalStdin], exitPromise} = streamInfo;
 
 	const abortController = new AbortController();
@@ -13,7 +13,7 @@ export const waitForStream = async (stream, index, streamInfo, {isSameDirection,
 			finished(stream, {cleanup: true, signal: abortController.signal}),
 		]);
 	} catch (error) {
-		handleStreamError(error, index, streamInfo, isSameDirection);
+		handleStreamError(error, fdNumber, streamInfo, isSameDirection);
 	} finally {
 		abortController.abort();
 	}
@@ -24,19 +24,19 @@ export const waitForStream = async (stream, index, streamInfo, {isSameDirection,
 // Those other streams might have a different direction due to the above.
 // When this happens, the direction of both the initial stream and the others should then be taken into account.
 // Therefore, we keep track of which file descriptor is currently propagating stream errors.
-export const handleStreamError = (error, index, streamInfo, isSameDirection) => {
-	if (!shouldIgnoreStreamError(error, index, streamInfo, isSameDirection)) {
+export const handleStreamError = (error, fdNumber, streamInfo, isSameDirection) => {
+	if (!shouldIgnoreStreamError(error, fdNumber, streamInfo, isSameDirection)) {
 		throw error;
 	}
 };
 
-const shouldIgnoreStreamError = (error, index, {stdioStreamsGroups, propagating}, isSameDirection = true) => {
-	if (propagating.has(index)) {
+const shouldIgnoreStreamError = (error, fdNumber, {stdioStreamsGroups, propagating}, isSameDirection = true) => {
+	if (propagating.has(fdNumber)) {
 		return isStreamEpipe(error) || isStreamAbort(error);
 	}
 
-	propagating.add(index);
-	return isInputFileDescriptor(index, stdioStreamsGroups) === isSameDirection
+	propagating.add(fdNumber);
+	return isInputFileDescriptor(fdNumber, stdioStreamsGroups) === isSameDirection
 		? isStreamEpipe(error)
 		: isStreamAbort(error);
 };
@@ -46,7 +46,7 @@ const shouldIgnoreStreamError = (error, index, {stdioStreamsGroups, propagating}
 // Therefore, we need to use the file descriptor's direction (`stdin` is input, `stdout` is output, etc.).
 // However, while `childProcess.std*` and transforms follow that direction, any stream passed the `std*` option has the opposite direction.
 // For example, `childProcess.stdin` is a writable, but the `stdin` option is a readable.
-export const isInputFileDescriptor = (index, stdioStreamsGroups) => stdioStreamsGroups[index][0].direction === 'input';
+export const isInputFileDescriptor = (fdNumber, stdioStreamsGroups) => stdioStreamsGroups[fdNumber][0].direction === 'input';
 
 // When `stream.destroy()` is called without an `error` argument, stream is aborted.
 // This is the only way to abort a readable stream, which can be useful in some instances.

--- a/test/fixtures/max-buffer.js
+++ b/test/fixtures/max-buffer.js
@@ -2,12 +2,12 @@
 import process from 'node:process';
 import {writeSync} from 'node:fs';
 
-const index = Number(process.argv[2]);
+const fdNumber = Number(process.argv[2]);
 const bytes = '.'.repeat(Number(process.argv[3] || 1e7));
-if (index === 1) {
+if (fdNumber === 1) {
 	process.stdout.write(bytes);
-} else if (index === 2) {
+} else if (fdNumber === 2) {
 	process.stderr.write(bytes);
 } else {
-	writeSync(index, bytes);
+	writeSync(fdNumber, bytes);
 }

--- a/test/fixtures/nested-stdio.js
+++ b/test/fixtures/nested-stdio.js
@@ -2,25 +2,25 @@
 import process from 'node:process';
 import {execa} from '../../index.js';
 
-const [stdioOption, index, file, ...args] = process.argv.slice(2);
+const [stdioOption, fdNumber, file, ...args] = process.argv.slice(2);
 let optionValue = JSON.parse(stdioOption);
 optionValue = typeof optionValue === 'string' ? process[optionValue] : optionValue;
 optionValue = Array.isArray(optionValue) && typeof optionValue[0] === 'string'
 	? [process[optionValue[0]], ...optionValue.slice(1)]
 	: optionValue;
 const stdio = ['ignore', 'inherit', 'inherit'];
-stdio[index] = optionValue;
-const childProcess = execa(file, [`${index}`, ...args], {stdio});
+stdio[fdNumber] = optionValue;
+const childProcess = execa(file, [`${fdNumber}`, ...args], {stdio});
 
 const shouldPipe = Array.isArray(optionValue) && optionValue.includes('pipe');
-const hasPipe = childProcess.stdio[index] !== null;
+const hasPipe = childProcess.stdio[fdNumber] !== null;
 
 if (shouldPipe && !hasPipe) {
-	throw new Error(`childProcess.stdio[${index}] is null.`);
+	throw new Error(`childProcess.stdio[${fdNumber}] is null.`);
 }
 
 if (!shouldPipe && hasPipe) {
-	throw new Error(`childProcess.stdio[${index}] should be null.`);
+	throw new Error(`childProcess.stdio[${fdNumber}] should be null.`);
 }
 
 await childProcess;

--- a/test/fixtures/stdin-fd.js
+++ b/test/fixtures/stdin-fd.js
@@ -2,9 +2,9 @@
 import process from 'node:process';
 import {readFileSync} from 'node:fs';
 
-const fileDescriptorIndex = Number(process.argv[2]);
-if (fileDescriptorIndex === 0) {
+const fdNumber = Number(process.argv[2]);
+if (fdNumber === 0) {
 	process.stdin.pipe(process.stdout);
 } else {
-	process.stdout.write(readFileSync(fileDescriptorIndex));
+	process.stdout.write(readFileSync(fdNumber));
 }

--- a/test/helpers/stdio.js
+++ b/test/helpers/stdio.js
@@ -2,13 +2,13 @@ import process from 'node:process';
 
 export const identity = value => value;
 
-export const getStdio = (indexOrName, stdioOption, length = 3) => {
-	if (typeof indexOrName === 'string') {
-		return {[indexOrName]: stdioOption};
+export const getStdio = (fdNumberOrName, stdioOption, length = 3) => {
+	if (typeof fdNumberOrName === 'string') {
+		return {[fdNumberOrName]: stdioOption};
 	}
 
 	const stdio = Array.from({length}).fill('pipe');
-	stdio[indexOrName] = stdioOption;
+	stdio[fdNumberOrName] = stdioOption;
 	return {stdio};
 };
 

--- a/test/pipe/setup.js
+++ b/test/pipe/setup.js
@@ -5,8 +5,8 @@ import {fullStdio} from '../helpers/stdio.js';
 
 setFixtureDir();
 
-const pipeToProcess = async (t, index, from, options) => {
-	const {stdout} = await execa('noop-fd.js', [`${index}`, 'test'], options)
+const pipeToProcess = async (t, fdNumber, from, options) => {
+	const {stdout} = await execa('noop-fd.js', [`${fdNumber}`, 'test'], options)
 		.pipe(execa('stdin.js'), {from});
 	t.is(stdout, 'test');
 };

--- a/test/return/error.js
+++ b/test/return/error.js
@@ -72,8 +72,8 @@ test('error.message contains stdout/stderr/stdio even with encoding "buffer", ob
 test('error.message contains all if available, objectMode', testStdioMessage, 'utf8', true, true);
 test('error.message contains all even with encoding "buffer", objectMode', testStdioMessage, 'buffer', true, true);
 
-const testPartialIgnoreMessage = async (t, index, stdioOption, output) => {
-	const {message} = await t.throwsAsync(execa('echo-fail.js', getStdio(index, stdioOption, 4)));
+const testPartialIgnoreMessage = async (t, fdNumber, stdioOption, output) => {
+	const {message} = await t.throwsAsync(execa('echo-fail.js', getStdio(fdNumber, stdioOption, 4)));
 	t.true(message.endsWith(`echo-fail.js\n\n${output}\n\nfd3`));
 };
 

--- a/test/return/output.js
+++ b/test/return/output.js
@@ -6,14 +6,14 @@ import {noopGenerator} from '../helpers/generator.js';
 
 setFixtureDir();
 
-const testOutput = async (t, index, execaMethod) => {
-	const {stdout, stderr, stdio} = await execaMethod('noop-fd.js', [`${index}`, 'foobar'], fullStdio);
-	t.is(stdio[index], 'foobar');
+const testOutput = async (t, fdNumber, execaMethod) => {
+	const {stdout, stderr, stdio} = await execaMethod('noop-fd.js', [`${fdNumber}`, 'foobar'], fullStdio);
+	t.is(stdio[fdNumber], 'foobar');
 
-	if (index === 1) {
-		t.is(stdio[index], stdout);
-	} else if (index === 2) {
-		t.is(stdio[index], stderr);
+	if (fdNumber === 1) {
+		t.is(stdio[fdNumber], stdout);
+	} else if (fdNumber === 2) {
+		t.is(stdio[fdNumber], stderr);
 	}
 };
 
@@ -112,9 +112,9 @@ const testErrorOutput = async (t, execaMethod) => {
 test('error.stdout/stderr/stdio is defined', testErrorOutput, execa);
 test('error.stdout/stderr/stdio is defined - sync', testErrorOutput, execaSync);
 
-const testStripFinalNewline = async (t, index, stripFinalNewline, execaMethod) => {
-	const {stdio} = await execaMethod('noop-fd.js', [`${index}`, 'foobar\n'], {...fullStdio, stripFinalNewline});
-	t.is(stdio[index], `foobar${stripFinalNewline === false ? '\n' : ''}`);
+const testStripFinalNewline = async (t, fdNumber, stripFinalNewline, execaMethod) => {
+	const {stdio} = await execaMethod('noop-fd.js', [`${fdNumber}`, 'foobar\n'], {...fullStdio, stripFinalNewline});
+	t.is(stdio[fdNumber], `foobar${stripFinalNewline === false ? '\n' : ''}`);
 };
 
 test('stripFinalNewline: undefined with stdout', testStripFinalNewline, 1, undefined, execa);

--- a/test/stdio/async.js
+++ b/test/stdio/async.js
@@ -31,9 +31,9 @@ const testListenersCleanup = async (t, isMultiple) => {
 		await onStdinRemoveListener();
 	}
 
-	for (const [index, streamNewListeners] of Object.entries(getStandardStreamsListeners())) {
+	for (const [fdNumber, streamNewListeners] of Object.entries(getStandardStreamsListeners())) {
 		const defaultListeners = Object.fromEntries(Reflect.ownKeys(streamNewListeners).map(eventName => [eventName, []]));
-		t.deepEqual(streamNewListeners, {...defaultListeners, ...streamsPreviousListeners[index]});
+		t.deepEqual(streamNewListeners, {...defaultListeners, ...streamsPreviousListeners[fdNumber]});
 	}
 };
 

--- a/test/stdio/direction.js
+++ b/test/stdio/direction.js
@@ -38,10 +38,10 @@ const testAmbiguousDirection = async (t, execaMethod) => {
 test('stdio[*] default direction is output', testAmbiguousDirection, execa);
 test('stdio[*] default direction is output - sync', testAmbiguousDirection, execaSync);
 
-const testAmbiguousMultiple = async (t, index) => {
+const testAmbiguousMultiple = async (t, fdNumber) => {
 	const filePath = tempfile();
 	await writeFile(filePath, 'foobar');
-	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [{file: filePath}, ['foo', 'bar']]));
+	const {stdout} = await execa('stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, [{file: filePath}, ['foo', 'bar']]));
 	t.is(stdout, 'foobarfoobar');
 	await rm(filePath);
 };

--- a/test/stdio/encoding-end.js
+++ b/test/stdio/encoding-end.js
@@ -14,24 +14,24 @@ const pExec = promisify(exec);
 
 setFixtureDir();
 
-const checkEncoding = async (t, encoding, index, execaMethod) => {
-	const {stdio} = await execaMethod('noop-fd.js', [`${index}`, STRING_TO_ENCODE], {...fullStdio, encoding});
-	compareValues(t, stdio[index], encoding);
+const checkEncoding = async (t, encoding, fdNumber, execaMethod) => {
+	const {stdio} = await execaMethod('noop-fd.js', [`${fdNumber}`, STRING_TO_ENCODE], {...fullStdio, encoding});
+	compareValues(t, stdio[fdNumber], encoding);
 
 	if (execaMethod !== execaSync) {
-		const childProcess = execaMethod('noop-fd.js', [`${index}`, STRING_TO_ENCODE], {...fullStdio, encoding, buffer: false});
+		const childProcess = execaMethod('noop-fd.js', [`${fdNumber}`, STRING_TO_ENCODE], {...fullStdio, encoding, buffer: false});
 		const getStreamMethod = encoding === 'buffer' ? getStreamAsBuffer : getStream;
-		const result = await getStreamMethod(childProcess.stdio[index]);
+		const result = await getStreamMethod(childProcess.stdio[fdNumber]);
 		compareValues(t, result, encoding);
 		await childProcess;
 	}
 
-	if (index === 3) {
+	if (fdNumber === 3) {
 		return;
 	}
 
-	const {stdout, stderr} = await pExec(`node noop-fd.js ${index} ${STRING_TO_ENCODE}`, {encoding, cwd: FIXTURES_DIR});
-	compareValues(t, index === 1 ? stdout : stderr, encoding);
+	const {stdout, stderr} = await pExec(`node noop-fd.js ${fdNumber} ${STRING_TO_ENCODE}`, {encoding, cwd: FIXTURES_DIR});
+	compareValues(t, fdNumber === 1 ? stdout : stderr, encoding);
 };
 
 const compareValues = (t, value, encoding) => {

--- a/test/stdio/encoding-start.js
+++ b/test/stdio/encoding-start.js
@@ -90,9 +90,9 @@ test('Next generator argument is Uint8Array with encoding "hex", with Uint8Array
 test('Next generator argument is object with default encoding, with object writes, objectMode first', testGeneratorNextEncoding, foobarObject, 'utf8', true, false, 'Object');
 test('Next generator argument is object with default encoding, with object writes, objectMode both', testGeneratorNextEncoding, foobarObject, 'utf8', true, true, 'Object');
 
-const testFirstOutputGeneratorArgument = async (t, index) => {
-	const {stdio} = await execa('noop-fd.js', [`${index}`], getStdio(index, getTypeofGenerator(true)));
-	t.deepEqual(stdio[index], ['[object String]']);
+const testFirstOutputGeneratorArgument = async (t, fdNumber) => {
+	const {stdio} = await execa('noop-fd.js', [`${fdNumber}`], getStdio(fdNumber, getTypeofGenerator(true)));
+	t.deepEqual(stdio[fdNumber], ['[object String]']);
 };
 
 test('The first generator with result.stdout does not receive an object argument even in objectMode', testFirstOutputGeneratorArgument, 1);

--- a/test/stdio/file-descriptor.js
+++ b/test/stdio/file-descriptor.js
@@ -7,10 +7,10 @@ import {getStdio} from '../helpers/stdio.js';
 
 setFixtureDir();
 
-const testFileDescriptorOption = async (t, index, execaMethod) => {
+const testFileDescriptorOption = async (t, fdNumber, execaMethod) => {
 	const filePath = tempfile();
 	const fileDescriptor = await open(filePath, 'w');
-	await execaMethod('noop-fd.js', [`${index}`, 'foobar'], getStdio(index, fileDescriptor));
+	await execaMethod('noop-fd.js', [`${fdNumber}`, 'foobar'], getStdio(fdNumber, fileDescriptor));
 	t.is(await readFile(filePath, 'utf8'), 'foobar');
 	await rm(filePath);
 	await fileDescriptor.close();
@@ -23,9 +23,9 @@ test('pass `stdout` to a file descriptor - sync', testFileDescriptorOption, 1, e
 test('pass `stderr` to a file descriptor - sync', testFileDescriptorOption, 2, execaSync);
 test('pass `stdio[*]` to a file descriptor - sync', testFileDescriptorOption, 3, execaSync);
 
-const testStdinWrite = async (t, index) => {
-	const subprocess = execa('stdin-fd.js', [`${index}`], getStdio(index, 'pipe'));
-	subprocess.stdio[index].end('unicorns');
+const testStdinWrite = async (t, fdNumber) => {
+	const subprocess = execa('stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, 'pipe'));
+	subprocess.stdio[fdNumber].end('unicorns');
 	const {stdout} = await subprocess;
 	t.is(stdout, 'unicorns');
 };

--- a/test/stdio/forward.js
+++ b/test/stdio/forward.js
@@ -5,8 +5,8 @@ import {setFixtureDir} from '../helpers/fixtures-dir.js';
 
 setFixtureDir();
 
-const testOverlapped = async (t, index) => {
-	const {stdout} = await execa('noop.js', ['foobar'], getStdio(index, ['overlapped', 'pipe']));
+const testOverlapped = async (t, fdNumber) => {
+	const {stdout} = await execa('noop.js', ['foobar'], getStdio(fdNumber, ['overlapped', 'pipe']));
 	t.is(stdout, 'foobar');
 };
 

--- a/test/stdio/generator.js
+++ b/test/stdio/generator.js
@@ -33,9 +33,9 @@ const getOutputObjectMode = objectMode => objectMode
 	? {generator: outputObjectGenerator, output: [foobarObject], getStreamMethod: getStreamAsArray}
 	: {generator: uppercaseGenerator, output: foobarUppercase, getStreamMethod: getStream};
 
-const testGeneratorInput = async (t, index, objectMode) => {
+const testGeneratorInput = async (t, fdNumber, objectMode) => {
 	const {input, generator, output} = getInputObjectMode(objectMode);
-	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [input, generator]));
+	const {stdout} = await execa('stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, [input, generator]));
 	t.is(stdout, output);
 };
 
@@ -74,11 +74,11 @@ test('Can use generators with childProcess.stdio[*] as input', testGeneratorStdi
 test('Can use generators with childProcess.stdio[*] as input, objectMode', testGeneratorStdioInputPipe, true);
 
 // eslint-disable-next-line max-params
-const testGeneratorOutput = async (t, index, reject, useShortcutProperty, objectMode) => {
+const testGeneratorOutput = async (t, fdNumber, reject, useShortcutProperty, objectMode) => {
 	const {generator, output} = getOutputObjectMode(objectMode);
 	const fixtureName = reject ? 'noop-fd.js' : 'noop-fail.js';
-	const {stdout, stderr, stdio} = await execa(fixtureName, [`${index}`, foobarString], {...getStdio(index, generator), reject});
-	const result = useShortcutProperty ? [stdout, stderr][index - 1] : stdio[index];
+	const {stdout, stderr, stdio} = await execa(fixtureName, [`${fdNumber}`, foobarString], {...getStdio(fdNumber, generator), reject});
+	const result = useShortcutProperty ? [stdout, stderr][fdNumber - 1] : stdio[fdNumber];
 	t.deepEqual(result, output);
 };
 
@@ -103,10 +103,10 @@ test('Can use generators with error.stdio[2], objectMode', testGeneratorOutput, 
 test('Can use generators with error.stderr, objectMode', testGeneratorOutput, 2, false, true, true);
 test('Can use generators with error.stdio[*] as output, objectMode', testGeneratorOutput, 3, false, false, true);
 
-const testGeneratorOutputPipe = async (t, index, useShortcutProperty, objectMode) => {
+const testGeneratorOutputPipe = async (t, fdNumber, useShortcutProperty, objectMode) => {
 	const {generator, output, getStreamMethod} = getOutputObjectMode(objectMode);
-	const childProcess = execa('noop-fd.js', [`${index}`, foobarString], {...getStdio(index, generator), buffer: false});
-	const stream = useShortcutProperty ? [childProcess.stdout, childProcess.stderr][index - 1] : childProcess.stdio[index];
+	const childProcess = execa('noop-fd.js', [`${fdNumber}`, foobarString], {...getStdio(fdNumber, generator), buffer: false});
+	const stream = useShortcutProperty ? [childProcess.stdout, childProcess.stderr][fdNumber - 1] : childProcess.stdio[fdNumber];
 	const [result] = await Promise.all([getStreamMethod(stream), childProcess]);
 	t.deepEqual(result, output);
 };

--- a/test/stdio/handle.js
+++ b/test/stdio/handle.js
@@ -5,9 +5,9 @@ import {setFixtureDir} from '../helpers/fixtures-dir.js';
 
 setFixtureDir();
 
-const testEmptyArray = (t, index, optionName, execaMethod) => {
+const testEmptyArray = (t, fdNumber, optionName, execaMethod) => {
 	t.throws(() => {
-		execaMethod('empty.js', getStdio(index, []));
+		execaMethod('empty.js', getStdio(fdNumber, []));
 	}, {message: `The \`${optionName}\` option must not be an empty array.`});
 };
 
@@ -20,9 +20,9 @@ test('Cannot pass an empty array to stdout - sync', testEmptyArray, 1, 'stdout',
 test('Cannot pass an empty array to stderr - sync', testEmptyArray, 2, 'stderr', execaSync);
 test('Cannot pass an empty array to stdio[*] - sync', testEmptyArray, 3, 'stdio[3]', execaSync);
 
-const testNoPipeOption = async (t, stdioOption, index) => {
-	const childProcess = execa('empty.js', getStdio(index, stdioOption));
-	t.is(childProcess.stdio[index], null);
+const testNoPipeOption = async (t, stdioOption, fdNumber) => {
+	const childProcess = execa('empty.js', getStdio(fdNumber, stdioOption));
+	t.is(childProcess.stdio[fdNumber], null);
 	await childProcess;
 };
 
@@ -63,9 +63,9 @@ test('stdio[*] can be ["inherit"]', testNoPipeOption, ['inherit'], 3);
 test('stdio[*] can be 3', testNoPipeOption, 3, 3);
 test('stdio[*] can be [3]', testNoPipeOption, [3], 3);
 
-const testInvalidArrayValue = (t, invalidStdio, index, execaMethod) => {
+const testInvalidArrayValue = (t, invalidStdio, fdNumber, execaMethod) => {
 	t.throws(() => {
-		execaMethod('empty.js', getStdio(index, ['pipe', invalidStdio]));
+		execaMethod('empty.js', getStdio(fdNumber, ['pipe', invalidStdio]));
 	}, {message: /must not include/});
 };
 

--- a/test/stdio/iterable.js
+++ b/test/stdio/iterable.js
@@ -29,8 +29,8 @@ const asyncGenerator = async function * () {
 
 setFixtureDir();
 
-const testIterable = async (t, stdioOption, index) => {
-	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, stdioOption));
+const testIterable = async (t, stdioOption, fdNumber) => {
+	const {stdout} = await execa('stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, stdioOption));
 	t.is(stdout, 'foobar');
 };
 
@@ -53,8 +53,8 @@ const foobarAsyncObjectGenerator = function * () {
 	yield foobarObject;
 };
 
-const testObjectIterable = async (t, stdioOption, index) => {
-	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [stdioOption, serializeGenerator]));
+const testObjectIterable = async (t, stdioOption, fdNumber) => {
+	const {stdout} = await execa('stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, [stdioOption, serializeGenerator]));
 	t.is(stdout, foobarObjectString);
 };
 
@@ -65,9 +65,9 @@ test('stdio[*] option can be an iterable of objects', testObjectIterable, foobar
 test('stdin option can be an async iterable of objects', testObjectIterable, foobarAsyncObjectGenerator(), 0);
 test('stdio[*] option can be an async iterable of objects', testObjectIterable, foobarAsyncObjectGenerator(), 3);
 
-const testIterableSync = (t, stdioOption, index) => {
+const testIterableSync = (t, stdioOption, fdNumber) => {
 	t.throws(() => {
-		execaSync('empty.js', getStdio(index, stdioOption));
+		execaSync('empty.js', getStdio(fdNumber, stdioOption));
 	}, {message: /an iterable in sync mode/});
 };
 
@@ -83,17 +83,17 @@ const throwingGenerator = function * () {
 	throw new Error('generator error');
 };
 
-const testIterableError = async (t, index) => {
-	const {originalMessage} = await t.throwsAsync(execa('stdin-fd.js', [`${index}`], getStdio(index, throwingGenerator())));
+const testIterableError = async (t, fdNumber) => {
+	const {originalMessage} = await t.throwsAsync(execa('stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, throwingGenerator())));
 	t.is(originalMessage, 'generator error');
 };
 
 test('stdin option handles errors in iterables', testIterableError, 0);
 test('stdio[*] option handles errors in iterables', testIterableError, 3);
 
-const testNoIterableOutput = (t, stdioOption, index, execaMethod) => {
+const testNoIterableOutput = (t, stdioOption, fdNumber, execaMethod) => {
 	t.throws(() => {
-		execaMethod('empty.js', getStdio(index, stdioOption));
+		execaMethod('empty.js', getStdio(fdNumber, stdioOption));
 	}, {message: /cannot be an iterable/});
 };
 
@@ -116,8 +116,8 @@ test('stdin option can be an infinite iterable', async t => {
 	t.deepEqual(await iterable.next(), {value: undefined, done: true});
 });
 
-const testMultipleIterable = async (t, index) => {
-	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, [stringGenerator(), asyncGenerator()]));
+const testMultipleIterable = async (t, fdNumber) => {
+	const {stdout} = await execa('stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, [stringGenerator(), asyncGenerator()]));
 	t.is(stdout, 'foobarfoobar');
 };
 

--- a/test/stdio/lines.js
+++ b/test/stdio/lines.js
@@ -58,17 +58,17 @@ const serializeResultItem = (resultItem, isUint8Array) => isUint8Array
 	: resultItem;
 
 // eslint-disable-next-line max-params
-const testLines = async (t, index, input, expectedLines, isUint8Array, objectMode) => {
+const testLines = async (t, fdNumber, input, expectedLines, isUint8Array, objectMode) => {
 	const lines = [];
-	const {stdio} = await execa('noop-fd.js', [`${index}`], {
-		...getStdio(index, [
+	const {stdio} = await execa('noop-fd.js', [`${fdNumber}`], {
+		...getStdio(fdNumber, [
 			{transform: inputGenerator.bind(undefined, stringsToUint8Arrays(input, isUint8Array)), objectMode},
 			{transform: resultGenerator.bind(undefined, lines), objectMode},
 		]),
 		encoding: isUint8Array ? 'buffer' : 'utf8',
 		stripFinalNewline: false,
 	});
-	t.is(input.join(''), serializeResult(stdio[index], isUint8Array, objectMode));
+	t.is(input.join(''), serializeResult(stdio[fdNumber], isUint8Array, objectMode));
 	t.deepEqual(lines, stringsToUint8Arrays(expectedLines, isUint8Array));
 };
 
@@ -146,13 +146,13 @@ test('Splits lines when "binary" is false, objectMode', testBinaryOption, false,
 test('Splits lines when "binary" is undefined, objectMode', testBinaryOption, undefined, simpleChunk, simpleLines, true);
 
 // eslint-disable-next-line max-params
-const testStreamLines = async (t, index, input, expectedLines, isUint8Array) => {
-	const {stdio} = await execa('noop-fd.js', [`${index}`, input], {
+const testStreamLines = async (t, fdNumber, input, expectedLines, isUint8Array) => {
+	const {stdio} = await execa('noop-fd.js', [`${fdNumber}`, input], {
 		...fullStdio,
 		lines: true,
 		encoding: isUint8Array ? 'buffer' : 'utf8',
 	});
-	t.deepEqual(stdio[index], stringsToUint8Arrays(expectedLines, isUint8Array));
+	t.deepEqual(stdio[fdNumber], stringsToUint8Arrays(expectedLines, isUint8Array));
 };
 
 test('"lines: true" splits lines, stdout, string', testStreamLines, 1, simpleChunk[0], simpleLines, false);

--- a/test/stdio/native.js
+++ b/test/stdio/native.js
@@ -6,13 +6,13 @@ import {setFixtureDir} from '../helpers/fixtures-dir.js';
 
 setFixtureDir();
 
-const testRedirect = async (t, stdioOption, index, isInput) => {
+const testRedirect = async (t, stdioOption, fdNumber, isInput) => {
 	const {fixtureName, ...options} = isInput
 		? {fixtureName: 'stdin-fd.js', input: 'foobar'}
 		: {fixtureName: 'noop-fd.js'};
-	const {stdio} = await execa('nested-stdio.js', [JSON.stringify(stdioOption), `${index}`, fixtureName, 'foobar'], options);
-	const resultIndex = isStderrDescriptor(stdioOption) ? 2 : 1;
-	t.is(stdio[resultIndex], 'foobar');
+	const {stdio} = await execa('nested-stdio.js', [JSON.stringify(stdioOption), `${fdNumber}`, fixtureName, 'foobar'], options);
+	const resultFdNumber = isStderrDescriptor(stdioOption) ? 2 : 1;
+	t.is(stdio[resultFdNumber], 'foobar');
 };
 
 const isStderrDescriptor = stdioOption => stdioOption === 2
@@ -76,8 +76,8 @@ const testInheritStderr = async (t, stderr) => {
 test('stderr can be ["inherit", "pipe"]', testInheritStderr, ['inherit', 'pipe']);
 test('stderr can be [2, "pipe"]', testInheritStderr, [2, 'pipe']);
 
-const testOverflowStream = async (t, index, stdioOption) => {
-	const {stdout} = await execa('nested.js', [JSON.stringify(getStdio(index, stdioOption)), 'empty.js'], fullStdio);
+const testOverflowStream = async (t, fdNumber, stdioOption) => {
+	const {stdout} = await execa('nested.js', [JSON.stringify(getStdio(fdNumber, stdioOption)), 'empty.js'], fullStdio);
 	t.is(stdout, '');
 };
 
@@ -95,9 +95,9 @@ if (platform === 'linux') {
 test('stdio[*] can use "inherit"', testOverflowStream, 3, 'inherit');
 test('stdio[*] can use ["inherit"]', testOverflowStream, 3, ['inherit']);
 
-const testOverflowStreamArray = (t, index, stdioOption) => {
+const testOverflowStreamArray = (t, fdNumber, stdioOption) => {
 	t.throws(() => {
-		execa('empty.js', getStdio(index, stdioOption));
+		execa('empty.js', getStdio(fdNumber, stdioOption));
 	}, {message: /no such standard stream/});
 };
 

--- a/test/stdio/pipeline.js
+++ b/test/stdio/pipeline.js
@@ -5,33 +5,33 @@ import {setFixtureDir} from '../helpers/fixtures-dir.js';
 
 setFixtureDir();
 
-const testDestroyStandard = async (t, index) => {
-	const childProcess = execa('forever.js', {...getStdio(index, [STANDARD_STREAMS[index], 'pipe']), timeout: 1});
+const testDestroyStandard = async (t, fdNumber) => {
+	const childProcess = execa('forever.js', {...getStdio(fdNumber, [STANDARD_STREAMS[fdNumber], 'pipe']), timeout: 1});
 	await t.throwsAsync(childProcess, {message: /timed out/});
-	t.false(STANDARD_STREAMS[index].destroyed);
+	t.false(STANDARD_STREAMS[fdNumber].destroyed);
 };
 
 test('Does not destroy process.stdin on child process errors', testDestroyStandard, 0);
 test('Does not destroy process.stdout on child process errors', testDestroyStandard, 1);
 test('Does not destroy process.stderr on child process errors', testDestroyStandard, 2);
 
-const testDestroyStandardSpawn = async (t, index) => {
-	await t.throwsAsync(execa('forever.js', {...getStdio(index, [STANDARD_STREAMS[index], 'pipe']), uid: -1}));
-	t.false(STANDARD_STREAMS[index].destroyed);
+const testDestroyStandardSpawn = async (t, fdNumber) => {
+	await t.throwsAsync(execa('forever.js', {...getStdio(fdNumber, [STANDARD_STREAMS[fdNumber], 'pipe']), uid: -1}));
+	t.false(STANDARD_STREAMS[fdNumber].destroyed);
 };
 
 test('Does not destroy process.stdin on spawn process errors', testDestroyStandardSpawn, 0);
 test('Does not destroy process.stdout on spawn process errors', testDestroyStandardSpawn, 1);
 test('Does not destroy process.stderr on spawn process errors', testDestroyStandardSpawn, 2);
 
-const testDestroyStandardStream = async (t, index) => {
-	const childProcess = execa('forever.js', getStdio(index, [STANDARD_STREAMS[index], 'pipe']));
+const testDestroyStandardStream = async (t, fdNumber) => {
+	const childProcess = execa('forever.js', getStdio(fdNumber, [STANDARD_STREAMS[fdNumber], 'pipe']));
 	const error = new Error('test');
-	childProcess.stdio[index].destroy(error);
+	childProcess.stdio[fdNumber].destroy(error);
 	childProcess.kill();
 	const thrownError = await t.throwsAsync(childProcess);
 	t.is(thrownError, error);
-	t.false(STANDARD_STREAMS[index].destroyed);
+	t.false(STANDARD_STREAMS[fdNumber].destroyed);
 };
 
 test('Does not destroy process.stdin on stream process errors', testDestroyStandardStream, 0);

--- a/test/stdio/type.js
+++ b/test/stdio/type.js
@@ -10,9 +10,9 @@ const uppercaseGenerator = function * (line) {
 	yield line.toUpperCase();
 };
 
-const testInvalidGenerator = (t, index, stdioOption) => {
+const testInvalidGenerator = (t, fdNumber, stdioOption) => {
 	t.throws(() => {
-		execa('empty.js', getStdio(index, {...noopGenerator(), ...stdioOption}));
+		execa('empty.js', getStdio(fdNumber, {...noopGenerator(), ...stdioOption}));
 	}, {message: /must be a generator/});
 };
 
@@ -25,9 +25,9 @@ test('Cannot use invalid "final" with stdout', testInvalidGenerator, 1, {final: 
 test('Cannot use invalid "final" with stderr', testInvalidGenerator, 2, {final: true});
 test('Cannot use invalid "final" with stdio[*]', testInvalidGenerator, 3, {final: true});
 
-const testInvalidBinary = (t, index, optionName) => {
+const testInvalidBinary = (t, fdNumber, optionName) => {
 	t.throws(() => {
-		execa('empty.js', getStdio(index, {transform: uppercaseGenerator, [optionName]: 'true'}));
+		execa('empty.js', getStdio(fdNumber, {transform: uppercaseGenerator, [optionName]: 'true'}));
 	}, {message: /a boolean/});
 };
 
@@ -40,9 +40,9 @@ test('Cannot use invalid "objectMode" with stdout', testInvalidBinary, 1, 'objec
 test('Cannot use invalid "objectMode" with stderr', testInvalidBinary, 2, 'objectMode');
 test('Cannot use invalid "objectMode" with stdio[*]', testInvalidBinary, 3, 'objectMode');
 
-const testSyncMethods = (t, index) => {
+const testSyncMethods = (t, fdNumber) => {
 	t.throws(() => {
-		execaSync('empty.js', getStdio(index, uppercaseGenerator));
+		execaSync('empty.js', getStdio(fdNumber, uppercaseGenerator));
 	}, {message: /cannot be a generator/});
 };
 

--- a/test/stdio/typed-array.js
+++ b/test/stdio/typed-array.js
@@ -6,8 +6,8 @@ import {foobarUint8Array} from '../helpers/input.js';
 
 setFixtureDir();
 
-const testUint8Array = async (t, index) => {
-	const {stdout} = await execa('stdin-fd.js', [`${index}`], getStdio(index, foobarUint8Array));
+const testUint8Array = async (t, fdNumber) => {
+	const {stdout} = await execa('stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, foobarUint8Array));
 	t.is(stdout, 'foobar');
 };
 
@@ -16,9 +16,9 @@ test('stdio[*] option can be a Uint8Array', testUint8Array, 3);
 test('stdin option can be a Uint8Array - sync', testUint8Array, 0);
 test('stdio[*] option can be a Uint8Array - sync', testUint8Array, 3);
 
-const testNoUint8ArrayOutput = (t, index, execaMethod) => {
+const testNoUint8ArrayOutput = (t, fdNumber, execaMethod) => {
 	t.throws(() => {
-		execaMethod('empty.js', getStdio(index, foobarUint8Array));
+		execaMethod('empty.js', getStdio(fdNumber, foobarUint8Array));
 	}, {message: /cannot be a Uint8Array/});
 };
 

--- a/test/stdio/validate.js
+++ b/test/stdio/validate.js
@@ -8,8 +8,8 @@ import {serializeGenerator, getOutputGenerator, convertTransformToFinal} from '.
 setFixtureDir();
 
 // eslint-disable-next-line max-params
-const testGeneratorReturn = async (t, index, generators, fixtureName, isNull) => {
-	const childProcess = execa(fixtureName, [`${index}`], getStdio(index, generators));
+const testGeneratorReturn = async (t, fdNumber, generators, fixtureName, isNull) => {
+	const childProcess = execa(fixtureName, [`${fdNumber}`], getStdio(fdNumber, generators));
 	const message = isNull ? /not be called at all/ : /a string or an Uint8Array/;
 	await t.throwsAsync(childProcess, {message});
 };

--- a/test/stream/exit.js
+++ b/test/stream/exit.js
@@ -7,16 +7,16 @@ import {fullStdio, getStdio} from '../helpers/stdio.js';
 
 setFixtureDir();
 
-const testBufferIgnore = async (t, index, all) => {
-	await t.notThrowsAsync(execa('max-buffer.js', [`${index}`], {...getStdio(index, 'ignore'), buffer: false, all}));
+const testBufferIgnore = async (t, fdNumber, all) => {
+	await t.notThrowsAsync(execa('max-buffer.js', [`${fdNumber}`], {...getStdio(fdNumber, 'ignore'), buffer: false, all}));
 };
 
 test('Process buffers stdout, which does not prevent exit if ignored', testBufferIgnore, 1, false);
 test('Process buffers stderr, which does not prevent exit if ignored', testBufferIgnore, 2, false);
 test('Process buffers all, which does not prevent exit if ignored', testBufferIgnore, 1, true);
 
-const testBufferNotRead = async (t, index, all) => {
-	const subprocess = execa('max-buffer.js', [`${index}`], {...fullStdio, buffer: false, all});
+const testBufferNotRead = async (t, fdNumber, all) => {
+	const subprocess = execa('max-buffer.js', [`${fdNumber}`], {...fullStdio, buffer: false, all});
 	await t.notThrowsAsync(subprocess);
 };
 
@@ -25,9 +25,9 @@ test('Process buffers stderr, which does not prevent exit if not read and buffer
 test('Process buffers stdio[*], which does not prevent exit if not read and buffer is false', testBufferNotRead, 3, false);
 test('Process buffers all, which does not prevent exit if not read and buffer is false', testBufferNotRead, 1, true);
 
-const testBufferRead = async (t, index, all) => {
-	const subprocess = execa('max-buffer.js', [`${index}`], {...fullStdio, buffer: false, all});
-	const stream = all ? subprocess.all : subprocess.stdio[index];
+const testBufferRead = async (t, fdNumber, all) => {
+	const subprocess = execa('max-buffer.js', [`${fdNumber}`], {...fullStdio, buffer: false, all});
+	const stream = all ? subprocess.all : subprocess.stdio[fdNumber];
 	stream.resume();
 	await t.notThrowsAsync(subprocess);
 };
@@ -37,11 +37,11 @@ test('Process buffers stderr, which does not prevent exit if read and buffer is 
 test('Process buffers stdio[*], which does not prevent exit if read and buffer is false', testBufferRead, 3, false);
 test('Process buffers all, which does not prevent exit if read and buffer is false', testBufferRead, 1, true);
 
-const testBufferExit = async (t, index, fixtureName, reject) => {
-	const childProcess = execa(fixtureName, [`${index}`], {...fullStdio, reject});
+const testBufferExit = async (t, fdNumber, fixtureName, reject) => {
+	const childProcess = execa(fixtureName, [`${fdNumber}`], {...fullStdio, reject});
 	await setTimeout(100);
 	const {stdio} = await childProcess;
-	t.is(stdio[index], 'foobar');
+	t.is(stdio[fdNumber], 'foobar');
 };
 
 test('Process buffers stdout before it is read', testBufferExit, 1, 'noop-delay.js', true);
@@ -54,23 +54,23 @@ test('Process buffers stdout right away, on failure', testBufferExit, 1, 'noop-f
 test('Process buffers stderr right away, on failure', testBufferExit, 2, 'noop-fail.js', false);
 test('Process buffers stdio[*] right away, on failure', testBufferExit, 3, 'noop-fail.js', false);
 
-const testBufferDirect = async (t, index) => {
-	const childProcess = execa('noop-fd.js', [`${index}`], fullStdio);
-	const data = await once(childProcess.stdio[index], 'data');
+const testBufferDirect = async (t, fdNumber) => {
+	const childProcess = execa('noop-fd.js', [`${fdNumber}`], fullStdio);
+	const data = await once(childProcess.stdio[fdNumber], 'data');
 	t.is(data.toString().trim(), 'foobar');
 	const result = await childProcess;
-	t.is(result.stdio[index], 'foobar');
+	t.is(result.stdio[fdNumber], 'foobar');
 };
 
 test('Process buffers stdout right away, even if directly read', testBufferDirect, 1);
 test('Process buffers stderr right away, even if directly read', testBufferDirect, 2);
 test('Process buffers stdio[*] right away, even if directly read', testBufferDirect, 3);
 
-const testBufferDestroyOnEnd = async (t, index) => {
-	const childProcess = execa('noop-fd.js', [`${index}`], fullStdio);
+const testBufferDestroyOnEnd = async (t, fdNumber) => {
+	const childProcess = execa('noop-fd.js', [`${fdNumber}`], fullStdio);
 	const result = await childProcess;
-	t.is(result.stdio[index], 'foobar');
-	t.true(childProcess.stdio[index].destroyed);
+	t.is(result.stdio[fdNumber], 'foobar');
+	t.true(childProcess.stdio[fdNumber].destroyed);
 };
 
 test('childProcess.stdout must be read right away', testBufferDestroyOnEnd, 1);

--- a/test/stream/resolve.js
+++ b/test/stream/resolve.js
@@ -5,9 +5,9 @@ import {getStdio} from '../helpers/stdio.js';
 
 setFixtureDir();
 
-const testIgnore = async (t, index, execaMethod) => {
-	const result = await execaMethod('noop.js', getStdio(index, 'ignore'));
-	t.is(result.stdio[index], undefined);
+const testIgnore = async (t, fdNumber, execaMethod) => {
+	const result = await execaMethod('noop.js', getStdio(fdNumber, 'ignore'));
+	t.is(result.stdio[fdNumber], undefined);
 };
 
 test('stdout is undefined if ignored', testIgnore, 1, execa);


### PR DESCRIPTION
This rename the variable `index` to `fdNumber`, when `index` describes a file descriptor number (`0` for `stdin`, `1` for `stdout`, etc.), since this is clearer.

This does not rename the instances of the `index` name when the variable is not related to the above.

This is internal-only and not exposed to users.