### PR TITLE
Improve error message when passing wrong arguments to `execaCommand()`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,19 +1,24 @@
+import isPlainObj from 'is-plain-obj';
 import {execa} from './async.js';
 import {execaSync} from './sync.js';
 
 export function execaCommand(command, options) {
-	const [file, ...args] = parseCommand(command);
+	const [file, ...args] = parseCommand(command, options);
 	return execa(file, args, options);
 }
 
 export function execaCommandSync(command, options) {
-	const [file, ...args] = parseCommand(command);
+	const [file, ...args] = parseCommand(command, options);
 	return execaSync(file, args, options);
 }
 
-const parseCommand = command => {
+const parseCommand = (command, options) => {
 	if (typeof command !== 'string') {
 		throw new TypeError(`First argument must be a string: ${command}.`);
+	}
+
+	if (options !== undefined && !isPlainObj(options)) {
+		throw new TypeError(`The command and its arguments must be passed as a single string: ${command} ${options}.`);
 	}
 
 	const tokens = [];

--- a/test/command.js
+++ b/test/command.js
@@ -50,11 +50,13 @@ test('execaCommandSync() must use a string', testInvalidCommand, execaCommandSyn
 test('execaCommand() must have an argument', testInvalidCommand, execaCommand, undefined);
 test('execaCommandSync() must have an argument', testInvalidCommand, execaCommandSync, undefined);
 
-const testInvalidArgs = (t, execaCommand) => {
+const testInvalidArgs = (t, secondArgument, execaCommand) => {
 	t.throws(() => {
-		execaCommand('echo', ['']);
-	}, {message: /Last argument must be an options object/});
+		execaCommand('echo', secondArgument);
+	}, {message: /The command and its arguments must be passed as a single string/});
 };
 
-test('execaCommand() must not pass an array of arguments', testInvalidArgs, execaCommand);
-test('execaCommandSync() must not pass an array of arguments', testInvalidArgs, execaCommandSync);
+test('execaCommand() must not pass an array of arguments', testInvalidArgs, [''], execaCommand);
+test('execaCommandSync() must not pass an array of arguments', testInvalidArgs, [''], execaCommandSync);
+test('execaCommand() must not pass non-options as second argument', testInvalidArgs, '', execaCommand);
+test('execaCommandSync() must not pass non-options as second argument', testInvalidArgs, '', execaCommandSync);


### PR DESCRIPTION
`execaCommand()` is intended to execute a user-defined / dynamic command. As such, its signature is `execaCommand(commandAndArgs, options)`. Notably, an arguments array cannot be passed.

Passing an arguments array already throws. This PR improves the error message to make it more precise.