### PR TITLE
Improve icons used in `verbose` option

### DIFF
--- a/lib/verbose/log.js
+++ b/lib/verbose/log.js
@@ -1,5 +1,6 @@
 import {writeFileSync} from 'node:fs';
 import process from 'node:process';
+import figures from 'figures';
 import {gray} from 'yoctocolors';
 
 // Write synchronously to ensure lines are properly ordered and not interleaved with `stdout`
@@ -36,7 +37,7 @@ const ICONS = {
 	command: '$',
 	pipedCommand: '|',
 	output: ' ',
-	error: '×',
-	warning: '‼',
-	success: '√',
+	error: figures.cross,
+	warning: figures.warning,
+	success: figures.tick,
 };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 	"dependencies": {
 		"@sindresorhus/merge-streams": "^3.0.0",
 		"cross-spawn": "^7.0.3",
+		"figures": "^6.1.0",
 		"get-stream": "^8.0.1",
 		"human-signals": "^6.0.0",
 		"is-plain-obj": "^4.1.0",

--- a/test/helpers/verbose.js
+++ b/test/helpers/verbose.js
@@ -1,5 +1,6 @@
 import {platform} from 'node:process';
 import {stripVTControlCharacters} from 'node:util';
+import {replaceSymbols} from 'figures';
 import {execa} from '../../index.js';
 import {foobarString} from './input.js';
 
@@ -48,7 +49,7 @@ const isCompletionLine = line => line.includes('(done in');
 export const getNormalizedLines = stderr => splitLines(normalizeStderr(stderr));
 const splitLines = stderr => stderr.split('\n');
 
-const normalizeStderr = stderr => normalizeDuration(normalizeTimestamp(stripVTControlCharacters(stderr)));
+const normalizeStderr = stderr => replaceSymbols(normalizeDuration(normalizeTimestamp(stripVTControlCharacters(stderr))), {useFallback: true});
 export const testTimestamp = '[00:00:00.000]';
 const normalizeTimestamp = stderr => stderr.replaceAll(/^\[\d{2}:\d{2}:\d{2}.\d{3}]/gm, testTimestamp);
 const normalizeDuration = stderr => stderr.replaceAll(/\(done in [^)]+\)/g, '(done in 0ms)');


### PR DESCRIPTION
This improves the icons used by the `verbose` option.

Before:

![Screenshot from 2024-03-05 17-44-53](https://github.com/sindresorhus/execa/assets/8136211/e5d4eff9-db6a-4b89-b648-0c98bd12ed58)

After:

![Screenshot from 2024-03-05 17-44-12](https://github.com/sindresorhus/execa/assets/8136211/f8334a7f-eb70-4d3c-8e59-fc35802e888c)