### PR TITLE
Improve test helpers

### DIFF
--- a/test/fixtures/delay.js
+++ b/test/fixtures/delay.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
 import process from 'node:process';
 
-setTimeout(() => {}, Number(process.argv[2]));
+const delay = Number(process.argv[2]);
+setTimeout(() => {}, delay);

--- a/test/fixtures/echo-fail.js
+++ b/test/fixtures/echo-fail.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {writeSync} from 'node:fs';
+import {getWriteStream} from '../helpers/fs.js';
 
 console.log('stdout');
 console.error('stderr');
-writeSync(3, 'fd3');
+getWriteStream(3).write('fd3');
 process.exitCode = 1;

--- a/test/fixtures/max-buffer.js
+++ b/test/fixtures/max-buffer.js
@@ -1,13 +1,7 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {writeSync} from 'node:fs';
+import {getWriteStream} from '../helpers/fs.js';
 
 const fdNumber = Number(process.argv[2]);
 const bytes = '.'.repeat(Number(process.argv[3] || 1e7));
-if (fdNumber === 1) {
-	process.stdout.write(bytes);
-} else if (fdNumber === 2) {
-	process.stderr.write(bytes);
-} else {
-	writeSync(fdNumber, bytes);
-}
+getWriteStream(fdNumber).write(bytes);

--- a/test/fixtures/nested-multiple-stderr.js
+++ b/test/fixtures/nested-multiple-stderr.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import {execa} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
 
 const [options] = process.argv.slice(2);
-const result = await execa('noop-fd.js', ['2', 'foobar'], {stderr: JSON.parse(options)});
+const result = await execa('noop-fd.js', ['2', foobarString], {stderr: JSON.parse(options)});
 process.stdout.write(`nested ${result.stderr}`);

--- a/test/fixtures/nested-multiple-stdin.js
+++ b/test/fixtures/nested-multiple-stdin.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import {execa} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
 
 const [options] = process.argv.slice(2);
 const subprocess = execa('stdin.js', {stdin: JSON.parse(options)});
-subprocess.stdin.write('foobar');
+subprocess.stdin.write(foobarString);
 const {stdout} = await subprocess;
 console.log(stdout);

--- a/test/fixtures/nested-multiple-stdout.js
+++ b/test/fixtures/nested-multiple-stdout.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import {execa} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
 
 const [options] = process.argv.slice(2);
-const result = await execa('noop.js', ['foobar'], {stdout: JSON.parse(options)});
+const result = await execa('noop.js', [foobarString], {stdout: JSON.parse(options)});
 process.stderr.write(`nested ${result.stdout}`);

--- a/test/fixtures/nested-node.js
+++ b/test/fixtures/nested-node.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {writeSync} from 'node:fs';
+import {getWriteStream} from '../helpers/fs.js';
 import {execa, execaNode} from '../../index.js';
 
 const [fakeExecArgv, execaMethod, nodeOptions, file, ...args] = process.argv.slice(2);
@@ -14,4 +14,4 @@ const {stdout, stderr} = await (execaMethod === 'execaNode'
 	? execaNode(file, args, {nodeOptions: filteredNodeOptions})
 	: execa(file, args, {nodeOptions: filteredNodeOptions, node: true}));
 console.log(stdout);
-writeSync(3, stderr);
+getWriteStream(3).write(stderr);

--- a/test/fixtures/noop-both-fail.js
+++ b/test/fixtures/noop-both-fail.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import process from 'node:process';
 
-process.stdout.write(process.argv[2]);
-process.stderr.write(process.argv[3]);
+const stdoutBytes = process.argv[2];
+const stderrBytes = process.argv[3];
+process.stdout.write(stdoutBytes);
+process.stderr.write(stderrBytes);
 process.exitCode = 1;

--- a/test/fixtures/noop-both.js
+++ b/test/fixtures/noop-both.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import process from 'node:process';
+import {foobarString} from '../helpers/input.js';
 
-const text = process.argv[2] || 'foobar';
-console.log(text);
-console.error(text);
+const bytes = process.argv[2] || foobarString;
+console.log(bytes);
+console.error(bytes);

--- a/test/fixtures/noop-continuous.js
+++ b/test/fixtures/noop-continuous.js
@@ -2,7 +2,8 @@
 import process from 'node:process';
 import {setTimeout} from 'node:timers/promises';
 
-for (const character of process.argv[2]) {
+const bytes = process.argv[2];
+for (const character of bytes) {
 	console.log(character);
 	// eslint-disable-next-line no-await-in-loop
 	await setTimeout(100);

--- a/test/fixtures/noop-delay.js
+++ b/test/fixtures/noop-delay.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {writeSync} from 'node:fs';
 import {setTimeout} from 'node:timers/promises';
+import {getWriteStream} from '../helpers/fs.js';
+import {foobarString} from '../helpers/input.js';
 
-writeSync(Number(process.argv[2]), 'foobar');
+const fdNumber = Number(process.argv[2]);
+getWriteStream(fdNumber).write(foobarString);
 await setTimeout(100);

--- a/test/fixtures/noop-fail.js
+++ b/test/fixtures/noop-fail.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {writeSync} from 'node:fs';
+import {getWriteStream} from '../helpers/fs.js';
+import {foobarString} from '../helpers/input.js';
 
-writeSync(Number(process.argv[2]), process.argv[3] || 'foobar');
+const fdNumber = Number(process.argv[2]);
+const bytes = process.argv[3] || foobarString;
+getWriteStream(fdNumber).write(bytes);
 process.exitCode = 2;

--- a/test/fixtures/noop-fd-ipc.js
+++ b/test/fixtures/noop-fd-ipc.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {writeSync} from 'node:fs';
+import {getWriteStream} from '../helpers/fs.js';
+import {foobarString} from '../helpers/input.js';
 
-writeSync(Number(process.argv[2]), process.argv[3] || 'foobar');
-process.send('');
+const fdNumber = Number(process.argv[2]);
+const bytes = process.argv[3] || foobarString;
+getWriteStream(fdNumber).write(bytes, () => {
+	process.send('');
+});

--- a/test/fixtures/noop-fd.js
+++ b/test/fixtures/noop-fd.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {writeSync} from 'node:fs';
+import {getWriteStream} from '../helpers/fs.js';
+import {foobarString} from '../helpers/input.js';
 
-writeSync(Number(process.argv[2]), process.argv[3] || 'foobar');
+const fdNumber = Number(process.argv[2]);
+const bytes = process.argv[3] || foobarString;
+getWriteStream(fdNumber).write(bytes);

--- a/test/fixtures/noop-forever.js
+++ b/test/fixtures/noop-forever.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import process from 'node:process';
 
-console.log(process.argv[2]);
+const bytes = process.argv[2];
+console.log(bytes);
 setTimeout(() => {}, 1e8);

--- a/test/fixtures/noop-progressive.js
+++ b/test/fixtures/noop-progressive.js
@@ -2,7 +2,8 @@
 import process from 'node:process';
 import {setTimeout} from 'node:timers/promises';
 
-for (const character of process.argv[2]) {
+const bytes = process.argv[2];
+for (const character of bytes) {
 	process.stdout.write(character);
 	// eslint-disable-next-line no-await-in-loop
 	await setTimeout(10);

--- a/test/fixtures/noop-repeat.js
+++ b/test/fixtures/noop-repeat.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {writeSync} from 'node:fs';
+import {getWriteStream} from '../helpers/fs.js';
+import {foobarString} from '../helpers/input.js';
 
+const fdNumber = Number(process.argv[2]) || 1;
+const bytes = process.argv[3] || foobarString;
 setInterval(() => {
-	writeSync(Number(process.argv[2]) || 1, process.argv[3] || '.');
+	getWriteStream(fdNumber).write(bytes);
 }, 10);

--- a/test/fixtures/noop-stdin-double.js
+++ b/test/fixtures/noop-stdin-double.js
@@ -2,5 +2,6 @@
 import process from 'node:process';
 import {text} from 'node:stream/consumers';
 
+const bytes = process.argv[2];
 const stdinString = await text(process.stdin);
-console.log(`${stdinString} ${process.argv[2]}`);
+console.log(`${stdinString} ${bytes}`);

--- a/test/fixtures/noop-stdin-fd.js
+++ b/test/fixtures/noop-stdin-fd.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {writeSync} from 'node:fs';
+import {getWriteStream} from '../helpers/fs.js';
 
-const writableFileDescriptor = Number(process.argv[2]);
-process.stdin.on('data', chunk => {
-	writeSync(writableFileDescriptor, chunk);
-});
+const fdNumber = Number(process.argv[2]);
+process.stdin.pipe(getWriteStream(fdNumber));

--- a/test/fixtures/noop.js
+++ b/test/fixtures/noop.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
 import process from 'node:process';
 
-console.log(process.argv[2]);
+const bytes = process.argv[2];
+console.log(bytes);

--- a/test/fixtures/stdin-fd-both.js
+++ b/test/fixtures/stdin-fd-both.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {readFileSync} from 'node:fs';
+import {getReadStream} from '../helpers/fs.js';
 
 const fdNumber = Number(process.argv[2]);
-
 process.stdin.pipe(process.stdout);
-process.stdout.write(readFileSync(fdNumber));
+getReadStream(fdNumber).pipe(process.stdout);

--- a/test/fixtures/stdin-fd.js
+++ b/test/fixtures/stdin-fd.js
@@ -1,10 +1,6 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {readFileSync} from 'node:fs';
+import {getReadStream} from '../helpers/fs.js';
 
 const fdNumber = Number(process.argv[2]);
-if (fdNumber === 0) {
-	process.stdin.pipe(process.stdout);
-} else {
-	process.stdout.write(readFileSync(fdNumber));
-}
+getReadStream(fdNumber).pipe(process.stdout);

--- a/test/helpers/fs.js
+++ b/test/helpers/fs.js
@@ -1,0 +1,18 @@
+import {createReadStream, createWriteStream} from 'node:fs';
+import process from 'node:process';
+
+export const getReadStream = fdNumber => fdNumber === 0
+	? process.stdin
+	: createReadStream(undefined, {fd: fdNumber});
+
+export const getWriteStream = fdNumber => {
+	if (fdNumber === 1) {
+		return process.stdout;
+	}
+
+	if (fdNumber === 2) {
+		return process.stderr;
+	}
+
+	return createWriteStream(undefined, {fd: fdNumber});
+};


### PR DESCRIPTION
This PR improves the the test helpers to use streaming I/O instead of synchronous ones.
The synchronous methods were sometimes randomly failing on Windows.