### PR TITLE
Improve documentation of global script options

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -361,8 +361,11 @@ $.verbose = true;
 
 ```js
 // Execa
-const $$ = $({verbose: true});
-await $$`echo example`;
+import {$ as $_} from 'execa';
+
+const $ = $_({verbose: true});
+
+await $`echo example`;
 ```
 
 Or:
@@ -549,7 +552,7 @@ const {
 // }
 ```
 
-### Shared options
+### Global/shared options
 
 ```sh
 # Bash
@@ -569,10 +572,13 @@ await $`echo three`.timeout(timeout);
 
 ```js
 // Execa
-const $$ = $({timeout: 5000});
-await $$`echo one`;
-await $$`echo two`;
-await $$`echo three`;
+import {$ as $_} from 'execa';
+
+const $ = $_({timeout: 5000});
+
+await $`echo one`;
+await $`echo two`;
+await $`echo three`;
 ```
 
 ### Background processes

--- a/readme.md
+++ b/readme.md
@@ -110,17 +110,17 @@ await $({stdio: 'inherit'})`echo unicorns`;
 //=> 'unicorns'
 ```
 
-#### Shared options
+#### Global/shared options
 
 ```js
-import {$} from 'execa';
+import {$ as $_} from 'execa';
 
-const $$ = $({stdio: 'inherit'});
+const $ = $_({stdio: 'inherit'});
 
-await $$`echo unicorns`;
+await $`echo unicorns`;
 //=> 'unicorns'
 
-await $$`echo rainbows`;
+await $`echo rainbows`;
 //=> 'rainbows'
 ```
 


### PR DESCRIPTION
This improves the documentation related to sharing options with `$`.

Unfortunately, users cannot just do:

```js
import {$} from 'execa';
$ = $(options);
```

Because imports are `const`.

Doing the following:

```js
import {$} from 'execa';
const $$ = $(options);
```

Requires renaming all `$` to `$$` in the file.

The following does not require any renaming:

```js
import {$ as $$} from 'execa';
const $ = $$(options);
```

I've tried thinking of a better pattern, but could not come up with one. :/