### PR TITLE
Improve streams pipe logic

### DIFF
--- a/lib/pipe/streaming.js
+++ b/lib/pipe/streaming.js
@@ -1,6 +1,7 @@
 import {finished} from 'node:stream/promises';
 import mergeStreams from '@sindresorhus/merge-streams';
 import {incrementMaxListeners} from '../utils.js';
+import {pipeStreams} from '../stdio/pipeline.js';
 
 // The piping behavior is like Bash.
 // In particular, when one process exits, the other is not terminated by a signal.
@@ -13,16 +14,15 @@ export const pipeProcessStream = (sourceStream, destinationStream, maxListenersC
 		? pipeMoreProcessStream(sourceStream, destinationStream)
 		: pipeFirstProcessStream(sourceStream, destinationStream);
 	incrementMaxListeners(sourceStream, SOURCE_LISTENERS_PER_PIPE, maxListenersController.signal);
+	incrementMaxListeners(destinationStream, DESTINATION_LISTENERS_PER_PIPE, maxListenersController.signal);
+	cleanupMergedStreamsMap(destinationStream);
 	return mergedStream;
 };
 
 // We use `merge-streams` to allow for multiple sources to pipe to the same destination.
 const pipeFirstProcessStream = (sourceStream, destinationStream) => {
 	const mergedStream = mergeStreams([sourceStream]);
-	mergedStream.pipe(destinationStream, {end: false});
-
-	onSourceStreamFinish(mergedStream, destinationStream);
-	onDestinationStreamFinish(mergedStream, destinationStream);
+	pipeStreams(mergedStream, destinationStream);
 	MERGED_STREAMS.set(destinationStream, mergedStream);
 	return mergedStream;
 };
@@ -33,33 +33,12 @@ const pipeMoreProcessStream = (sourceStream, destinationStream) => {
 	return mergedStream;
 };
 
-const onSourceStreamFinish = async (mergedStream, destinationStream) => {
-	try {
-		await finished(mergedStream, {cleanup: true, readable: true, writable: false});
-	} catch {}
-
-	endDestinationStream(destinationStream);
-};
-
-export const endDestinationStream = destinationStream => {
-	if (destinationStream.writable) {
-		destinationStream.end();
-	}
-};
-
-const onDestinationStreamFinish = async (mergedStream, destinationStream) => {
+const cleanupMergedStreamsMap = async destinationStream => {
 	try {
 		await finished(destinationStream, {cleanup: true, readable: false, writable: true});
 	} catch {}
 
-	abortSourceStream(mergedStream);
 	MERGED_STREAMS.delete(destinationStream);
-};
-
-export const abortSourceStream = mergedStream => {
-	if (mergedStream.readable) {
-		mergedStream.destroy();
-	}
 };
 
 const MERGED_STREAMS = new WeakMap();
@@ -67,3 +46,6 @@ const MERGED_STREAMS = new WeakMap();
 // Number of listeners set up on `sourceStream` by each `sourceStream.pipe(destinationStream)`
 // Those are added by `merge-streams`
 const SOURCE_LISTENERS_PER_PIPE = 2;
+// Number of listeners set up on `destinationStream` by each `sourceStream.pipe(destinationStream)`
+// Those are added by `finished()` in `cleanupMergedStreamsMap()`
+const DESTINATION_LISTENERS_PER_PIPE = 1;

--- a/lib/pipe/throw.js
+++ b/lib/pipe/throw.js
@@ -1,5 +1,5 @@
 import {makeEarlyError} from '../return/error.js';
-import {abortSourceStream, endDestinationStream} from './streaming.js';
+import {abortSourceStream, endDestinationStream} from '../stdio/pipeline.js';
 
 export const handlePipeArgumentsError = ({
 	sourceStream,

--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -1,6 +1,7 @@
 import {createReadStream, createWriteStream} from 'node:fs';
 import {Buffer} from 'node:buffer';
 import {Readable, Writable} from 'node:stream';
+import mergeStreams from '@sindresorhus/merge-streams';
 import {isStandardStream, incrementMaxListeners} from '../utils.js';
 import {handleInput} from './handle.js';
 import {pipeStreams} from './pipeline.js';
@@ -51,7 +52,8 @@ export const pipeOutputAsync = (spawned, stdioStreamsGroups, stdioState, control
 	}
 
 	for (const [fdNumber, inputStreams] of Object.entries(inputStreamsGroups)) {
-		pipeStreams(inputStreams, spawned.stdio[fdNumber]);
+		const inputStream = inputStreams.length === 1 ? inputStreams[0] : mergeStreams(inputStreams);
+		pipeStreams(inputStream, spawned.stdio[fdNumber]);
 	}
 };
 
@@ -63,7 +65,7 @@ const pipeStdioOption = (spawned, {type, value, direction, fdNumber}, inputStrea
 	setStandardStreamMaxListeners(value, controller);
 
 	if (direction === 'output') {
-		pipeStreams([spawned.stdio[fdNumber]], value);
+		pipeStreams(spawned.stdio[fdNumber], value);
 	} else {
 		inputStreamsGroups[fdNumber] = [...(inputStreamsGroups[fdNumber] ?? []), value];
 	}

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -87,9 +87,9 @@ export const generatorToDuplexStream = ({
 // `childProcess.stdin|stdout|stderr|stdio` is directly mutated.
 export const pipeGenerator = (spawned, {value, direction, fdNumber}) => {
 	if (direction === 'output') {
-		pipeStreams([spawned.stdio[fdNumber]], value);
+		pipeStreams(spawned.stdio[fdNumber], value);
 	} else {
-		pipeStreams([value], spawned.stdio[fdNumber]);
+		pipeStreams(value, spawned.stdio[fdNumber]);
 	}
 
 	const streamProperty = PROCESS_STREAM_PROPERTIES[fdNumber];

--- a/lib/stdio/pipeline.js
+++ b/lib/stdio/pipeline.js
@@ -1,60 +1,48 @@
 import {finished} from 'node:stream/promises';
-import mergeStreams from '@sindresorhus/merge-streams';
-import {isStreamAbort} from '../stream/wait.js';
 import {isStandardStream} from '../utils.js';
 
 // Like `Stream.pipeline(source, destination)`, but does not destroy standard streams.
-// `sources` might be a single stream, or multiple ones combined with `merge-stream`.
-export const pipeStreams = (sources, destination) => {
-	const finishedStreams = new Set();
-
-	if (sources.length === 1) {
-		sources[0].pipe(destination);
-	} else {
-		const mergedSource = mergeStreams(sources);
-		mergedSource.pipe(destination);
-		handleStreamError(destination, mergedSource, finishedStreams);
-	}
-
-	for (const source of sources) {
-		handleStreamError(source, destination, finishedStreams);
-		handleStreamError(destination, source, finishedStreams);
-	}
+export const pipeStreams = (source, destination) => {
+	source.pipe(destination);
+	onSourceFinish(source, destination);
+	onDestinationFinish(source, destination);
 };
 
 // `source.pipe(destination)` makes `destination` end when `source` ends.
 // But it does not propagate aborts or errors. This function does it.
+const onSourceFinish = async (source, destination) => {
+	if (isStandardStream(source) || isStandardStream(destination)) {
+		return;
+	}
+
+	try {
+		await finished(source, {cleanup: true, readable: true, writable: false});
+	} catch {}
+
+	endDestinationStream(destination);
+};
+
+export const endDestinationStream = destination => {
+	if (destination.writable) {
+		destination.end();
+	}
+};
+
 // We do the same thing in the other direction as well.
-const handleStreamError = async (stream, otherStream, finishedStreams) => {
-	if (isStandardStream(stream) || isStandardStream(otherStream)) {
+const onDestinationFinish = async (source, destination) => {
+	if (isStandardStream(source) || isStandardStream(destination)) {
 		return;
 	}
 
 	try {
-		await onFinishedStream(stream, finishedStreams);
-	} catch (error) {
-		destroyStream(otherStream, finishedStreams, error);
-	}
+		await finished(destination, {cleanup: true, readable: false, writable: true});
+	} catch {}
+
+	abortSourceStream(source);
 };
 
-// Both functions above call each other recursively.
-// `finishedStreams` prevents this cycle.
-const onFinishedStream = async (stream, finishedStreams) => {
-	try {
-		await finished(stream, {cleanup: true});
-	} finally {
-		finishedStreams.add(stream);
-	}
-};
-
-const destroyStream = (stream, finishedStreams, error) => {
-	if (finishedStreams.has(stream)) {
-		return;
-	}
-
-	if (isStreamAbort(error)) {
-		stream.destroy();
-	} else {
-		stream.destroy(error);
+export const abortSourceStream = source => {
+	if (source.readable) {
+		source.destroy();
 	}
 };

--- a/lib/stream/wait.js
+++ b/lib/stream/wait.js
@@ -54,7 +54,7 @@ export const isInputFileDescriptor = (fdNumber, stdioStreamsGroups) => {
 // When `stream.destroy()` is called without an `error` argument, stream is aborted.
 // This is the only way to abort a readable stream, which can be useful in some instances.
 // Therefore, we ignore this error on readable streams.
-export const isStreamAbort = error => error?.code === 'ERR_STREAM_PREMATURE_CLOSE';
+const isStreamAbort = error => error?.code === 'ERR_STREAM_PREMATURE_CLOSE';
 
 // When `stream.write()` is called but the underlying source has been closed, `EPIPE` is emitted.
 // When piping processes, the source process usually decides when to stop piping.

--- a/test/helpers/stream.js
+++ b/test/helpers/stream.js
@@ -1,7 +1,7 @@
-import {Readable, Writable, Duplex} from 'node:stream';
+import {Readable, Writable, PassThrough} from 'node:stream';
 import {foobarString} from './input.js';
 
 export const noopReadable = () => new Readable({read() {}});
 export const noopWritable = () => new Writable({write() {}});
-export const noopDuplex = () => new Duplex({read() {}, write() {}});
+export const noopDuplex = () => new PassThrough().resume();
 export const simpleReadable = () => Readable.from([foobarString]);

--- a/test/stream/wait.js
+++ b/test/stream/wait.js
@@ -117,24 +117,6 @@ test('Throws abort error when output stdio[*] option aborts with no more writes,
 test('Throws abort error when output stdio[*] Duplex option aborts with no more writes, with a transform', testStreamAbortFail, destroyOptionStream, noopDuplex(), 3, true);
 
 // eslint-disable-next-line max-params
-const testStreamEpipeSuccess = async (t, streamMethod, stream, fdNumber, useTransform) => {
-	const childProcess = execa('noop-stdin-fd.js', [`${fdNumber}`], getStreamStdio(fdNumber, stream, useTransform));
-	streamMethod({stream, childProcess, fdNumber});
-	childProcess.stdin.end(foobarString);
-
-	const {stdio} = await childProcess;
-	t.is(stdio[fdNumber], foobarString);
-	t.true(stream.destroyed);
-};
-
-test('Passes when stdout option ends with more writes', testStreamEpipeSuccess, endOptionStream, noopWritable(), 1, false);
-test('Passes when stderr option ends with more writes', testStreamEpipeSuccess, endOptionStream, noopWritable(), 2, false);
-test('Passes when output stdio[*] option ends with more writes', testStreamEpipeSuccess, endOptionStream, noopWritable(), 3, false);
-test('Passes when stdout option ends with more writes, with a transform', testStreamEpipeSuccess, endOptionStream, noopWritable(), 1, true);
-test('Passes when stderr option ends with more writes, with a transform', testStreamEpipeSuccess, endOptionStream, noopWritable(), 2, true);
-test('Passes when output stdio[*] option ends with more writes, with a transform', testStreamEpipeSuccess, endOptionStream, noopWritable(), 3, true);
-
-// eslint-disable-next-line max-params
 const testStreamEpipeFail = async (t, streamMethod, stream, fdNumber, useTransform) => {
 	const childProcess = execa('noop-stdin-fd.js', [`${fdNumber}`], getStreamStdio(fdNumber, stream, useTransform));
 	streamMethod({stream, childProcess, fdNumber});
@@ -150,10 +132,13 @@ const testStreamEpipeFail = async (t, streamMethod, stream, fdNumber, useTransfo
 	}
 };
 
+test('Throws EPIPE when stdout option ends with more writes', testStreamEpipeFail, endOptionStream, noopWritable(), 1, false);
 test('Throws EPIPE when stdout option aborts with more writes', testStreamEpipeFail, destroyOptionStream, noopWritable(), 1, false);
 test('Throws EPIPE when stdout option Duplex aborts with more writes', testStreamEpipeFail, destroyOptionStream, noopDuplex(), 1, false);
+test('Throws EPIPE when stderr option ends with more writes', testStreamEpipeFail, endOptionStream, noopWritable(), 2, false);
 test('Throws EPIPE when stderr option aborts with more writes', testStreamEpipeFail, destroyOptionStream, noopWritable(), 2, false);
 test('Throws EPIPE when stderr option Duplex aborts with more writes', testStreamEpipeFail, destroyOptionStream, noopDuplex(), 2, false);
+test('Throws EPIPE when output stdio[*] option ends with more writes', testStreamEpipeFail, endOptionStream, noopWritable(), 3, false);
 test('Throws EPIPE when output stdio[*] option aborts with more writes', testStreamEpipeFail, destroyOptionStream, noopWritable(), 3, false);
 test('Throws EPIPE when output stdio[*] option Duplex aborts with more writes', testStreamEpipeFail, destroyOptionStream, noopDuplex(), 3, false);
 test('Throws EPIPE when childProcess.stdout aborts with more writes', testStreamEpipeFail, destroyChildStream, noopWritable(), 1, false);
@@ -162,10 +147,13 @@ test('Throws EPIPE when childProcess.stderr aborts with more writes', testStream
 test('Throws EPIPE when childProcess.stderr Duplex aborts with more writes', testStreamEpipeFail, destroyChildStream, noopDuplex(), 2, false);
 test('Throws EPIPE when output childProcess.stdio[*] aborts with more writes', testStreamEpipeFail, destroyChildStream, noopWritable(), 3, false);
 test('Throws EPIPE when output childProcess.stdio[*] Duplex aborts with more writes', testStreamEpipeFail, destroyChildStream, noopDuplex(), 3, false);
+test('Throws EPIPE when stdout option ends with more writes, with a transform', testStreamEpipeFail, endOptionStream, noopWritable(), 1, true);
 test('Throws EPIPE when stdout option aborts with more writes, with a transform', testStreamEpipeFail, destroyOptionStream, noopWritable(), 1, true);
 test('Throws EPIPE when stdout option Duplex aborts with more writes, with a transform', testStreamEpipeFail, destroyOptionStream, noopDuplex(), 1, true);
+test('Throws EPIPE when stderr option ends with more writes, with a transform', testStreamEpipeFail, endOptionStream, noopWritable(), 2, true);
 test('Throws EPIPE when stderr option aborts with more writes, with a transform', testStreamEpipeFail, destroyOptionStream, noopWritable(), 2, true);
 test('Throws EPIPE when stderr option Duplex aborts with more writes, with a transform', testStreamEpipeFail, destroyOptionStream, noopDuplex(), 2, true);
+test('Throws EPIPE when output stdio[*] option ends with more writes, with a transform', testStreamEpipeFail, endOptionStream, noopWritable(), 3, true);
 test('Throws EPIPE when output stdio[*] option aborts with more writes, with a transform', testStreamEpipeFail, destroyOptionStream, noopWritable(), 3, true);
 test('Throws EPIPE when output stdio[*] option Duplex aborts with more writes, with a transform', testStreamEpipeFail, destroyOptionStream, noopDuplex(), 3, true);
 test('Throws EPIPE when childProcess.stdout aborts with more writes, with a transform', testStreamEpipeFail, destroyChildStream, noopWritable(), 1, true);


### PR DESCRIPTION
This PR improves the logic related to piping streams, which is used both by the `std*` option and by `childProcess.pipe(otherProcess)`. This makes both features share the same piping logic. This also includes minor improvements of that logic. Finally, this removes some code duplication thanks to recent tweaks of the `merge-streams` library. 