### PR TITLE
Strip newlines in transforms

### DIFF
--- a/docs/transform.md
+++ b/docs/transform.md
@@ -66,14 +66,14 @@ const transform = function * (line) { /* ... */ };
 await execa('./run.js', {stdout: transform});
 ```
 
-However, if a `{transform, newline: true}` plain object is passed, newlines are kept.
+However, if a `{transform, preserveNewlines: true}` plain object is passed, newlines are kept.
 
 ```js
 // `line`'s value ends with '\n'.
 // The output's last `line` might or might not end with '\n', depending on the output.
 const transform = function * (line) { /* ... */ };
 
-await execa('./run.js', {stdout: {transform, newline: true}});
+await execa('./run.js', {stdout: {transform, preserveNewlines: true}});
 ```
 
 Each `yield` produces at least one line. Calling `yield` multiple times or calling `yield *` produces multiples lines.
@@ -98,7 +98,7 @@ const transform = function * (line) {
 await execa('./run.js', {stdout: transform});
 ```
 
-However, if a `{transform, newline: true}` plain object is passed, multiple `yield`s produce a single line instead.
+However, if a `{transform, preserveNewlines: true}` plain object is passed, multiple `yield`s produce a single line instead.
 
 ```js
 const transform = function * (line) {
@@ -111,7 +111,7 @@ const transform = function * (line) {
 	yield line
 };
 
-await execa('./run.js', {stdout: {transform, newline: true}});
+await execa('./run.js', {stdout: {transform, preserveNewlines: true}});
 ```
 
 ## Object mode

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ type StdioTransformFull = {
 	transform: StdioTransform;
 	final?: StdioFinal;
 	binary?: boolean;
+	newline?: boolean;
 	objectMode?: boolean;
 };
 
@@ -418,6 +419,8 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	/**
 	Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
+
+	If the `lines` option is true, this applies to each output line instead.
 
 	@default true
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ type StdioTransformFull = {
 	transform: StdioTransform;
 	final?: StdioFinal;
 	binary?: boolean;
-	newline?: boolean;
+	preserveNewlines?: boolean;
 	objectMode?: boolean;
 };
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1069,13 +1069,13 @@ execa('unicorns', {stdin: {transform: unknownGenerator, final: asyncFinal}});
 expectError(execaSync('unicorns', {stdin: {transform: unknownGenerator, final: asyncFinal}}));
 expectError(execa('unicorns', {stdin: {}}));
 expectError(execa('unicorns', {stdin: {binary: true}}));
-expectError(execa('unicorns', {stdin: {newline: true}}));
+expectError(execa('unicorns', {stdin: {preserveNewlines: true}}));
 expectError(execa('unicorns', {stdin: {objectMode: true}}));
 expectError(execa('unicorns', {stdin: {final: unknownFinal}}));
 execa('unicorns', {stdin: {transform: unknownGenerator, binary: true}});
 expectError(execa('unicorns', {stdin: {transform: unknownGenerator, binary: 'true'}}));
-execa('unicorns', {stdin: {transform: unknownGenerator, newline: true}});
-expectError(execa('unicorns', {stdin: {transform: unknownGenerator, newline: 'true'}}));
+execa('unicorns', {stdin: {transform: unknownGenerator, preserveNewlines: true}});
+expectError(execa('unicorns', {stdin: {transform: unknownGenerator, preserveNewlines: 'true'}}));
 execa('unicorns', {stdin: {transform: unknownGenerator, objectMode: true}});
 expectError(execa('unicorns', {stdin: {transform: unknownGenerator, objectMode: 'true'}}));
 execa('unicorns', {stdin: undefined});
@@ -1170,13 +1170,13 @@ execa('unicorns', {stdout: {transform: unknownGenerator, final: asyncFinal}});
 expectError(execaSync('unicorns', {stdout: {transform: unknownGenerator, final: asyncFinal}}));
 expectError(execa('unicorns', {stdout: {}}));
 expectError(execa('unicorns', {stdout: {binary: true}}));
-expectError(execa('unicorns', {stdout: {newline: true}}));
+expectError(execa('unicorns', {stdout: {preserveNewlines: true}}));
 expectError(execa('unicorns', {stdout: {objectMode: true}}));
 expectError(execa('unicorns', {stdout: {final: unknownFinal}}));
 execa('unicorns', {stdout: {transform: unknownGenerator, binary: true}});
 expectError(execa('unicorns', {stdout: {transform: unknownGenerator, binary: 'true'}}));
-execa('unicorns', {stdout: {transform: unknownGenerator, newline: true}});
-expectError(execa('unicorns', {stdout: {transform: unknownGenerator, newline: 'true'}}));
+execa('unicorns', {stdout: {transform: unknownGenerator, preserveNewlines: true}});
+expectError(execa('unicorns', {stdout: {transform: unknownGenerator, preserveNewlines: 'true'}}));
 execa('unicorns', {stdout: {transform: unknownGenerator, objectMode: true}});
 expectError(execa('unicorns', {stdout: {transform: unknownGenerator, objectMode: 'true'}}));
 execa('unicorns', {stdout: undefined});
@@ -1271,13 +1271,13 @@ execa('unicorns', {stderr: {transform: unknownGenerator, final: asyncFinal}});
 expectError(execaSync('unicorns', {stderr: {transform: unknownGenerator, final: asyncFinal}}));
 expectError(execa('unicorns', {stderr: {}}));
 expectError(execa('unicorns', {stderr: {binary: true}}));
-expectError(execa('unicorns', {stderr: {newline: true}}));
+expectError(execa('unicorns', {stderr: {preserveNewlines: true}}));
 expectError(execa('unicorns', {stderr: {objectMode: true}}));
 expectError(execa('unicorns', {stderr: {final: unknownFinal}}));
 execa('unicorns', {stderr: {transform: unknownGenerator, binary: true}});
 expectError(execa('unicorns', {stderr: {transform: unknownGenerator, binary: 'true'}}));
-execa('unicorns', {stderr: {transform: unknownGenerator, newline: true}});
-expectError(execa('unicorns', {stderr: {transform: unknownGenerator, newline: 'true'}}));
+execa('unicorns', {stderr: {transform: unknownGenerator, preserveNewlines: true}});
+expectError(execa('unicorns', {stderr: {transform: unknownGenerator, preserveNewlines: 'true'}}));
 execa('unicorns', {stderr: {transform: unknownGenerator, objectMode: true}});
 expectError(execa('unicorns', {stderr: {transform: unknownGenerator, objectMode: 'true'}}));
 execa('unicorns', {stderr: undefined});
@@ -1373,7 +1373,7 @@ execa('unicorns', {
 		unknownGenerator,
 		{transform: unknownGenerator},
 		{transform: unknownGenerator, binary: true},
-		{transform: unknownGenerator, newline: true},
+		{transform: unknownGenerator, preserveNewlines: true},
 		{transform: unknownGenerator, objectMode: true},
 		{transform: unknownGenerator, final: unknownFinal},
 		undefined,
@@ -1424,7 +1424,7 @@ execa('unicorns', {
 		[unknownGenerator],
 		[{transform: unknownGenerator}],
 		[{transform: unknownGenerator, binary: true}],
-		[{transform: unknownGenerator, newline: true}],
+		[{transform: unknownGenerator, preserveNewlines: true}],
 		[{transform: unknownGenerator, objectMode: true}],
 		[{transform: unknownGenerator, final: unknownFinal}],
 		[undefined],

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1069,10 +1069,13 @@ execa('unicorns', {stdin: {transform: unknownGenerator, final: asyncFinal}});
 expectError(execaSync('unicorns', {stdin: {transform: unknownGenerator, final: asyncFinal}}));
 expectError(execa('unicorns', {stdin: {}}));
 expectError(execa('unicorns', {stdin: {binary: true}}));
+expectError(execa('unicorns', {stdin: {newline: true}}));
 expectError(execa('unicorns', {stdin: {objectMode: true}}));
 expectError(execa('unicorns', {stdin: {final: unknownFinal}}));
 execa('unicorns', {stdin: {transform: unknownGenerator, binary: true}});
 expectError(execa('unicorns', {stdin: {transform: unknownGenerator, binary: 'true'}}));
+execa('unicorns', {stdin: {transform: unknownGenerator, newline: true}});
+expectError(execa('unicorns', {stdin: {transform: unknownGenerator, newline: 'true'}}));
 execa('unicorns', {stdin: {transform: unknownGenerator, objectMode: true}});
 expectError(execa('unicorns', {stdin: {transform: unknownGenerator, objectMode: 'true'}}));
 execa('unicorns', {stdin: undefined});
@@ -1167,10 +1170,13 @@ execa('unicorns', {stdout: {transform: unknownGenerator, final: asyncFinal}});
 expectError(execaSync('unicorns', {stdout: {transform: unknownGenerator, final: asyncFinal}}));
 expectError(execa('unicorns', {stdout: {}}));
 expectError(execa('unicorns', {stdout: {binary: true}}));
+expectError(execa('unicorns', {stdout: {newline: true}}));
 expectError(execa('unicorns', {stdout: {objectMode: true}}));
 expectError(execa('unicorns', {stdout: {final: unknownFinal}}));
 execa('unicorns', {stdout: {transform: unknownGenerator, binary: true}});
 expectError(execa('unicorns', {stdout: {transform: unknownGenerator, binary: 'true'}}));
+execa('unicorns', {stdout: {transform: unknownGenerator, newline: true}});
+expectError(execa('unicorns', {stdout: {transform: unknownGenerator, newline: 'true'}}));
 execa('unicorns', {stdout: {transform: unknownGenerator, objectMode: true}});
 expectError(execa('unicorns', {stdout: {transform: unknownGenerator, objectMode: 'true'}}));
 execa('unicorns', {stdout: undefined});
@@ -1265,10 +1271,13 @@ execa('unicorns', {stderr: {transform: unknownGenerator, final: asyncFinal}});
 expectError(execaSync('unicorns', {stderr: {transform: unknownGenerator, final: asyncFinal}}));
 expectError(execa('unicorns', {stderr: {}}));
 expectError(execa('unicorns', {stderr: {binary: true}}));
+expectError(execa('unicorns', {stderr: {newline: true}}));
 expectError(execa('unicorns', {stderr: {objectMode: true}}));
 expectError(execa('unicorns', {stderr: {final: unknownFinal}}));
 execa('unicorns', {stderr: {transform: unknownGenerator, binary: true}});
 expectError(execa('unicorns', {stderr: {transform: unknownGenerator, binary: 'true'}}));
+execa('unicorns', {stderr: {transform: unknownGenerator, newline: true}});
+expectError(execa('unicorns', {stderr: {transform: unknownGenerator, newline: 'true'}}));
 execa('unicorns', {stderr: {transform: unknownGenerator, objectMode: true}});
 expectError(execa('unicorns', {stderr: {transform: unknownGenerator, objectMode: 'true'}}));
 execa('unicorns', {stderr: undefined});
@@ -1364,6 +1373,7 @@ execa('unicorns', {
 		unknownGenerator,
 		{transform: unknownGenerator},
 		{transform: unknownGenerator, binary: true},
+		{transform: unknownGenerator, newline: true},
 		{transform: unknownGenerator, objectMode: true},
 		{transform: unknownGenerator, final: unknownFinal},
 		undefined,
@@ -1414,6 +1424,7 @@ execa('unicorns', {
 		[unknownGenerator],
 		[{transform: unknownGenerator}],
 		[{transform: unknownGenerator, binary: true}],
+		[{transform: unknownGenerator, newline: true}],
 		[{transform: unknownGenerator, objectMode: true}],
 		[{transform: unknownGenerator, final: unknownFinal}],
 		[undefined],

--- a/lib/return/error.js
+++ b/lib/return/error.js
@@ -180,7 +180,7 @@ const getOriginalMessage = (originalError, cwd) => {
 };
 
 const serializeMessagePart = messagePart => Array.isArray(messagePart)
-	? messagePart.map(messageItem => serializeMessageItem(messageItem)).join('')
+	? messagePart.map(messageItem => stripFinalNewline(serializeMessageItem(messageItem))).filter(Boolean).join('\n')
 	: serializeMessageItem(messagePart);
 
 const serializeMessageItem = messageItem => {

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -1,6 +1,6 @@
 import {generatorsToTransform} from './transform.js';
 import {getEncodingTransformGenerator} from './encoding-transform.js';
-import {getLinesGenerator} from './split.js';
+import {getSplitLinesGenerator, getAppendNewlineGenerator} from './split.js';
 import {pipeStreams} from './pipeline.js';
 import {isGeneratorOptions, isAsyncGenerator} from './type.js';
 import {getValidateTransformReturn} from './validate.js';
@@ -19,11 +19,11 @@ export const normalizeGenerators = stdioStreams => {
 };
 
 const normalizeGenerator = ({value, ...stdioStream}, index, newGenerators) => {
-	const {transform, final, binary = false, objectMode} = isGeneratorOptions(value) ? value : {transform: value};
+	const {transform, final, binary = false, newline = false, objectMode} = isGeneratorOptions(value) ? value : {transform: value};
 	const objectModes = stdioStream.direction === 'output'
 		? getOutputObjectModes(objectMode, index, newGenerators)
 		: getInputObjectModes(objectMode, index, newGenerators);
-	return {...stdioStream, value: {transform, final, binary, ...objectModes}};
+	return {...stdioStream, value: {transform, final, binary, newline, ...objectModes}};
 };
 
 /*
@@ -68,16 +68,18 @@ The `highWaterMark` is kept as the default value, since this is what `subprocess
 Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
 */
 export const generatorToDuplexStream = ({
-	value: {transform, final, binary, writableObjectMode, readableObjectMode},
+	value: {transform, final, binary, writableObjectMode, readableObjectMode, newline},
 	encoding,
 	forceEncoding,
 	optionName,
 }) => {
+	const state = {};
 	const generators = [
 		getEncodingTransformGenerator(encoding, writableObjectMode, forceEncoding),
-		getLinesGenerator(encoding, writableObjectMode, binary),
+		getSplitLinesGenerator({encoding, binary, newline, writableObjectMode, state}),
 		{transform, final},
 		{transform: getValidateTransformReturn(readableObjectMode, optionName)},
+		getAppendNewlineGenerator({binary, newline, readableObjectMode, state}),
 	].filter(Boolean);
 	const transformAsync = isAsyncGenerator(transform);
 	const finalAsync = isAsyncGenerator(final);

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -19,11 +19,11 @@ export const normalizeGenerators = stdioStreams => {
 };
 
 const normalizeGenerator = ({value, ...stdioStream}, index, newGenerators) => {
-	const {transform, final, binary = false, newline = false, objectMode} = isGeneratorOptions(value) ? value : {transform: value};
+	const {transform, final, binary = false, preserveNewlines = false, objectMode} = isGeneratorOptions(value) ? value : {transform: value};
 	const objectModes = stdioStream.direction === 'output'
 		? getOutputObjectModes(objectMode, index, newGenerators)
 		: getInputObjectModes(objectMode, index, newGenerators);
-	return {...stdioStream, value: {transform, final, binary, newline, ...objectModes}};
+	return {...stdioStream, value: {transform, final, binary, preserveNewlines, ...objectModes}};
 };
 
 /*
@@ -68,7 +68,7 @@ The `highWaterMark` is kept as the default value, since this is what `subprocess
 Chunks are currently processed serially. We could add a `concurrency` option to parallelize in the future.
 */
 export const generatorToDuplexStream = ({
-	value: {transform, final, binary, writableObjectMode, readableObjectMode, newline},
+	value: {transform, final, binary, writableObjectMode, readableObjectMode, preserveNewlines},
 	encoding,
 	forceEncoding,
 	optionName,
@@ -76,10 +76,10 @@ export const generatorToDuplexStream = ({
 	const state = {};
 	const generators = [
 		getEncodingTransformGenerator(encoding, writableObjectMode, forceEncoding),
-		getSplitLinesGenerator({encoding, binary, newline, writableObjectMode, state}),
+		getSplitLinesGenerator({encoding, binary, preserveNewlines, writableObjectMode, state}),
 		{transform, final},
 		{transform: getValidateTransformReturn(readableObjectMode, optionName)},
-		getAppendNewlineGenerator({binary, newline, readableObjectMode, state}),
+		getAppendNewlineGenerator({binary, preserveNewlines, readableObjectMode, state}),
 	].filter(Boolean);
 	const transformAsync = isAsyncGenerator(transform);
 	const finalAsync = isAsyncGenerator(final);

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -4,7 +4,7 @@ import {addStreamDirection} from './direction.js';
 import {normalizeStdio} from './option.js';
 import {handleNativeStream} from './native.js';
 import {handleInputOptions} from './input.js';
-import {handleStreamsLines} from './split.js';
+import {handleStreamsLines} from './lines.js';
 import {handleStreamsEncoding} from './encoding-final.js';
 import {normalizeGenerators} from './generator.js';
 import {forwardStdio} from './forward.js';

--- a/lib/stdio/lines.js
+++ b/lib/stdio/lines.js
@@ -1,0 +1,23 @@
+import {willPipeStreams} from './forward.js';
+
+// Split chunks line-wise for streams exposed to users like `subprocess.stdout`.
+// Appending a noop transform in object mode is enough to do this, since every non-binary transform iterates line-wise.
+export const handleStreamsLines = (stdioStreams, {lines, stripFinalNewline}, isSync) => shouldSplitLines(stdioStreams, lines, isSync)
+	? [
+		...stdioStreams,
+		{
+			...stdioStreams[0],
+			type: 'generator',
+			value: {transform: linesEndGenerator, objectMode: true, newline: !stripFinalNewline},
+		},
+	]
+	: stdioStreams;
+
+const shouldSplitLines = (stdioStreams, lines, isSync) => stdioStreams[0].direction === 'output'
+	&& lines
+	&& !isSync
+	&& willPipeStreams(stdioStreams);
+
+const linesEndGenerator = function * (chunk) {
+	yield chunk;
+};

--- a/lib/stdio/lines.js
+++ b/lib/stdio/lines.js
@@ -8,7 +8,7 @@ export const handleStreamsLines = (stdioStreams, {lines, stripFinalNewline}, isS
 		{
 			...stdioStreams[0],
 			type: 'generator',
-			value: {transform: linesEndGenerator, objectMode: true, newline: !stripFinalNewline},
+			value: {transform: linesEndGenerator, objectMode: true, preserveNewlines: !stripFinalNewline},
 		},
 	]
 	: stdioStreams;

--- a/lib/stdio/split.js
+++ b/lib/stdio/split.js
@@ -1,7 +1,7 @@
 import {isUint8Array} from '../utils.js';
 
 // Split chunks line-wise for generators passed to the `std*` options
-export const getSplitLinesGenerator = ({encoding, binary, newline, writableObjectMode, state}) => {
+export const getSplitLinesGenerator = ({encoding, binary, preserveNewlines, writableObjectMode, state}) => {
 	if (binary || writableObjectMode) {
 		return;
 	}
@@ -9,7 +9,7 @@ export const getSplitLinesGenerator = ({encoding, binary, newline, writableObjec
 	const info = encoding === 'buffer' ? linesUint8ArrayInfo : linesStringInfo;
 	state.previousChunks = info.emptyValue;
 	return {
-		transform: splitGenerator.bind(undefined, state, newline, info),
+		transform: splitGenerator.bind(undefined, state, preserveNewlines, info),
 		final: linesFinal.bind(undefined, state),
 	};
 };
@@ -48,13 +48,13 @@ const linesInfo = [linesStringInfo, linesUint8ArrayInfo];
 
 // This imperative logic is much faster than using `String.split()` and uses very low memory.
 // Also, it allows sharing it with `Uint8Array`.
-const splitGenerator = function * (state, newline, {emptyValue, CR, LF, concatBytes}, chunk) {
+const splitGenerator = function * (state, preserveNewlines, {emptyValue, CR, LF, concatBytes}, chunk) {
 	let {previousChunks} = state;
 	let start = -1;
 
 	for (let end = 0; end < chunk.length; end += 1) {
 		if (chunk[end] === LF) {
-			const newlineLength = getNewlineLength({chunk, end, CR, newline, state});
+			const newlineLength = getNewlineLength({chunk, end, CR, preserveNewlines, state});
 			let line = chunk.slice(start + 1, end + 1 - newlineLength);
 
 			if (previousChunks.length > 0) {
@@ -74,8 +74,8 @@ const splitGenerator = function * (state, newline, {emptyValue, CR, LF, concatBy
 	state.previousChunks = previousChunks;
 };
 
-const getNewlineLength = ({chunk, end, CR, newline, state}) => {
-	if (newline) {
+const getNewlineLength = ({chunk, end, CR, preserveNewlines, state}) => {
+	if (preserveNewlines) {
 		return 0;
 	}
 
@@ -89,9 +89,9 @@ const linesFinal = function * ({previousChunks}) {
 	}
 };
 
-// When `newline: false` is used, we strip the newline of each line.
+// Unless `preserveNewlines: true` is used, we strip the newline of each line.
 // This re-adds them after the user `transform` code has run.
-export const getAppendNewlineGenerator = ({binary, newline, readableObjectMode, state}) => binary || newline || readableObjectMode
+export const getAppendNewlineGenerator = ({binary, preserveNewlines, readableObjectMode, state}) => binary || preserveNewlines || readableObjectMode
 	? undefined
 	: {transform: appendNewlineGenerator.bind(undefined, state)};
 
@@ -103,6 +103,6 @@ const appendNewlineGenerator = function * ({isWindowsNewline = false}, chunk) {
 		return;
 	}
 
-	const newlineString = isWindowsNewline ? windowsNewline : unixNewline;
-	yield concatBytes(chunk, newlineString);
+	const newline = isWindowsNewline ? windowsNewline : unixNewline;
+	yield concatBytes(chunk, newline);
 };

--- a/lib/stdio/split.js
+++ b/lib/stdio/split.js
@@ -1,38 +1,15 @@
 import {isUint8Array} from '../utils.js';
-import {willPipeStreams} from './forward.js';
-
-// Split chunks line-wise for streams exposed to users like `subprocess.stdout`.
-// Appending a noop transform in object mode is enough to do this, since every non-binary transform iterates line-wise.
-export const handleStreamsLines = (stdioStreams, {lines}, isSync) => shouldSplitLines(stdioStreams, lines, isSync)
-	? [
-		...stdioStreams,
-		{
-			...stdioStreams[0],
-			type: 'generator',
-			value: {transform: linesEndGenerator, objectMode: true},
-		},
-	]
-	: stdioStreams;
-
-const shouldSplitLines = (stdioStreams, lines, isSync) => stdioStreams[0].direction === 'output'
-	&& lines
-	&& !isSync
-	&& willPipeStreams(stdioStreams);
-
-const linesEndGenerator = function * (chunk) {
-	yield chunk;
-};
 
 // Split chunks line-wise for generators passed to the `std*` options
-export const getLinesGenerator = (encoding, writableObjectMode, binary) => {
+export const getSplitLinesGenerator = ({encoding, binary, newline, writableObjectMode, state}) => {
 	if (binary || writableObjectMode) {
 		return;
 	}
 
 	const info = encoding === 'buffer' ? linesUint8ArrayInfo : linesStringInfo;
-	const state = {previousChunks: info.emptyValue};
+	state.previousChunks = info.emptyValue;
 	return {
-		transform: linesGenerator.bind(undefined, state, info),
+		transform: splitGenerator.bind(undefined, state, newline, info),
 		final: linesFinal.bind(undefined, state),
 	};
 };
@@ -46,8 +23,11 @@ const concatUint8Array = (firstChunk, secondChunk) => {
 
 const linesUint8ArrayInfo = {
 	emptyValue: new Uint8Array(0),
-	newline: 0x0A,
-	concat: concatUint8Array,
+	windowsNewline: new Uint8Array([0x0D, 0x0A]),
+	unixNewline: new Uint8Array([0x0A]),
+	CR: 0x0D,
+	LF: 0x0A,
+	concatBytes: concatUint8Array,
 	isValidType: isUint8Array,
 };
 
@@ -56,23 +36,29 @@ const isString = chunk => typeof chunk === 'string';
 
 const linesStringInfo = {
 	emptyValue: '',
-	newline: '\n',
-	concat: concatString,
+	windowsNewline: '\r\n',
+	unixNewline: '\n',
+	CR: '\r',
+	LF: '\n',
+	concatBytes: concatString,
 	isValidType: isString,
 };
 
+const linesInfo = [linesStringInfo, linesUint8ArrayInfo];
+
 // This imperative logic is much faster than using `String.split()` and uses very low memory.
 // Also, it allows sharing it with `Uint8Array`.
-const linesGenerator = function * (state, {emptyValue, newline, concat}, chunk) {
+const splitGenerator = function * (state, newline, {emptyValue, CR, LF, concatBytes}, chunk) {
 	let {previousChunks} = state;
 	let start = -1;
 
 	for (let end = 0; end < chunk.length; end += 1) {
-		if (chunk[end] === newline) {
-			let line = chunk.slice(start + 1, end + 1);
+		if (chunk[end] === LF) {
+			const newlineLength = getNewlineLength({chunk, end, CR, newline, state});
+			let line = chunk.slice(start + 1, end + 1 - newlineLength);
 
 			if (previousChunks.length > 0) {
-				line = concat(previousChunks, line);
+				line = concatBytes(previousChunks, line);
 				previousChunks = emptyValue;
 			}
 
@@ -82,14 +68,41 @@ const linesGenerator = function * (state, {emptyValue, newline, concat}, chunk) 
 	}
 
 	if (start !== chunk.length - 1) {
-		previousChunks = concat(previousChunks, chunk.slice(start + 1));
+		previousChunks = concatBytes(previousChunks, chunk.slice(start + 1));
 	}
 
 	state.previousChunks = previousChunks;
+};
+
+const getNewlineLength = ({chunk, end, CR, newline, state}) => {
+	if (newline) {
+		return 0;
+	}
+
+	state.isWindowsNewline = end !== 0 && chunk[end - 1] === CR;
+	return state.isWindowsNewline ? 2 : 1;
 };
 
 const linesFinal = function * ({previousChunks}) {
 	if (previousChunks.length > 0) {
 		yield previousChunks;
 	}
+};
+
+// When `newline: false` is used, we strip the newline of each line.
+// This re-adds them after the user `transform` code has run.
+export const getAppendNewlineGenerator = ({binary, newline, readableObjectMode, state}) => binary || newline || readableObjectMode
+	? undefined
+	: {transform: appendNewlineGenerator.bind(undefined, state)};
+
+const appendNewlineGenerator = function * ({isWindowsNewline = false}, chunk) {
+	const {unixNewline, windowsNewline, LF, concatBytes} = linesInfo.find(({isValidType}) => isValidType(chunk));
+
+	if (chunk.at(-1) === LF) {
+		yield chunk;
+		return;
+	}
+
+	const newlineString = isWindowsNewline ? windowsNewline : unixNewline;
+	yield concatBytes(chunk, newlineString);
 };

--- a/lib/verbose/output.js
+++ b/lib/verbose/output.js
@@ -1,5 +1,4 @@
 import {inspect} from 'node:util';
-import stripFinalNewline from 'strip-final-newline';
 import {escapeLines} from '../arguments/escape.js';
 import {PIPED_STDIO_VALUES} from '../stdio/forward.js';
 import {verboseLog} from './log.js';
@@ -58,7 +57,7 @@ const isPiping = stream => stream._readableState.pipes.length > 0;
 
 // When `verbose` is `full`, print stdout|stderr
 const logOutput = (line, {verboseId}) => {
-	const lines = typeof line === 'string' ? stripFinalNewline(line) : inspect(line);
+	const lines = typeof line === 'string' ? line : inspect(line);
 	const escapedLines = escapeLines(lines);
 	const spacedLines = escapedLines.replaceAll('\t', ' '.repeat(TAB_SIZE));
 	verboseLog(spacedLines, verboseId, 'output');

--- a/readme.md
+++ b/readme.md
@@ -918,6 +918,8 @@ Default: `true`
 
 Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
 
+If the [`lines` option](#lines) is true, this applies to each output line instead.
+
 #### maxBuffer
 
 Type: `number`\

--- a/test/convert/readable.js
+++ b/test/convert/readable.js
@@ -318,13 +318,13 @@ test('.readable() can iterate over lines', async t => {
 		lines.push(line);
 	}
 
-	const expectedLines = ['aaa\n', 'bbb\n', 'ccc'];
+	const expectedLines = ['aaa', 'bbb', 'ccc'];
 	t.deepEqual(lines, expectedLines);
 	await assertSubprocessOutput(t, subprocess, expectedLines);
 });
 
 test('.readable() can wait for data', async t => {
-	const subprocess = execa('noop.js', {stdout: getChunksGenerator([foobarString, foobarString])});
+	const subprocess = execa('noop.js', {stdout: getChunksGenerator([foobarString, foobarString], false, true)});
 	const stream = subprocess.readable();
 
 	t.is(stream.read(), null);

--- a/test/convert/writable.js
+++ b/test/convert/writable.js
@@ -254,7 +254,7 @@ test('.writable() can be used with Stream.compose()', async t => {
 });
 
 test('.writable() works with objectMode', async t => {
-	const subprocess = getReadWriteSubprocess({stdin: serializeGenerator});
+	const subprocess = getReadWriteSubprocess({stdin: serializeGenerator(true, true)});
 	const stream = subprocess.writable();
 	t.true(stream.writableObjectMode);
 	t.is(stream.writableHighWaterMark, defaultObjectHighWaterMark);
@@ -265,7 +265,7 @@ test('.writable() works with objectMode', async t => {
 });
 
 test('.duplex() works with objectMode and writes', async t => {
-	const subprocess = getReadWriteSubprocess({stdin: serializeGenerator});
+	const subprocess = getReadWriteSubprocess({stdin: serializeGenerator(true, true)});
 	const stream = subprocess.duplex();
 	t.false(stream.readableObjectMode);
 	t.is(stream.readableHighWaterMark, defaultHighWaterMark);
@@ -319,7 +319,7 @@ const writeUntilFull = async (t, stream, subprocess) => {
 };
 
 test('.writable() waits when its buffer is full', async t => {
-	const subprocess = getReadWriteSubprocess({stdin: noopAsyncGenerator()});
+	const subprocess = getReadWriteSubprocess({stdin: noopAsyncGenerator(false, true)});
 	const stream = subprocess.writable();
 
 	const expectedOutput = await writeUntilFull(t, stream, subprocess);
@@ -328,7 +328,7 @@ test('.writable() waits when its buffer is full', async t => {
 });
 
 test('.duplex() waits when its buffer is full', async t => {
-	const subprocess = getReadWriteSubprocess({stdin: noopAsyncGenerator()});
+	const subprocess = getReadWriteSubprocess({stdin: noopAsyncGenerator(false, true)});
 	const stream = subprocess.duplex();
 
 	const expectedOutput = await writeUntilFull(t, stream, subprocess);

--- a/test/fixtures/nested-inherit.js
+++ b/test/fixtures/nested-inherit.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 import {execa} from '../../index.js';
+import {uppercaseGenerator} from '../helpers/generator.js';
 
-const uppercaseGenerator = function * (line) {
-	yield line.toUpperCase();
-};
-
-await execa('noop-fd.js', ['1'], {stdout: ['inherit', uppercaseGenerator]});
+await execa('noop-fd.js', ['1'], {stdout: ['inherit', uppercaseGenerator()]});

--- a/test/fixtures/nested-transform.js
+++ b/test/fixtures/nested-transform.js
@@ -4,4 +4,4 @@ import {execa} from '../../index.js';
 import {uppercaseGenerator} from '../helpers/generator.js';
 
 const [options, file, ...args] = process.argv.slice(2);
-await execa(file, args, {stdout: uppercaseGenerator, ...JSON.parse(options)});
+await execa(file, args, {stdout: uppercaseGenerator(), ...JSON.parse(options)});

--- a/test/helpers/generator.js
+++ b/test/helpers/generator.js
@@ -1,10 +1,12 @@
 import {setImmediate, setInterval} from 'node:timers/promises';
 import {foobarObject} from './input.js';
 
-export const noopAsyncGenerator = () => ({
+export const noopAsyncGenerator = (objectMode, binary) => ({
 	async * transform(line) {
 		yield line;
 	},
+	objectMode,
+	binary,
 });
 
 export const addNoopGenerator = (transform, addNoopTransform) => addNoopTransform
@@ -19,12 +21,13 @@ export const noopGenerator = (objectMode, binary) => ({
 	binary,
 });
 
-export const serializeGenerator = {
+export const serializeGenerator = (objectMode, binary) => ({
 	* transform(object) {
 		yield JSON.stringify(object);
 	},
-	objectMode: true,
-};
+	objectMode,
+	binary,
+});
 
 export const getOutputsGenerator = (inputs, objectMode) => ({
 	* transform() {
@@ -41,9 +44,10 @@ export const identityAsyncGenerator = input => async function * () {
 	yield input;
 };
 
-export const getOutputGenerator = (input, objectMode) => ({
+export const getOutputGenerator = (input, objectMode, binary) => ({
 	transform: identityGenerator(input),
 	objectMode,
+	binary,
 });
 
 export const outputObjectGenerator = getOutputGenerator(foobarObject, true);
@@ -82,9 +86,13 @@ export const infiniteGenerator = async function * () {
 	}
 };
 
-export const uppercaseGenerator = function * (line) {
-	yield line.toUpperCase();
-};
+export const uppercaseGenerator = (objectMode, binary) => ({
+	* transform(line) {
+		yield line.toUpperCase();
+	},
+	objectMode,
+	binary,
+});
 
 // eslint-disable-next-line require-yield
 export const throwingGenerator = function * () {

--- a/test/helpers/lines.js
+++ b/test/helpers/lines.js
@@ -1,0 +1,28 @@
+import {Buffer} from 'node:buffer';
+
+export const simpleFull = 'aaa\nbbb\nccc';
+export const simpleChunks = [simpleFull];
+export const simpleLines = ['aaa\n', 'bbb\n', 'ccc'];
+export const simpleFullEndLines = ['aaa\n', 'bbb\n', 'ccc\n'];
+export const noNewlinesChunks = ['aaa', 'bbb', 'ccc'];
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export const getEncoding = isUint8Array => isUint8Array ? 'buffer' : 'utf8';
+
+export const stringsToUint8Arrays = (strings, isUint8Array) => isUint8Array
+	? strings.map(string => textEncoder.encode(string))
+	: strings;
+
+export const stringsToBuffers = (strings, isUint8Array) => isUint8Array
+	? strings.map(string => Buffer.from(string))
+	: strings;
+
+export const serializeResult = (result, isUint8Array) => Array.isArray(result)
+	? result.map(resultItem => serializeResultItem(resultItem, isUint8Array))
+	: serializeResultItem(result, isUint8Array);
+
+const serializeResultItem = (resultItem, isUint8Array) => isUint8Array
+	? textDecoder.decode(resultItem)
+	: resultItem;

--- a/test/pipe/streaming.js
+++ b/test/pipe/streaming.js
@@ -227,7 +227,7 @@ test('Can pipe two sources to same destination in objectMode', async t => {
 
 	t.like(await source, {stdout: [[foobarString]]});
 	t.like(await secondSource, {stdout: [[foobarString]]});
-	t.like(await destination, {stdout: `${foobarString}${foobarString}`});
+	t.like(await destination, {stdout: `${foobarString}\n${foobarString}`});
 	t.is(await pipePromise, await destination);
 	t.is(await secondPipePromise, await destination);
 });

--- a/test/return/output.js
+++ b/test/return/output.js
@@ -137,6 +137,6 @@ test('stripFinalNewline: true with stdio[*] - sync', testStripFinalNewline, 3, t
 test('stripFinalNewline: false with stdio[*] - sync', testStripFinalNewline, 3, false, execaSync);
 
 test('stripFinalNewline is not used in objectMode', async t => {
-	const {stdout} = await execa('noop-fd.js', ['1', 'foobar\n'], {stripFinalNewline: true, stdout: noopGenerator(true)});
+	const {stdout} = await execa('noop-fd.js', ['1', 'foobar\n'], {stripFinalNewline: true, stdout: noopGenerator(true, true)});
 	t.deepEqual(stdout, ['foobar\n']);
 });

--- a/test/stdio/iterable.js
+++ b/test/stdio/iterable.js
@@ -54,7 +54,7 @@ const foobarAsyncObjectGenerator = function * () {
 };
 
 const testObjectIterable = async (t, stdioOption, fdNumber) => {
-	const {stdout} = await execa('stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, [stdioOption, serializeGenerator]));
+	const {stdout} = await execa('stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, [stdioOption, serializeGenerator(true)]));
 	t.is(stdout, foobarObjectString);
 };
 

--- a/test/stdio/lines.js
+++ b/test/stdio/lines.js
@@ -1,0 +1,149 @@
+import {once} from 'node:events';
+import {Writable} from 'node:stream';
+import test from 'ava';
+import {execa, execaSync} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {fullStdio} from '../helpers/stdio.js';
+import {getChunksGenerator} from '../helpers/generator.js';
+import {foobarObject} from '../helpers/input.js';
+import {
+	simpleFull,
+	simpleChunks,
+	simpleLines,
+	simpleFullEndLines,
+	noNewlinesChunks,
+	getEncoding,
+	stringsToUint8Arrays,
+	stringsToBuffers,
+	serializeResult,
+} from '../helpers/lines.js';
+
+setFixtureDir();
+
+// eslint-disable-next-line max-params
+const testStreamLines = async (t, fdNumber, input, expectedOutput, isUint8Array, stripFinalNewline) => {
+	const {stdio} = await execa('noop-fd.js', [`${fdNumber}`, input], {
+		...fullStdio,
+		lines: true,
+		encoding: getEncoding(isUint8Array),
+		stripFinalNewline,
+	});
+	const output = serializeResult(stdio[fdNumber], isUint8Array);
+	t.deepEqual(output, expectedOutput);
+};
+
+test('"lines: true" splits lines, stdout, string', testStreamLines, 1, simpleFull, simpleLines, false, false);
+test('"lines: true" splits lines, stdout, Uint8Array', testStreamLines, 1, simpleFull, simpleLines, true, false);
+test('"lines: true" splits lines, stderr, string', testStreamLines, 2, simpleFull, simpleLines, false, false);
+test('"lines: true" splits lines, stderr, Uint8Array', testStreamLines, 2, simpleFull, simpleLines, true, false);
+test('"lines: true" splits lines, stdio[*], string', testStreamLines, 3, simpleFull, simpleLines, false, false);
+test('"lines: true" splits lines, stdio[*], Uint8Array', testStreamLines, 3, simpleFull, simpleLines, true, false);
+test('"lines: true" splits lines, stdout, string, stripFinalNewline', testStreamLines, 1, simpleFull, noNewlinesChunks, false, true);
+test('"lines: true" splits lines, stdout, Uint8Array, stripFinalNewline', testStreamLines, 1, simpleFull, noNewlinesChunks, true, true);
+test('"lines: true" splits lines, stderr, string, stripFinalNewline', testStreamLines, 2, simpleFull, noNewlinesChunks, false, true);
+test('"lines: true" splits lines, stderr, Uint8Array, stripFinalNewline', testStreamLines, 2, simpleFull, noNewlinesChunks, true, true);
+test('"lines: true" splits lines, stdio[*], string, stripFinalNewline', testStreamLines, 3, simpleFull, noNewlinesChunks, false, true);
+test('"lines: true" splits lines, stdio[*], Uint8Array, stripFinalNewline', testStreamLines, 3, simpleFull, noNewlinesChunks, true, true);
+
+const testStreamLinesNoop = async (t, lines, execaMethod) => {
+	const {stdout} = await execaMethod('noop-fd.js', ['1', simpleFull], {lines});
+	t.is(stdout, simpleFull);
+};
+
+test('"lines: false" is a noop with execa()', testStreamLinesNoop, false, execa);
+test('"lines: false" is a noop with execaSync()', testStreamLinesNoop, false, execaSync);
+test('"lines: true" is a noop with execaSync()', testStreamLinesNoop, true, execaSync);
+
+const bigArray = Array.from({length: 1e5}).fill('.\n');
+const bigString = bigArray.join('');
+const bigStringNoNewlines = '.'.repeat(1e6);
+const bigStringNoNewlinesEnd = `${bigStringNoNewlines}\n`;
+
+// eslint-disable-next-line max-params
+const testStreamLinesGenerator = async (t, input, expectedLines, objectMode, binary) => {
+	const {stdout} = await execa('noop.js', {
+		stdout: getChunksGenerator(input, objectMode, binary),
+		lines: true,
+		stripFinalNewline: false,
+	});
+	t.deepEqual(stdout, expectedLines);
+};
+
+test('"lines: true" works with strings generators', testStreamLinesGenerator, simpleChunks, simpleFullEndLines, false, false);
+test('"lines: true" works with strings generators, objectMode', testStreamLinesGenerator, simpleChunks, simpleChunks, true, false);
+test('"lines: true" works with strings generators, binary', testStreamLinesGenerator, simpleChunks, simpleLines, false, true);
+test('"lines: true" works with strings generators, binary, objectMode', testStreamLinesGenerator, simpleChunks, simpleChunks, true, true);
+test('"lines: true" works with big strings generators', testStreamLinesGenerator, [bigString], bigArray, false, false);
+test('"lines: true" works with big strings generators, objectMode', testStreamLinesGenerator, [bigString], [bigString], true, false);
+test('"lines: true" works with big strings generators without newlines', testStreamLinesGenerator, [bigStringNoNewlines], [bigStringNoNewlinesEnd], false, false);
+test('"lines: true" works with big strings generators without newlines, objectMode', testStreamLinesGenerator, [bigStringNoNewlines], [bigStringNoNewlines], true, false);
+
+test('"lines: true" is a noop with objects generators, objectMode', async t => {
+	const {stdout} = await execa('noop.js', {
+		stdout: getChunksGenerator([foobarObject], true),
+		lines: true,
+	});
+	t.deepEqual(stdout, [foobarObject]);
+});
+
+const singleLine = 'a\n';
+const singleLineStrip = 'a';
+
+const testOtherEncoding = async (t, stripFinalNewline, strippedLine) => {
+	const {stdout} = await execa('noop-fd.js', ['1', `${singleLine}${singleLine}`], {
+		lines: true,
+		encoding: 'base64',
+		stripFinalNewline,
+	});
+	t.deepEqual(stdout, [strippedLine, strippedLine]);
+};
+
+test('"lines: true" does not work with other encodings', testOtherEncoding, false, singleLine);
+test('"lines: true" does not work with other encodings, stripFinalNewline', testOtherEncoding, true, singleLineStrip);
+
+const getSimpleChunkSubprocess = (isUint8Array, stripFinalNewline, options) => execa('noop-fd.js', ['1', ...simpleChunks], {
+	lines: true,
+	encoding: getEncoding(isUint8Array),
+	stripFinalNewline,
+	...options,
+});
+
+const testAsyncIteration = async (t, expectedOutput, isUint8Array, stripFinalNewline) => {
+	const subprocess = getSimpleChunkSubprocess(isUint8Array, stripFinalNewline);
+	const [stdout] = await Promise.all([subprocess.stdout.toArray(), subprocess]);
+	t.deepEqual(stdout, stringsToUint8Arrays(expectedOutput, isUint8Array));
+};
+
+test('"lines: true" works with stream async iteration, string', testAsyncIteration, simpleLines, false, false);
+test('"lines: true" works with stream async iteration, Uint8Array', testAsyncIteration, simpleLines, true, false);
+test('"lines: true" works with stream async iteration, string, stripFinalNewline', testAsyncIteration, noNewlinesChunks, false, true);
+test('"lines: true" works with stream async iteration, Uint8Array, stripFinalNewline', testAsyncIteration, noNewlinesChunks, true, true);
+
+const testDataEvents = async (t, expectedOutput, isUint8Array, stripFinalNewline) => {
+	const subprocess = getSimpleChunkSubprocess(isUint8Array, stripFinalNewline);
+	const [[firstLine]] = await Promise.all([once(subprocess.stdout, 'data'), subprocess]);
+	t.deepEqual(firstLine, stringsToUint8Arrays(expectedOutput, isUint8Array)[0]);
+};
+
+test('"lines: true" works with stream "data" events, string', testDataEvents, simpleLines, false, false);
+test('"lines: true" works with stream "data" events, Uint8Array', testDataEvents, simpleLines, true, false);
+test('"lines: true" works with stream "data" events, string, stripFinalNewline', testDataEvents, noNewlinesChunks, false, true);
+test('"lines: true" works with stream "data" events, Uint8Array, stripFinalNewline', testDataEvents, noNewlinesChunks, true, true);
+
+const testWritableStream = async (t, expectedOutput, isUint8Array, stripFinalNewline) => {
+	const lines = [];
+	const writable = new Writable({
+		write(line, encoding, done) {
+			lines.push(line);
+			done();
+		},
+		decodeStrings: false,
+	});
+	await getSimpleChunkSubprocess(isUint8Array, stripFinalNewline, {stdout: ['pipe', writable]});
+	t.deepEqual(lines, stringsToBuffers(expectedOutput, isUint8Array));
+};
+
+test('"lines: true" works with writable streams targets, string', testWritableStream, simpleLines, false, false);
+test('"lines: true" works with writable streams targets, Uint8Array', testWritableStream, simpleLines, true, false);
+test('"lines: true" works with writable streams targets, string, stripFinalNewline', testWritableStream, noNewlinesChunks, false, true);
+test('"lines: true" works with writable streams targets, Uint8Array, stripFinalNewline', testWritableStream, noNewlinesChunks, true, true);

--- a/test/stdio/split.js
+++ b/test/stdio/split.js
@@ -1,250 +1,328 @@
-import {Buffer} from 'node:buffer';
-import {once} from 'node:events';
-import {Writable} from 'node:stream';
-import {scheduler} from 'node:timers/promises';
 import test from 'ava';
-import {execa, execaSync} from '../../index.js';
+import {execa} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
-import {fullStdio, getStdio} from '../helpers/stdio.js';
-import {getChunksGenerator} from '../helpers/generator.js';
-import {foobarObject} from '../helpers/input.js';
+import {getStdio} from '../helpers/stdio.js';
+import {
+	getChunksGenerator,
+	getOutputsGenerator,
+	noopGenerator,
+	noopAsyncGenerator,
+} from '../helpers/generator.js';
+import {foobarString, foobarUint8Array, foobarObject, foobarObjectString} from '../helpers/input.js';
+import {
+	simpleFull,
+	simpleChunks,
+	simpleLines,
+	simpleFullEndLines,
+	noNewlinesChunks,
+	getEncoding,
+	stringsToUint8Arrays,
+	serializeResult,
+} from '../helpers/lines.js';
 
 setFixtureDir();
 
-const simpleChunk = ['aaa\nbbb\nccc'];
-const simpleLines = ['aaa\n', 'bbb\n', 'ccc'];
-const windowsChunk = ['aaa\r\nbbb\r\nccc'];
+const simpleFullEnd = `${simpleFull}\n`;
+const simpleFullEndChunks = [simpleFullEnd];
+const windowsFull = 'aaa\r\nbbb\r\nccc';
+const windowsFullEnd = `${windowsFull}\r\n`;
+const windowsChunks = [windowsFull];
 const windowsLines = ['aaa\r\n', 'bbb\r\n', 'ccc'];
-const newlineEndChunk = ['aaa\nbbb\nccc\n'];
-const newlineEndLines = ['aaa\n', 'bbb\n', 'ccc\n'];
-const noNewlinesChunk = ['aaa'];
-const noNewlinesChunks = ['aaa', 'bbb', 'ccc'];
+const noNewlinesFull = 'aaabbbccc';
+const noNewlinesFullEnd = `${noNewlinesFull}\n`;
 const noNewlinesLines = ['aaabbbccc'];
-const newlineChunk = ['\n'];
-const newlinesChunk = ['\n\n\n'];
+const singleFull = 'aaa';
+const singleFullEnd = `${singleFull}\n`;
+const singleFullEndWindows = `${singleFull}\r\n`;
+const singleChunks = [singleFull];
+const noLines = [];
+const emptyFull = '';
+const emptyChunks = [emptyFull];
+const manyEmptyChunks = [emptyFull, emptyFull, emptyFull];
+const newlineFull = '\n';
+const newlineChunks = [newlineFull];
+const newlinesFull = '\n\n\n';
+const newlinesChunks = [newlinesFull];
 const newlinesLines = ['\n', '\n', '\n'];
-const windowsNewlinesChunk = ['\r\n\r\n\r\n'];
+const windowsNewlinesFull = '\r\n\r\n\r\n';
+const windowsNewlinesChunks = [windowsNewlinesFull];
 const windowsNewlinesLines = ['\r\n', '\r\n', '\r\n'];
 const runOverChunks = ['aaa\nb', 'b', 'b\nccc'];
-
-const bigLine = '.'.repeat(1e5);
+const bigFull = '.'.repeat(1e5);
+const bigFullEnd = `${bigFull}\n`;
+const bigChunks = [bigFull];
 const manyChunks = Array.from({length: 1e3}).fill('.');
-
-const inputGenerator = async function * (input) {
-	for (const inputItem of input) {
-		yield inputItem;
-		// eslint-disable-next-line no-await-in-loop
-		await scheduler.yield();
-	}
-};
+const manyFull = manyChunks.join('');
+const manyFullEnd = `${manyFull}\n`;
+const manyLines = [manyFull];
+const mixedNewlines = '.\n.\r\n.\n.\r\n.\n';
 
 const resultGenerator = function * (lines, chunk) {
 	lines.push(chunk);
 	yield chunk;
 };
 
-const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
-
-const getEncoding = isUint8Array => isUint8Array ? 'buffer' : 'utf8';
-
-const stringsToUint8Arrays = (strings, isUint8Array) => isUint8Array
-	? strings.map(string => textEncoder.encode(string))
-	: strings;
-
-const stringsToBuffers = (strings, isUint8Array) => isUint8Array
-	? strings.map(string => Buffer.from(string))
-	: strings;
-
-const getSimpleChunkSubprocess = (isUint8Array, options) => execa('noop-fd.js', ['1', ...simpleChunk], {
-	lines: true,
-	encoding: getEncoding(isUint8Array),
-	...options,
-});
-
-const serializeResult = (result, isUint8Array, objectMode) => objectMode
-	? result.map(resultItem => serializeResultItem(resultItem, isUint8Array)).join('')
-	: serializeResultItem(result, isUint8Array);
-
-const serializeResultItem = (resultItem, isUint8Array) => isUint8Array
-	? textDecoder.decode(resultItem)
-	: resultItem;
-
 // eslint-disable-next-line max-params
-const testLines = async (t, fdNumber, input, expectedLines, isUint8Array, objectMode) => {
+const testLines = async (t, fdNumber, input, expectedLines, expectedOutput, isUint8Array, objectMode, newline) => {
 	const lines = [];
 	const {stdio} = await execa('noop-fd.js', [`${fdNumber}`], {
 		...getStdio(fdNumber, [
-			{transform: inputGenerator.bind(undefined, stringsToUint8Arrays(input, isUint8Array)), objectMode},
-			{transform: resultGenerator.bind(undefined, lines), objectMode},
+			getChunksGenerator(input, false, true),
+			{transform: resultGenerator.bind(undefined, lines), newline, objectMode},
 		]),
 		encoding: getEncoding(isUint8Array),
 		stripFinalNewline: false,
 	});
-	t.is(input.join(''), serializeResult(stdio[fdNumber], isUint8Array, objectMode));
+	const output = serializeResult(stdio[fdNumber], isUint8Array);
 	t.deepEqual(lines, stringsToUint8Arrays(expectedLines, isUint8Array));
+	t.deepEqual(output, expectedOutput);
 };
 
-test('Split string stdout - n newlines, 1 chunk', testLines, 1, simpleChunk, simpleLines, false, false);
-test('Split string stderr - n newlines, 1 chunk', testLines, 2, simpleChunk, simpleLines, false, false);
-test('Split string stdio[*] - n newlines, 1 chunk', testLines, 3, simpleChunk, simpleLines, false, false);
-test('Split string stdout - no newline, n chunks', testLines, 1, noNewlinesChunks, noNewlinesLines, false, false);
-test('Split string stdout - 0 newlines, 1 chunk', testLines, 1, noNewlinesChunk, noNewlinesChunk, false, false);
-test('Split string stdout - Windows newlines', testLines, 1, windowsChunk, windowsLines, false, false);
-test('Split string stdout - chunk ends with newline', testLines, 1, newlineEndChunk, newlineEndLines, false, false);
-test('Split string stdout - single newline', testLines, 1, newlineChunk, newlineChunk, false, false);
-test('Split string stdout - only newlines', testLines, 1, newlinesChunk, newlinesLines, false, false);
-test('Split string stdout - only Windows newlines', testLines, 1, windowsNewlinesChunk, windowsNewlinesLines, false, false);
-test('Split string stdout - line split over multiple chunks', testLines, 1, runOverChunks, simpleLines, false, false);
-test('Split string stdout - 0 newlines, big line', testLines, 1, [bigLine], [bigLine], false, false);
-test('Split string stdout - 0 newlines, many chunks', testLines, 1, manyChunks, [manyChunks.join('')], false, false);
-test('Split Uint8Array stdout - n newlines, 1 chunk', testLines, 1, simpleChunk, simpleLines, true, false);
-test('Split Uint8Array stderr - n newlines, 1 chunk', testLines, 2, simpleChunk, simpleLines, true, false);
-test('Split Uint8Array stdio[*] - n newlines, 1 chunk', testLines, 3, simpleChunk, simpleLines, true, false);
-test('Split Uint8Array stdout - no newline, n chunks', testLines, 1, noNewlinesChunks, noNewlinesLines, true, false);
-test('Split Uint8Array stdout - 0 newlines, 1 chunk', testLines, 1, noNewlinesChunk, noNewlinesChunk, true, false);
-test('Split Uint8Array stdout - Windows newlines', testLines, 1, windowsChunk, windowsLines, true, false);
-test('Split Uint8Array stdout - chunk ends with newline', testLines, 1, newlineEndChunk, newlineEndLines, true, false);
-test('Split Uint8Array stdout - single newline', testLines, 1, newlineChunk, newlineChunk, true, false);
-test('Split Uint8Array stdout - only newlines', testLines, 1, newlinesChunk, newlinesLines, true, false);
-test('Split Uint8Array stdout - only Windows newlines', testLines, 1, windowsNewlinesChunk, windowsNewlinesLines, true, false);
-test('Split Uint8Array stdout - line split over multiple chunks', testLines, 1, runOverChunks, simpleLines, true, false);
-test('Split Uint8Array stdout - 0 newlines, big line', testLines, 1, [bigLine], [bigLine], true, false);
-test('Split Uint8Array stdout - 0 newlines, many chunks', testLines, 1, manyChunks, [manyChunks.join('')], true, false);
-test('Split string stdout - n newlines, 1 chunk, objectMode', testLines, 1, simpleChunk, simpleChunk, false, true);
-test('Split string stderr - n newlines, 1 chunk, objectMode', testLines, 2, simpleChunk, simpleChunk, false, true);
-test('Split string stdio[*] - n newlines, 1 chunk, objectMode', testLines, 3, simpleChunk, simpleChunk, false, true);
-test('Split string stdout - no newline, n chunks, objectMode', testLines, 1, noNewlinesChunks, noNewlinesChunks, false, true);
-test('Split string stdout - 0 newlines, 1 chunk, objectMode', testLines, 1, noNewlinesChunk, noNewlinesChunk, false, true);
-test('Split string stdout - Windows newlines, objectMode', testLines, 1, windowsChunk, windowsChunk, false, true);
-test('Split string stdout - chunk ends with newline, objectMode', testLines, 1, newlineEndChunk, newlineEndChunk, false, true);
-test('Split string stdout - single newline, objectMode', testLines, 1, newlineChunk, newlineChunk, false, true);
-test('Split string stdout - only newlines, objectMode', testLines, 1, newlinesChunk, newlinesChunk, false, true);
-test('Split string stdout - only Windows newlines, objectMode', testLines, 1, windowsNewlinesChunk, windowsNewlinesChunk, false, true);
-test('Split string stdout - line split over multiple chunks, objectMode', testLines, 1, runOverChunks, runOverChunks, false, true);
-test('Split string stdout - 0 newlines, big line, objectMode', testLines, 1, [bigLine], [bigLine], false, true);
-test('Split string stdout - 0 newlines, many chunks, objectMode', testLines, 1, manyChunks, manyChunks, false, true);
-test('Split Uint8Array stdout - n newlines, 1 chunk, objectMode', testLines, 1, simpleChunk, simpleChunk, true, true);
-test('Split Uint8Array stderr - n newlines, 1 chunk, objectMode', testLines, 2, simpleChunk, simpleChunk, true, true);
-test('Split Uint8Array stdio[*] - n newlines, 1 chunk, objectMode', testLines, 3, simpleChunk, simpleChunk, true, true);
-test('Split Uint8Array stdout - no newline, n chunks, objectMode', testLines, 1, noNewlinesChunks, noNewlinesChunks, true, true);
-test('Split Uint8Array stdout - 0 newlines, 1 chunk, objectMode', testLines, 1, noNewlinesChunk, noNewlinesChunk, true, true);
-test('Split Uint8Array stdout - Windows newlines, objectMode', testLines, 1, windowsChunk, windowsChunk, true, true);
-test('Split Uint8Array stdout - chunk ends with newline, objectMode', testLines, 1, newlineEndChunk, newlineEndChunk, true, true);
-test('Split Uint8Array stdout - single newline, objectMode', testLines, 1, newlineChunk, newlineChunk, true, true);
-test('Split Uint8Array stdout - only newlines, objectMode', testLines, 1, newlinesChunk, newlinesChunk, true, true);
-test('Split Uint8Array stdout - only Windows newlines, objectMode', testLines, 1, windowsNewlinesChunk, windowsNewlinesChunk, true, true);
-test('Split Uint8Array stdout - line split over multiple chunks, objectMode', testLines, 1, runOverChunks, runOverChunks, true, true);
-test('Split Uint8Array stdout - 0 newlines, big line, objectMode', testLines, 1, [bigLine], [bigLine], true, true);
-test('Split Uint8Array stdout - 0 newlines, many chunks, objectMode', testLines, 1, manyChunks, manyChunks, true, true);
+test('Split string stdout - n newlines, 1 chunk', testLines, 1, simpleChunks, simpleLines, simpleFull, false, false, true);
+test('Split string stderr - n newlines, 1 chunk', testLines, 2, simpleChunks, simpleLines, simpleFull, false, false, true);
+test('Split string stdio[*] - n newlines, 1 chunk', testLines, 3, simpleChunks, simpleLines, simpleFull, false, false, true);
+test('Split string stdout - keep newline, n chunks', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFull, false, false, true);
+test('Split string stdout - 0 newlines, 1 chunk', testLines, 1, singleChunks, singleChunks, singleFull, false, false, true);
+test('Split string stdout - empty, 1 chunk', testLines, 1, emptyChunks, noLines, emptyFull, false, false, true);
+test('Split string stdout - Windows newlines', testLines, 1, windowsChunks, windowsLines, windowsFull, false, false, true);
+test('Split string stdout - chunk ends with newline', testLines, 1, simpleFullEndChunks, simpleFullEndLines, simpleFullEnd, false, false, true);
+test('Split string stdout - single newline', testLines, 1, newlineChunks, newlineChunks, newlineFull, false, false, true);
+test('Split string stdout - only newlines', testLines, 1, newlinesChunks, newlinesLines, newlinesFull, false, false, true);
+test('Split string stdout - only Windows newlines', testLines, 1, windowsNewlinesChunks, windowsNewlinesLines, windowsNewlinesFull, false, false, true);
+test('Split string stdout - line split over multiple chunks', testLines, 1, runOverChunks, simpleLines, simpleFull, false, false, true);
+test('Split string stdout - 0 newlines, big line', testLines, 1, bigChunks, bigChunks, bigFull, false, false, true);
+test('Split string stdout - 0 newlines, many chunks', testLines, 1, manyChunks, manyLines, manyFull, false, false, true);
+test('Split Uint8Array stdout - n newlines, 1 chunk', testLines, 1, simpleChunks, simpleLines, simpleFull, true, false, true);
+test('Split Uint8Array stderr - n newlines, 1 chunk', testLines, 2, simpleChunks, simpleLines, simpleFull, true, false, true);
+test('Split Uint8Array stdio[*] - n newlines, 1 chunk', testLines, 3, simpleChunks, simpleLines, simpleFull, true, false, true);
+test('Split Uint8Array stdout - keep newline, n chunks', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFull, true, false, true);
+test('Split Uint8Array stdout - empty, 1 chunk', testLines, 1, emptyChunks, noLines, emptyFull, true, false, true);
+test('Split Uint8Array stdout - 0 newlines, 1 chunk', testLines, 1, singleChunks, singleChunks, singleFull, true, false, true);
+test('Split Uint8Array stdout - Windows newlines', testLines, 1, windowsChunks, windowsLines, windowsFull, true, false, true);
+test('Split Uint8Array stdout - chunk ends with newline', testLines, 1, simpleFullEndChunks, simpleFullEndLines, simpleFullEnd, true, false, true);
+test('Split Uint8Array stdout - single newline', testLines, 1, newlineChunks, newlineChunks, newlineFull, true, false, true);
+test('Split Uint8Array stdout - only newlines', testLines, 1, newlinesChunks, newlinesLines, newlinesFull, true, false, true);
+test('Split Uint8Array stdout - only Windows newlines', testLines, 1, windowsNewlinesChunks, windowsNewlinesLines, windowsNewlinesFull, true, false, true);
+test('Split Uint8Array stdout - line split over multiple chunks', testLines, 1, runOverChunks, simpleLines, simpleFull, true, false, true);
+test('Split Uint8Array stdout - 0 newlines, big line', testLines, 1, bigChunks, bigChunks, bigFull, true, false, true);
+test('Split Uint8Array stdout - 0 newlines, many chunks', testLines, 1, manyChunks, manyLines, manyFull, true, false, true);
+test('Split string stdout - n newlines, 1 chunk, objectMode', testLines, 1, simpleChunks, simpleLines, simpleLines, false, true, true);
+test('Split string stderr - n newlines, 1 chunk, objectMode', testLines, 2, simpleChunks, simpleLines, simpleLines, false, true, true);
+test('Split string stdio[*] - n newlines, 1 chunk, objectMode', testLines, 3, simpleChunks, simpleLines, simpleLines, false, true, true);
+test('Split string stdout - keep newline, n chunks, objectMode', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, false, true, true);
+test('Split string stdout - empty, 1 chunk, objectMode', testLines, 1, emptyChunks, noLines, noLines, false, true, true);
+test('Split string stdout - 0 newlines, 1 chunk, objectMode', testLines, 1, singleChunks, singleChunks, singleChunks, false, true, true);
+test('Split string stdout - Windows newlines, objectMode', testLines, 1, windowsChunks, windowsLines, windowsLines, false, true, true);
+test('Split string stdout - chunk ends with newline, objectMode', testLines, 1, simpleFullEndChunks, simpleFullEndLines, simpleFullEndLines, false, true, true);
+test('Split string stdout - single newline, objectMode', testLines, 1, newlineChunks, newlineChunks, newlineChunks, false, true, true);
+test('Split string stdout - only newlines, objectMode', testLines, 1, newlinesChunks, newlinesLines, newlinesLines, false, true, true);
+test('Split string stdout - only Windows newlines, objectMode', testLines, 1, windowsNewlinesChunks, windowsNewlinesLines, windowsNewlinesLines, false, true, true);
+test('Split string stdout - line split over multiple chunks, objectMode', testLines, 1, runOverChunks, simpleLines, simpleLines, false, true, true);
+test('Split string stdout - 0 newlines, big line, objectMode', testLines, 1, bigChunks, bigChunks, bigChunks, false, true, true);
+test('Split string stdout - 0 newlines, many chunks, objectMode', testLines, 1, manyChunks, manyLines, manyLines, false, true, true);
+test('Split Uint8Array stdout - n newlines, 1 chunk, objectMode', testLines, 1, simpleChunks, simpleLines, simpleLines, true, true, true);
+test('Split Uint8Array stderr - n newlines, 1 chunk, objectMode', testLines, 2, simpleChunks, simpleLines, simpleLines, true, true, true);
+test('Split Uint8Array stdio[*] - n newlines, 1 chunk, objectMode', testLines, 3, simpleChunks, simpleLines, simpleLines, true, true, true);
+test('Split Uint8Array stdout - keep newline, n chunks, objectMode', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, true, true, true);
+test('Split Uint8Array stdout - empty, 1 chunk, objectMode', testLines, 1, emptyChunks, noLines, noLines, true, true, true);
+test('Split Uint8Array stdout - 0 newlines, 1 chunk, objectMode', testLines, 1, singleChunks, singleChunks, singleChunks, true, true, true);
+test('Split Uint8Array stdout - Windows newlines, objectMode', testLines, 1, windowsChunks, windowsLines, windowsLines, true, true, true);
+test('Split Uint8Array stdout - chunk ends with newline, objectMode', testLines, 1, simpleFullEndChunks, simpleFullEndLines, simpleFullEndLines, true, true, true);
+test('Split Uint8Array stdout - single newline, objectMode', testLines, 1, newlineChunks, newlineChunks, newlineChunks, true, true, true);
+test('Split Uint8Array stdout - only newlines, objectMode', testLines, 1, newlinesChunks, newlinesLines, newlinesLines, true, true, true);
+test('Split Uint8Array stdout - only Windows newlines, objectMode', testLines, 1, windowsNewlinesChunks, windowsNewlinesLines, windowsNewlinesLines, true, true, true);
+test('Split Uint8Array stdout - line split over multiple chunks, objectMode', testLines, 1, runOverChunks, simpleLines, simpleLines, true, true, true);
+test('Split Uint8Array stdout - 0 newlines, big line, objectMode', testLines, 1, bigChunks, bigChunks, bigChunks, true, true, true);
+test('Split Uint8Array stdout - 0 newlines, many chunks, objectMode', testLines, 1, manyChunks, manyLines, manyLines, true, true, true);
+test('Split string stdout - n newlines, 1 chunk, keep newline', testLines, 1, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
+test('Split string stderr - n newlines, 1 chunk, keep newline', testLines, 2, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
+test('Split string stdio[*] - n newlines, 1 chunk, keep newline', testLines, 3, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
+test('Split string stdout - keep newline, n chunks, keep newline', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFullEnd, false, false, false);
+test('Split string stdout - empty, 1 chunk, keep newline', testLines, 1, emptyChunks, noLines, emptyFull, false, false, false);
+test('Split string stdout - 0 newlines, 1 chunk, keep newline', testLines, 1, singleChunks, singleChunks, singleFullEnd, false, false, false);
+test('Split string stdout - Windows newlines, keep newline', testLines, 1, windowsChunks, noNewlinesChunks, windowsFullEnd, false, false, false);
+test('Split string stdout - chunk ends with newline, keep newline', testLines, 1, simpleFullEndChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
+test('Split string stdout - single newline, keep newline', testLines, 1, newlineChunks, emptyChunks, newlineFull, false, false, false);
+test('Split string stdout - only newlines, keep newline', testLines, 1, newlinesChunks, manyEmptyChunks, newlinesFull, false, false, false);
+test('Split string stdout - only Windows newlines, keep newline', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, windowsNewlinesFull, false, false, false);
+test('Split string stdout - line split over multiple chunks, keep newline', testLines, 1, runOverChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
+test('Split string stdout - 0 newlines, big line, keep newline', testLines, 1, bigChunks, bigChunks, bigFullEnd, false, false, false);
+test('Split string stdout - 0 newlines, many chunks, keep newline', testLines, 1, manyChunks, manyLines, manyFullEnd, false, false, false);
+test('Split Uint8Array stdout - n newlines, 1 chunk, keep newline', testLines, 1, simpleChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
+test('Split Uint8Array stderr - n newlines, 1 chunk, keep newline', testLines, 2, simpleChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
+test('Split Uint8Array stdio[*] - n newlines, 1 chunk, keep newline', testLines, 3, simpleChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
+test('Split Uint8Array stdout - keep newline, n chunks, keep newline', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFullEnd, true, false, false);
+test('Split Uint8Array stdout - empty, 1 chunk, keep newline', testLines, 1, emptyChunks, noLines, emptyFull, true, false, false);
+test('Split Uint8Array stdout - 0 newlines, 1 chunk, keep newline', testLines, 1, singleChunks, singleChunks, singleFullEnd, true, false, false);
+test('Split Uint8Array stdout - Windows newlines, keep newline', testLines, 1, windowsChunks, noNewlinesChunks, windowsFullEnd, true, false, false);
+test('Split Uint8Array stdout - chunk ends with newline, keep newline', testLines, 1, simpleFullEndChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
+test('Split Uint8Array stdout - single newline, keep newline', testLines, 1, newlineChunks, emptyChunks, newlineFull, true, false, false);
+test('Split Uint8Array stdout - only newlines, keep newline', testLines, 1, newlinesChunks, manyEmptyChunks, newlinesFull, true, false, false);
+test('Split Uint8Array stdout - only Windows newlines, keep newline', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, windowsNewlinesFull, true, false, false);
+test('Split Uint8Array stdout - line split over multiple chunks, keep newline', testLines, 1, runOverChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
+test('Split Uint8Array stdout - 0 newlines, big line, keep newline', testLines, 1, bigChunks, bigChunks, bigFullEnd, true, false, false);
+test('Split Uint8Array stdout - 0 newlines, many chunks, keep newline', testLines, 1, manyChunks, manyLines, manyFullEnd, true, false, false);
+test('Split string stdout - n newlines, 1 chunk, objectMode, keep newline', testLines, 1, simpleChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stderr - n newlines, 1 chunk, objectMode, keep newline', testLines, 2, simpleChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stdio[*] - n newlines, 1 chunk, objectMode, keep newline', testLines, 3, simpleChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stdout - keep newline, n chunks, objectMode, keep newline', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, false, true, false);
+test('Split string stdout - empty, 1 chunk, objectMode, keep newline', testLines, 1, emptyChunks, noLines, noLines, false, true, false);
+test('Split string stdout - 0 newlines, 1 chunk, objectMode, keep newline', testLines, 1, singleChunks, singleChunks, singleChunks, false, true, false);
+test('Split string stdout - Windows newlines, objectMode, keep newline', testLines, 1, windowsChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stdout - chunk ends with newline, objectMode, keep newline', testLines, 1, simpleFullEndChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stdout - single newline, objectMode, keep newline', testLines, 1, newlineChunks, emptyChunks, emptyChunks, false, true, false);
+test('Split string stdout - only newlines, objectMode, keep newline', testLines, 1, newlinesChunks, manyEmptyChunks, manyEmptyChunks, false, true, false);
+test('Split string stdout - only Windows newlines, objectMode, keep newline', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, manyEmptyChunks, false, true, false);
+test('Split string stdout - line split over multiple chunks, objectMode, keep newline', testLines, 1, runOverChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stdout - 0 newlines, big line, objectMode, keep newline', testLines, 1, bigChunks, bigChunks, bigChunks, false, true, false);
+test('Split string stdout - 0 newlines, many chunks, objectMode, keep newline', testLines, 1, manyChunks, manyLines, manyLines, false, true, false);
+test('Split Uint8Array stdout - n newlines, 1 chunk, objectMode, keep newline', testLines, 1, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stderr - n newlines, 1 chunk, objectMode, keep newline', testLines, 2, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stdio[*] - n newlines, 1 chunk, objectMode, keep newline', testLines, 3, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stdout - keep newline, n chunks, objectMode, keep newline', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, true, true, false);
+test('Split Uint8Array stdout - empty, 1 chunk, objectMode, keep newline', testLines, 1, emptyChunks, noLines, noLines, true, true, false);
+test('Split Uint8Array stdout - 0 newlines, 1 chunk, objectMode, keep newline', testLines, 1, singleChunks, singleChunks, singleChunks, true, true, false);
+test('Split Uint8Array stdout - Windows newlines, objectMode, keep newline', testLines, 1, windowsChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stdout - chunk ends with newline, objectMode, keep newline', testLines, 1, simpleFullEndChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stdout - single newline, objectMode, keep newline', testLines, 1, newlineChunks, emptyChunks, emptyChunks, true, true, false);
+test('Split Uint8Array stdout - only newlines, objectMode, keep newline', testLines, 1, newlinesChunks, manyEmptyChunks, manyEmptyChunks, true, true, false);
+test('Split Uint8Array stdout - only Windows newlines, objectMode, keep newline', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, manyEmptyChunks, true, true, false);
+test('Split Uint8Array stdout - line split over multiple chunks, objectMode, keep newline', testLines, 1, runOverChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stdout - 0 newlines, big line, objectMode, keep newline', testLines, 1, bigChunks, bigChunks, bigChunks, true, true, false);
+test('Split Uint8Array stdout - 0 newlines, many chunks, objectMode, keep newline', testLines, 1, manyChunks, manyLines, manyLines, true, true, false);
 
 // eslint-disable-next-line max-params
-const testBinaryOption = async (t, binary, input, expectedLines, objectMode) => {
+const testBinaryOption = async (t, binary, input, expectedLines, expectedOutput, objectMode, newline) => {
 	const lines = [];
-	const {stdout} = await execa('noop-fd.js', ['1'], {
+	const {stdout} = await execa('noop.js', {
 		stdout: [
-			{transform: inputGenerator.bind(undefined, input), objectMode},
-			{transform: resultGenerator.bind(undefined, lines), objectMode, binary},
+			getChunksGenerator(input, false, true),
+			{transform: resultGenerator.bind(undefined, lines), binary, newline, objectMode},
 		],
+		stripFinalNewline: false,
 	});
-	t.is(input.join(''), objectMode ? stdout.join('') : stdout);
 	t.deepEqual(lines, expectedLines);
+	t.deepEqual(stdout, expectedOutput);
 };
 
-test('Does not split lines when "binary" is true', testBinaryOption, true, simpleChunk, simpleChunk, false);
-test('Splits lines when "binary" is false', testBinaryOption, false, simpleChunk, simpleLines, false);
-test('Splits lines when "binary" is undefined', testBinaryOption, undefined, simpleChunk, simpleLines, false);
-test('Does not split lines when "binary" is true, objectMode', testBinaryOption, true, simpleChunk, simpleChunk, true);
-test('Splits lines when "binary" is false, objectMode', testBinaryOption, false, simpleChunk, simpleChunk, true);
-test('Splits lines when "binary" is undefined, objectMode', testBinaryOption, undefined, simpleChunk, simpleChunk, true);
+test('Does not split lines when "binary" is true', testBinaryOption, true, simpleChunks, simpleChunks, simpleFull, false, true);
+test('Splits lines when "binary" is false', testBinaryOption, false, simpleChunks, simpleLines, simpleFull, false, true);
+test('Splits lines when "binary" is undefined', testBinaryOption, undefined, simpleChunks, simpleLines, simpleFull, false, true);
+test('Does not split lines when "binary" is true, objectMode', testBinaryOption, true, simpleChunks, simpleChunks, simpleChunks, true, true);
+test('Splits lines when "binary" is false, objectMode', testBinaryOption, false, simpleChunks, simpleLines, simpleLines, true, true);
+test('Splits lines when "binary" is undefined, objectMode', testBinaryOption, undefined, simpleChunks, simpleLines, simpleLines, true, true);
+test('Does not split lines when "binary" is true, keep newline', testBinaryOption, true, simpleChunks, simpleChunks, simpleFull, false, false);
+test('Splits lines when "binary" is false, keep newline', testBinaryOption, false, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false);
+test('Splits lines when "binary" is undefined, keep newline', testBinaryOption, undefined, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false);
+test('Does not split lines when "binary" is true, objectMode, keep newline', testBinaryOption, true, simpleChunks, simpleChunks, simpleChunks, true, false);
+test('Splits lines when "binary" is false, objectMode, keep newline', testBinaryOption, false, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, false);
+test('Splits lines when "binary" is undefined, objectMode, keep newline', testBinaryOption, undefined, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, false);
 
-// eslint-disable-next-line max-params
-const testStreamLines = async (t, fdNumber, input, expectedLines, isUint8Array) => {
-	const {stdio} = await execa('noop-fd.js', [`${fdNumber}`, input], {
-		...fullStdio,
-		lines: true,
-		encoding: getEncoding(isUint8Array),
-	});
-	t.deepEqual(stdio[fdNumber], stringsToUint8Arrays(expectedLines, isUint8Array));
+const resultStringGenerator = function * (lines, chunk) {
+	lines.push(chunk);
+	yield new TextDecoder().decode(chunk);
 };
 
-test('"lines: true" splits lines, stdout, string', testStreamLines, 1, simpleChunk[0], simpleLines, false);
-test('"lines: true" splits lines, stdout, Uint8Array', testStreamLines, 1, simpleChunk[0], simpleLines, true);
-test('"lines: true" splits lines, stderr, string', testStreamLines, 2, simpleChunk[0], simpleLines, false);
-test('"lines: true" splits lines, stderr, Uint8Array', testStreamLines, 2, simpleChunk[0], simpleLines, true);
-test('"lines: true" splits lines, stdio[*], string', testStreamLines, 3, simpleChunk[0], simpleLines, false);
-test('"lines: true" splits lines, stdio[*], Uint8Array', testStreamLines, 3, simpleChunk[0], simpleLines, true);
-
-const testStreamLinesNoop = async (t, lines, execaMethod) => {
-	const {stdout} = await execaMethod('noop-fd.js', ['1', simpleChunk[0]], {lines});
-	t.is(stdout, simpleChunk[0]);
-};
-
-test('"lines: false" is a noop with execa()', testStreamLinesNoop, false, execa);
-test('"lines: false" is a noop with execaSync()', testStreamLinesNoop, false, execaSync);
-test('"lines: true" is a noop with execaSync()', testStreamLinesNoop, true, execaSync);
-
-const bigArray = Array.from({length: 1e5}).fill('.\n');
-const bigString = bigArray.join('');
-const bigStringNoNewlines = '.'.repeat(1e6);
-
-// eslint-disable-next-line max-params
-const testStreamLinesGenerator = async (t, input, expectedLines, objectMode, binary) => {
-	const {stdout} = await execa('noop.js', {lines: true, stdout: getChunksGenerator(input, objectMode, binary)});
-	t.deepEqual(stdout, expectedLines);
-};
-
-test('"lines: true" works with strings generators', testStreamLinesGenerator, simpleChunk, simpleLines, false, false);
-test('"lines: true" works with strings generators, objectMode', testStreamLinesGenerator, simpleChunk, simpleChunk, true, false);
-test('"lines: true" works with strings generators, binary', testStreamLinesGenerator, simpleChunk, simpleLines, false, true);
-test('"lines: true" works with strings generators, binary, objectMode', testStreamLinesGenerator, simpleChunk, simpleChunk, true, true);
-test('"lines: true" works with big strings generators', testStreamLinesGenerator, [bigString], bigArray, false, false);
-test('"lines: true" works with big strings generators, objectMode', testStreamLinesGenerator, [bigString], [bigString], true, false);
-test('"lines: true" works with big strings generators without newlines', testStreamLinesGenerator, [bigStringNoNewlines], [bigStringNoNewlines], false, false);
-test('"lines: true" works with big strings generators without newlines, objectMode', testStreamLinesGenerator, [bigStringNoNewlines], [bigStringNoNewlines], true, false);
-
-test('"lines: true" is a noop with objects generators, objectMode', async t => {
-	const {stdout} = await execa('noop.js', {lines: true, stdout: getChunksGenerator([foobarObject], true)});
-	t.deepEqual(stdout, [foobarObject]);
-});
-
-const singleLine = 'a\n';
-
-test('"lines: true" does not work with other encodings', async t => {
-	const {stdout} = await execa('noop-fd.js', ['1', `${singleLine}${singleLine}`], {lines: true, encoding: 'base64'});
-	t.deepEqual(stdout, [singleLine, singleLine]);
-});
-
-const testAsyncIteration = async (t, isUint8Array) => {
-	const subprocess = getSimpleChunkSubprocess(isUint8Array);
-	const [stdout] = await Promise.all([subprocess.stdout.toArray(), subprocess]);
-	t.deepEqual(stdout, stringsToUint8Arrays(simpleLines, isUint8Array));
-};
-
-test('"lines: true" works with stream async iteration, string', testAsyncIteration, false);
-test('"lines: true" works with stream async iteration, Uint8Array', testAsyncIteration, true);
-
-const testDataEvents = async (t, isUint8Array) => {
-	const subprocess = getSimpleChunkSubprocess(isUint8Array);
-	const [[firstLine]] = await Promise.all([once(subprocess.stdout, 'data'), subprocess]);
-	t.deepEqual(firstLine, stringsToUint8Arrays(simpleLines, isUint8Array)[0]);
-};
-
-test('"lines: true" works with stream "data" events, string', testDataEvents, false);
-test('"lines: true" works with stream "data" events, Uint8Array', testDataEvents, true);
-
-const testWritableStream = async (t, isUint8Array) => {
+const testUint8ArrayToString = async (t, expectedOutput, objectMode, newline) => {
 	const lines = [];
-	const writable = new Writable({
-		write(line, encoding, done) {
-			lines.push(line);
-			done();
+	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {
+		stdout: {
+			transform: resultStringGenerator.bind(undefined, lines),
+			objectMode,
+			newline,
 		},
-		decodeStrings: false,
+		encoding: 'buffer',
+		lines: true,
 	});
-	await getSimpleChunkSubprocess(isUint8Array, {stdout: ['pipe', writable]});
-	t.deepEqual(lines, stringsToBuffers(simpleLines, isUint8Array));
+	t.deepEqual(lines, [foobarUint8Array]);
+	t.deepEqual(stdout, expectedOutput);
 };
 
-test('"lines: true" works with writable streams targets, string', testWritableStream, false);
-test('"lines: true" works with writable streams targets, Uint8Array', testWritableStream, true);
+test('Line splitting when converting from Uint8Array to string', testUint8ArrayToString, [foobarUint8Array], false, true);
+test('Line splitting when converting from Uint8Array to string, objectMode', testUint8ArrayToString, [foobarString], true, true);
+test('Line splitting when converting from Uint8Array to string, keep newline', testUint8ArrayToString, [foobarUint8Array], false, false);
+test('Line splitting when converting from Uint8Array to string, objectMode, keep newline', testUint8ArrayToString, [foobarString], true, false);
+
+const resultUint8ArrayGenerator = function * (lines, chunk) {
+	lines.push(chunk);
+	yield new TextEncoder().encode(chunk);
+};
+
+const testStringToUint8Array = async (t, expectedOutput, objectMode, newline) => {
+	const lines = [];
+	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {
+		stdout: {
+			transform: resultUint8ArrayGenerator.bind(undefined, lines),
+			objectMode,
+			newline,
+		},
+		lines: true,
+	});
+	t.deepEqual(lines, [foobarString]);
+	t.deepEqual(stdout, expectedOutput);
+};
+
+test('Line splitting when converting from string to Uint8Array', testStringToUint8Array, [foobarString], false, true);
+test('Line splitting when converting from string to Uint8Array, objectMode', testStringToUint8Array, [foobarUint8Array], true, true);
+test('Line splitting when converting from string to Uint8Array, keep newline', testStringToUint8Array, [foobarString], false, false);
+test('Line splitting when converting from string to Uint8Array, objectMode, keep newline', testStringToUint8Array, [foobarUint8Array], true, false);
+
+const testStripNewline = async (t, input, expectedOutput) => {
+	const {stdout} = await execa('noop.js', {
+		stdout: getChunksGenerator([input]),
+		stripFinalNewline: false,
+	});
+	t.is(stdout, expectedOutput);
+};
+
+test('Strips newline when user do not mistakenly yield one at the end', testStripNewline, singleFull, singleFullEnd);
+test('Strips newline when user mistakenly yielded one at the end', testStripNewline, singleFullEnd, singleFullEnd);
+test('Strips newline when user mistakenly yielded one at the end, Windows newline', testStripNewline, singleFullEndWindows, singleFullEndWindows);
+
+const testMixNewlines = async (t, generator) => {
+	const {stdout} = await execa('noop-fd.js', ['1', mixedNewlines], {
+		stdout: generator(),
+		stripFinalNewline: false,
+	});
+	t.is(stdout, mixedNewlines);
+};
+
+test('Can mix Unix and Windows newlines', testMixNewlines, noopGenerator);
+test('Can mix Unix and Windows newlines, async', testMixNewlines, noopAsyncGenerator);
+
+const serializeResultGenerator = function * (lines, chunk) {
+	lines.push(chunk);
+	yield JSON.stringify(chunk);
+};
+
+const testUnsetObjectMode = async (t, expectedOutput, newline) => {
+	const lines = [];
+	const {stdout} = await execa('noop.js', {
+		stdout: [
+			getChunksGenerator([foobarObject], true),
+			{transform: serializeResultGenerator.bind(undefined, lines), newline, objectMode: false},
+		],
+		stripFinalNewline: false,
+	});
+	t.deepEqual(lines, [foobarObject]);
+	t.is(stdout, expectedOutput);
+};
+
+test('Can switch from objectMode to non-objectMode', testUnsetObjectMode, `${foobarObjectString}\n`, false);
+test('Can switch from objectMode to non-objectMode, keep newline', testUnsetObjectMode, foobarObjectString, true);
+
+const testYieldArray = async (t, input, expectedLines, expectedOutput) => {
+	const lines = [];
+	const {stdout} = await execa('noop.js', {
+		stdout: [
+			getOutputsGenerator(input),
+			resultGenerator.bind(undefined, lines),
+		],
+		stripFinalNewline: false,
+	});
+	t.deepEqual(lines, expectedLines);
+	t.deepEqual(stdout, expectedOutput);
+};
+
+test('Can use "yield* array" to produce multiple lines', testYieldArray, [foobarString, foobarString], [foobarString, foobarString], `${foobarString}\n${foobarString}\n`);
+test('Can use "yield* array" to produce empty lines', testYieldArray, [foobarString, ''], [foobarString, ''], `${foobarString}\n\n`);

--- a/test/stdio/split.js
+++ b/test/stdio/split.js
@@ -63,12 +63,12 @@ const resultGenerator = function * (lines, chunk) {
 };
 
 // eslint-disable-next-line max-params
-const testLines = async (t, fdNumber, input, expectedLines, expectedOutput, isUint8Array, objectMode, newline) => {
+const testLines = async (t, fdNumber, input, expectedLines, expectedOutput, isUint8Array, objectMode, preserveNewlines) => {
 	const lines = [];
 	const {stdio} = await execa('noop-fd.js', [`${fdNumber}`], {
 		...getStdio(fdNumber, [
 			getChunksGenerator(input, false, true),
-			{transform: resultGenerator.bind(undefined, lines), newline, objectMode},
+			{transform: resultGenerator.bind(undefined, lines), preserveNewlines, objectMode},
 		]),
 		encoding: getEncoding(isUint8Array),
 		stripFinalNewline: false,
@@ -81,7 +81,7 @@ const testLines = async (t, fdNumber, input, expectedLines, expectedOutput, isUi
 test('Split string stdout - n newlines, 1 chunk', testLines, 1, simpleChunks, simpleLines, simpleFull, false, false, true);
 test('Split string stderr - n newlines, 1 chunk', testLines, 2, simpleChunks, simpleLines, simpleFull, false, false, true);
 test('Split string stdio[*] - n newlines, 1 chunk', testLines, 3, simpleChunks, simpleLines, simpleFull, false, false, true);
-test('Split string stdout - keep newline, n chunks', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFull, false, false, true);
+test('Split string stdout - preserveNewlines, n chunks', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFull, false, false, true);
 test('Split string stdout - 0 newlines, 1 chunk', testLines, 1, singleChunks, singleChunks, singleFull, false, false, true);
 test('Split string stdout - empty, 1 chunk', testLines, 1, emptyChunks, noLines, emptyFull, false, false, true);
 test('Split string stdout - Windows newlines', testLines, 1, windowsChunks, windowsLines, windowsFull, false, false, true);
@@ -95,7 +95,7 @@ test('Split string stdout - 0 newlines, many chunks', testLines, 1, manyChunks, 
 test('Split Uint8Array stdout - n newlines, 1 chunk', testLines, 1, simpleChunks, simpleLines, simpleFull, true, false, true);
 test('Split Uint8Array stderr - n newlines, 1 chunk', testLines, 2, simpleChunks, simpleLines, simpleFull, true, false, true);
 test('Split Uint8Array stdio[*] - n newlines, 1 chunk', testLines, 3, simpleChunks, simpleLines, simpleFull, true, false, true);
-test('Split Uint8Array stdout - keep newline, n chunks', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFull, true, false, true);
+test('Split Uint8Array stdout - preserveNewlines, n chunks', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFull, true, false, true);
 test('Split Uint8Array stdout - empty, 1 chunk', testLines, 1, emptyChunks, noLines, emptyFull, true, false, true);
 test('Split Uint8Array stdout - 0 newlines, 1 chunk', testLines, 1, singleChunks, singleChunks, singleFull, true, false, true);
 test('Split Uint8Array stdout - Windows newlines', testLines, 1, windowsChunks, windowsLines, windowsFull, true, false, true);
@@ -109,7 +109,7 @@ test('Split Uint8Array stdout - 0 newlines, many chunks', testLines, 1, manyChun
 test('Split string stdout - n newlines, 1 chunk, objectMode', testLines, 1, simpleChunks, simpleLines, simpleLines, false, true, true);
 test('Split string stderr - n newlines, 1 chunk, objectMode', testLines, 2, simpleChunks, simpleLines, simpleLines, false, true, true);
 test('Split string stdio[*] - n newlines, 1 chunk, objectMode', testLines, 3, simpleChunks, simpleLines, simpleLines, false, true, true);
-test('Split string stdout - keep newline, n chunks, objectMode', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, false, true, true);
+test('Split string stdout - preserveNewlines, n chunks, objectMode', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, false, true, true);
 test('Split string stdout - empty, 1 chunk, objectMode', testLines, 1, emptyChunks, noLines, noLines, false, true, true);
 test('Split string stdout - 0 newlines, 1 chunk, objectMode', testLines, 1, singleChunks, singleChunks, singleChunks, false, true, true);
 test('Split string stdout - Windows newlines, objectMode', testLines, 1, windowsChunks, windowsLines, windowsLines, false, true, true);
@@ -123,7 +123,7 @@ test('Split string stdout - 0 newlines, many chunks, objectMode', testLines, 1, 
 test('Split Uint8Array stdout - n newlines, 1 chunk, objectMode', testLines, 1, simpleChunks, simpleLines, simpleLines, true, true, true);
 test('Split Uint8Array stderr - n newlines, 1 chunk, objectMode', testLines, 2, simpleChunks, simpleLines, simpleLines, true, true, true);
 test('Split Uint8Array stdio[*] - n newlines, 1 chunk, objectMode', testLines, 3, simpleChunks, simpleLines, simpleLines, true, true, true);
-test('Split Uint8Array stdout - keep newline, n chunks, objectMode', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, true, true, true);
+test('Split Uint8Array stdout - preserveNewlines, n chunks, objectMode', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, true, true, true);
 test('Split Uint8Array stdout - empty, 1 chunk, objectMode', testLines, 1, emptyChunks, noLines, noLines, true, true, true);
 test('Split Uint8Array stdout - 0 newlines, 1 chunk, objectMode', testLines, 1, singleChunks, singleChunks, singleChunks, true, true, true);
 test('Split Uint8Array stdout - Windows newlines, objectMode', testLines, 1, windowsChunks, windowsLines, windowsLines, true, true, true);
@@ -134,70 +134,70 @@ test('Split Uint8Array stdout - only Windows newlines, objectMode', testLines, 1
 test('Split Uint8Array stdout - line split over multiple chunks, objectMode', testLines, 1, runOverChunks, simpleLines, simpleLines, true, true, true);
 test('Split Uint8Array stdout - 0 newlines, big line, objectMode', testLines, 1, bigChunks, bigChunks, bigChunks, true, true, true);
 test('Split Uint8Array stdout - 0 newlines, many chunks, objectMode', testLines, 1, manyChunks, manyLines, manyLines, true, true, true);
-test('Split string stdout - n newlines, 1 chunk, keep newline', testLines, 1, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
-test('Split string stderr - n newlines, 1 chunk, keep newline', testLines, 2, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
-test('Split string stdio[*] - n newlines, 1 chunk, keep newline', testLines, 3, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
-test('Split string stdout - keep newline, n chunks, keep newline', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFullEnd, false, false, false);
-test('Split string stdout - empty, 1 chunk, keep newline', testLines, 1, emptyChunks, noLines, emptyFull, false, false, false);
-test('Split string stdout - 0 newlines, 1 chunk, keep newline', testLines, 1, singleChunks, singleChunks, singleFullEnd, false, false, false);
-test('Split string stdout - Windows newlines, keep newline', testLines, 1, windowsChunks, noNewlinesChunks, windowsFullEnd, false, false, false);
-test('Split string stdout - chunk ends with newline, keep newline', testLines, 1, simpleFullEndChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
-test('Split string stdout - single newline, keep newline', testLines, 1, newlineChunks, emptyChunks, newlineFull, false, false, false);
-test('Split string stdout - only newlines, keep newline', testLines, 1, newlinesChunks, manyEmptyChunks, newlinesFull, false, false, false);
-test('Split string stdout - only Windows newlines, keep newline', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, windowsNewlinesFull, false, false, false);
-test('Split string stdout - line split over multiple chunks, keep newline', testLines, 1, runOverChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
-test('Split string stdout - 0 newlines, big line, keep newline', testLines, 1, bigChunks, bigChunks, bigFullEnd, false, false, false);
-test('Split string stdout - 0 newlines, many chunks, keep newline', testLines, 1, manyChunks, manyLines, manyFullEnd, false, false, false);
-test('Split Uint8Array stdout - n newlines, 1 chunk, keep newline', testLines, 1, simpleChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
-test('Split Uint8Array stderr - n newlines, 1 chunk, keep newline', testLines, 2, simpleChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
-test('Split Uint8Array stdio[*] - n newlines, 1 chunk, keep newline', testLines, 3, simpleChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
-test('Split Uint8Array stdout - keep newline, n chunks, keep newline', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFullEnd, true, false, false);
-test('Split Uint8Array stdout - empty, 1 chunk, keep newline', testLines, 1, emptyChunks, noLines, emptyFull, true, false, false);
-test('Split Uint8Array stdout - 0 newlines, 1 chunk, keep newline', testLines, 1, singleChunks, singleChunks, singleFullEnd, true, false, false);
-test('Split Uint8Array stdout - Windows newlines, keep newline', testLines, 1, windowsChunks, noNewlinesChunks, windowsFullEnd, true, false, false);
-test('Split Uint8Array stdout - chunk ends with newline, keep newline', testLines, 1, simpleFullEndChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
-test('Split Uint8Array stdout - single newline, keep newline', testLines, 1, newlineChunks, emptyChunks, newlineFull, true, false, false);
-test('Split Uint8Array stdout - only newlines, keep newline', testLines, 1, newlinesChunks, manyEmptyChunks, newlinesFull, true, false, false);
-test('Split Uint8Array stdout - only Windows newlines, keep newline', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, windowsNewlinesFull, true, false, false);
-test('Split Uint8Array stdout - line split over multiple chunks, keep newline', testLines, 1, runOverChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
-test('Split Uint8Array stdout - 0 newlines, big line, keep newline', testLines, 1, bigChunks, bigChunks, bigFullEnd, true, false, false);
-test('Split Uint8Array stdout - 0 newlines, many chunks, keep newline', testLines, 1, manyChunks, manyLines, manyFullEnd, true, false, false);
-test('Split string stdout - n newlines, 1 chunk, objectMode, keep newline', testLines, 1, simpleChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
-test('Split string stderr - n newlines, 1 chunk, objectMode, keep newline', testLines, 2, simpleChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
-test('Split string stdio[*] - n newlines, 1 chunk, objectMode, keep newline', testLines, 3, simpleChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
-test('Split string stdout - keep newline, n chunks, objectMode, keep newline', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, false, true, false);
-test('Split string stdout - empty, 1 chunk, objectMode, keep newline', testLines, 1, emptyChunks, noLines, noLines, false, true, false);
-test('Split string stdout - 0 newlines, 1 chunk, objectMode, keep newline', testLines, 1, singleChunks, singleChunks, singleChunks, false, true, false);
-test('Split string stdout - Windows newlines, objectMode, keep newline', testLines, 1, windowsChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
-test('Split string stdout - chunk ends with newline, objectMode, keep newline', testLines, 1, simpleFullEndChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
-test('Split string stdout - single newline, objectMode, keep newline', testLines, 1, newlineChunks, emptyChunks, emptyChunks, false, true, false);
-test('Split string stdout - only newlines, objectMode, keep newline', testLines, 1, newlinesChunks, manyEmptyChunks, manyEmptyChunks, false, true, false);
-test('Split string stdout - only Windows newlines, objectMode, keep newline', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, manyEmptyChunks, false, true, false);
-test('Split string stdout - line split over multiple chunks, objectMode, keep newline', testLines, 1, runOverChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
-test('Split string stdout - 0 newlines, big line, objectMode, keep newline', testLines, 1, bigChunks, bigChunks, bigChunks, false, true, false);
-test('Split string stdout - 0 newlines, many chunks, objectMode, keep newline', testLines, 1, manyChunks, manyLines, manyLines, false, true, false);
-test('Split Uint8Array stdout - n newlines, 1 chunk, objectMode, keep newline', testLines, 1, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
-test('Split Uint8Array stderr - n newlines, 1 chunk, objectMode, keep newline', testLines, 2, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
-test('Split Uint8Array stdio[*] - n newlines, 1 chunk, objectMode, keep newline', testLines, 3, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
-test('Split Uint8Array stdout - keep newline, n chunks, objectMode, keep newline', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, true, true, false);
-test('Split Uint8Array stdout - empty, 1 chunk, objectMode, keep newline', testLines, 1, emptyChunks, noLines, noLines, true, true, false);
-test('Split Uint8Array stdout - 0 newlines, 1 chunk, objectMode, keep newline', testLines, 1, singleChunks, singleChunks, singleChunks, true, true, false);
-test('Split Uint8Array stdout - Windows newlines, objectMode, keep newline', testLines, 1, windowsChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
-test('Split Uint8Array stdout - chunk ends with newline, objectMode, keep newline', testLines, 1, simpleFullEndChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
-test('Split Uint8Array stdout - single newline, objectMode, keep newline', testLines, 1, newlineChunks, emptyChunks, emptyChunks, true, true, false);
-test('Split Uint8Array stdout - only newlines, objectMode, keep newline', testLines, 1, newlinesChunks, manyEmptyChunks, manyEmptyChunks, true, true, false);
-test('Split Uint8Array stdout - only Windows newlines, objectMode, keep newline', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, manyEmptyChunks, true, true, false);
-test('Split Uint8Array stdout - line split over multiple chunks, objectMode, keep newline', testLines, 1, runOverChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
-test('Split Uint8Array stdout - 0 newlines, big line, objectMode, keep newline', testLines, 1, bigChunks, bigChunks, bigChunks, true, true, false);
-test('Split Uint8Array stdout - 0 newlines, many chunks, objectMode, keep newline', testLines, 1, manyChunks, manyLines, manyLines, true, true, false);
+test('Split string stdout - n newlines, 1 chunk, preserveNewlines', testLines, 1, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
+test('Split string stderr - n newlines, 1 chunk, preserveNewlines', testLines, 2, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
+test('Split string stdio[*] - n newlines, 1 chunk, preserveNewlines', testLines, 3, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
+test('Split string stdout - preserveNewlines, n chunks, preserveNewlines', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFullEnd, false, false, false);
+test('Split string stdout - empty, 1 chunk, preserveNewlines', testLines, 1, emptyChunks, noLines, emptyFull, false, false, false);
+test('Split string stdout - 0 newlines, 1 chunk, preserveNewlines', testLines, 1, singleChunks, singleChunks, singleFullEnd, false, false, false);
+test('Split string stdout - Windows newlines, preserveNewlines', testLines, 1, windowsChunks, noNewlinesChunks, windowsFullEnd, false, false, false);
+test('Split string stdout - chunk ends with newline, preserveNewlines', testLines, 1, simpleFullEndChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
+test('Split string stdout - single newline, preserveNewlines', testLines, 1, newlineChunks, emptyChunks, newlineFull, false, false, false);
+test('Split string stdout - only newlines, preserveNewlines', testLines, 1, newlinesChunks, manyEmptyChunks, newlinesFull, false, false, false);
+test('Split string stdout - only Windows newlines, preserveNewlines', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, windowsNewlinesFull, false, false, false);
+test('Split string stdout - line split over multiple chunks, preserveNewlines', testLines, 1, runOverChunks, noNewlinesChunks, simpleFullEnd, false, false, false);
+test('Split string stdout - 0 newlines, big line, preserveNewlines', testLines, 1, bigChunks, bigChunks, bigFullEnd, false, false, false);
+test('Split string stdout - 0 newlines, many chunks, preserveNewlines', testLines, 1, manyChunks, manyLines, manyFullEnd, false, false, false);
+test('Split Uint8Array stdout - n newlines, 1 chunk, preserveNewlines', testLines, 1, simpleChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
+test('Split Uint8Array stderr - n newlines, 1 chunk, preserveNewlines', testLines, 2, simpleChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
+test('Split Uint8Array stdio[*] - n newlines, 1 chunk, preserveNewlines', testLines, 3, simpleChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
+test('Split Uint8Array stdout - preserveNewlines, n chunks, preserveNewlines', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesFullEnd, true, false, false);
+test('Split Uint8Array stdout - empty, 1 chunk, preserveNewlines', testLines, 1, emptyChunks, noLines, emptyFull, true, false, false);
+test('Split Uint8Array stdout - 0 newlines, 1 chunk, preserveNewlines', testLines, 1, singleChunks, singleChunks, singleFullEnd, true, false, false);
+test('Split Uint8Array stdout - Windows newlines, preserveNewlines', testLines, 1, windowsChunks, noNewlinesChunks, windowsFullEnd, true, false, false);
+test('Split Uint8Array stdout - chunk ends with newline, preserveNewlines', testLines, 1, simpleFullEndChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
+test('Split Uint8Array stdout - single newline, preserveNewlines', testLines, 1, newlineChunks, emptyChunks, newlineFull, true, false, false);
+test('Split Uint8Array stdout - only newlines, preserveNewlines', testLines, 1, newlinesChunks, manyEmptyChunks, newlinesFull, true, false, false);
+test('Split Uint8Array stdout - only Windows newlines, preserveNewlines', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, windowsNewlinesFull, true, false, false);
+test('Split Uint8Array stdout - line split over multiple chunks, preserveNewlines', testLines, 1, runOverChunks, noNewlinesChunks, simpleFullEnd, true, false, false);
+test('Split Uint8Array stdout - 0 newlines, big line, preserveNewlines', testLines, 1, bigChunks, bigChunks, bigFullEnd, true, false, false);
+test('Split Uint8Array stdout - 0 newlines, many chunks, preserveNewlines', testLines, 1, manyChunks, manyLines, manyFullEnd, true, false, false);
+test('Split string stdout - n newlines, 1 chunk, objectMode, preserveNewlines', testLines, 1, simpleChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stderr - n newlines, 1 chunk, objectMode, preserveNewlines', testLines, 2, simpleChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stdio[*] - n newlines, 1 chunk, objectMode, preserveNewlines', testLines, 3, simpleChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stdout - preserveNewlines, n chunks, objectMode, preserveNewlines', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, false, true, false);
+test('Split string stdout - empty, 1 chunk, objectMode, preserveNewlines', testLines, 1, emptyChunks, noLines, noLines, false, true, false);
+test('Split string stdout - 0 newlines, 1 chunk, objectMode, preserveNewlines', testLines, 1, singleChunks, singleChunks, singleChunks, false, true, false);
+test('Split string stdout - Windows newlines, objectMode, preserveNewlines', testLines, 1, windowsChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stdout - chunk ends with newline, objectMode, preserveNewlines', testLines, 1, simpleFullEndChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stdout - single newline, objectMode, preserveNewlines', testLines, 1, newlineChunks, emptyChunks, emptyChunks, false, true, false);
+test('Split string stdout - only newlines, objectMode, preserveNewlines', testLines, 1, newlinesChunks, manyEmptyChunks, manyEmptyChunks, false, true, false);
+test('Split string stdout - only Windows newlines, objectMode, preserveNewlines', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, manyEmptyChunks, false, true, false);
+test('Split string stdout - line split over multiple chunks, objectMode, preserveNewlines', testLines, 1, runOverChunks, noNewlinesChunks, noNewlinesChunks, false, true, false);
+test('Split string stdout - 0 newlines, big line, objectMode, preserveNewlines', testLines, 1, bigChunks, bigChunks, bigChunks, false, true, false);
+test('Split string stdout - 0 newlines, many chunks, objectMode, preserveNewlines', testLines, 1, manyChunks, manyLines, manyLines, false, true, false);
+test('Split Uint8Array stdout - n newlines, 1 chunk, objectMode, preserveNewlines', testLines, 1, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stderr - n newlines, 1 chunk, objectMode, preserveNewlines', testLines, 2, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stdio[*] - n newlines, 1 chunk, objectMode, preserveNewlines', testLines, 3, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stdout - preserveNewlines, n chunks, objectMode, preserveNewlines', testLines, 1, noNewlinesChunks, noNewlinesLines, noNewlinesLines, true, true, false);
+test('Split Uint8Array stdout - empty, 1 chunk, objectMode, preserveNewlines', testLines, 1, emptyChunks, noLines, noLines, true, true, false);
+test('Split Uint8Array stdout - 0 newlines, 1 chunk, objectMode, preserveNewlines', testLines, 1, singleChunks, singleChunks, singleChunks, true, true, false);
+test('Split Uint8Array stdout - Windows newlines, objectMode, preserveNewlines', testLines, 1, windowsChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stdout - chunk ends with newline, objectMode, preserveNewlines', testLines, 1, simpleFullEndChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stdout - single newline, objectMode, preserveNewlines', testLines, 1, newlineChunks, emptyChunks, emptyChunks, true, true, false);
+test('Split Uint8Array stdout - only newlines, objectMode, preserveNewlines', testLines, 1, newlinesChunks, manyEmptyChunks, manyEmptyChunks, true, true, false);
+test('Split Uint8Array stdout - only Windows newlines, objectMode, preserveNewlines', testLines, 1, windowsNewlinesChunks, manyEmptyChunks, manyEmptyChunks, true, true, false);
+test('Split Uint8Array stdout - line split over multiple chunks, objectMode, preserveNewlines', testLines, 1, runOverChunks, noNewlinesChunks, noNewlinesChunks, true, true, false);
+test('Split Uint8Array stdout - 0 newlines, big line, objectMode, preserveNewlines', testLines, 1, bigChunks, bigChunks, bigChunks, true, true, false);
+test('Split Uint8Array stdout - 0 newlines, many chunks, objectMode, preserveNewlines', testLines, 1, manyChunks, manyLines, manyLines, true, true, false);
 
 // eslint-disable-next-line max-params
-const testBinaryOption = async (t, binary, input, expectedLines, expectedOutput, objectMode, newline) => {
+const testBinaryOption = async (t, binary, input, expectedLines, expectedOutput, objectMode, preserveNewlines) => {
 	const lines = [];
 	const {stdout} = await execa('noop.js', {
 		stdout: [
 			getChunksGenerator(input, false, true),
-			{transform: resultGenerator.bind(undefined, lines), binary, newline, objectMode},
+			{transform: resultGenerator.bind(undefined, lines), binary, preserveNewlines, objectMode},
 		],
 		stripFinalNewline: false,
 	});
@@ -211,25 +211,25 @@ test('Splits lines when "binary" is undefined', testBinaryOption, undefined, sim
 test('Does not split lines when "binary" is true, objectMode', testBinaryOption, true, simpleChunks, simpleChunks, simpleChunks, true, true);
 test('Splits lines when "binary" is false, objectMode', testBinaryOption, false, simpleChunks, simpleLines, simpleLines, true, true);
 test('Splits lines when "binary" is undefined, objectMode', testBinaryOption, undefined, simpleChunks, simpleLines, simpleLines, true, true);
-test('Does not split lines when "binary" is true, keep newline', testBinaryOption, true, simpleChunks, simpleChunks, simpleFull, false, false);
-test('Splits lines when "binary" is false, keep newline', testBinaryOption, false, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false);
-test('Splits lines when "binary" is undefined, keep newline', testBinaryOption, undefined, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false);
-test('Does not split lines when "binary" is true, objectMode, keep newline', testBinaryOption, true, simpleChunks, simpleChunks, simpleChunks, true, false);
-test('Splits lines when "binary" is false, objectMode, keep newline', testBinaryOption, false, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, false);
-test('Splits lines when "binary" is undefined, objectMode, keep newline', testBinaryOption, undefined, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, false);
+test('Does not split lines when "binary" is true, preserveNewlines', testBinaryOption, true, simpleChunks, simpleChunks, simpleFull, false, false);
+test('Splits lines when "binary" is false, preserveNewlines', testBinaryOption, false, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false);
+test('Splits lines when "binary" is undefined, preserveNewlines', testBinaryOption, undefined, simpleChunks, noNewlinesChunks, simpleFullEnd, false, false);
+test('Does not split lines when "binary" is true, objectMode, preserveNewlines', testBinaryOption, true, simpleChunks, simpleChunks, simpleChunks, true, false);
+test('Splits lines when "binary" is false, objectMode, preserveNewlines', testBinaryOption, false, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, false);
+test('Splits lines when "binary" is undefined, objectMode, preserveNewlines', testBinaryOption, undefined, simpleChunks, noNewlinesChunks, noNewlinesChunks, true, false);
 
 const resultStringGenerator = function * (lines, chunk) {
 	lines.push(chunk);
 	yield new TextDecoder().decode(chunk);
 };
 
-const testUint8ArrayToString = async (t, expectedOutput, objectMode, newline) => {
+const testUint8ArrayToString = async (t, expectedOutput, objectMode, preserveNewlines) => {
 	const lines = [];
 	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {
 		stdout: {
 			transform: resultStringGenerator.bind(undefined, lines),
 			objectMode,
-			newline,
+			preserveNewlines,
 		},
 		encoding: 'buffer',
 		lines: true,
@@ -240,21 +240,21 @@ const testUint8ArrayToString = async (t, expectedOutput, objectMode, newline) =>
 
 test('Line splitting when converting from Uint8Array to string', testUint8ArrayToString, [foobarUint8Array], false, true);
 test('Line splitting when converting from Uint8Array to string, objectMode', testUint8ArrayToString, [foobarString], true, true);
-test('Line splitting when converting from Uint8Array to string, keep newline', testUint8ArrayToString, [foobarUint8Array], false, false);
-test('Line splitting when converting from Uint8Array to string, objectMode, keep newline', testUint8ArrayToString, [foobarString], true, false);
+test('Line splitting when converting from Uint8Array to string, preserveNewlines', testUint8ArrayToString, [foobarUint8Array], false, false);
+test('Line splitting when converting from Uint8Array to string, objectMode, preserveNewlines', testUint8ArrayToString, [foobarString], true, false);
 
 const resultUint8ArrayGenerator = function * (lines, chunk) {
 	lines.push(chunk);
 	yield new TextEncoder().encode(chunk);
 };
 
-const testStringToUint8Array = async (t, expectedOutput, objectMode, newline) => {
+const testStringToUint8Array = async (t, expectedOutput, objectMode, preserveNewlines) => {
 	const lines = [];
 	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {
 		stdout: {
 			transform: resultUint8ArrayGenerator.bind(undefined, lines),
 			objectMode,
-			newline,
+			preserveNewlines,
 		},
 		lines: true,
 	});
@@ -264,8 +264,8 @@ const testStringToUint8Array = async (t, expectedOutput, objectMode, newline) =>
 
 test('Line splitting when converting from string to Uint8Array', testStringToUint8Array, [foobarString], false, true);
 test('Line splitting when converting from string to Uint8Array, objectMode', testStringToUint8Array, [foobarUint8Array], true, true);
-test('Line splitting when converting from string to Uint8Array, keep newline', testStringToUint8Array, [foobarString], false, false);
-test('Line splitting when converting from string to Uint8Array, objectMode, keep newline', testStringToUint8Array, [foobarUint8Array], true, false);
+test('Line splitting when converting from string to Uint8Array, preserveNewlines', testStringToUint8Array, [foobarString], false, false);
+test('Line splitting when converting from string to Uint8Array, objectMode, preserveNewlines', testStringToUint8Array, [foobarUint8Array], true, false);
 
 const testStripNewline = async (t, input, expectedOutput) => {
 	const {stdout} = await execa('noop.js', {
@@ -295,12 +295,12 @@ const serializeResultGenerator = function * (lines, chunk) {
 	yield JSON.stringify(chunk);
 };
 
-const testUnsetObjectMode = async (t, expectedOutput, newline) => {
+const testUnsetObjectMode = async (t, expectedOutput, preserveNewlines) => {
 	const lines = [];
 	const {stdout} = await execa('noop.js', {
 		stdout: [
 			getChunksGenerator([foobarObject], true),
-			{transform: serializeResultGenerator.bind(undefined, lines), newline, objectMode: false},
+			{transform: serializeResultGenerator.bind(undefined, lines), preserveNewlines, objectMode: false},
 		],
 		stripFinalNewline: false,
 	});
@@ -309,7 +309,7 @@ const testUnsetObjectMode = async (t, expectedOutput, newline) => {
 };
 
 test('Can switch from objectMode to non-objectMode', testUnsetObjectMode, `${foobarObjectString}\n`, false);
-test('Can switch from objectMode to non-objectMode, keep newline', testUnsetObjectMode, foobarObjectString, true);
+test('Can switch from objectMode to non-objectMode, preserveNewlines', testUnsetObjectMode, foobarObjectString, true);
 
 const testYieldArray = async (t, input, expectedLines, expectedOutput) => {
 	const lines = [];

--- a/test/stdio/transform.js
+++ b/test/stdio/transform.js
@@ -32,7 +32,7 @@ test('Generators "final" can be used', testGeneratorFinal, 'noop.js');
 test('Generators "final" is used even on empty streams', testGeneratorFinal, 'empty.js');
 
 const testFinalAlone = async (t, final) => {
-	const {stdout} = await execa('noop-fd.js', ['1', '.'], {stdout: {final: final(foobarString)}});
+	const {stdout} = await execa('noop-fd.js', ['1', '.'], {stdout: {final: final(foobarString), binary: true}});
 	t.is(stdout, `.${foobarString}`);
 };
 
@@ -101,7 +101,7 @@ const multipleYieldGenerator = async function * (line = foobarString) {
 
 const testMultipleYields = async (t, final) => {
 	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {stdout: convertTransformToFinal(multipleYieldGenerator, final)});
-	t.is(stdout, `${prefix}${foobarString}${suffix}`);
+	t.is(stdout, `${prefix}\n${foobarString}\n${suffix}`);
 };
 
 test('Generator can yield "transform" multiple times at different moments', testMultipleYields, false);
@@ -139,7 +139,10 @@ const maxBuffer = 10;
 
 test('Generators take "maxBuffer" into account', async t => {
 	const bigString = '.'.repeat(maxBuffer);
-	const {stdout} = await execa('noop.js', {maxBuffer, stdout: getOutputGenerator(bigString, false)});
+	const {stdout} = await execa('noop.js', {
+		maxBuffer,
+		stdout: getOutputGenerator(bigString, false, true),
+	});
 	t.is(stdout, bigString);
 
 	await t.throwsAsync(execa('noop.js', {maxBuffer, stdout: getOutputGenerator(`${bigString}.`, false)}));
@@ -147,7 +150,10 @@ test('Generators take "maxBuffer" into account', async t => {
 
 test('Generators take "maxBuffer" into account, objectMode', async t => {
 	const bigArray = Array.from({length: maxBuffer}).fill('.');
-	const {stdout} = await execa('noop.js', {maxBuffer, stdout: getOutputsGenerator(bigArray, true)});
+	const {stdout} = await execa('noop.js', {
+		maxBuffer,
+		stdout: getOutputsGenerator(bigArray, true, true),
+	});
 	t.is(stdout.length, maxBuffer);
 
 	await t.throwsAsync(execa('noop.js', {maxBuffer, stdout: getOutputsGenerator([...bigArray, ''], true)}));

--- a/test/stdio/type.js
+++ b/test/stdio/type.js
@@ -1,14 +1,10 @@
 import test from 'ava';
 import {execa, execaSync} from '../../index.js';
 import {getStdio} from '../helpers/stdio.js';
-import {noopGenerator} from '../helpers/generator.js';
+import {noopGenerator, uppercaseGenerator} from '../helpers/generator.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 
 setFixtureDir();
-
-const uppercaseGenerator = function * (line) {
-	yield line.toUpperCase();
-};
 
 const testInvalidGenerator = (t, fdNumber, stdioOption) => {
 	t.throws(() => {
@@ -27,7 +23,7 @@ test('Cannot use invalid "final" with stdio[*]', testInvalidGenerator, 3, {final
 
 const testInvalidBinary = (t, fdNumber, optionName) => {
 	t.throws(() => {
-		execa('empty.js', getStdio(fdNumber, {transform: uppercaseGenerator, [optionName]: 'true'}));
+		execa('empty.js', getStdio(fdNumber, {...uppercaseGenerator(), [optionName]: 'true'}));
 	}, {message: /a boolean/});
 };
 
@@ -42,7 +38,7 @@ test('Cannot use invalid "objectMode" with stdio[*]', testInvalidBinary, 3, 'obj
 
 const testSyncMethods = (t, fdNumber) => {
 	t.throws(() => {
-		execaSync('empty.js', getStdio(fdNumber, uppercaseGenerator));
+		execaSync('empty.js', getStdio(fdNumber, uppercaseGenerator()));
 	}, {message: /cannot be a generator/});
 };
 

--- a/test/stdio/validate.js
+++ b/test/stdio/validate.js
@@ -29,7 +29,7 @@ const getMessage = input => {
 };
 
 const lastInputGenerator = (input, objectMode) => [foobarUint8Array, getOutputGenerator(input, objectMode)];
-const inputGenerator = (input, objectMode) => [...lastInputGenerator(input, objectMode), serializeGenerator];
+const inputGenerator = (input, objectMode) => [...lastInputGenerator(input, objectMode), serializeGenerator(true)];
 
 test('Generators with result.stdin cannot return an object if not in objectMode', testGeneratorReturn, 0, inputGenerator, foobarObject, false, true);
 test('Generators with result.stdio[*] as input cannot return an object if not in objectMode', testGeneratorReturn, 3, inputGenerator, foobarObject, false, true);


### PR DESCRIPTION
This PR improves how newlines are handled in transforms:
  - The newline is now automatically stripped from each `line` argument passed to transforms
  - `yield string` statements do not need to add a newline at the end of `string` anymore. Each `yield` produces a new line (kindof like `console.log()`).

The above behavior can be disabled by passing a `{transform, newline: true}` plain object.

As an added bonus, the `stripFinalNewline` option now works with the `lines` option. If `lines: true` is used, and `stripFinalNewline: true` is used too, it will be applied to each line, i.e. each item of the `result.stdout`/`result.stderr` array.