### PR TITLE
Improve handling of early errors

### DIFF
--- a/lib/return/early-error.js
+++ b/lib/return/early-error.js
@@ -10,19 +10,20 @@ export const handleEarlyError = ({error, command, escapedCommand, stdioStreamsGr
 	cleanupStdioStreams(stdioStreamsGroups);
 
 	const subprocess = new ChildProcess();
-	createDummyStreams(subprocess);
+	createDummyStreams(subprocess, stdioStreamsGroups);
 
 	const earlyError = makeEarlyError({error, command, escapedCommand, stdioStreamsGroups, options, startTime});
 	const promise = handleDummyPromise(earlyError, verboseInfo, options);
 	return {subprocess, promise};
 };
 
-const createDummyStreams = subprocess => {
+const createDummyStreams = (subprocess, stdioStreamsGroups) => {
 	const stdin = createDummyStream();
 	const stdout = createDummyStream();
 	const stderr = createDummyStream();
+	const extraStdio = Array.from({length: stdioStreamsGroups.length - 3}, createDummyStream);
 	const all = createDummyStream();
-	const stdio = [stdin, stdout, stderr];
+	const stdio = [stdin, stdout, stderr, ...extraStdio];
 	Object.assign(subprocess, {stdin, stdout, stderr, all, stdio});
 };
 

--- a/test/return/early-error.js
+++ b/test/return/early-error.js
@@ -2,6 +2,7 @@ import process from 'node:process';
 import test from 'ava';
 import {execa, execaSync, $} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {fullStdio} from '../helpers/stdio.js';
 import {earlyErrorOptions, getEarlyErrorSubprocess, getEarlyErrorSubprocessSync, expectedEarlyError} from '../helpers/early-error.js';
 
 setFixtureDir();
@@ -77,8 +78,8 @@ test('child_process.spawn() early errors can use .pipe() multiple times', testEa
 test('child_process.spawn() early errors can use .pipe``', testEarlyErrorPipe, () => $(earlyErrorOptions)`empty.js`.pipe(earlyErrorOptions)`empty.js`);
 test('child_process.spawn() early errors can use .pipe`` multiple times', testEarlyErrorPipe, () => $(earlyErrorOptions)`empty.js`.pipe(earlyErrorOptions)`empty.js`.pipe`empty.js`);
 
-const testEarlyErrorStream = async (t, getStreamProperty, all) => {
-	const subprocess = getEarlyErrorSubprocess({all});
+const testEarlyErrorStream = async (t, getStreamProperty, options) => {
+	const subprocess = getEarlyErrorSubprocess(options);
 	const stream = getStreamProperty(subprocess);
 	stream.on('close', () => {});
 	stream.read?.();
@@ -86,8 +87,9 @@ const testEarlyErrorStream = async (t, getStreamProperty, all) => {
 	await t.throwsAsync(subprocess);
 };
 
-test('child_process.spawn() early errors can use .stdin', testEarlyErrorStream, ({stdin}) => stdin, false);
-test('child_process.spawn() early errors can use .stdout', testEarlyErrorStream, ({stdout}) => stdout, false);
-test('child_process.spawn() early errors can use .stderr', testEarlyErrorStream, ({stderr}) => stderr, false);
-test('child_process.spawn() early errors can use .stdio', testEarlyErrorStream, ({stdio}) => stdio[1], false);
-test('child_process.spawn() early errors can use .all', testEarlyErrorStream, ({all}) => all, true);
+test('child_process.spawn() early errors can use .stdin', testEarlyErrorStream, ({stdin}) => stdin);
+test('child_process.spawn() early errors can use .stdout', testEarlyErrorStream, ({stdout}) => stdout);
+test('child_process.spawn() early errors can use .stderr', testEarlyErrorStream, ({stderr}) => stderr);
+test('child_process.spawn() early errors can use .stdio[1]', testEarlyErrorStream, ({stdio}) => stdio[1]);
+test('child_process.spawn() early errors can use .stdio[3]', testEarlyErrorStream, ({stdio}) => stdio[3], fullStdio);
+test('child_process.spawn() early errors can use .all', testEarlyErrorStream, ({all}) => all, {all: true});


### PR DESCRIPTION
When subprocesses fail to be spawned, we reject the error asynchronously. Because of this, we need to return a dummy subprocess instance. 

This PR does a minor improvement on that dummy subprocess instance, so that it better mimics the `subprocess.stdio[*]` property.