### PR TITLE
Allow using a `final` function without a `transform`

### DIFF
--- a/docs/transform.md
+++ b/docs/transform.md
@@ -95,7 +95,7 @@ const transform = function * (line) {
 
 ## Finalizing
 
-To create additional lines after the last one, a `final` generator function can be used by passing a `{transform, final}` plain object.
+To create additional lines after the last one, a `final` generator function can be used by passing a `{final}` or `{transform, final}` plain object.
 
 ```js
 let count = 0;

--- a/lib/stdio/transform.js
+++ b/lib/stdio/transform.js
@@ -49,7 +49,7 @@ const transformChunk = async function * (chunk, generators, index) {
 		return;
 	}
 
-	const {transform} = generators[index];
+	const {transform = identityGenerator} = generators[index];
 	for await (const transformedChunk of transform(chunk)) {
 		yield * transformChunk(transformedChunk, generators, index + 1);
 	}
@@ -104,7 +104,7 @@ const transformChunkSync = function * (chunk, generators, index) {
 		return;
 	}
 
-	const {transform} = generators[index];
+	const {transform = identityGenerator} = generators[index];
 	for (const transformedChunk of transform(chunk)) {
 		yield * transformChunkSync(transformedChunk, generators, index + 1);
 	}
@@ -124,4 +124,8 @@ const generatorFinalChunksSync = function * (final, index, generators) {
 	for (const finalChunk of final()) {
 		yield * transformChunkSync(finalChunk, generators, index + 1);
 	}
+};
+
+const identityGenerator = function * (chunk) {
+	yield chunk;
 };

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -39,7 +39,7 @@ export const getStdioOptionType = (stdioOption, optionName) => {
 };
 
 const getGeneratorObjectType = ({transform, final, binary, objectMode}, optionName) => {
-	if (!isGenerator(transform)) {
+	if (transform !== undefined && !isGenerator(transform)) {
 		throw new TypeError(`The \`${optionName}.transform\` option must be a generator.`);
 	}
 
@@ -64,7 +64,7 @@ export const isAsyncGenerator = stdioOption => Object.prototype.toString.call(st
 const isSyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object GeneratorFunction]';
 export const isGeneratorOptions = stdioOption => typeof stdioOption === 'object'
 	&& stdioOption !== null
-	&& stdioOption.transform !== undefined;
+	&& (stdioOption.transform !== undefined || stdioOption.final !== undefined);
 
 export const isUrl = stdioOption => Object.prototype.toString.call(stdioOption) === '[object URL]';
 export const isRegularUrl = stdioOption => isUrl(stdioOption) && stdioOption.protocol !== 'file:';

--- a/test/helpers/generator.js
+++ b/test/helpers/generator.js
@@ -33,10 +33,16 @@ export const getOutputsGenerator = (inputs, objectMode) => ({
 	objectMode,
 });
 
+export const identityGenerator = input => function * () {
+	yield input;
+};
+
+export const identityAsyncGenerator = input => async function * () {
+	yield input;
+};
+
 export const getOutputGenerator = (input, objectMode) => ({
-	* transform() {
-		yield input;
-	},
+	transform: identityGenerator(input),
 	objectMode,
 });
 

--- a/test/stdio/transform.js
+++ b/test/stdio/transform.js
@@ -7,6 +7,8 @@ import {execa} from '../../index.js';
 import {foobarString} from '../helpers/input.js';
 import {
 	noopGenerator,
+	identityGenerator,
+	identityAsyncGenerator,
 	getOutputsGenerator,
 	getOutputGenerator,
 	infiniteGenerator,
@@ -28,6 +30,22 @@ const testGeneratorFinal = async (t, fixtureName) => {
 
 test('Generators "final" can be used', testGeneratorFinal, 'noop.js');
 test('Generators "final" is used even on empty streams', testGeneratorFinal, 'empty.js');
+
+const testFinalAlone = async (t, final) => {
+	const {stdout} = await execa('noop-fd.js', ['1', '.'], {stdout: {final: final(foobarString)}});
+	t.is(stdout, `.${foobarString}`);
+};
+
+test('Generators "final" can be used without "transform"', testFinalAlone, identityGenerator);
+test('Generators "final" can be used without "transform", async', testFinalAlone, identityAsyncGenerator);
+
+const testFinalNoOutput = async (t, final) => {
+	const {stdout} = await execa('empty.js', {stdout: {final: final(foobarString)}});
+	t.is(stdout, foobarString);
+};
+
+test('Generators "final" can be used without "transform" nor output', testFinalNoOutput, identityGenerator);
+test('Generators "final" can be used without "transform" nor output, async', testFinalNoOutput, identityAsyncGenerator);
 
 const repeatCount = defaultHighWaterMark * 3;
 


### PR DESCRIPTION
Transforms can optionally specify a `final` function to output some data at the end of `stdout`/`stderr`.

At the moment, a `final` function can only be used if a `transform` function is used too. However, there are some use cases for using a `final` function alone. For example, one can append data with:

```js
const final = function * () {
  yield 'Last line.';
};

const {stdout} = await execa(..., {stdout: {final}});
console.log(stdout); // Ends with "Last line."
```

This PR enables this.