### PR TITLE
Refactor `reject` option

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -2,7 +2,7 @@ import {setMaxListeners} from 'node:events';
 import {spawn} from 'node:child_process';
 import {normalizeArguments, handleArguments} from './arguments/options.js';
 import {makeError, makeSuccessResult} from './return/error.js';
-import {handleOutput} from './return/output.js';
+import {handleOutput, handleResult} from './return/output.js';
 import {handleEarlyError} from './return/early-error.js';
 import {handleInputAsync, pipeOutputAsync} from './stdio/async.js';
 import {spawnedKill} from './exit/kill.js';
@@ -14,17 +14,26 @@ import {getSpawnedResult} from './stream/resolve.js';
 import {mergePromise} from './promise.js';
 
 export const execa = (rawFile, rawArgs, rawOptions) => {
-	const {spawned, promise, options, stdioStreamsGroups} = runExeca(rawFile, rawArgs, rawOptions);
+	const {file, args, command, escapedCommand, options} = handleAsyncArguments(rawFile, rawArgs, rawOptions);
+	const stdioStreamsGroups = handleInputAsync(options);
+	const {spawned, promise} = runExeca({file, args, options, command, escapedCommand, stdioStreamsGroups});
 	spawned.pipe = pipeToProcess.bind(undefined, {source: spawned, sourcePromise: promise, stdioStreamsGroups, destinationOptions: {}});
 	mergePromise(spawned, promise);
 	PROCESS_OPTIONS.set(spawned, options);
 	return spawned;
 };
 
-const runExeca = (rawFile, rawArgs, rawOptions) => {
-	const {file, args, command, escapedCommand, options} = handleAsyncArguments(rawFile, rawArgs, rawOptions);
-	const stdioStreamsGroups = handleInputAsync(options);
+const handleAsyncArguments = (rawFile, rawArgs, rawOptions) => {
+	[rawFile, rawArgs, rawOptions] = normalizeArguments(rawFile, rawArgs, rawOptions);
+	const {file, args, command, escapedCommand, options: normalizedOptions} = handleArguments(rawFile, rawArgs, rawOptions);
+	const options = handleAsyncOptions(normalizedOptions);
+	return {file, args, command, escapedCommand, options};
+};
 
+// Prevent passing the `timeout` option directly to `child_process.spawn()`
+const handleAsyncOptions = ({timeout, ...options}) => ({...options, timeoutDuration: timeout});
+
+const runExeca = ({file, args, options, command, escapedCommand, stdioStreamsGroups}) => {
 	let spawned;
 	try {
 		spawned = spawn(file, args, options);
@@ -43,18 +52,8 @@ const runExeca = (rawFile, rawArgs, rawOptions) => {
 	spawned.all = makeAllStream(spawned, options);
 
 	const promise = handlePromise({spawned, options, stdioStreamsGroups, originalStreams, command, escapedCommand, controller});
-	return {spawned, promise, options, stdioStreamsGroups};
+	return {spawned, promise};
 };
-
-const handleAsyncArguments = (rawFile, rawArgs, rawOptions) => {
-	[rawFile, rawArgs, rawOptions] = normalizeArguments(rawFile, rawArgs, rawOptions);
-	const {file, args, command, escapedCommand, options: normalizedOptions} = handleArguments(rawFile, rawArgs, rawOptions);
-	const options = handleAsyncOptions(normalizedOptions);
-	return {file, args, command, escapedCommand, options};
-};
-
-// Prevent passing the `timeout` option directly to `child_process.spawn()`
-const handleAsyncOptions = ({timeout, ...options}) => ({...options, timeoutDuration: timeout});
 
 const handlePromise = async ({spawned, options, stdioStreamsGroups, originalStreams, command, escapedCommand, controller}) => {
 	const context = {timedOut: false};
@@ -69,28 +68,21 @@ const handlePromise = async ({spawned, options, stdioStreamsGroups, originalStre
 
 	const stdio = stdioResults.map(stdioResult => handleOutput(options, stdioResult));
 	const all = handleOutput(options, allResult);
-
-	if ('error' in errorInfo) {
-		const isCanceled = options.signal?.aborted === true;
-		const returnedError = makeError({
-			error: errorInfo.error,
-			command,
-			escapedCommand,
-			timedOut: context.timedOut,
-			isCanceled,
-			exitCode,
-			signal,
-			stdio,
-			all,
-			options,
-		});
-
-		if (!options.reject) {
-			return returnedError;
-		}
-
-		throw returnedError;
-	}
-
-	return makeSuccessResult({command, escapedCommand, stdio, all, options});
+	const result = getAsyncResult({errorInfo, exitCode, signal, stdio, all, context, options, command, escapedCommand});
+	return handleResult(result, options);
 };
+
+const getAsyncResult = ({errorInfo, exitCode, signal, stdio, all, context, options, command, escapedCommand}) => 'error' in errorInfo
+	? makeError({
+		error: errorInfo.error,
+		command,
+		escapedCommand,
+		timedOut: context.timedOut,
+		isCanceled: options.signal?.aborted === true,
+		exitCode,
+		signal,
+		stdio,
+		all,
+		options,
+	})
+	: makeSuccessResult({command, escapedCommand, stdio, all, options});

--- a/lib/return/early-error.js
+++ b/lib/return/early-error.js
@@ -2,6 +2,7 @@ import {ChildProcess} from 'node:child_process';
 import {PassThrough} from 'node:stream';
 import {cleanupStdioStreams} from '../stdio/async.js';
 import {makeEarlyError} from './error.js';
+import {handleResult} from './output.js';
 
 // When the child process fails to spawn.
 // We ensure the returned error is always both a promise and a child process.
@@ -11,9 +12,9 @@ export const handleEarlyError = ({error, command, escapedCommand, stdioStreamsGr
 	const spawned = new ChildProcess();
 	createDummyStreams(spawned);
 
-	const errorInstance = makeEarlyError({error, command, escapedCommand, stdioStreamsGroups, options});
-	const promise = handleDummyPromise(errorInstance, options);
-	return {spawned, promise, options, stdioStreamsGroups};
+	const earlyError = makeEarlyError({error, command, escapedCommand, stdioStreamsGroups, options});
+	const promise = handleDummyPromise(earlyError, options);
+	return {spawned, promise};
 };
 
 const createDummyStreams = spawned => {
@@ -31,10 +32,4 @@ const createDummyStream = () => {
 	return stream;
 };
 
-const handleDummyPromise = async (error, {reject}) => {
-	if (reject) {
-		throw error;
-	}
-
-	return error;
-};
+const handleDummyPromise = async (error, options) => handleResult(error, options);

--- a/lib/return/output.js
+++ b/lib/return/output.js
@@ -17,3 +17,11 @@ export const handleOutput = (options, value) => {
 
 	return options.stripFinalNewline ? stripFinalNewline(value) : value;
 };
+
+export const handleResult = (result, {reject}) => {
+	if (result.failed && reject) {
+		throw result;
+	}
+
+	return result;
+};

--- a/lib/stdio/sync.js
+++ b/lib/stdio/sync.js
@@ -47,14 +47,14 @@ const addInputOptionSync = (stdioStreamsGroups, options) => {
 const serializeInput = ({type, value}) => type === 'string' ? value : binaryToString(value);
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, after spawning, in sync mode
-export const pipeOutputSync = (stdioStreamsGroups, result) => {
-	if (result.output === null) {
+export const pipeOutputSync = (stdioStreamsGroups, {output}) => {
+	if (output === null) {
 		return;
 	}
 
 	for (const stdioStreams of stdioStreamsGroups) {
 		for (const stdioStream of stdioStreams) {
-			pipeStdioOptionSync(result.output[stdioStream.fdNumber], stdioStream);
+			pipeStdioOptionSync(output[stdioStream.fdNumber], stdioStream);
 		}
 	}
 };

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,53 +1,15 @@
 import {spawnSync} from 'node:child_process';
 import {normalizeArguments, handleArguments} from './arguments/options.js';
 import {makeError, makeEarlyError, makeSuccessResult} from './return/error.js';
-import {handleOutput} from './return/output.js';
+import {handleOutput, handleResult} from './return/output.js';
 import {handleInputSync, pipeOutputSync} from './stdio/sync.js';
 import {isFailedExit} from './exit/code.js';
 
 export const execaSync = (rawFile, rawArgs, rawOptions) => {
 	const {file, args, command, escapedCommand, options} = handleSyncArguments(rawFile, rawArgs, rawOptions);
 	const stdioStreamsGroups = handleInputSync(options);
-
-	let result;
-	try {
-		result = spawnSync(file, args, options);
-	} catch (error) {
-		const errorInstance = makeEarlyError({error, command, escapedCommand, stdioStreamsGroups, options});
-
-		if (!options.reject) {
-			return errorInstance;
-		}
-
-		throw errorInstance;
-	}
-
-	pipeOutputSync(stdioStreamsGroups, result);
-
-	const output = result.output || Array.from({length: 3});
-	const stdio = output.map(stdioOutput => handleOutput(options, stdioOutput));
-
-	if (result.error !== undefined || isFailedExit(result.status, result.signal)) {
-		const error = makeError({
-			error: result.error,
-			command,
-			escapedCommand,
-			timedOut: result.error && result.error.code === 'ETIMEDOUT',
-			isCanceled: false,
-			exitCode: result.status,
-			signal: result.signal,
-			stdio,
-			options,
-		});
-
-		if (!options.reject) {
-			return error;
-		}
-
-		throw error;
-	}
-
-	return makeSuccessResult({command, escapedCommand, stdio, options});
+	const result = runExecaSync({file, args, options, command, escapedCommand, stdioStreamsGroups});
+	return handleResult(result, options);
 };
 
 const handleSyncArguments = (rawFile, rawArgs, rawOptions) => {
@@ -65,3 +27,32 @@ const validateSyncOptions = ({ipc}) => {
 		throw new TypeError('The "ipc: true" option cannot be used with synchronous methods.');
 	}
 };
+
+const runExecaSync = ({file, args, options, command, escapedCommand, stdioStreamsGroups}) => {
+	let syncResult;
+	try {
+		syncResult = spawnSync(file, args, options);
+	} catch (error) {
+		return makeEarlyError({error, command, escapedCommand, stdioStreamsGroups, options});
+	}
+
+	pipeOutputSync(stdioStreamsGroups, syncResult);
+
+	const output = syncResult.output || Array.from({length: 3});
+	const stdio = output.map(stdioOutput => handleOutput(options, stdioOutput));
+	return getSyncResult(syncResult, {stdio, options, command, escapedCommand});
+};
+
+const getSyncResult = ({error, status, signal}, {stdio, options, command, escapedCommand}) => error !== undefined || isFailedExit(status, signal)
+	? makeError({
+		error,
+		command,
+		escapedCommand,
+		timedOut: error && error.code === 'ETIMEDOUT',
+		isCanceled: false,
+		exitCode: status,
+		signal,
+		stdio,
+		options,
+	})
+	: makeSuccessResult({command, escapedCommand, stdio, options});


### PR DESCRIPTION
This PR refactors the `reject` option. Instead of replicating the code between `execa()` and `execaSync()`, this creates an internal function that both use.

This PR does not change the behavior, this is only refactoring. This also makes it easier to add some logic to run on any child process completion (failed or not), which is something I am needing as part of #751.