### PR TITLE
Add `.readable()`, `.writable()` and `.duplex()` methods

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -2,7 +2,7 @@
 // `process.stdin`, `process.stderr`, and `process.stdout`
 // to get treated as `any` by `@typescript-eslint/no-unsafe-assignment`.
 import * as process from 'node:process';
-import {Readable, Writable} from 'node:stream';
+import {Readable, Writable, type Duplex} from 'node:stream';
 import {createWriteStream} from 'node:fs';
 import {expectType, expectNotType, expectError, expectAssignable, expectNotAssignable} from 'tsd';
 import {
@@ -257,6 +257,36 @@ try {
 	expectType<string>(scriptShortcutPipeResult.stdout);
 	const ignoreShortcutScriptPipeResult = await scriptPromise.pipe('stdin', {stdout: 'ignore'});
 	expectType<undefined>(ignoreShortcutScriptPipeResult.stdout);
+
+	expectType<Readable>(scriptPromise.readable());
+	expectType<Writable>(scriptPromise.writable());
+	expectType<Duplex>(scriptPromise.duplex());
+
+	scriptPromise.readable({});
+	scriptPromise.readable({from: 'stdout'});
+	scriptPromise.readable({from: 'stderr'});
+	scriptPromise.readable({from: 'all'});
+	scriptPromise.readable({from: 3});
+	expectError(scriptPromise.readable('stdout'));
+	expectError(scriptPromise.readable({from: 'stdin'}));
+	expectError(scriptPromise.readable({other: 'stdout'}));
+	scriptPromise.writable({});
+	scriptPromise.writable({to: 'stdin'});
+	scriptPromise.writable({to: 3});
+	expectError(scriptPromise.writable('stdin'));
+	expectError(scriptPromise.writable({to: 'stdout'}));
+	expectError(scriptPromise.writable({other: 'stdin'}));
+	scriptPromise.duplex({});
+	scriptPromise.duplex({from: 'stdout'});
+	scriptPromise.duplex({from: 'stderr'});
+	scriptPromise.duplex({from: 'all'});
+	scriptPromise.duplex({from: 3});
+	scriptPromise.duplex({from: 'stdout', to: 'stdin'});
+	scriptPromise.duplex({from: 'stdout', to: 3});
+	expectError(scriptPromise.duplex('stdout'));
+	expectError(scriptPromise.duplex({from: 'stdin'}));
+	expectError(scriptPromise.duplex({from: 'stderr', to: 'stdout'}));
+	expectError(scriptPromise.duplex({other: 'stdout'}));
 
 	expectType<Readable>(execaPromise.all);
 	const noAllPromise = execa('unicorns');

--- a/lib/async.js
+++ b/lib/async.js
@@ -11,6 +11,7 @@ import {pipeToSubprocess} from './pipe/setup.js';
 import {SUBPROCESS_OPTIONS} from './pipe/validate.js';
 import {logEarlyResult} from './verbose/complete.js';
 import {makeAllStream} from './stream/all.js';
+import {addConvertedStreams} from './convert/add.js';
 import {getSubprocessResult} from './stream/resolve.js';
 import {mergePromise} from './promise.js';
 
@@ -64,6 +65,7 @@ const spawnSubprocessAsync = ({file, args, options, startTime, verboseInfo, comm
 
 	subprocess.kill = subprocessKill.bind(undefined, {kill: subprocess.kill.bind(subprocess), subprocess, options, controller});
 	subprocess.all = makeAllStream(subprocess, options);
+	addConvertedStreams(subprocess);
 
 	const promise = handlePromise({subprocess, options, startTime, verboseInfo, stdioStreamsGroups, originalStreams, command, escapedCommand, controller});
 	return {subprocess, promise};

--- a/lib/convert/add.js
+++ b/lib/convert/add.js
@@ -1,0 +1,11 @@
+import {initializeConcurrentStreams} from './concurrent.js';
+import {createReadable} from './readable.js';
+import {createWritable} from './writable.js';
+import {createDuplex} from './duplex.js';
+
+export const addConvertedStreams = subprocess => {
+	const concurrentStreams = initializeConcurrentStreams();
+	subprocess.readable = createReadable.bind(undefined, {subprocess, concurrentStreams});
+	subprocess.writable = createWritable.bind(undefined, {subprocess, concurrentStreams});
+	subprocess.duplex = createDuplex.bind(undefined, {subprocess, concurrentStreams});
+};

--- a/lib/convert/concurrent.js
+++ b/lib/convert/concurrent.js
@@ -1,0 +1,39 @@
+// When using multiple `.readable()`/`.writable()`/`.duplex()`, `final` and `destroy` should wait for other streams
+export const initializeConcurrentStreams = () => ({
+	readableDestroy: new WeakMap(),
+	writableFinal: new WeakMap(),
+	writableDestroy: new WeakMap(),
+});
+
+// Each file descriptor + `waitName` has its own array of promises.
+// Each promise is a single `.readable()`/`.writable()`/`.duplex()` call.
+export const addConcurrentStream = (concurrentStreams, stream, waitName) => {
+	const weakMap = concurrentStreams[waitName];
+	if (!weakMap.has(stream)) {
+		weakMap.set(stream, []);
+	}
+
+	const promises = weakMap.get(stream);
+	const promise = createDeferred();
+	promises.push(promise);
+	const resolve = promise.resolve.bind(promise);
+	return {resolve, promises};
+};
+
+const createDeferred = () => {
+	let resolve;
+	const promise = new Promise(resolve_ => {
+		resolve = resolve_;
+	});
+	return Object.assign(promise, {resolve});
+};
+
+// Wait for other streams, but stop waiting when subprocess ends
+export const waitForConcurrentStreams = async ({resolve, promises}, subprocess) => {
+	resolve();
+	const [isSubprocessExit] = await Promise.race([
+		Promise.allSettled([true, subprocess]),
+		Promise.all([false, ...promises]),
+	]);
+	return !isSubprocessExit;
+};

--- a/lib/convert/duplex.js
+++ b/lib/convert/duplex.js
@@ -1,0 +1,40 @@
+import {Duplex} from 'node:stream';
+import {callbackify} from 'node:util';
+import {
+	getSubprocessStdout,
+	getReadableMethods,
+	onStdoutFinished,
+	onReadableDestroy,
+} from './readable.js';
+import {
+	getSubprocessStdin,
+	getWritableMethods,
+	onStdinFinished,
+	onWritableDestroy,
+} from './writable.js';
+
+// Create a `Duplex` stream combining both
+export const createDuplex = ({subprocess, concurrentStreams}, {from, to} = {}) => {
+	const {subprocessStdout, waitReadableDestroy} = getSubprocessStdout(subprocess, from, concurrentStreams);
+	const {subprocessStdin, waitWritableFinal, waitWritableDestroy} = getSubprocessStdin(subprocess, to, concurrentStreams);
+	const duplex = new Duplex({
+		...getReadableMethods(subprocessStdout, subprocess),
+		...getWritableMethods(subprocessStdin, subprocess, waitWritableFinal),
+		destroy: callbackify(onDuplexDestroy.bind(undefined, {subprocessStdout, subprocessStdin, subprocess, waitReadableDestroy, waitWritableFinal, waitWritableDestroy})),
+		readableHighWaterMark: subprocessStdout.readableHighWaterMark,
+		writableHighWaterMark: subprocessStdin.writableHighWaterMark,
+		readableObjectMode: subprocessStdout.readableObjectMode,
+		writableObjectMode: subprocessStdin.writableObjectMode,
+		encoding: subprocessStdout.readableEncoding,
+	});
+	onStdoutFinished(subprocessStdout, duplex, subprocess, subprocessStdin);
+	onStdinFinished(subprocessStdin, duplex, subprocessStdout);
+	return duplex;
+};
+
+const onDuplexDestroy = async ({subprocessStdout, subprocessStdin, subprocess, waitReadableDestroy, waitWritableFinal, waitWritableDestroy}, error) => {
+	await Promise.all([
+		onReadableDestroy({subprocessStdout, subprocess, waitReadableDestroy}, error),
+		onWritableDestroy({subprocessStdin, subprocess, waitWritableFinal, waitWritableDestroy}, error),
+	]);
+};

--- a/lib/convert/readable.js
+++ b/lib/convert/readable.js
@@ -1,0 +1,104 @@
+import {on} from 'node:events';
+import {Readable} from 'node:stream';
+import {callbackify} from 'node:util';
+import {getReadable} from '../pipe/validate.js';
+import {addConcurrentStream, waitForConcurrentStreams} from './concurrent.js';
+import {
+	safeWaitForSubprocessStdin,
+	waitForSubprocessStdout,
+	waitForSubprocess,
+	destroyOtherStream,
+} from './shared.js';
+
+// Create a `Readable` stream that forwards from `stdout` and awaits the subprocess
+export const createReadable = ({subprocess, concurrentStreams}, {from} = {}) => {
+	const {subprocessStdout, waitReadableDestroy} = getSubprocessStdout(subprocess, from, concurrentStreams);
+	const readable = new Readable({
+		...getReadableMethods(subprocessStdout, subprocess),
+		destroy: callbackify(onReadableDestroy.bind(undefined, {subprocessStdout, subprocess, waitReadableDestroy})),
+		highWaterMark: subprocessStdout.readableHighWaterMark,
+		objectMode: subprocessStdout.readableObjectMode,
+		encoding: subprocessStdout.readableEncoding,
+	});
+	onStdoutFinished(subprocessStdout, readable, subprocess);
+	return readable;
+};
+
+// Retrieve `stdout` (or other stream depending on `from`)
+export const getSubprocessStdout = (subprocess, from, concurrentStreams) => {
+	const subprocessStdout = getReadable(subprocess, from);
+	const waitReadableDestroy = addConcurrentStream(concurrentStreams, subprocessStdout, 'readableDestroy');
+	return {subprocessStdout, waitReadableDestroy};
+};
+
+export const getReadableMethods = (subprocessStdout, subprocess) => {
+	const controller = new AbortController();
+	stopReadingOnExit(subprocess, controller);
+	const onStdoutData = on(subprocessStdout, 'data', {
+		signal: controller.signal,
+		highWaterMark: HIGH_WATER_MARK,
+		// Backward compatibility with older name for this option
+		// See https://github.com/nodejs/node/pull/52080#discussion_r1525227861
+		// @todo Remove after removing support for Node 21
+		highWatermark: HIGH_WATER_MARK,
+	});
+
+	return {
+		read() {
+			onRead(this, onStdoutData);
+		},
+	};
+};
+
+const stopReadingOnExit = async (subprocess, controller) => {
+	try {
+		await subprocess;
+	} catch {} finally {
+		controller.abort();
+	}
+};
+
+// The `highWaterMark` of `events.on()` is measured in number of events, not in bytes.
+// Not knowing the average amount of bytes per `data` event, we use the same heuristic as streams in objectMode, since they have the same issue.
+// Therefore, we use the value of `getDefaultHighWaterMark(true)`.
+// Note: this option does not exist on Node 18, but this is ok since the logic works without it. It just consumes more memory.
+const HIGH_WATER_MARK = 16;
+
+// Forwards data from `stdout` to `readable`
+const onRead = async (readable, onStdoutData) => {
+	try {
+		const {value, done} = await onStdoutData.next();
+		if (!done) {
+			readable.push(value[0]);
+		}
+	} catch {}
+};
+
+// When `subprocess.stdout` ends/aborts/errors, do the same on `readable`.
+// Await the subprocess, for the same reason as above.
+export const onStdoutFinished = async (subprocessStdout, readable, subprocess, subprocessStdin) => {
+	try {
+		await waitForSubprocessStdout(subprocessStdout);
+		await subprocess;
+		await safeWaitForSubprocessStdin(subprocessStdin);
+
+		if (readable.readable) {
+			readable.push(null);
+		}
+	} catch (error) {
+		await safeWaitForSubprocessStdin(subprocessStdin);
+		destroyOtherReadable(readable, error);
+	}
+};
+
+// When `readable` aborts/errors, do the same on `subprocess.stdout`
+export const onReadableDestroy = async ({subprocessStdout, subprocess, waitReadableDestroy}, error) => {
+	if (await waitForConcurrentStreams(waitReadableDestroy, subprocess)) {
+		destroyOtherReadable(subprocessStdout, error);
+		await waitForSubprocess(subprocess, error);
+	}
+};
+
+const destroyOtherReadable = (stream, error) => {
+	destroyOtherStream(stream, stream.readable, error);
+};

--- a/lib/convert/shared.js
+++ b/lib/convert/shared.js
@@ -1,0 +1,46 @@
+import {finished} from 'node:stream/promises';
+import {isStreamAbort} from '../stream/wait.js';
+
+export const safeWaitForSubprocessStdin = async subprocessStdin => {
+	if (subprocessStdin === undefined) {
+		return;
+	}
+
+	try {
+		await waitForSubprocessStdin(subprocessStdin);
+	} catch {}
+};
+
+export const safeWaitForSubprocessStdout = async subprocessStdout => {
+	if (subprocessStdout === undefined) {
+		return;
+	}
+
+	try {
+		await waitForSubprocessStdout(subprocessStdout);
+	} catch {}
+};
+
+export const waitForSubprocessStdin = async subprocessStdin => {
+	await finished(subprocessStdin, {cleanup: true, readable: false, writable: true});
+};
+
+export const waitForSubprocessStdout = async subprocessStdout => {
+	await finished(subprocessStdout, {cleanup: true, readable: true, writable: false});
+};
+
+// When `readable` or `writable` aborts/errors, awaits the subprocess, for the reason mentioned above
+export const waitForSubprocess = async (subprocess, error) => {
+	await subprocess;
+	if (error) {
+		throw error;
+	}
+};
+
+export const destroyOtherStream = (stream, isOpen, error) => {
+	if (error && !isStreamAbort(error)) {
+		stream.destroy(error);
+	} else if (isOpen) {
+		stream.destroy();
+	}
+};

--- a/lib/convert/writable.js
+++ b/lib/convert/writable.js
@@ -1,0 +1,85 @@
+import {Writable} from 'node:stream';
+import {callbackify} from 'node:util';
+import {getWritable} from '../pipe/validate.js';
+import {addConcurrentStream, waitForConcurrentStreams} from './concurrent.js';
+import {
+	safeWaitForSubprocessStdout,
+	waitForSubprocessStdin,
+	waitForSubprocess,
+	destroyOtherStream,
+} from './shared.js';
+
+// Create a `Writable` stream that forwards to `stdin` and awaits the subprocess
+export const createWritable = ({subprocess, concurrentStreams}, {to} = {}) => {
+	const {subprocessStdin, waitWritableFinal, waitWritableDestroy} = getSubprocessStdin(subprocess, to, concurrentStreams);
+	const writable = new Writable({
+		...getWritableMethods(subprocessStdin, subprocess, waitWritableFinal),
+		destroy: callbackify(onWritableDestroy.bind(undefined, {subprocessStdin, subprocess, waitWritableFinal, waitWritableDestroy})),
+		highWaterMark: subprocessStdin.writableHighWaterMark,
+		objectMode: subprocessStdin.writableObjectMode,
+	});
+	onStdinFinished(subprocessStdin, writable);
+	return writable;
+};
+
+// Retrieve `stdin` (or other stream depending on `to`)
+export const getSubprocessStdin = (subprocess, to, concurrentStreams) => {
+	const subprocessStdin = getWritable(subprocess, to);
+	const waitWritableFinal = addConcurrentStream(concurrentStreams, subprocessStdin, 'writableFinal');
+	const waitWritableDestroy = addConcurrentStream(concurrentStreams, subprocessStdin, 'writableDestroy');
+	return {subprocessStdin, waitWritableFinal, waitWritableDestroy};
+};
+
+export const getWritableMethods = (subprocessStdin, subprocess, waitWritableFinal) => ({
+	write: onWrite.bind(undefined, subprocessStdin),
+	final: callbackify(onWritableFinal.bind(undefined, subprocessStdin, subprocess, waitWritableFinal)),
+});
+
+// Forwards data from `writable` to `stdin`
+const onWrite = (subprocessStdin, chunk, encoding, done) => {
+	if (subprocessStdin.write(chunk, encoding)) {
+		done();
+	} else {
+		subprocessStdin.once('drain', done);
+	}
+};
+
+// Ensures that the writable `final` and readable `end` events awaits the subprocess.
+// Like this, any subprocess failure is propagated as a stream `error` event, instead of being lost.
+// The user does not need to `await` the subprocess anymore, but now needs to await the stream completion or error.
+// When multiple writables are targeting the same stream, they wait for each other, unless the subprocess ends first.
+const onWritableFinal = async (subprocessStdin, subprocess, waitWritableFinal) => {
+	if (await waitForConcurrentStreams(waitWritableFinal, subprocess)) {
+		if (subprocessStdin.writable) {
+			subprocessStdin.end();
+		}
+
+		await subprocess;
+	}
+};
+
+// When `subprocess.stdin` ends/aborts/errors, do the same on `writable`.
+export const onStdinFinished = async (subprocessStdin, writable, subprocessStdout) => {
+	try {
+		await waitForSubprocessStdin(subprocessStdin);
+		if (writable.writable) {
+			writable.end();
+		}
+	} catch (error) {
+		await safeWaitForSubprocessStdout(subprocessStdout);
+		destroyOtherWritable(writable, error);
+	}
+};
+
+// When `writable` aborts/errors, do the same on `subprocess.stdin`
+export const onWritableDestroy = async ({subprocessStdin, subprocess, waitWritableFinal, waitWritableDestroy}, error) => {
+	await waitForConcurrentStreams(waitWritableFinal, subprocess);
+	if (await waitForConcurrentStreams(waitWritableDestroy, subprocess)) {
+		destroyOtherWritable(subprocessStdin, error);
+		await waitForSubprocess(subprocess, error);
+	}
+};
+
+const destroyOtherWritable = (stream, error) => {
+	destroyOtherStream(stream, stream.writable, error);
+};

--- a/lib/pipe/validate.js
+++ b/lib/pipe/validate.js
@@ -73,7 +73,7 @@ const PIPED_SUBPROCESS_OPTIONS = {stdin: 'pipe', piped: true};
 
 export const SUBPROCESS_OPTIONS = new WeakMap();
 
-const getWritable = (destination, to = 'stdin') => {
+export const getWritable = (destination, to = 'stdin') => {
 	const isWritable = true;
 	const {options, stdioStreamsGroups} = SUBPROCESS_OPTIONS.get(destination);
 	const fdNumber = getFdNumber(stdioStreamsGroups, to, isWritable);
@@ -95,7 +95,7 @@ const getSourceStream = (source, from) => {
 	}
 };
 
-const getReadable = (source, from = 'stdout') => {
+export const getReadable = (source, from = 'stdout') => {
 	const isWritable = false;
 	const {options, stdioStreamsGroups} = SUBPROCESS_OPTIONS.get(source);
 	const fdNumber = getFdNumber(stdioStreamsGroups, from, isWritable);

--- a/lib/return/early-error.js
+++ b/lib/return/early-error.js
@@ -1,5 +1,5 @@
 import {ChildProcess} from 'node:child_process';
-import {PassThrough} from 'node:stream';
+import {PassThrough, Readable, Writable, Duplex} from 'node:stream';
 import {cleanupStdioStreams} from '../stdio/async.js';
 import {makeEarlyError} from './error.js';
 import {handleResult} from './output.js';
@@ -11,6 +11,7 @@ export const handleEarlyError = ({error, command, escapedCommand, stdioStreamsGr
 
 	const subprocess = new ChildProcess();
 	createDummyStreams(subprocess, stdioStreamsGroups);
+	Object.assign(subprocess, {readable, writable, duplex});
 
 	const earlyError = makeEarlyError({error, command, escapedCommand, stdioStreamsGroups, options, startTime, isSync: false});
 	const promise = handleDummyPromise(earlyError, verboseInfo, options);
@@ -32,5 +33,9 @@ const createDummyStream = () => {
 	stream.end();
 	return stream;
 };
+
+const readable = () => new Readable({read() {}});
+const writable = () => new Writable({write() {}});
+const duplex = () => new Duplex({read() {}, write() {}});
 
 const handleDummyPromise = async (error, verboseInfo, options) => handleResult(error, verboseInfo, options);

--- a/lib/stream/wait.js
+++ b/lib/stream/wait.js
@@ -89,7 +89,7 @@ export const isInputFileDescriptor = (fdNumber, stdioStreamsGroups) => {
 // When `stream.destroy()` is called without an `error` argument, stream is aborted.
 // This is the only way to abort a readable stream, which can be useful in some instances.
 // Therefore, we ignore this error on readable streams.
-const isStreamAbort = error => error?.code === 'ERR_STREAM_PREMATURE_CLOSE';
+export const isStreamAbort = error => error?.code === 'ERR_STREAM_PREMATURE_CLOSE';
 
 // When `stream.write()` is called but the underlying source has been closed, `EPIPE` is emitted.
 // When piping subprocesses, the source subprocess usually decides when to stop piping.

--- a/readme.md
+++ b/readme.md
@@ -438,6 +438,63 @@ When an error is passed as argument, it is set to the subprocess' [`error.cause`
 
 [More info.](https://nodejs.org/api/child_process.html#subprocesskillsignal)
 
+#### readable(streamOptions?)
+
+`streamOptions`: [`StreamOptions`](#streamoptions)\
+_Returns_: [`Readable`](https://nodejs.org/api/stream.html#class-streamreadable) Node.js stream
+
+Converts the subprocess to a readable stream.
+
+Unlike [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), the stream waits for the subprocess to end and emits an [`error`](https://nodejs.org/api/stream.html#event-error) event if the subprocess [fails](#subprocessresult). This means you do not need to `await` the subprocess' [promise](#subprocess). On the other hand, you do need to handle to the stream `error` event. This can be done by using [`await finished(stream)`](https://nodejs.org/api/stream.html#streamfinishedstream-options), [`await pipeline(..., stream)`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options) or [`await text(stream)`](https://nodejs.org/api/webstreams.html#streamconsumerstextstream) which throw an exception when the stream errors.
+
+Before using this method, please first consider the [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1)/[`stdio`](#stdio-1) options or the [`subprocess.pipe()`](#pipefile-arguments-options) method.
+
+#### writable(streamOptions?)
+
+`streamOptions`: [`StreamOptions`](#streamoptions)\
+_Returns_: [`Writable`](https://nodejs.org/api/stream.html#class-streamwritable) Node.js stream
+
+Converts the subprocess to a writable stream.
+
+Unlike [`subprocess.stdin`](https://nodejs.org/api/child_process.html#subprocessstdin), the stream waits for the subprocess to end and emits an [`error`](https://nodejs.org/api/stream.html#event-error) event if the subprocess [fails](#subprocessresult). This means you do not need to `await` the subprocess' [promise](#subprocess). On the other hand, you do need to handle to the stream `error` event. This can be done by using [`await finished(stream)`](https://nodejs.org/api/stream.html#streamfinishedstream-options) or [`await pipeline(stream, ...)`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options) which throw an exception when the stream errors.
+
+Before using this method, please first consider the [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1)/[`stdio`](#stdio-1) options or the [`subprocess.pipe()`](#pipefile-arguments-options) method.
+
+#### duplex(streamOptions?)
+
+`streamOptions`: [`StreamOptions`](#streamoptions)\
+_Returns_: [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) Node.js stream
+
+Converts the subprocess to a duplex stream.
+
+The stream waits for the subprocess to end and emits an [`error`](https://nodejs.org/api/stream.html#event-error) event if the subprocess [fails](#subprocessresult). This means you do not need to `await` the subprocess' [promise](#subprocess). On the other hand, you do need to handle to the stream `error` event. This can be done by using [`await finished(stream)`](https://nodejs.org/api/stream.html#streamfinishedstream-options), [`await pipeline(..., stream, ...)`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options) or [`await text(stream)`](https://nodejs.org/api/webstreams.html#streamconsumerstextstream) which throw an exception when the stream errors.
+
+Before using this method, please first consider the [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1)/[`stdio`](#stdio-1) options or the [`subprocess.pipe()`](#pipefile-arguments-options) method.
+
+##### streamOptions
+
+Type: `object`
+
+##### streamOptions.from
+
+Type: `"stdout" | "stderr" | "all" | number`\
+Default: `"stdout"`
+
+Which stream to read from the subprocess. A file descriptor number can also be passed.
+
+`"all"` reads both `stdout` and `stderr`. This requires the [`all` option](#all-2) to be `true`.
+
+Only available with [`.readable()`](#readablestreamoptions) and [`.duplex()`](#duplexstreamoptions), not [`.writable()`](#writablestreamoptions).
+
+##### streamOptions.to
+
+Type: `"stdin" | number`\
+Default: `"stdin"`
+
+Which stream to write to the subprocess. A file descriptor number can also be passed.
+
+Only available with [`.writable()`](#writablestreamoptions) and [`.duplex()`](#duplexstreamoptions), not [`.readable()`](#readablestreamoptions).
+
 ### SubprocessResult
 
 Type: `object`
@@ -844,7 +901,7 @@ Default: `false`
 
 Split `stdout` and `stderr` into lines.
 - [`result.stdout`](#stdout), [`result.stderr`](#stderr), [`result.all`](#all-1) and [`result.stdio`](#stdio) are arrays of lines.
-- [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), [`subprocess.all`](#all) and [`subprocess.stdio`](https://nodejs.org/api/child_process.html#subprocessstdio) iterate over lines instead of arbitrary chunks.
+- [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), [`subprocess.all`](#all), [`subprocess.stdio`](https://nodejs.org/api/child_process.html#subprocessstdio), [`subprocess.readable()`](#readablestreamoptions) and [`subprocess.duplex`](#duplexstreamoptions) iterate over lines instead of arbitrary chunks.
 - Any stream passed to the [`stdout`](#stdout-1), [`stderr`](#stderr-1) or [`stdio`](#stdio-1) option receives lines instead of arbitrary chunks.
 
 #### encoding

--- a/test/convert/concurrent.js
+++ b/test/convert/concurrent.js
@@ -1,0 +1,372 @@
+import {setTimeout} from 'node:timers/promises';
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {foobarString} from '../helpers/input.js';
+import {fullReadableStdio} from '../helpers/stdio.js';
+import {
+	finishedStream,
+	assertStreamOutput,
+	assertStreamError,
+	assertStreamReadError,
+	assertSubprocessOutput,
+	assertSubprocessError,
+	getReadWriteSubprocess,
+} from '../helpers/convert.js';
+
+setFixtureDir();
+
+const endStream = async stream => {
+	stream.end(foobarString);
+	await setTimeout(0);
+};
+
+// eslint-disable-next-line max-params
+const endSameWritable = async (t, stream, secondStream, subprocess, fdNumber) => {
+	await endStream(stream);
+	t.true(subprocess.stdio[fdNumber].writable);
+
+	await endStream(secondStream);
+	t.false(subprocess.stdio[fdNumber].writable);
+};
+
+// eslint-disable-next-line max-params
+const endDifferentWritable = async (t, stream, secondStream, subprocess, fdNumber = 0, secondFdNumber = 3) => {
+	await endStream(stream);
+	t.false(subprocess.stdio[fdNumber].writable);
+	t.true(subprocess.stdio[secondFdNumber].writable);
+
+	await endStream(secondStream);
+	t.false(subprocess.stdio[secondFdNumber].writable);
+};
+
+const testReadableTwice = async (t, fdNumber, from) => {
+	const subprocess = execa('noop-fd.js', [`${fdNumber}`, foobarString]);
+	const stream = subprocess.readable({from});
+	const secondStream = subprocess.readable({from});
+
+	await Promise.all([
+		assertStreamOutput(t, stream),
+		assertStreamOutput(t, secondStream),
+	]);
+	await assertSubprocessOutput(t, subprocess, foobarString, fdNumber);
+};
+
+test('Can call .readable() twice on same file descriptor', testReadableTwice, 1, undefined);
+test('Can call .readable({from: "stderr"}) twice on same file descriptor', testReadableTwice, 2, 'stderr');
+
+const testWritableTwice = async (t, fdNumber, options) => {
+	const subprocess = execa('stdin-fd.js', [`${fdNumber}`], options);
+	const stream = subprocess.writable({to: fdNumber});
+	const secondStream = subprocess.writable({to: fdNumber});
+
+	await Promise.all([
+		finishedStream(stream),
+		finishedStream(secondStream),
+		endSameWritable(t, stream, secondStream, subprocess, fdNumber),
+	]);
+	await assertSubprocessOutput(t, subprocess, `${foobarString}${foobarString}`);
+};
+
+test('Can call .writable() twice on same file descriptor', testWritableTwice, 0, {});
+test('Can call .writable({to: 3}) twice on same file descriptor', testWritableTwice, 3, fullReadableStdio());
+
+const testDuplexTwice = async (t, fdNumber, options) => {
+	const subprocess = execa('stdin-fd.js', [`${fdNumber}`], options);
+	const stream = subprocess.duplex({to: fdNumber});
+	const secondStream = subprocess.duplex({to: fdNumber});
+
+	const expectedOutput = `${foobarString}${foobarString}`;
+	await Promise.all([
+		assertStreamOutput(t, stream, expectedOutput),
+		assertStreamOutput(t, secondStream, expectedOutput),
+		endSameWritable(t, stream, secondStream, subprocess, fdNumber),
+	]);
+	await assertSubprocessOutput(t, subprocess, expectedOutput);
+};
+
+test('Can call .duplex() twice on same file descriptor', testDuplexTwice, 0, {});
+test('Can call .duplex({to: 3}) twice on same file descriptor', testDuplexTwice, 3, fullReadableStdio());
+
+test('Can call .duplex() twice on same readable file descriptor but different writable one', async t => {
+	const subprocess = execa('stdin-fd-both.js', ['3'], fullReadableStdio());
+	const stream = subprocess.duplex({to: 0});
+	const secondStream = subprocess.duplex({to: 3});
+
+	const expectedOutput = `${foobarString}${foobarString}`;
+	await Promise.all([
+		assertStreamOutput(t, stream, expectedOutput),
+		assertStreamOutput(t, secondStream, expectedOutput),
+		endDifferentWritable(t, stream, secondStream, subprocess),
+	]);
+	await assertSubprocessOutput(t, subprocess, expectedOutput);
+});
+
+test('Can call .readable() twice on different file descriptors', async t => {
+	const subprocess = execa('noop-both.js', [foobarString]);
+	const stream = subprocess.readable();
+	const secondStream = subprocess.readable({from: 'stderr'});
+
+	const expectedOutput = `${foobarString}\n`;
+	await Promise.all([
+		assertStreamOutput(t, stream, expectedOutput),
+		assertStreamOutput(t, secondStream, expectedOutput),
+	]);
+	await assertSubprocessOutput(t, subprocess);
+	await assertSubprocessOutput(t, subprocess, foobarString, 2);
+});
+
+test('Can call .writable() twice on different file descriptors', async t => {
+	const subprocess = execa('stdin-fd-both.js', ['3'], fullReadableStdio());
+	const stream = subprocess.writable();
+	const secondStream = subprocess.writable({to: 3});
+
+	await Promise.all([
+		finishedStream(stream),
+		finishedStream(secondStream),
+		endDifferentWritable(t, stream, secondStream, subprocess),
+	]);
+	await assertSubprocessOutput(t, subprocess, `${foobarString}${foobarString}`);
+});
+
+test('Can call .duplex() twice on different file descriptors', async t => {
+	const subprocess = execa('stdin-twice-both.js', ['3'], fullReadableStdio());
+	const stream = subprocess.duplex();
+	const secondStream = subprocess.duplex({from: 'stderr', to: 3});
+
+	await Promise.all([
+		assertStreamOutput(t, stream),
+		assertStreamOutput(t, secondStream),
+		endDifferentWritable(t, stream, secondStream, subprocess),
+	]);
+	await assertSubprocessOutput(t, subprocess);
+	await assertSubprocessOutput(t, subprocess, foobarString, 2);
+});
+
+test('Can call .readable() and .writable()', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.writable();
+	const secondStream = subprocess.readable();
+	stream.end(foobarString);
+
+	await Promise.all([
+		finishedStream(stream),
+		assertStreamOutput(t, secondStream),
+	]);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('Can call .writable() and .duplex()', async t => {
+	const subprocess = execa('stdin-fd-both.js', ['3'], fullReadableStdio());
+	const stream = subprocess.duplex();
+	const secondStream = subprocess.writable({to: 3});
+
+	const expectedOutput = `${foobarString}${foobarString}`;
+	await Promise.all([
+		assertStreamOutput(t, stream, expectedOutput),
+		finishedStream(secondStream),
+		endDifferentWritable(t, stream, secondStream, subprocess),
+	]);
+	await assertSubprocessOutput(t, subprocess, expectedOutput);
+});
+
+test('Can call .readable() and .duplex()', async t => {
+	const subprocess = execa('stdin-both.js');
+	const stream = subprocess.duplex();
+	const secondStream = subprocess.readable({from: 'stderr'});
+	stream.end(foobarString);
+
+	await Promise.all([
+		assertStreamOutput(t, stream),
+		assertStreamOutput(t, secondStream),
+	]);
+	await assertSubprocessOutput(t, subprocess);
+	await assertSubprocessOutput(t, subprocess, foobarString, 2);
+});
+
+test('Can error one of two .readable() on same file descriptor', async t => {
+	const subprocess = execa('noop-fd.js', ['1', foobarString]);
+	const stream = subprocess.readable();
+	const secondStream = subprocess.readable();
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+
+	await Promise.all([
+		assertStreamReadError(t, stream, cause),
+		assertStreamOutput(t, secondStream),
+	]);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('Can error both .readable() on same file descriptor', async t => {
+	const subprocess = execa('noop-fd.js', ['1', foobarString]);
+	const stream = subprocess.readable();
+	const secondStream = subprocess.readable();
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+	secondStream.destroy(cause);
+
+	const [error, secondError] = await Promise.all([
+		assertStreamReadError(t, stream, {cause}),
+		assertStreamReadError(t, secondStream, {cause}),
+	]);
+	t.is(error, secondError);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('Can error one of two .readable() on different file descriptors', async t => {
+	const subprocess = execa('noop-both.js', [foobarString]);
+	const stream = subprocess.readable();
+	const secondStream = subprocess.readable({from: 'stderr'});
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+
+	const [error, secondError] = await Promise.all([
+		assertStreamReadError(t, stream, {cause}),
+		assertStreamReadError(t, secondStream, {cause}),
+	]);
+	t.is(error, secondError);
+	t.is(error.stderr, foobarString);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('Can error both .readable() on different file descriptors', async t => {
+	const subprocess = execa('noop-both.js', [foobarString]);
+	const stream = subprocess.readable();
+	const secondStream = subprocess.readable({from: 'stderr'});
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+	secondStream.destroy(cause);
+
+	const [error, secondError] = await Promise.all([
+		assertStreamReadError(t, stream, {cause}),
+		assertStreamReadError(t, secondStream, {cause}),
+	]);
+	t.is(error, secondError);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('Can error one of two .writable() on same file descriptor', async t => {
+	const subprocess = execa('stdin.js');
+	const stream = subprocess.writable();
+	const secondStream = subprocess.writable();
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+	secondStream.end(foobarString);
+
+	await Promise.all([
+		assertStreamError(t, stream, cause),
+		finishedStream(secondStream),
+	]);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('Can error both .writable() on same file descriptor', async t => {
+	const subprocess = execa('stdin.js');
+	const stream = subprocess.writable();
+	const secondStream = subprocess.writable();
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+	secondStream.destroy(cause);
+
+	const [error, secondError] = await Promise.all([
+		assertStreamError(t, stream, {cause}),
+		assertStreamError(t, secondStream, {cause}),
+	]);
+	t.is(error, secondError);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('Can error one of two .writable() on different file descriptors', async t => {
+	const subprocess = execa('stdin-fd-both.js', ['3'], fullReadableStdio());
+	const stream = subprocess.writable();
+	const secondStream = subprocess.writable({to: 3});
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+	secondStream.end(foobarString);
+
+	const [error, secondError] = await Promise.all([
+		assertStreamError(t, stream, {cause}),
+		assertStreamError(t, secondStream, {cause}),
+	]);
+	t.is(error, secondError);
+	t.is(error.stdout, foobarString);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('Can error both .writable() on different file descriptors', async t => {
+	const subprocess = execa('stdin-fd-both.js', ['3'], fullReadableStdio());
+	const stream = subprocess.writable();
+	const secondStream = subprocess.writable({to: 3});
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+	secondStream.destroy(cause);
+
+	const [error, secondError] = await Promise.all([
+		assertStreamError(t, stream, {cause}),
+		assertStreamError(t, secondStream, {cause}),
+	]);
+	t.is(error, secondError);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('Can error one of two .duplex() on same file descriptor', async t => {
+	const subprocess = execa('stdin.js');
+	const stream = subprocess.duplex();
+	const secondStream = subprocess.duplex();
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+	secondStream.end(foobarString);
+
+	await Promise.all([
+		assertStreamReadError(t, stream, cause),
+		assertStreamOutput(t, secondStream),
+	]);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('Can error both .duplex() on same file descriptor', async t => {
+	const subprocess = execa('stdin.js');
+	const stream = subprocess.duplex();
+	const secondStream = subprocess.duplex();
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+	secondStream.destroy(cause);
+
+	await Promise.all([
+		assertStreamReadError(t, stream, cause),
+		assertStreamReadError(t, secondStream, cause),
+	]);
+	await assertSubprocessError(t, subprocess, {cause});
+});
+
+test('Can error one of two .duplex() on different file descriptors', async t => {
+	const subprocess = execa('stdin-twice-both.js', ['3'], fullReadableStdio());
+	const stream = subprocess.duplex();
+	const secondStream = subprocess.duplex({from: 'stderr', to: 3});
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+	secondStream.end(foobarString);
+
+	const [error] = await Promise.all([
+		assertStreamReadError(t, secondStream, {cause}),
+		assertStreamReadError(t, stream, cause),
+	]);
+	t.is(error.stderr, foobarString);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('Can error both .duplex() on different file descriptors', async t => {
+	const subprocess = execa('stdin-twice-both.js', ['3'], fullReadableStdio());
+	const stream = subprocess.duplex();
+	const secondStream = subprocess.duplex({from: 'stderr', to: 3});
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+	secondStream.destroy(cause);
+
+	await Promise.all([
+		assertStreamReadError(t, stream, cause),
+		assertStreamReadError(t, secondStream, cause),
+	]);
+	await assertSubprocessError(t, subprocess, {cause});
+});

--- a/test/convert/duplex.js
+++ b/test/convert/duplex.js
@@ -1,0 +1,188 @@
+import {compose, Readable, Writable, PassThrough} from 'node:stream';
+import {pipeline} from 'node:stream/promises';
+import {text} from 'node:stream/consumers';
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {
+	finishedStream,
+	assertReadableAborted,
+	assertWritableAborted,
+	assertProcessNormalExit,
+	assertStreamOutput,
+	assertStreamError,
+	assertStreamReadError,
+	assertSubprocessOutput,
+	assertSubprocessError,
+	assertPromiseError,
+	getReadWriteSubprocess,
+} from '../helpers/convert.js';
+import {foobarString} from '../helpers/input.js';
+import {prematureClose, fullStdio, fullReadableStdio} from '../helpers/stdio.js';
+import {defaultHighWaterMark} from '../helpers/stream.js';
+
+setFixtureDir();
+
+test('.duplex() success', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.duplex();
+
+	t.true(stream instanceof Writable);
+	t.true(stream.writable);
+	t.true(stream instanceof Readable);
+	t.true(stream.readable);
+
+	stream.end(foobarString);
+
+	await assertStreamOutput(t, stream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+// eslint-disable-next-line max-params
+const testReadableDuplexDefault = async (t, fdNumber, from, options, hasResult) => {
+	const subprocess = execa('noop-stdin-fd.js', [`${fdNumber}`], options);
+	const stream = subprocess.duplex({from});
+	stream.end(foobarString);
+
+	await assertStreamOutput(t, stream, hasResult ? foobarString : '');
+	await assertSubprocessOutput(t, subprocess, foobarString, fdNumber);
+};
+
+test('.duplex() can use stdout', testReadableDuplexDefault, 1, 1, {}, true);
+test('.duplex() can use stderr', testReadableDuplexDefault, 2, 2, {}, true);
+test('.duplex() can use output stdio[*]', testReadableDuplexDefault, 3, 3, fullStdio, true);
+test('.duplex() uses stdout by default', testReadableDuplexDefault, 1, undefined, {}, true);
+test('.duplex() does not use stderr by default', testReadableDuplexDefault, 2, undefined, {}, false);
+test('.duplex() does not use stdio[*] by default', testReadableDuplexDefault, 3, undefined, fullStdio, false);
+test('.duplex() uses stdout even if stderr is "ignore"', testReadableDuplexDefault, 1, 1, {stderr: 'ignore'}, true);
+test('.duplex() uses stderr even if stdout is "ignore"', testReadableDuplexDefault, 2, 2, {stdout: 'ignore'}, true);
+test('.duplex() uses stdout if "all" is used', testReadableDuplexDefault, 1, 'all', {all: true}, true);
+test('.duplex() uses stderr if "all" is used', testReadableDuplexDefault, 2, 'all', {all: true}, true);
+
+const testWritableDuplexDefault = async (t, fdNumber, to, options) => {
+	const subprocess = execa('stdin-fd.js', [`${fdNumber}`], options);
+	const stream = subprocess.duplex({to});
+
+	stream.end(foobarString);
+
+	await assertStreamOutput(t, stream, foobarString);
+	await assertSubprocessOutput(t, subprocess);
+};
+
+test('.duplex() can use stdin', testWritableDuplexDefault, 0, 0, {});
+test('.duplex() can use input stdio[*]', testWritableDuplexDefault, 3, 3, fullReadableStdio());
+test('.duplex() uses stdin by default', testWritableDuplexDefault, 0, undefined, {});
+
+test('.duplex() abort -> subprocess fail', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.duplex();
+	const textPromise = text(stream);
+
+	stream.destroy();
+
+	const error = await t.throwsAsync(textPromise);
+	t.like(error, prematureClose);
+	assertProcessNormalExit(t, error);
+	assertWritableAborted(t, subprocess.stdin);
+	assertReadableAborted(t, subprocess.stdout);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.duplex() error -> subprocess fail', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.duplex();
+
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+
+	const error = await assertStreamError(t, stream, {cause});
+	assertProcessNormalExit(t, error);
+	t.is(subprocess.stdin.errored, cause);
+	t.is(subprocess.stdout.errored, cause);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.duplex() can be used with Stream.pipeline()', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const inputStream = Readable.from([foobarString]);
+	const stream = subprocess.duplex();
+	const outputStream = new PassThrough();
+
+	await pipeline(inputStream, stream, outputStream);
+
+	await finishedStream(inputStream);
+	await finishedStream(stream);
+	await assertStreamOutput(t, outputStream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('.duplex() can error with Stream.pipeline()', async t => {
+	const subprocess = execa('stdin-fail.js');
+	const inputStream = Readable.from([foobarString]);
+	const stream = subprocess.duplex();
+	const outputStream = new PassThrough();
+
+	const error = await t.throwsAsync(pipeline(inputStream, stream, outputStream));
+	assertProcessNormalExit(t, error, 2);
+	t.like(error, {stdout: foobarString});
+
+	await finishedStream(inputStream);
+	await assertStreamError(t, stream, error);
+	await assertStreamReadError(t, outputStream, error);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.duplex() can pipe to errored stream with Stream.pipeline()', async t => {
+	const subprocess = execa('stdin-fail.js');
+	const inputStream = Readable.from([foobarString]);
+	const stream = subprocess.duplex();
+	const outputStream = new PassThrough();
+
+	const cause = new Error('test');
+	outputStream.destroy(cause);
+
+	await assertPromiseError(t, pipeline(inputStream, stream, outputStream), cause);
+
+	await assertStreamError(t, inputStream, cause);
+	const error = await assertStreamError(t, stream, {cause});
+	await assertStreamReadError(t, outputStream, cause);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.duplex() can be piped to errored stream with Stream.pipeline()', async t => {
+	const subprocess = execa('stdin-fail.js');
+	const inputStream = Readable.from([foobarString]);
+	const stream = subprocess.duplex();
+	const outputStream = new PassThrough();
+
+	const cause = new Error('test');
+	inputStream.destroy(cause);
+
+	await assertPromiseError(t, pipeline(inputStream, stream, outputStream), cause);
+
+	await assertStreamError(t, inputStream, cause);
+	const error = await assertStreamError(t, stream, {cause});
+	await assertStreamReadError(t, outputStream, cause);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.duplex() can be used with Stream.compose()', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const inputStream = Readable.from([foobarString]);
+	const stream = subprocess.duplex();
+	const outputStream = new PassThrough();
+
+	await assertStreamOutput(t, compose(inputStream, stream, outputStream));
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('.duplex() has the right highWaterMark', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.duplex();
+	t.is(stream.readableHighWaterMark, defaultHighWaterMark);
+	t.is(stream.writableHighWaterMark, defaultHighWaterMark);
+	stream.end();
+	await text(stream);
+});

--- a/test/convert/readable.js
+++ b/test/convert/readable.js
@@ -1,0 +1,454 @@
+import {once} from 'node:events';
+import process from 'node:process';
+import {compose, Readable, Writable, PassThrough, getDefaultHighWaterMark} from 'node:stream';
+import {pipeline} from 'node:stream/promises';
+import {text} from 'node:stream/consumers';
+import {setTimeout} from 'node:timers/promises';
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {
+	finishedStream,
+	assertReadableAborted,
+	assertWritableAborted,
+	assertProcessNormalExit,
+	assertStreamOutput,
+	assertStreamError,
+	assertStreamReadError,
+	assertSubprocessOutput,
+	assertSubprocessError,
+	assertPromiseError,
+	getReadableSubprocess,
+	getReadWriteSubprocess,
+} from '../helpers/convert.js';
+import {foobarString, foobarBuffer, foobarObject} from '../helpers/input.js';
+import {prematureClose, fullStdio} from '../helpers/stdio.js';
+import {outputObjectGenerator, getChunksGenerator} from '../helpers/generator.js';
+import {defaultHighWaterMark, defaultObjectHighWaterMark} from '../helpers/stream.js';
+
+setFixtureDir();
+
+test('.readable() success', async t => {
+	const subprocess = getReadableSubprocess();
+	const stream = subprocess.readable();
+
+	t.false(stream instanceof Writable);
+	t.is(stream.writable, undefined);
+	t.true(stream instanceof Readable);
+	t.true(stream.readable);
+
+	await assertStreamOutput(t, stream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+// eslint-disable-next-line max-params
+const testReadableDefault = async (t, fdNumber, from, options, hasResult) => {
+	const subprocess = execa('noop-stdin-fd.js', [`${fdNumber}`], options);
+	const stream = subprocess.readable({from});
+	subprocess.stdin.end(foobarString);
+
+	await assertStreamOutput(t, stream, hasResult ? foobarString : '');
+	await assertSubprocessOutput(t, subprocess, foobarString, fdNumber);
+};
+
+test('.readable() can use stdout', testReadableDefault, 1, 1, {}, true);
+test('.readable() can use stderr', testReadableDefault, 2, 2, {}, true);
+test('.readable() can use stdio[*]', testReadableDefault, 3, 3, fullStdio, true);
+test('.readable() uses stdout by default', testReadableDefault, 1, undefined, {}, true);
+test('.readable() does not use stderr by default', testReadableDefault, 2, undefined, {}, false);
+test('.readable() does not use stdio[*] by default', testReadableDefault, 3, undefined, fullStdio, false);
+test('.readable() uses stdout even if stderr is "ignore"', testReadableDefault, 1, 1, {stderr: 'ignore'}, true);
+test('.readable() uses stderr even if stdout is "ignore"', testReadableDefault, 2, 2, {stdout: 'ignore'}, true);
+test('.readable() uses stdout if "all" is used', testReadableDefault, 1, 'all', {all: true}, true);
+test('.readable() uses stderr if "all" is used', testReadableDefault, 2, 'all', {all: true}, true);
+
+const testBuffering = async (t, methodName) => {
+	const subprocess = execa('noop-stdin-fd.js', ['1'], {buffer: false});
+	const stream = subprocess[methodName]();
+
+	subprocess.stdin.write(foobarString);
+	await once(subprocess.stdout, 'readable');
+	subprocess.stdin.end();
+
+	await assertStreamOutput(t, stream);
+};
+
+test('.readable() buffers until read', testBuffering, 'readable');
+test('.duplex() buffers until read', testBuffering, 'duplex');
+
+test('.readable() abort -> subprocess fail', async t => {
+	const subprocess = execa('noop-repeat.js');
+	const stream = subprocess.readable();
+
+	stream.destroy();
+
+	const error = await t.throwsAsync(text(stream));
+	assertProcessNormalExit(t, error, 1);
+	t.true(error.message.includes('EPIPE'));
+	assertWritableAborted(t, subprocess.stdin);
+	assertReadableAborted(t, subprocess.stdout);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.readable() error -> subprocess fail', async t => {
+	const subprocess = execa('noop-repeat.js');
+	const stream = subprocess.readable();
+
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+
+	const error = await assertStreamReadError(t, stream, {cause});
+	assertProcessNormalExit(t, error, 1);
+	t.true(error.message.includes('EPIPE'));
+	assertWritableAborted(t, subprocess.stdin);
+	t.is(subprocess.stdout.errored, cause);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+const testStdoutAbort = async (t, methodName) => {
+	const subprocess = execa('ipc-exit.js', {ipc: true});
+	const stream = subprocess[methodName]();
+
+	subprocess.stdout.destroy();
+	subprocess.send(foobarString);
+
+	const [error, [message]] = await Promise.all([
+		t.throwsAsync(finishedStream(stream)),
+		once(subprocess, 'message'),
+	]);
+	t.like(error, prematureClose);
+	t.is(message, foobarString);
+	assertWritableAborted(t, subprocess.stdin);
+	assertReadableAborted(t, subprocess.stdout);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessOutput(t, subprocess, '');
+};
+
+test('subprocess.stdout abort + no more writes -> .readable() error + subprocess success', testStdoutAbort, 'readable');
+test('subprocess.stdout abort + no more writes -> .duplex() error + subprocess success', testStdoutAbort, 'duplex');
+
+const testStdoutError = async (t, methodName) => {
+	const subprocess = execa('ipc-exit.js', {ipc: true});
+	const stream = subprocess[methodName]();
+
+	const cause = new Error(foobarString);
+	subprocess.stdout.destroy(cause);
+	subprocess.send(foobarString);
+
+	const [error, [message]] = await Promise.all([
+		t.throwsAsync(finishedStream(stream)),
+		once(subprocess, 'message'),
+	]);
+	t.is(message, foobarString);
+	t.is(error.cause, cause);
+	assertProcessNormalExit(t, error);
+	t.is(subprocess.stdout.errored, cause);
+	t.true(subprocess.stderr.readableEnded);
+	assertWritableAborted(t, subprocess.stdin);
+
+	await assertSubprocessError(t, subprocess, error);
+};
+
+test('subprocess.stdout error + no more writes -> .readable() error + subprocess fail', testStdoutError, 'readable');
+test('subprocess.stdout error + no more writes -> .duplex() error + subprocess fail', testStdoutError, 'duplex');
+
+const testStdinAbortWrites = async (t, methodName) => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess[methodName]();
+
+	subprocess.stdout.destroy();
+	subprocess.stdin.end(foobarString);
+
+	const error = await t.throwsAsync(finishedStream(stream));
+	assertProcessNormalExit(t, error, 1);
+	t.true(subprocess.stdin.writableEnded);
+	assertReadableAborted(t, subprocess.stdout);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessError(t, subprocess, error);
+};
+
+test('subprocess.stdout abort + more writes -> .readable() error + subprocess fail', testStdinAbortWrites, 'readable');
+test('subprocess.stdout abort + more writes -> .duplex() error + subprocess fail', testStdinAbortWrites, 'duplex');
+
+const testStdinErrorWrites = async (t, methodName) => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess[methodName]();
+
+	const cause = new Error(foobarString);
+	subprocess.stdout.destroy(cause);
+	subprocess.stdin.end(foobarString);
+
+	const error = await assertStreamError(t, stream, {cause});
+	assertProcessNormalExit(t, error, 1);
+	t.true(subprocess.stdin.writableEnded);
+	t.is(subprocess.stdout.errored, cause);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessError(t, subprocess, error);
+};
+
+test('subprocess.stdout error + more writes -> .readable() error + subprocess fail', testStdinErrorWrites, 'readable');
+test('subprocess.stdout error + more writes -> .duplex() error + subprocess fail', testStdinErrorWrites, 'duplex');
+
+test('.readable() can be used with Stream.pipeline()', async t => {
+	const subprocess = getReadableSubprocess();
+	const stream = subprocess.readable();
+	const outputStream = new PassThrough();
+
+	await pipeline(stream, outputStream);
+
+	await finishedStream(stream);
+	await assertStreamOutput(t, outputStream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('.readable() can error with Stream.pipeline()', async t => {
+	const subprocess = execa('noop-fail.js', ['1', foobarString]);
+	const stream = subprocess.readable();
+	const outputStream = new PassThrough();
+
+	const error = await t.throwsAsync(pipeline(stream, outputStream));
+	assertProcessNormalExit(t, error, 2);
+	t.like(error, {stdout: foobarString});
+
+	await assertStreamError(t, stream, error);
+	await assertStreamReadError(t, outputStream, error);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.readable() can pipe to errored stream with Stream.pipeline()', async t => {
+	const subprocess = getReadableSubprocess();
+	const stream = subprocess.readable();
+	const outputStream = new PassThrough();
+
+	const cause = new Error('test');
+	outputStream.destroy(cause);
+
+	await assertPromiseError(t, pipeline(stream, outputStream), cause);
+
+	const error = await assertStreamError(t, stream, {cause});
+	await assertStreamReadError(t, outputStream, cause);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.readable() can be used with Stream.compose()', async t => {
+	const subprocess = getReadableSubprocess();
+	const stream = subprocess.readable();
+	const outputStream = new PassThrough();
+
+	await assertStreamOutput(t, compose(stream, outputStream));
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('.readable() works with objectMode', async t => {
+	const subprocess = execa('noop.js', {stdout: outputObjectGenerator});
+	const stream = subprocess.readable();
+	t.true(stream.readableObjectMode);
+	t.is(stream.readableHighWaterMark, defaultObjectHighWaterMark);
+
+	t.deepEqual(await stream.toArray(), [foobarObject]);
+	await assertSubprocessOutput(t, subprocess, [foobarObject]);
+});
+
+test('.duplex() works with objectMode and reads', async t => {
+	const subprocess = getReadWriteSubprocess({stdout: outputObjectGenerator});
+	const stream = subprocess.duplex();
+	t.true(stream.readableObjectMode);
+	t.is(stream.readableHighWaterMark, defaultObjectHighWaterMark);
+	t.false(stream.writableObjectMode);
+	t.is(stream.writableHighWaterMark, defaultHighWaterMark);
+	stream.end(foobarString);
+
+	t.deepEqual(await stream.toArray(), [foobarObject]);
+	await assertSubprocessOutput(t, subprocess, [foobarObject]);
+});
+
+test('.readable() works with default encoding', async t => {
+	const subprocess = getReadableSubprocess();
+	const stream = subprocess.readable();
+	t.is(stream.readableEncoding, null);
+
+	t.deepEqual(await stream.toArray(), [foobarBuffer]);
+	await assertSubprocessOutput(t, subprocess, foobarString);
+});
+
+test('.duplex() works with default encoding', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.duplex();
+	t.is(stream.readableEncoding, null);
+	stream.end(foobarString);
+
+	t.deepEqual(await stream.toArray(), [foobarBuffer]);
+	await assertSubprocessOutput(t, subprocess, foobarString);
+});
+
+test('.readable() works with encoding "utf8"', async t => {
+	const subprocess = getReadableSubprocess();
+	subprocess.stdout.setEncoding('utf8');
+	const stream = subprocess.readable();
+	t.is(stream.readableEncoding, 'utf8');
+
+	t.deepEqual(await stream.toArray(), [foobarString]);
+	await assertSubprocessOutput(t, subprocess, foobarString);
+});
+
+test('.duplex() works with encoding "utf8"', async t => {
+	const subprocess = getReadWriteSubprocess();
+	subprocess.stdout.setEncoding('utf8');
+	const stream = subprocess.duplex();
+	t.is(stream.readableEncoding, 'utf8');
+	stream.end(foobarBuffer);
+
+	t.deepEqual(await stream.toArray(), [foobarString]);
+	await assertSubprocessOutput(t, subprocess, foobarString);
+});
+
+test('.readable() has the right highWaterMark', async t => {
+	const subprocess = execa('noop.js');
+	const stream = subprocess.readable();
+	t.is(stream.readableHighWaterMark, defaultHighWaterMark);
+	await text(stream);
+});
+
+test('.readable() can iterate over lines', async t => {
+	const subprocess = execa('noop-fd.js', ['1', 'aaa\nbbb\nccc'], {lines: true});
+	const lines = [];
+	for await (const line of subprocess.readable()) {
+		lines.push(line);
+	}
+
+	const expectedLines = ['aaa\n', 'bbb\n', 'ccc'];
+	t.deepEqual(lines, expectedLines);
+	await assertSubprocessOutput(t, subprocess, expectedLines);
+});
+
+test('.readable() can wait for data', async t => {
+	const subprocess = execa('noop.js', {stdout: getChunksGenerator([foobarString, foobarString])});
+	const stream = subprocess.readable();
+
+	t.is(stream.read(), null);
+	await once(stream, 'readable');
+	t.is(stream.read().toString(), foobarString);
+	t.is(stream.read(), null);
+	await once(stream, 'readable');
+	t.is(stream.read().toString(), foobarString);
+	t.is(stream.read(), null);
+	await once(stream, 'readable');
+	t.is(stream.read(), null);
+
+	await finishedStream(stream);
+	await assertSubprocessOutput(t, subprocess, `${foobarString}${foobarString}`);
+});
+
+const testBufferData = async (t, methodName) => {
+	const chunk = '.'.repeat(defaultHighWaterMark).repeat(2);
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess[methodName]();
+	subprocess.stdin.end(chunk);
+
+	await assertStreamOutput(t, stream, chunk);
+	await assertSubprocessOutput(t, subprocess, chunk);
+};
+
+test('.readable() can buffer data', testBufferData, 'readable');
+test('.duplex() can buffer data', testBufferData, 'duplex');
+
+const assertDataEvents = async (t, stream, subprocess) => {
+	const [output] = await once(stream, 'data');
+	t.is(output.toString(), foobarString);
+
+	await finishedStream(stream);
+	await assertSubprocessOutput(t, subprocess);
+};
+
+test('.readable() can be read with "data" events', async t => {
+	const subprocess = getReadableSubprocess();
+	const stream = subprocess.readable();
+
+	await assertDataEvents(t, stream, subprocess);
+});
+
+test('.duplex() can be read with "data" events', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.duplex();
+	stream.end(foobarString);
+
+	await assertDataEvents(t, stream, subprocess);
+});
+
+const assertPause = async (t, stream, subprocess) => {
+	const onceData = once(stream, 'data');
+	stream.pause();
+
+	t.is(stream.readableLength, 0);
+	do {
+		// eslint-disable-next-line no-await-in-loop
+		await setTimeout(10);
+	} while (stream.readableLength === 0);
+
+	t.false(await Promise.race([onceData, false]));
+
+	stream.resume();
+	const [output] = await onceData;
+	t.is(output.toString(), foobarString);
+
+	await finishedStream(stream);
+	await assertSubprocessOutput(t, subprocess);
+};
+
+test('.readable() can be paused', async t => {
+	const subprocess = getReadableSubprocess();
+	const stream = subprocess.readable();
+
+	await assertPause(t, stream, subprocess);
+});
+
+test('.duplex() can be paused', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.duplex();
+	stream.end(foobarString);
+
+	await assertPause(t, stream, subprocess);
+});
+
+// This feature does not work on Node 18.
+// @todo: remove after dropping support for Node 18.
+const majorVersion = Number(process.version.split('.')[0].slice(1));
+if (majorVersion >= 20) {
+	const testHighWaterMark = async (t, methodName) => {
+		const subprocess = execa('stdin.js');
+		const stream = subprocess[methodName]();
+
+		let count = 0;
+		const onPause = once(subprocess.stdout, 'pause');
+		for (; !subprocess.stdout.isPaused(); count += 1) {
+			subprocess.stdin.write('.');
+			// eslint-disable-next-line no-await-in-loop
+			await Promise.race([onPause, once(subprocess.stdout, 'data')]);
+		}
+
+		const expectedCount = getDefaultHighWaterMark(true) + 1;
+		const expectedOutput = '.'.repeat(expectedCount);
+		t.is(count, expectedCount);
+		subprocess.stdin.end();
+		await assertStreamOutput(t, stream, expectedOutput);
+		await assertSubprocessOutput(t, subprocess, expectedOutput);
+	};
+
+	test('.readable() pauses its buffering when too high', testHighWaterMark, 'readable');
+	test('.duplex() pauses its buffering when too high', testHighWaterMark, 'duplex');
+}
+
+const testBigOutput = async (t, methodName) => {
+	const bigChunk = '.'.repeat(1e6);
+	const subprocess = execa('stdin.js');
+	subprocess.stdin.end(bigChunk);
+	const stream = subprocess[methodName]();
+
+	await assertStreamOutput(t, stream, bigChunk);
+	await assertSubprocessOutput(t, subprocess, bigChunk);
+};
+
+test('.readable() with big output', testBigOutput, 'readable');
+test('.duplex() with big output', testBigOutput, 'duplex');

--- a/test/convert/shared.js
+++ b/test/convert/shared.js
@@ -1,0 +1,56 @@
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {
+	finishedStream,
+	assertWritableAborted,
+	assertStreamError,
+	assertSubprocessError,
+	getReadWriteSubprocess,
+} from '../helpers/convert.js';
+import {foobarString} from '../helpers/input.js';
+
+setFixtureDir();
+
+const testSubprocessFail = async (t, methodName) => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess[methodName]();
+
+	const cause = new Error(foobarString);
+	subprocess.kill(cause);
+
+	const error = await assertStreamError(t, stream, {cause});
+	assertWritableAborted(t, subprocess.stdin);
+	t.true(subprocess.stdout.readableEnded);
+	t.true(subprocess.stderr.readableEnded);
+
+	await assertSubprocessError(t, subprocess, error);
+};
+
+test('subprocess fail -> .readable() error', testSubprocessFail, 'readable');
+test('subprocess fail -> .writable() error', testSubprocessFail, 'writable');
+test('subprocess fail -> .duplex() error', testSubprocessFail, 'duplex');
+
+const testErrorEvent = async (t, methodName) => {
+	const subprocess = execa('empty.js');
+	const stream = subprocess[methodName]();
+	t.is(stream.listenerCount('error'), 0);
+	stream.destroy();
+	await t.throwsAsync(finishedStream(stream));
+};
+
+test('.readable() requires listening to "error" event', testErrorEvent, 'readable');
+test('.writable() requires listening to "error" event', testErrorEvent, 'writable');
+test('.duplex() requires listening to "error" event', testErrorEvent, 'duplex');
+
+const testSubprocessError = async (t, methodName) => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess[methodName]();
+	const cause = new Error(foobarString);
+	subprocess.kill(cause);
+	await assertStreamError(t, stream, {cause});
+};
+
+test('Do not need to await subprocess with .readable()', testSubprocessError, 'readable');
+test('Do not need to await subprocess with .writable()', testSubprocessError, 'writable');
+test('Do not need to await subprocess with .duplex()', testSubprocessError, 'duplex');

--- a/test/convert/writable.js
+++ b/test/convert/writable.js
@@ -1,0 +1,389 @@
+import {once} from 'node:events';
+import {compose, Readable, Writable} from 'node:stream';
+import {pipeline} from 'node:stream/promises';
+import {text} from 'node:stream/consumers';
+import {setTimeout, scheduler} from 'node:timers/promises';
+import {promisify} from 'node:util';
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {
+	finishedStream,
+	assertWritableAborted,
+	assertProcessNormalExit,
+	assertStreamOutput,
+	assertStreamError,
+	assertSubprocessOutput,
+	assertSubprocessError,
+	assertPromiseError,
+	getWritableSubprocess,
+	getReadableSubprocess,
+	getReadWriteSubprocess,
+} from '../helpers/convert.js';
+import {foobarString, foobarBuffer, foobarObject, foobarObjectString} from '../helpers/input.js';
+import {prematureClose, fullReadableStdio} from '../helpers/stdio.js';
+import {
+	throwingGenerator,
+	GENERATOR_ERROR_REGEXP,
+	serializeGenerator,
+	noopAsyncGenerator,
+} from '../helpers/generator.js';
+import {defaultHighWaterMark, defaultObjectHighWaterMark} from '../helpers/stream.js';
+
+setFixtureDir();
+
+test('.writable() success', async t => {
+	const subprocess = getWritableSubprocess();
+	const stream = subprocess.writable();
+
+	t.true(stream instanceof Writable);
+	t.true(stream.writable);
+	t.false(stream instanceof Readable);
+	t.is(stream.readable, undefined);
+
+	stream.end(foobarString);
+
+	await finishedStream(stream);
+	await assertSubprocessOutput(t, subprocess, foobarString, 2);
+});
+
+const testWritableDefault = async (t, fdNumber, to, options) => {
+	const subprocess = execa('stdin-fd.js', [`${fdNumber}`], options);
+	const stream = subprocess.writable({to});
+
+	stream.end(foobarString);
+
+	await finishedStream(stream);
+	await assertSubprocessOutput(t, subprocess);
+};
+
+test('.writable() can use stdin', testWritableDefault, 0, 0, {});
+test('.writable() can use stdio[*]', testWritableDefault, 3, 3, fullReadableStdio());
+test('.writable() uses stdin by default', testWritableDefault, 0, undefined, {});
+
+test('.writable() hangs until ended', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.writable();
+
+	stream.write(foobarString);
+	await setTimeout(1e2);
+	stream.end();
+
+	await finishedStream(stream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('.duplex() hangs until ended', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.duplex();
+
+	stream.write(foobarString);
+	await setTimeout(1e2);
+	stream.end();
+
+	await assertStreamOutput(t, stream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+const testEarlySuccess = async (t, methodName, hasWrites) => {
+	const subprocess = hasWrites ? getReadableSubprocess() : execa('empty.js');
+	const stream = subprocess[methodName]();
+
+	const error = await t.throwsAsync(finishedStream(stream));
+	t.like(error, prematureClose);
+	assertWritableAborted(t, subprocess.stdin);
+	t.true(subprocess.stdout.readableEnded);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessOutput(t, subprocess, hasWrites ? foobarString : '');
+};
+
+test('subprocess early success with no writes -> .writable() abort', testEarlySuccess, 'writable', false);
+test('subprocess early success with no writes -> .duplex() abort', testEarlySuccess, 'duplex', false);
+test('subprocess early success with writes -> .writable() abort', testEarlySuccess, 'writable', true);
+test('subprocess early success with writes -> .duplex() abort', testEarlySuccess, 'duplex', true);
+
+test('.writable() abort -> subprocess fail', async t => {
+	const subprocess = getWritableSubprocess();
+	const stream = subprocess.writable();
+
+	stream.destroy();
+
+	const error = await t.throwsAsync(finishedStream(stream));
+	t.like(error, prematureClose);
+	assertProcessNormalExit(t, error);
+	assertWritableAborted(t, subprocess.stdin);
+	t.true(subprocess.stdout.readableEnded);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.writable() error -> subprocess fail', async t => {
+	const subprocess = getWritableSubprocess();
+	const stream = subprocess.writable();
+
+	const cause = new Error(foobarString);
+	stream.destroy(cause);
+
+	const error = await assertStreamError(t, stream, {cause});
+	assertProcessNormalExit(t, error);
+	t.is(subprocess.stdin.errored, cause);
+	t.true(subprocess.stdout.readableEnded);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.writable() EPIPE error -> subprocess success', async t => {
+	const subprocess = getWritableSubprocess();
+	const stream = subprocess.writable();
+
+	const error = new Error(foobarString);
+	error.code = 'EPIPE';
+	stream.destroy(error);
+
+	await assertStreamError(t, stream, error);
+	t.is(subprocess.stdin.errored, error);
+	t.true(subprocess.stdout.readableEnded);
+	t.true(subprocess.stderr.readableEnded);
+	await subprocess;
+});
+
+test('subprocess.stdin end -> .writable() end + subprocess success', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.writable();
+
+	subprocess.stdin.end(foobarString);
+
+	await finishedStream(stream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('subprocess.stdin end -> .duplex() end + subprocess success', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.duplex();
+
+	subprocess.stdin.end(foobarString);
+
+	await assertStreamOutput(t, stream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+const testStdinAbort = async (t, methodName) => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess[methodName]();
+
+	subprocess.stdin.destroy();
+
+	const error = await t.throwsAsync(finishedStream(stream));
+	t.like(error, prematureClose);
+	assertProcessNormalExit(t, error);
+	assertWritableAborted(t, subprocess.stdin);
+	t.true(subprocess.stdout.readableEnded);
+	t.true(subprocess.stderr.readableEnded);
+	await assertSubprocessError(t, subprocess, error);
+};
+
+test('subprocess.stdin abort -> .writable() error + subprocess fail', testStdinAbort, 'writable');
+test('subprocess.stdin abort -> .duplex() error + subprocess fail', testStdinAbort, 'duplex');
+
+const testStdinError = async (t, methodName) => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess[methodName]();
+
+	const cause = new Error(foobarString);
+	subprocess.stdin.destroy(cause);
+
+	const error = await assertStreamError(t, stream, {cause});
+	assertProcessNormalExit(t, error);
+	t.is(subprocess.stdin.errored, cause);
+	t.true(subprocess.stderr.readableEnded);
+	t.true(subprocess.stdout.readableEnded);
+	await assertSubprocessError(t, subprocess, error);
+};
+
+test('subprocess.stdin error -> .writable() error + subprocess fail', testStdinError, 'writable');
+test('subprocess.stdin error -> .duplex() error + subprocess fail', testStdinError, 'duplex');
+
+test('.writable() can be used with Stream.pipeline()', async t => {
+	const subprocess = getWritableSubprocess();
+	const inputStream = Readable.from([foobarString]);
+	const stream = subprocess.writable();
+
+	await pipeline(inputStream, stream);
+
+	await finishedStream(inputStream);
+	await finishedStream(stream);
+	await assertSubprocessOutput(t, subprocess, foobarString, 2);
+});
+
+test('.writable() can error with Stream.pipeline()', async t => {
+	const subprocess = execa('noop-stdin-fail.js', ['2']);
+	const inputStream = Readable.from([foobarString]);
+	const stream = subprocess.writable();
+
+	const error = await t.throwsAsync(pipeline(inputStream, stream));
+	assertProcessNormalExit(t, error, 2);
+	t.is(error.stderr, foobarString);
+
+	await finishedStream(inputStream);
+	await assertStreamError(t, stream, error);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.writable() can pipe to errored stream with Stream.pipeline()', async t => {
+	const subprocess = getWritableSubprocess();
+	const inputStream = Readable.from([foobarString]);
+	const stream = subprocess.writable();
+
+	const cause = new Error('test');
+	inputStream.destroy(cause);
+
+	await assertPromiseError(t, pipeline(inputStream, stream), cause);
+
+	await assertStreamError(t, inputStream, cause);
+	const error = await assertStreamError(t, stream, {cause});
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.writable() can be used with Stream.compose()', async t => {
+	const subprocess = getWritableSubprocess();
+	const inputStream = Readable.from([foobarString]);
+	const stream = subprocess.writable();
+
+	await finishedStream(compose(inputStream, stream));
+	await assertSubprocessOutput(t, subprocess, foobarString, 2);
+});
+
+test('.writable() works with objectMode', async t => {
+	const subprocess = getReadWriteSubprocess({stdin: serializeGenerator});
+	const stream = subprocess.writable();
+	t.true(stream.writableObjectMode);
+	t.is(stream.writableHighWaterMark, defaultObjectHighWaterMark);
+	stream.end(foobarObject);
+
+	await finishedStream(stream);
+	await assertSubprocessOutput(t, subprocess, foobarObjectString);
+});
+
+test('.duplex() works with objectMode and writes', async t => {
+	const subprocess = getReadWriteSubprocess({stdin: serializeGenerator});
+	const stream = subprocess.duplex();
+	t.false(stream.readableObjectMode);
+	t.is(stream.readableHighWaterMark, defaultHighWaterMark);
+	t.true(stream.writableObjectMode);
+	t.is(stream.writableHighWaterMark, defaultObjectHighWaterMark);
+	stream.end(foobarObject);
+
+	await assertStreamOutput(t, stream, foobarObjectString);
+	await assertSubprocessOutput(t, subprocess, foobarObjectString);
+});
+
+test('.writable() has the right highWaterMark', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.writable();
+	t.is(stream.writableHighWaterMark, defaultHighWaterMark);
+	stream.end();
+	await finishedStream(stream);
+});
+
+const writeUntilFull = async (t, stream, subprocess) => {
+	const size = stream.writableHighWaterMark / 2;
+	const chunk = '.'.repeat(size);
+
+	t.is(subprocess.stdin.writableLength, 0);
+	t.is(stream.writableLength, 0);
+	t.false(subprocess.stdin.writableNeedDrain);
+	t.false(stream.writableNeedDrain);
+
+	t.true(stream.write(chunk));
+	t.is(subprocess.stdin.writableLength, size);
+	t.is(stream.writableLength, 0);
+	t.false(subprocess.stdin.writableNeedDrain);
+	t.false(stream.writableNeedDrain);
+
+	t.true(stream.write(chunk));
+	t.is(subprocess.stdin.writableLength, size * 2);
+	t.is(stream.writableLength, size);
+	t.true(subprocess.stdin.writableNeedDrain);
+	t.false(stream.writableNeedDrain);
+
+	t.false(stream.write(chunk));
+	t.is(subprocess.stdin.writableLength, size * 2);
+	t.is(stream.writableLength, size * 2);
+	t.true(subprocess.stdin.writableNeedDrain);
+	t.true(stream.writableNeedDrain);
+
+	await once(stream, 'drain');
+	stream.end();
+
+	return '.'.repeat(size * 3);
+};
+
+test('.writable() waits when its buffer is full', async t => {
+	const subprocess = getReadWriteSubprocess({stdin: noopAsyncGenerator()});
+	const stream = subprocess.writable();
+
+	const expectedOutput = await writeUntilFull(t, stream, subprocess);
+
+	await assertSubprocessOutput(t, subprocess, expectedOutput);
+});
+
+test('.duplex() waits when its buffer is full', async t => {
+	const subprocess = getReadWriteSubprocess({stdin: noopAsyncGenerator()});
+	const stream = subprocess.duplex();
+
+	const expectedOutput = await writeUntilFull(t, stream, subprocess);
+
+	await assertStreamOutput(t, stream, expectedOutput);
+	await assertSubprocessOutput(t, subprocess, expectedOutput);
+});
+
+const testPropagateError = async (t, methodName) => {
+	const subprocess = getReadWriteSubprocess({stdin: throwingGenerator});
+	const stream = subprocess[methodName]();
+	stream.end('.');
+	await t.throwsAsync(finishedStream(stream), {message: GENERATOR_ERROR_REGEXP});
+};
+
+test('.writable() propagates write errors', testPropagateError, 'writable');
+test('.duplex() propagates write errors', testPropagateError, 'duplex');
+
+const testWritev = async (t, methodName, waitForStream) => {
+	const subprocess = getReadWriteSubprocess({stdin: noopAsyncGenerator()});
+	const stream = subprocess[methodName]();
+
+	const chunk = '.'.repeat(stream.writableHighWaterMark);
+	stream.write(chunk);
+	t.true(stream.writableNeedDrain);
+
+	const [writeInOneTick] = await Promise.race([
+		Promise.all([true, promisify(stream.write.bind(stream))(chunk)]),
+		Promise.all([false, scheduler.yield()]),
+	]);
+	t.true(writeInOneTick);
+
+	stream.end();
+	await waitForStream(stream);
+};
+
+test('.writable() can use .writev()', testWritev, 'writable', finishedStream);
+test('.duplex() can use .writev()', testWritev, 'duplex', text);
+
+test('.writable() can set encoding', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.writable();
+
+	stream.end(foobarBuffer.toString('hex'), 'hex');
+
+	await finishedStream(stream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('.duplex() can set encoding', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess.duplex();
+
+	stream.end(foobarBuffer.toString('hex'), 'hex');
+
+	await assertStreamOutput(t, stream);
+	await assertSubprocessOutput(t, subprocess);
+});

--- a/test/fixtures/ipc-exit.js
+++ b/test/fixtures/ipc-exit.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import process from 'node:process';
+
+process.once('message', message => {
+	process.send(message);
+});

--- a/test/fixtures/noop-stdin-fail.js
+++ b/test/fixtures/noop-stdin-fail.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {text} from 'node:stream/consumers';
+import {getWriteStream} from '../helpers/fs.js';
+
+const fdNumber = Number(process.argv[2]);
+const stdinString = await text(process.stdin);
+getWriteStream(fdNumber).write(stdinString);
+process.exitCode = 2;

--- a/test/fixtures/stdin-twice-both.js
+++ b/test/fixtures/stdin-twice-both.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {getReadStream} from '../helpers/fs.js';
+
+const fdNumber = Number(process.argv[2]);
+
+process.stdin.pipe(process.stdout);
+getReadStream(fdNumber).pipe(process.stderr);

--- a/test/helpers/convert.js
+++ b/test/helpers/convert.js
@@ -1,0 +1,57 @@
+import {text} from 'node:stream/consumers';
+import {finished} from 'node:stream/promises';
+import isPlainObj from 'is-plain-obj';
+import {execa} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+export const finishedStream = stream => finished(stream, {cleanup: true});
+
+export const assertWritableAborted = (t, writable) => {
+	t.false(writable.writableEnded);
+	t.is(writable.errored, null);
+	t.false(writable.writable);
+};
+
+export const assertReadableAborted = (t, readable) => {
+	t.false(readable.readableEnded);
+	t.is(readable.errored, null);
+	t.false(readable.readable);
+};
+
+export const assertProcessNormalExit = (t, error, exitCode = 0) => {
+	t.is(error.exitCode, exitCode);
+	t.is(error.signal, undefined);
+};
+
+export const assertStreamOutput = async (t, stream, expectedOutput = foobarString) => {
+	t.is(await text(stream), expectedOutput);
+};
+
+export const assertSubprocessOutput = async (t, subprocess, expectedOutput = foobarString, fdNumber = 1) => {
+	const result = await subprocess;
+	t.deepEqual(result.stdio[fdNumber], expectedOutput);
+};
+
+export const assertStreamError = (t, stream, error) => assertPromiseError(t, finishedStream(stream), error);
+
+export const assertStreamReadError = (t, stream, error) => assertPromiseError(t, text(stream), error);
+
+export const assertSubprocessError = (t, subprocess, error) => assertPromiseError(t, subprocess, error);
+
+export const assertPromiseError = async (t, promise, error) => {
+	const thrownError = await t.throwsAsync(promise);
+
+	if (isPlainObj(error) && error.cause !== undefined) {
+		t.is(thrownError.cause, error.cause);
+	} else {
+		t.is(thrownError, error);
+	}
+
+	return thrownError;
+};
+
+export const getReadableSubprocess = () => execa('noop-fd.js', ['1', foobarString]);
+
+export const getWritableSubprocess = () => execa('noop-stdin-fd.js', ['2']);
+
+export const getReadWriteSubprocess = options => execa('stdin.js', options);

--- a/test/helpers/generator.js
+++ b/test/helpers/generator.js
@@ -1,6 +1,12 @@
 import {setImmediate, setInterval} from 'node:timers/promises';
 import {foobarObject} from './input.js';
 
+export const noopAsyncGenerator = () => ({
+	async * transform(line) {
+		yield line;
+	},
+});
+
 export const addNoopGenerator = (transform, addNoopTransform) => addNoopTransform
 	? [transform, noopGenerator(undefined, true)]
 	: [transform];
@@ -73,3 +79,10 @@ export const infiniteGenerator = async function * () {
 export const uppercaseGenerator = function * (line) {
 	yield line.toUpperCase();
 };
+
+// eslint-disable-next-line require-yield
+export const throwingGenerator = function * () {
+	throw new Error('Generator error');
+};
+
+export const GENERATOR_ERROR_REGEXP = /Generator error/;

--- a/test/helpers/stream.js
+++ b/test/helpers/stream.js
@@ -7,3 +7,4 @@ export const noopDuplex = () => new PassThrough().resume();
 export const simpleReadable = () => Readable.from([foobarString]);
 
 export const defaultHighWaterMark = getDefaultHighWaterMark(false);
+export const defaultObjectHighWaterMark = getDefaultHighWaterMark(true);

--- a/test/pipe/validate.js
+++ b/test/pipe/validate.js
@@ -56,7 +56,30 @@ const testPipeError = async (t, {
 	await assertPipeError(t, pipePromise, getMessage(message));
 };
 
+const testNodeStream = async (t, {
+	message,
+	sourceOptions = {},
+	getSource = () => execa('empty.js', sourceOptions),
+	from,
+	to,
+	writable = to !== undefined,
+}) => {
+	assertNodeStream({t, message, getSource, from, to, methodName: writable ? 'writable' : 'readable'});
+	assertNodeStream({t, message, getSource, from, to, methodName: 'duplex'});
+};
+
+const assertNodeStream = ({t, message, getSource, from, to, methodName}) => {
+	const error = t.throws(() => {
+		getSource()[methodName]({from, to});
+	});
+	t.true(error.message.includes(getMessage(message)));
+};
+
 test('Must set "all" option to "true" to use .pipe("all")', testPipeError, {
+	from: 'all',
+	message: '"all" option must be true',
+});
+test('Must set "all" option to "true" to use .duplex("all")', testNodeStream, {
 	from: 'all',
 	message: '"all" option must be true',
 });
@@ -72,12 +95,20 @@ test('.pipe() "from" option cannot be "stdin"', testPipeError, {
 	from: 'stdin',
 	message: '"from" must not be',
 });
+test('.duplex() "from" option cannot be "stdin"', testNodeStream, {
+	from: 'stdin',
+	message: '"from" must not be',
+});
 test('$.pipe() "from" option cannot be "stdin"', testPipeError, {
 	from: 'stdin',
 	isScript: true,
 	message: '"from" must not be',
 });
 test('.pipe() "to" option cannot be "stdout"', testPipeError, {
+	to: 'stdout',
+	message: '"to" must not be',
+});
+test('.duplex() "to" option cannot be "stdout"', testNodeStream, {
 	to: 'stdout',
 	message: '"to" must not be',
 });
@@ -90,7 +121,15 @@ test('.pipe() "from" option cannot be any string', testPipeError, {
 	from: 'other',
 	message: 'must be "stdout", "stderr", "all"',
 });
+test('.duplex() "from" option cannot be any string', testNodeStream, {
+	from: 'other',
+	message: 'must be "stdout", "stderr", "all"',
+});
 test('.pipe() "to" option cannot be any string', testPipeError, {
+	to: 'other',
+	message: 'must be "stdin"',
+});
+test('.duplex() "to" option cannot be any string', testNodeStream, {
 	to: 'other',
 	message: 'must be "stdin"',
 });
@@ -98,7 +137,15 @@ test('.pipe() "from" option cannot be a float', testPipeError, {
 	from: 1.5,
 	message: 'must be "stdout", "stderr", "all"',
 });
+test('.duplex() "from" option cannot be a float', testNodeStream, {
+	from: 1.5,
+	message: 'must be "stdout", "stderr", "all"',
+});
 test('.pipe() "to" option cannot be a float', testPipeError, {
+	to: 1.5,
+	message: 'must be "stdin"',
+});
+test('.duplex() "to" option cannot be a float', testNodeStream, {
 	to: 1.5,
 	message: 'must be "stdin"',
 });
@@ -106,7 +153,15 @@ test('.pipe() "from" option cannot be a negative number', testPipeError, {
 	from: -1,
 	message: 'must be "stdout", "stderr", "all"',
 });
+test('.duplex() "from" option cannot be a negative number', testNodeStream, {
+	from: -1,
+	message: 'must be "stdout", "stderr", "all"',
+});
 test('.pipe() "to" option cannot be a negative number', testPipeError, {
+	to: -1,
+	message: 'must be "stdin"',
+});
+test('.duplex() "to" option cannot be a negative number', testNodeStream, {
 	to: -1,
 	message: 'must be "stdin"',
 });
@@ -114,11 +169,24 @@ test('.pipe() "from" option cannot be a non-existing file descriptor', testPipeE
 	from: 3,
 	message: 'file descriptor does not exist',
 });
+test('.duplex() "from" cannot be a non-existing file descriptor', testNodeStream, {
+	from: 3,
+	message: 'file descriptor does not exist',
+});
 test('.pipe() "to" option cannot be a non-existing file descriptor', testPipeError, {
 	to: 3,
 	message: 'file descriptor does not exist',
 });
+test('.duplex() "to" cannot be a non-existing file descriptor', testNodeStream, {
+	to: 3,
+	message: 'file descriptor does not exist',
+});
 test('.pipe() "from" option cannot be an input file descriptor', testPipeError, {
+	sourceOptions: getStdio(3, new Uint8Array()),
+	from: 3,
+	message: 'must be a readable stream',
+});
+test('.duplex() "from" option cannot be an input file descriptor', testNodeStream, {
 	sourceOptions: getStdio(3, new Uint8Array()),
 	from: 3,
 	message: 'must be a readable stream',
@@ -128,7 +196,16 @@ test('.pipe() "to" option cannot be an output file descriptor', testPipeError, {
 	to: 3,
 	message: 'must be a writable stream',
 });
+test('.duplex() "to" option cannot be an output file descriptor', testNodeStream, {
+	sourceOptions: fullStdio,
+	to: 3,
+	message: 'must be a writable stream',
+});
 test('Cannot set "stdout" option to "ignore" to use .pipe()', testPipeError, {
+	sourceOptions: {stdout: 'ignore'},
+	message: ['stdout', '\'ignore\''],
+});
+test('Cannot set "stdout" option to "ignore" to use .duplex()', testNodeStream, {
 	sourceOptions: {stdout: 'ignore'},
 	message: ['stdout', '\'ignore\''],
 });
@@ -136,7 +213,17 @@ test('Cannot set "stdin" option to "ignore" to use .pipe()', testPipeError, {
 	destinationOptions: {stdin: 'ignore'},
 	message: ['stdin', '\'ignore\''],
 });
+test('Cannot set "stdin" option to "ignore" to use .duplex()', testNodeStream, {
+	sourceOptions: {stdin: 'ignore'},
+	message: ['stdin', '\'ignore\''],
+	writable: true,
+});
 test('Cannot set "stdout" option to "ignore" to use .pipe(1)', testPipeError, {
+	sourceOptions: {stdout: 'ignore'},
+	from: 1,
+	message: ['stdout', '\'ignore\''],
+});
+test('Cannot set "stdout" option to "ignore" to use .duplex(1)', testNodeStream, {
 	sourceOptions: {stdout: 'ignore'},
 	from: 1,
 	message: ['stdout', '\'ignore\''],
@@ -146,7 +233,17 @@ test('Cannot set "stdin" option to "ignore" to use .pipe(0)', testPipeError, {
 	message: ['stdin', '\'ignore\''],
 	to: 0,
 });
+test('Cannot set "stdin" option to "ignore" to use .duplex(0)', testNodeStream, {
+	sourceOptions: {stdin: 'ignore'},
+	message: ['stdin', '\'ignore\''],
+	to: 0,
+});
 test('Cannot set "stdout" option to "ignore" to use .pipe("stdout")', testPipeError, {
+	sourceOptions: {stdout: 'ignore'},
+	from: 'stdout',
+	message: ['stdout', '\'ignore\''],
+});
+test('Cannot set "stdout" option to "ignore" to use .duplex("stdout")', testNodeStream, {
 	sourceOptions: {stdout: 'ignore'},
 	from: 'stdout',
 	message: ['stdout', '\'ignore\''],
@@ -156,11 +253,25 @@ test('Cannot set "stdin" option to "ignore" to use .pipe("stdin")', testPipeErro
 	message: ['stdin', '\'ignore\''],
 	to: 'stdin',
 });
+test('Cannot set "stdin" option to "ignore" to use .duplex("stdin")', testNodeStream, {
+	sourceOptions: {stdin: 'ignore'},
+	message: ['stdin', '\'ignore\''],
+	to: 'stdin',
+});
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe()', testPipeError, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
 	message: ['stdout', '\'ignore\''],
 });
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex()', testNodeStream, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
+	message: ['stdout', '\'ignore\''],
+});
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe(1)', testPipeError, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
+	from: 1,
+	message: ['stdout', '\'ignore\''],
+});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex(1)', testNodeStream, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
 	from: 1,
 	message: ['stdout', '\'ignore\''],
@@ -170,7 +281,16 @@ test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe("stdout")',
 	from: 'stdout',
 	message: ['stdout', '\'ignore\''],
 });
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex("stdout")', testNodeStream, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
+	from: 'stdout',
+	message: ['stdout', '\'ignore\''],
+});
 test('Cannot set "stdio[1]" option to "ignore" to use .pipe()', testPipeError, {
+	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
+	message: ['stdio[1]', '\'ignore\''],
+});
+test('Cannot set "stdio[1]" option to "ignore" to use .duplex()', testNodeStream, {
 	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
 	message: ['stdio[1]', '\'ignore\''],
 });
@@ -178,7 +298,17 @@ test('Cannot set "stdio[0]" option to "ignore" to use .pipe()', testPipeError, {
 	destinationOptions: {stdio: ['ignore', 'pipe', 'pipe']},
 	message: ['stdio[0]', '\'ignore\''],
 });
+test('Cannot set "stdio[0]" option to "ignore" to use .duplex()', testNodeStream, {
+	sourceOptions: {stdio: ['ignore', 'pipe', 'pipe']},
+	message: ['stdio[0]', '\'ignore\''],
+	writable: true,
+});
 test('Cannot set "stdio[1]" option to "ignore" to use .pipe(1)', testPipeError, {
+	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
+	from: 1,
+	message: ['stdio[1]', '\'ignore\''],
+});
+test('Cannot set "stdio[1]" option to "ignore" to use .duplex(1)', testNodeStream, {
 	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
 	from: 1,
 	message: ['stdio[1]', '\'ignore\''],
@@ -188,7 +318,17 @@ test('Cannot set "stdio[0]" option to "ignore" to use .pipe(0)', testPipeError, 
 	message: ['stdio[0]', '\'ignore\''],
 	to: 0,
 });
+test('Cannot set "stdio[0]" option to "ignore" to use .duplex(0)', testNodeStream, {
+	sourceOptions: {stdio: ['ignore', 'pipe', 'pipe']},
+	message: ['stdio[0]', '\'ignore\''],
+	to: 0,
+});
 test('Cannot set "stdio[1]" option to "ignore" to use .pipe("stdout")', testPipeError, {
+	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
+	from: 'stdout',
+	message: ['stdio[1]', '\'ignore\''],
+});
+test('Cannot set "stdio[1]" option to "ignore" to use .duplex("stdout")', testNodeStream, {
 	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
 	from: 'stdout',
 	message: ['stdio[1]', '\'ignore\''],
@@ -198,7 +338,17 @@ test('Cannot set "stdio[0]" option to "ignore" to use .pipe("stdin")', testPipeE
 	message: ['stdio[0]', '\'ignore\''],
 	to: 'stdin',
 });
+test('Cannot set "stdio[0]" option to "ignore" to use .duplex("stdin")', testNodeStream, {
+	sourceOptions: {stdio: ['ignore', 'pipe', 'pipe']},
+	message: ['stdio[0]', '\'ignore\''],
+	to: 'stdin',
+});
 test('Cannot set "stderr" option to "ignore" to use .pipe(2)', testPipeError, {
+	sourceOptions: {stderr: 'ignore'},
+	from: 2,
+	message: ['stderr', '\'ignore\''],
+});
+test('Cannot set "stderr" option to "ignore" to use .duplex(2)', testNodeStream, {
 	sourceOptions: {stderr: 'ignore'},
 	from: 2,
 	message: ['stderr', '\'ignore\''],
@@ -208,7 +358,17 @@ test('Cannot set "stderr" option to "ignore" to use .pipe("stderr")', testPipeEr
 	from: 'stderr',
 	message: ['stderr', '\'ignore\''],
 });
+test('Cannot set "stderr" option to "ignore" to use .duplex("stderr")', testNodeStream, {
+	sourceOptions: {stderr: 'ignore'},
+	from: 'stderr',
+	message: ['stderr', '\'ignore\''],
+});
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe(2)', testPipeError, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
+	from: 2,
+	message: ['stderr', '\'ignore\''],
+});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex(2)', testNodeStream, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
 	from: 2,
 	message: ['stderr', '\'ignore\''],
@@ -218,7 +378,17 @@ test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe("stderr")',
 	from: 'stderr',
 	message: ['stderr', '\'ignore\''],
 });
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex("stderr")', testNodeStream, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
+	from: 'stderr',
+	message: ['stderr', '\'ignore\''],
+});
 test('Cannot set "stdio[2]" option to "ignore" to use .pipe(2)', testPipeError, {
+	sourceOptions: {stdio: ['pipe', 'pipe', 'ignore']},
+	from: 2,
+	message: ['stdio[2]', '\'ignore\''],
+});
+test('Cannot set "stdio[2]" option to "ignore" to use .duplex(2)', testNodeStream, {
 	sourceOptions: {stdio: ['pipe', 'pipe', 'ignore']},
 	from: 2,
 	message: ['stdio[2]', '\'ignore\''],
@@ -228,7 +398,17 @@ test('Cannot set "stdio[2]" option to "ignore" to use .pipe("stderr")', testPipe
 	from: 'stderr',
 	message: ['stdio[2]', '\'ignore\''],
 });
+test('Cannot set "stdio[2]" option to "ignore" to use .duplex("stderr")', testNodeStream, {
+	sourceOptions: {stdio: ['pipe', 'pipe', 'ignore']},
+	from: 'stderr',
+	message: ['stdio[2]', '\'ignore\''],
+});
 test('Cannot set "stdio[3]" option to "ignore" to use .pipe(3)', testPipeError, {
+	sourceOptions: getStdio(3, 'ignore'),
+	from: 3,
+	message: ['stdio[3]', '\'ignore\''],
+});
+test('Cannot set "stdio[3]" option to "ignore" to use .duplex(3)', testNodeStream, {
 	sourceOptions: getStdio(3, 'ignore'),
 	from: 3,
 	message: ['stdio[3]', '\'ignore\''],
@@ -238,7 +418,17 @@ test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe("all")', te
 	from: 'all',
 	message: ['stdout', '\'ignore\''],
 });
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex("all")', testNodeStream, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore', all: true},
+	from: 'all',
+	message: ['stdout', '\'ignore\''],
+});
 test('Cannot set "stdio[1]" + "stdio[2]" option to "ignore" to use .pipe("all")', testPipeError, {
+	sourceOptions: {stdio: ['pipe', 'ignore', 'ignore'], all: true},
+	from: 'all',
+	message: ['stdio[1]', '\'ignore\''],
+});
+test('Cannot set "stdio[1]" + "stdio[2]" option to "ignore" to use .duplex("all")', testNodeStream, {
 	sourceOptions: {stdio: ['pipe', 'ignore', 'ignore'], all: true},
 	from: 'all',
 	message: ['stdio[1]', '\'ignore\''],
@@ -247,11 +437,24 @@ test('Cannot set "stdout" option to "inherit" to use .pipe()', testPipeError, {
 	sourceOptions: {stdout: 'inherit'},
 	message: ['stdout', '\'inherit\''],
 });
+test('Cannot set "stdout" option to "inherit" to use .duplex()', testNodeStream, {
+	sourceOptions: {stdout: 'inherit'},
+	message: ['stdout', '\'inherit\''],
+});
 test('Cannot set "stdin" option to "inherit" to use .pipe()', testPipeError, {
 	destinationOptions: {stdin: 'inherit'},
 	message: ['stdin', '\'inherit\''],
 });
+test('Cannot set "stdin" option to "inherit" to use .duplex()', testNodeStream, {
+	sourceOptions: {stdin: 'inherit'},
+	message: ['stdin', '\'inherit\''],
+	writable: true,
+});
 test('Cannot set "stdout" option to "ipc" to use .pipe()', testPipeError, {
+	sourceOptions: {stdout: 'ipc'},
+	message: ['stdout', '\'ipc\''],
+});
+test('Cannot set "stdout" option to "ipc" to use .duplex()', testNodeStream, {
 	sourceOptions: {stdout: 'ipc'},
 	message: ['stdout', '\'ipc\''],
 });
@@ -259,7 +462,16 @@ test('Cannot set "stdin" option to "ipc" to use .pipe()', testPipeError, {
 	destinationOptions: {stdin: 'ipc'},
 	message: ['stdin', '\'ipc\''],
 });
+test('Cannot set "stdin" option to "ipc" to use .duplex()', testNodeStream, {
+	sourceOptions: {stdin: 'ipc'},
+	message: ['stdin', '\'ipc\''],
+	writable: true,
+});
 test('Cannot set "stdout" option to file descriptors to use .pipe()', testPipeError, {
+	sourceOptions: {stdout: 1},
+	message: ['stdout', '1'],
+});
+test('Cannot set "stdout" option to file descriptors to use .duplex()', testNodeStream, {
 	sourceOptions: {stdout: 1},
 	message: ['stdout', '1'],
 });
@@ -267,7 +479,16 @@ test('Cannot set "stdin" option to file descriptors to use .pipe()', testPipeErr
 	destinationOptions: {stdin: 0},
 	message: ['stdin', '0'],
 });
+test('Cannot set "stdin" option to file descriptors to use .duplex()', testNodeStream, {
+	sourceOptions: {stdin: 0},
+	message: ['stdin', '0'],
+	writable: true,
+});
 test('Cannot set "stdout" option to Node.js streams to use .pipe()', testPipeError, {
+	sourceOptions: {stdout: process.stdout},
+	message: ['stdout', 'Stream'],
+});
+test('Cannot set "stdout" option to Node.js streams to use .duplex()', testNodeStream, {
 	sourceOptions: {stdout: process.stdout},
 	message: ['stdout', 'Stream'],
 });
@@ -275,13 +496,28 @@ test('Cannot set "stdin" option to Node.js streams to use .pipe()', testPipeErro
 	destinationOptions: {stdin: process.stdin},
 	message: ['stdin', 'Stream'],
 });
+test('Cannot set "stdin" option to Node.js streams to use .duplex()', testNodeStream, {
+	sourceOptions: {stdin: process.stdin},
+	message: ['stdin', 'Stream'],
+	writable: true,
+});
 test('Cannot set "stdio[3]" option to Node.js Writable streams to use .pipe()', testPipeError, {
+	sourceOptions: getStdio(3, process.stdout),
+	message: ['stdio[3]', 'Stream'],
+	from: 3,
+});
+test('Cannot set "stdio[3]" option to Node.js Writable streams to use .duplex()', testNodeStream, {
 	sourceOptions: getStdio(3, process.stdout),
 	message: ['stdio[3]', 'Stream'],
 	from: 3,
 });
 test('Cannot set "stdio[3]" option to Node.js Readable streams to use .pipe()', testPipeError, {
 	destinationOptions: getStdio(3, process.stdin),
+	message: ['stdio[3]', 'Stream'],
+	to: 3,
+});
+test('Cannot set "stdio[3]" option to Node.js Readable streams to use .duplex()', testNodeStream, {
+	sourceOptions: getStdio(3, process.stdin),
 	message: ['stdio[3]', 'Stream'],
 	to: 3,
 });

--- a/test/return/early-error.js
+++ b/test/return/early-error.js
@@ -78,6 +78,19 @@ test('child_process.spawn() early errors can use .pipe() multiple times', testEa
 test('child_process.spawn() early errors can use .pipe``', testEarlyErrorPipe, () => $(earlyErrorOptions)`empty.js`.pipe(earlyErrorOptions)`empty.js`);
 test('child_process.spawn() early errors can use .pipe`` multiple times', testEarlyErrorPipe, () => $(earlyErrorOptions)`empty.js`.pipe(earlyErrorOptions)`empty.js`.pipe`empty.js`);
 
+const testEarlyErrorConvertor = async (t, streamMethod) => {
+	const subprocess = getEarlyErrorSubprocess();
+	const stream = subprocess[streamMethod]();
+	stream.on('close', () => {});
+	stream.read?.();
+	stream.write?.('.');
+	await t.throwsAsync(subprocess);
+};
+
+test('child_process.spawn() early errors can use .readable()', testEarlyErrorConvertor, 'readable');
+test('child_process.spawn() early errors can use .writable()', testEarlyErrorConvertor, 'writable');
+test('child_process.spawn() early errors can use .duplex()', testEarlyErrorConvertor, 'duplex');
+
 const testEarlyErrorStream = async (t, getStreamProperty, options) => {
 	const subprocess = getEarlyErrorSubprocess(options);
 	const stream = getStreamProperty(subprocess);

--- a/test/stdio/transform.js
+++ b/test/stdio/transform.js
@@ -13,6 +13,8 @@ import {
 	outputObjectGenerator,
 	convertTransformToFinal,
 	noYieldGenerator,
+	throwingGenerator,
+	GENERATOR_ERROR_REGEXP,
 } from '../helpers/generator.js';
 import {defaultHighWaterMark} from '../helpers/stream.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
@@ -148,13 +150,6 @@ const testAsyncGenerators = async (t, final) => {
 
 test('Generators "transform" is awaited on success', testAsyncGenerators, false);
 test('Generators "final" is awaited on success', testAsyncGenerators, true);
-
-// eslint-disable-next-line require-yield
-const throwingGenerator = function * () {
-	throw new Error('Generator error');
-};
-
-const GENERATOR_ERROR_REGEXP = /Generator error/;
 
 const testThrowingGenerator = async (t, final) => {
 	await t.throwsAsync(


### PR DESCRIPTION
Fixes #143.

The [following comment](https://github.com/sindresorhus/execa/issues/143#issuecomment-2002306393) explains the background behind the following points:
  - three different methods instead of only `.duplex()`
  - `.readable()` not named `.readableStream()`
  - Node.js streams instead of web streams
  - not using `.readable` and `.writable` properties as suggested in #591

This was some pretty hard work there!
I had to re-implement the whole PR from scratch 3 or 4 times. Streams are difficult! :)