### PR TITLE
Fix race condition with `subprocess.stdin.destroy()`

### DIFF
--- a/lib/stream/resolve.js
+++ b/lib/stream/resolve.js
@@ -19,7 +19,7 @@ export const getSubprocessResult = async ({
 	controller,
 }) => {
 	const exitPromise = waitForExit(subprocess);
-	const streamInfo = {originalStreams, stdioStreamsGroups, exitPromise, propagating: new Set([])};
+	const streamInfo = {originalStreams, stdioStreamsGroups, subprocess, exitPromise, propagating: new Set([])};
 
 	const stdioPromises = waitForSubprocessStreams({subprocess, encoding, buffer, maxBuffer, streamInfo});
 	const allPromise = waitForAllStream({subprocess, encoding, buffer, maxBuffer, streamInfo});

--- a/lib/stream/wait.js
+++ b/lib/stream/wait.js
@@ -4,18 +4,53 @@ import {finished} from 'node:stream/promises';
 //  - When the subprocess exits, Node.js automatically calls `subprocess.stdin.destroy()`, which we need to ignore.
 //  - However, we still need to throw if `subprocess.stdin.destroy()` is called before subprocess exit.
 export const waitForStream = async (stream, fdNumber, streamInfo, {isSameDirection, stopOnExit = false} = {}) => {
-	const {originalStreams: [originalStdin], exitPromise} = streamInfo;
-
+	const state = handleStdinDestroy(stream, streamInfo);
 	const abortController = new AbortController();
 	try {
 		await Promise.race([
-			...(stopOnExit || stream === originalStdin ? [exitPromise] : []),
+			...(stopOnExit ? [streamInfo.exitPromise] : []),
 			finished(stream, {cleanup: true, signal: abortController.signal}),
 		]);
 	} catch (error) {
-		handleStreamError(error, fdNumber, streamInfo, isSameDirection);
+		if (!state.stdinCleanedUp) {
+			handleStreamError(error, fdNumber, streamInfo, isSameDirection);
+		}
 	} finally {
 		abortController.abort();
+	}
+};
+
+// If `subprocess.stdin` is destroyed before being fully written to, it is considered aborted and should throw an error.
+// This can happen for example when user called `subprocess.stdin.destroy()` before `subprocess.stdin.end()`.
+// However, Node.js calls `subprocess.stdin.destroy()` on exit for cleanup purposes.
+// https://github.com/nodejs/node/blob/0b4cdb4b42956cbd7019058e409e06700a199e11/lib/internal/child_process.js#L278
+// This is normal and should not throw an error.
+// Therefore, we need to differentiate between both situations to know whether to throw an error.
+// Unfortunately, events (`close`, `error`, `end`, `exit`) cannot be used because `.destroy()` can take an arbitrary amount of time.
+// For example, `stdin: 'pipe'` is implemented as a TCP socket, and its `.destroy()` method waits for TCP disconnection.
+// Therefore `.destroy()` might end before or after subprocess exit, based on OS speed and load.
+// The only way to detect this is to spy on `subprocess.stdin._destroy()` by wrapping it.
+// If `subprocess.exitCode` or `subprocess.signalCode` is set, it means `.destroy()` is being called by Node.js itself.
+const handleStdinDestroy = (stream, {originalStreams: [originalStdin], subprocess}) => {
+	const state = {stdinCleanedUp: false};
+	if (stream === originalStdin) {
+		spyOnStdinDestroy(stream, subprocess, state);
+	}
+
+	return state;
+};
+
+const spyOnStdinDestroy = (subprocessStdin, subprocess, state) => {
+	const {_destroy} = subprocessStdin;
+	subprocessStdin._destroy = (...args) => {
+		setStdinCleanedUp(subprocess, state);
+		_destroy.call(subprocessStdin, ...args);
+	};
+};
+
+const setStdinCleanedUp = ({exitCode, signalCode}, state) => {
+	if (exitCode !== null || signalCode !== null) {
+		state.stdinCleanedUp = true;
 	}
 };
 

--- a/test/stdio/async.js
+++ b/test/stdio/async.js
@@ -19,14 +19,13 @@ const getComplexStdio = isMultiple => ({
 	stderr: ['pipe', 'inherit', ...(isMultiple ? [2, process.stderr] : [])],
 });
 
-const onStdinRemoveListener = () => once(process.stdin, 'removeListener', {cleanup: true});
+const onStdinRemoveListener = () => once(process.stdin, 'removeListener');
 
 const testListenersCleanup = async (t, isMultiple) => {
 	const streamsPreviousListeners = getStandardStreamsListeners();
 	const subprocess = execa('empty.js', getComplexStdio(isMultiple));
 	t.notDeepEqual(getStandardStreamsListeners(), streamsPreviousListeners);
-	await subprocess;
-	await onStdinRemoveListener();
+	await Promise.all([subprocess, onStdinRemoveListener()]);
 	if (isMultiple) {
 		await onStdinRemoveListener();
 	}


### PR DESCRIPTION
Some tests are randomly failing due to a timing-related race condition (explained in this PR's comment).
This PR fixes this.