### PR TITLE
Rename `from|to: 3` to `from|to: 'fd3'`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -902,19 +902,20 @@ type AllIfStderr<StderrResultIgnored extends boolean> = StderrResultIgnored exte
 	? undefined
 	: Readable;
 
-type FromOption = 'stdout' | 'stderr' | 'all' | number;
-type ToOption = 'stdin' | number;
+type FileDescriptorOption = `fd${number}`;
+type FromOption = 'stdout' | 'stderr' | 'all' | FileDescriptorOption;
+type ToOption = 'stdin' | FileDescriptorOption;
 
 type PipeOptions = {
 	/**
-	Which stream to pipe from the source subprocess. A file descriptor number can also be passed.
+	Which stream to pipe from the source subprocess. A file descriptor like `"fd3"` can also be passed.
 
 	`"all"` pipes both `stdout` and `stderr`. This requires the `all` option to be `true`.
 	*/
 	readonly from?: FromOption;
 
 	/**
-	Which stream to pipe to the destination subprocess. A file descriptor number can also be passed.
+	Which stream to pipe to the destination subprocess. A file descriptor like `"fd3"` can also be passed.
 	*/
 	readonly to?: ToOption;
 
@@ -970,7 +971,7 @@ type PipableSubprocess = {
 
 type ReadableStreamOptions = {
 	/**
-	Which stream to read from the subprocess. A file descriptor number can also be passed.
+	Which stream to read from the subprocess. A file descriptor like `"fd3"` can also be passed.
 
 	`"all"` reads both `stdout` and `stderr`. This requires the `all` option to be `true`.
 	*/
@@ -979,7 +980,7 @@ type ReadableStreamOptions = {
 
 type WritableStreamOptions = {
 	/**
-	Which stream to write to the subprocess. A file descriptor number can also be passed.
+	Which stream to write to the subprocess. A file descriptor like `"fd3"` can also be passed.
 	*/
 	readonly to?: ToOption;
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -88,7 +88,7 @@ try {
 
 	const scriptPromise = $`unicorns`;
 
-	const pipeOptions = {from: 'stderr', to: 3, all: true} as const;
+	const pipeOptions = {from: 'stderr', to: 'fd3', all: true} as const;
 
 	type BufferExecaReturnValue = typeof bufferResult;
 	type EmptyExecaReturnValue = ExecaResult<{}>;
@@ -170,12 +170,12 @@ try {
 	await scriptPromise.pipe({from: 'all'})`stdin`;
 	await execaPromise.pipe('stdin', {from: 'all'});
 	await scriptPromise.pipe('stdin', {from: 'all'});
-	await execaPromise.pipe(execaBufferPromise, {from: 3});
-	await scriptPromise.pipe(execaBufferPromise, {from: 3});
-	await execaPromise.pipe({from: 3})`stdin`;
-	await scriptPromise.pipe({from: 3})`stdin`;
-	await execaPromise.pipe('stdin', {from: 3});
-	await scriptPromise.pipe('stdin', {from: 3});
+	await execaPromise.pipe(execaBufferPromise, {from: 'fd3'});
+	await scriptPromise.pipe(execaBufferPromise, {from: 'fd3'});
+	await execaPromise.pipe({from: 'fd3'})`stdin`;
+	await scriptPromise.pipe({from: 'fd3'})`stdin`;
+	await execaPromise.pipe('stdin', {from: 'fd3'});
+	await scriptPromise.pipe('stdin', {from: 'fd3'});
 	expectError(execaPromise.pipe(execaBufferPromise, {from: 'stdin'}));
 	expectError(scriptPromise.pipe(execaBufferPromise, {from: 'stdin'}));
 	expectError(execaPromise.pipe({from: 'stdin'})`stdin`);
@@ -188,12 +188,12 @@ try {
 	await scriptPromise.pipe({to: 'stdin'})`stdin`;
 	await execaPromise.pipe('stdin', {to: 'stdin'});
 	await scriptPromise.pipe('stdin', {to: 'stdin'});
-	await execaPromise.pipe(execaBufferPromise, {to: 3});
-	await scriptPromise.pipe(execaBufferPromise, {to: 3});
-	await execaPromise.pipe({to: 3})`stdin`;
-	await scriptPromise.pipe({to: 3})`stdin`;
-	await execaPromise.pipe('stdin', {to: 3});
-	await scriptPromise.pipe('stdin', {to: 3});
+	await execaPromise.pipe(execaBufferPromise, {to: 'fd3'});
+	await scriptPromise.pipe(execaBufferPromise, {to: 'fd3'});
+	await execaPromise.pipe({to: 'fd3'})`stdin`;
+	await scriptPromise.pipe({to: 'fd3'})`stdin`;
+	await execaPromise.pipe('stdin', {to: 'fd3'});
+	await scriptPromise.pipe('stdin', {to: 'fd3'});
 	expectError(execaPromise.pipe(execaBufferPromise, {to: 'stdout'}));
 	expectError(scriptPromise.pipe(execaBufferPromise, {to: 'stdout'}));
 	expectError(execaPromise.pipe({to: 'stdout'})`stdin`);
@@ -235,8 +235,18 @@ try {
 	expectError(await execaPromise.pipe('stdin', [], false));
 	expectError(await execaPromise.pipe('stdin', {other: true}));
 	expectError(await execaPromise.pipe('stdin', [], {other: true}));
+	expectError(await execaPromise.pipe('stdin', {from: 'fd'}));
+	expectError(await execaPromise.pipe('stdin', [], {from: 'fd'}));
+	expectError(await execaPromise.pipe('stdin', {from: 'fdNotANumber'}));
+	expectError(await execaPromise.pipe('stdin', [], {from: 'fdNotANumber'}));
 	expectError(await execaPromise.pipe('stdin', {from: 'other'}));
 	expectError(await execaPromise.pipe('stdin', [], {from: 'other'}));
+	expectError(await execaPromise.pipe('stdin', {to: 'fd'}));
+	expectError(await execaPromise.pipe('stdin', [], {to: 'fd'}));
+	expectError(await execaPromise.pipe('stdin', {to: 'fdNotANumber'}));
+	expectError(await execaPromise.pipe('stdin', [], {to: 'fdNotANumber'}));
+	expectError(await execaPromise.pipe('stdin', {to: 'other'}));
+	expectError(await execaPromise.pipe('stdin', [], {to: 'other'}));
 
 	const pipeResult = await execaPromise.pipe`stdin`;
 	expectType<string>(pipeResult.stdout);
@@ -266,26 +276,34 @@ try {
 	scriptPromise.readable({from: 'stdout'});
 	scriptPromise.readable({from: 'stderr'});
 	scriptPromise.readable({from: 'all'});
-	scriptPromise.readable({from: 3});
+	scriptPromise.readable({from: 'fd3'});
 	expectError(scriptPromise.readable('stdout'));
 	expectError(scriptPromise.readable({from: 'stdin'}));
+	expectError(scriptPromise.readable({from: 'fd'}));
+	expectError(scriptPromise.readable({from: 'fdNotANumber'}));
 	expectError(scriptPromise.readable({other: 'stdout'}));
 	scriptPromise.writable({});
 	scriptPromise.writable({to: 'stdin'});
-	scriptPromise.writable({to: 3});
+	scriptPromise.writable({to: 'fd3'});
 	expectError(scriptPromise.writable('stdin'));
 	expectError(scriptPromise.writable({to: 'stdout'}));
+	expectError(scriptPromise.writable({to: 'fd'}));
+	expectError(scriptPromise.writable({to: 'fdNotANumber'}));
 	expectError(scriptPromise.writable({other: 'stdin'}));
 	scriptPromise.duplex({});
 	scriptPromise.duplex({from: 'stdout'});
 	scriptPromise.duplex({from: 'stderr'});
 	scriptPromise.duplex({from: 'all'});
-	scriptPromise.duplex({from: 3});
+	scriptPromise.duplex({from: 'fd3'});
 	scriptPromise.duplex({from: 'stdout', to: 'stdin'});
-	scriptPromise.duplex({from: 'stdout', to: 3});
+	scriptPromise.duplex({from: 'stdout', to: 'fd3'});
 	expectError(scriptPromise.duplex('stdout'));
 	expectError(scriptPromise.duplex({from: 'stdin'}));
 	expectError(scriptPromise.duplex({from: 'stderr', to: 'stdout'}));
+	expectError(scriptPromise.duplex({from: 'fd'}));
+	expectError(scriptPromise.duplex({from: 'fdNotANumber'}));
+	expectError(scriptPromise.duplex({to: 'fd'}));
+	expectError(scriptPromise.duplex({to: 'fdNotANumber'}));
 	expectError(scriptPromise.duplex({other: 'stdout'}));
 
 	expectType<Readable>(execaPromise.all);

--- a/lib/pipe/validate.js
+++ b/lib/pipe/validate.js
@@ -109,38 +109,50 @@ export const getReadable = (source, from = 'stdout') => {
 };
 
 const getFdNumber = (stdioStreamsGroups, fdName, isWritable) => {
-	const fdNumber = STANDARD_STREAMS_ALIASES.includes(fdName)
-		? STANDARD_STREAMS_ALIASES.indexOf(fdName)
-		: fdName;
+	const fdNumber = parseFdNumber(fdName, isWritable);
+	validateFdNumber(fdNumber, fdName, isWritable, stdioStreamsGroups);
+	return fdNumber;
+};
 
-	if (fdNumber === 'all') {
-		return fdNumber;
+const parseFdNumber = (fdName, isWritable) => {
+	if (fdName === 'all') {
+		return fdName;
 	}
 
-	if (!Number.isInteger(fdNumber) || fdNumber < 0) {
-		const {validOptions, defaultValue} = isWritable
-			? {validOptions: '"stdin"', defaultValue: 'stdin'}
-			: {validOptions: '"stdout", "stderr", "all"', defaultValue: 'stdout'};
-		throw new TypeError(`"${getOptionName(isWritable)}" must not be "${fdNumber}".
-It must be ${validOptions} or a file descriptor integer.
+	if (STANDARD_STREAMS_ALIASES.includes(fdName)) {
+		return STANDARD_STREAMS_ALIASES.indexOf(fdName);
+	}
+
+	const regexpResult = FD_REGEXP.exec(fdName);
+	if (regexpResult !== null) {
+		return Number(regexpResult[1]);
+	}
+
+	const {validOptions, defaultValue} = isWritable
+		? {validOptions: '"stdin"', defaultValue: 'stdin'}
+		: {validOptions: '"stdout", "stderr", "all"', defaultValue: 'stdout'};
+	throw new TypeError(`"${getOptionName(isWritable)}" must not be "${fdName}".
+It must be ${validOptions} or "fd3", "fd4" (and so on).
 It is optional and defaults to "${defaultValue}".`);
-	}
+};
 
-	const stdioStreams = stdioStreamsGroups[fdNumber];
+const FD_REGEXP = /^fd(\d+)$/;
+
+const validateFdNumber = (fdNumber, fdName, isWritable, stdioStreamsGroups) => {
+	const usedDescriptor = getUsedDescriptor(fdNumber);
+	const stdioStreams = stdioStreamsGroups[usedDescriptor];
 	if (stdioStreams === undefined) {
-		throw new TypeError(`"${getOptionName(isWritable)}" must not be ${fdNumber}. That file descriptor does not exist.
+		throw new TypeError(`"${getOptionName(isWritable)}" must not be ${fdName}. That file descriptor does not exist.
 Please set the "stdio" option to ensure that file descriptor exists.`);
 	}
 
 	if (stdioStreams[0].direction === 'input' && !isWritable) {
-		throw new TypeError(`"${getOptionName(isWritable)}" must not be ${fdNumber}. It must be a readable stream, not writable.`);
+		throw new TypeError(`"${getOptionName(isWritable)}" must not be ${fdName}. It must be a readable stream, not writable.`);
 	}
 
 	if (stdioStreams[0].direction !== 'input' && isWritable) {
-		throw new TypeError(`"${getOptionName(isWritable)}" must not be ${fdNumber}. It must be a writable stream, not readable.`);
+		throw new TypeError(`"${getOptionName(isWritable)}" must not be ${fdName}. It must be a writable stream, not readable.`);
 	}
-
-	return fdNumber;
 };
 
 const getInvalidStdioOptionMessage = (fdNumber, fdName, options, isWritable) => {
@@ -154,7 +166,7 @@ Please set this option with "pipe" instead.`;
 };
 
 const getInvalidStdioOption = (fdNumber, {stdin, stdout, stderr, stdio}) => {
-	const usedDescriptor = fdNumber === 'all' ? 1 : fdNumber;
+	const usedDescriptor = getUsedDescriptor(fdNumber);
 
 	if (usedDescriptor === 0 && stdin !== undefined) {
 		return {optionName: 'stdin', optionValue: stdin};
@@ -170,6 +182,8 @@ const getInvalidStdioOption = (fdNumber, {stdin, stdout, stderr, stdio}) => {
 
 	return {optionName: `stdio[${usedDescriptor}]`, optionValue: stdio[usedDescriptor]};
 };
+
+const getUsedDescriptor = fdNumber => fdNumber === 'all' ? 1 : fdNumber;
 
 const serializeOptionValue = optionValue => {
 	if (typeof optionValue === 'string') {

--- a/readme.md
+++ b/readme.md
@@ -401,19 +401,19 @@ Type: `object`
 
 ##### pipeOptions.from
 
-Type: `"stdout" | "stderr" | "all" | number`\
+Type: `"stdout" | "stderr" | "all" | "fd3" | "fd4" | ...`\
 Default: `"stdout"`
 
-Which stream to pipe from the source subprocess. A file descriptor number can also be passed.
+Which stream to pipe from the source subprocess. A file descriptor like `"fd3"` can also be passed.
 
 `"all"` pipes both `stdout` and `stderr`. This requires the [`all` option](#all-2) to be `true`.
 
 ##### pipeOptions.to
 
-Type: `"stdin" | number`\
+Type: `"stdin" | "fd3" | "fd4" | ...`\
 Default: `"stdin"`
 
-Which stream to pipe to the destination subprocess. A file descriptor number can also be passed.
+Which stream to pipe to the destination subprocess. A file descriptor like `"fd3"` can also be passed.
 
 ##### pipeOptions.unpipeSignal
 
@@ -477,10 +477,10 @@ Type: `object`
 
 ##### streamOptions.from
 
-Type: `"stdout" | "stderr" | "all" | number`\
+Type: `"stdout" | "stderr" | "all" | "fd3" | "fd4" | ...`\
 Default: `"stdout"`
 
-Which stream to read from the subprocess. A file descriptor number can also be passed.
+Which stream to read from the subprocess. A file descriptor like `"fd3"` can also be passed.
 
 `"all"` reads both `stdout` and `stderr`. This requires the [`all` option](#all-2) to be `true`.
 
@@ -488,10 +488,10 @@ Only available with [`.readable()`](#readablestreamoptions) and [`.duplex()`](#d
 
 ##### streamOptions.to
 
-Type: `"stdin" | number`\
+Type: `"stdin" | "fd3" | "fd4" | ...`\
 Default: `"stdin"`
 
-Which stream to write to the subprocess. A file descriptor number can also be passed.
+Which stream to write to the subprocess. A file descriptor like `"fd3"` can also be passed.
 
 Only available with [`.writable()`](#writablestreamoptions) and [`.duplex()`](#duplexstreamoptions), not [`.readable()`](#readablestreamoptions).
 

--- a/test/convert/duplex.js
+++ b/test/convert/duplex.js
@@ -48,14 +48,14 @@ const testReadableDuplexDefault = async (t, fdNumber, from, options, hasResult) 
 	await assertSubprocessOutput(t, subprocess, foobarString, fdNumber);
 };
 
-test('.duplex() can use stdout', testReadableDuplexDefault, 1, 1, {}, true);
-test('.duplex() can use stderr', testReadableDuplexDefault, 2, 2, {}, true);
-test('.duplex() can use output stdio[*]', testReadableDuplexDefault, 3, 3, fullStdio, true);
+test('.duplex() can use stdout', testReadableDuplexDefault, 1, 'stdout', {}, true);
+test('.duplex() can use stderr', testReadableDuplexDefault, 2, 'stderr', {}, true);
+test('.duplex() can use output stdio[*]', testReadableDuplexDefault, 3, 'fd3', fullStdio, true);
 test('.duplex() uses stdout by default', testReadableDuplexDefault, 1, undefined, {}, true);
 test('.duplex() does not use stderr by default', testReadableDuplexDefault, 2, undefined, {}, false);
 test('.duplex() does not use stdio[*] by default', testReadableDuplexDefault, 3, undefined, fullStdio, false);
-test('.duplex() uses stdout even if stderr is "ignore"', testReadableDuplexDefault, 1, 1, {stderr: 'ignore'}, true);
-test('.duplex() uses stderr even if stdout is "ignore"', testReadableDuplexDefault, 2, 2, {stdout: 'ignore'}, true);
+test('.duplex() uses stdout even if stderr is "ignore"', testReadableDuplexDefault, 1, 'stdout', {stderr: 'ignore'}, true);
+test('.duplex() uses stderr even if stdout is "ignore"', testReadableDuplexDefault, 2, 'stderr', {stdout: 'ignore'}, true);
 test('.duplex() uses stdout if "all" is used', testReadableDuplexDefault, 1, 'all', {all: true}, true);
 test('.duplex() uses stderr if "all" is used', testReadableDuplexDefault, 2, 'all', {all: true}, true);
 
@@ -69,8 +69,8 @@ const testWritableDuplexDefault = async (t, fdNumber, to, options) => {
 	await assertSubprocessOutput(t, subprocess);
 };
 
-test('.duplex() can use stdin', testWritableDuplexDefault, 0, 0, {});
-test('.duplex() can use input stdio[*]', testWritableDuplexDefault, 3, 3, fullReadableStdio());
+test('.duplex() can use stdin', testWritableDuplexDefault, 0, 'stdin', {});
+test('.duplex() can use input stdio[*]', testWritableDuplexDefault, 3, 'fd3', fullReadableStdio());
 test('.duplex() uses stdin by default', testWritableDuplexDefault, 0, undefined, {});
 
 test('.duplex() abort -> subprocess fail', async t => {

--- a/test/convert/readable.js
+++ b/test/convert/readable.js
@@ -51,14 +51,14 @@ const testReadableDefault = async (t, fdNumber, from, options, hasResult) => {
 	await assertSubprocessOutput(t, subprocess, foobarString, fdNumber);
 };
 
-test('.readable() can use stdout', testReadableDefault, 1, 1, {}, true);
-test('.readable() can use stderr', testReadableDefault, 2, 2, {}, true);
-test('.readable() can use stdio[*]', testReadableDefault, 3, 3, fullStdio, true);
+test('.readable() can use stdout', testReadableDefault, 1, 'stdout', {}, true);
+test('.readable() can use stderr', testReadableDefault, 2, 'stderr', {}, true);
+test('.readable() can use stdio[*]', testReadableDefault, 3, 'fd3', fullStdio, true);
 test('.readable() uses stdout by default', testReadableDefault, 1, undefined, {}, true);
 test('.readable() does not use stderr by default', testReadableDefault, 2, undefined, {}, false);
 test('.readable() does not use stdio[*] by default', testReadableDefault, 3, undefined, fullStdio, false);
-test('.readable() uses stdout even if stderr is "ignore"', testReadableDefault, 1, 1, {stderr: 'ignore'}, true);
-test('.readable() uses stderr even if stdout is "ignore"', testReadableDefault, 2, 2, {stdout: 'ignore'}, true);
+test('.readable() uses stdout even if stderr is "ignore"', testReadableDefault, 1, 'stdout', {stderr: 'ignore'}, true);
+test('.readable() uses stderr even if stdout is "ignore"', testReadableDefault, 2, 'stderr', {stdout: 'ignore'}, true);
 test('.readable() uses stdout if "all" is used', testReadableDefault, 1, 'all', {all: true}, true);
 test('.readable() uses stderr if "all" is used', testReadableDefault, 2, 'all', {all: true}, true);
 

--- a/test/convert/writable.js
+++ b/test/convert/writable.js
@@ -57,8 +57,8 @@ const testWritableDefault = async (t, fdNumber, to, options) => {
 	await assertSubprocessOutput(t, subprocess);
 };
 
-test('.writable() can use stdin', testWritableDefault, 0, 0, {});
-test('.writable() can use stdio[*]', testWritableDefault, 3, 3, fullReadableStdio());
+test('.writable() can use stdin', testWritableDefault, 0, 'stdin', {});
+test('.writable() can use stdio[*]', testWritableDefault, 3, 'fd3', fullReadableStdio());
 test('.writable() uses stdin by default', testWritableDefault, 0, undefined, {});
 
 test('.writable() hangs until ended', async t => {

--- a/test/pipe/setup.js
+++ b/test/pipe/setup.js
@@ -15,14 +15,14 @@ const pipeToSubprocess = async (t, readableFdNumber, writableFdNumber, from, to,
 
 test('pipe(...) can pipe', pipeToSubprocess, 1, 0);
 test('pipe(..., {from: "stdout"}) can pipe', pipeToSubprocess, 1, 0, 'stdout');
-test('pipe(..., {from: 1}) can pipe', pipeToSubprocess, 1, 0, 1);
+test('pipe(..., {from: "fd1"}) can pipe', pipeToSubprocess, 1, 0, 'fd1');
 test('pipe(..., {from: "stderr"}) can pipe stderr', pipeToSubprocess, 2, 0, 'stderr');
-test('pipe(..., {from: 2}) can pipe', pipeToSubprocess, 2, 0, 2);
-test('pipe(..., {from: 3}) can pipe', pipeToSubprocess, 3, 0, 3, undefined, fullStdio);
+test('pipe(..., {from: "fd2"}) can pipe', pipeToSubprocess, 2, 0, 'fd2');
+test('pipe(..., {from: "fd3"}) can pipe', pipeToSubprocess, 3, 0, 'fd3', undefined, fullStdio);
 test('pipe(..., {from: "all"}) can pipe stdout', pipeToSubprocess, 1, 0, 'all', undefined, {all: true});
 test('pipe(..., {from: "all"}) can pipe stderr', pipeToSubprocess, 2, 0, 'all', undefined, {all: true});
 test('pipe(..., {from: "all"}) can pipe stdout even with "stderr: ignore"', pipeToSubprocess, 1, 0, 'all', undefined, {all: true, stderr: 'ignore'});
 test('pipe(..., {from: "all"}) can pipe stderr even with "stdout: ignore"', pipeToSubprocess, 2, 0, 'all', undefined, {all: true, stdout: 'ignore'});
 test('pipe(..., {to: "stdin"}) can pipe', pipeToSubprocess, 1, 0, undefined, 'stdin');
-test('pipe(..., {to: 0}) can pipe', pipeToSubprocess, 1, 0, undefined, 0);
-test('pipe(..., {to: 3}) can pipe', pipeToSubprocess, 1, 3, undefined, 3, {}, fullReadableStdio());
+test('pipe(..., {to: "fd0"}) can pipe', pipeToSubprocess, 1, 0, undefined, 'fd0');
+test('pipe(..., {to: "fd3"}) can pipe', pipeToSubprocess, 1, 3, undefined, 'fd3', {}, fullReadableStdio());

--- a/test/pipe/streaming.js
+++ b/test/pipe/streaming.js
@@ -92,7 +92,7 @@ test('Can pipe same source to two streams from same subprocess', async t => {
 	const source = execa('noop-fd.js', ['1', foobarString]);
 	const destination = execa('stdin-fd-both.js', ['3'], fullReadableStdio());
 	const pipePromise = source.pipe(destination);
-	const secondPipePromise = source.pipe(destination, {to: 3});
+	const secondPipePromise = source.pipe(destination, {to: 'fd3'});
 
 	t.like(await source, {stdout: foobarString});
 	t.like(await destination, {stdout: `${foobarString}${foobarString}`});

--- a/test/pipe/validate.js
+++ b/test/pipe/validate.js
@@ -133,72 +133,114 @@ test('.duplex() "to" option cannot be any string', testNodeStream, {
 	to: 'other',
 	message: 'must be "stdin"',
 });
+test('.pipe() "from" option cannot be a number without "fd"', testPipeError, {
+	from: '1',
+	message: 'must be "stdout", "stderr", "all"',
+});
+test('.duplex() "from" option cannot be a number without "fd"', testNodeStream, {
+	from: '1',
+	message: 'must be "stdout", "stderr", "all"',
+});
+test('.pipe() "to" option cannot be a number without "fd"', testPipeError, {
+	to: '0',
+	message: 'must be "stdin"',
+});
+test('.duplex() "to" option cannot be a number without "fd"', testNodeStream, {
+	to: '0',
+	message: 'must be "stdin"',
+});
+test('.pipe() "from" option cannot be just "fd"', testPipeError, {
+	from: 'fd',
+	message: 'must be "stdout", "stderr", "all"',
+});
+test('.duplex() "from" option cannot be just "fd"', testNodeStream, {
+	from: 'fd',
+	message: 'must be "stdout", "stderr", "all"',
+});
+test('.pipe() "to" option cannot be just "fd"', testPipeError, {
+	to: 'fd',
+	message: 'must be "stdin"',
+});
+test('.duplex() "to" option cannot be just "fd"', testNodeStream, {
+	to: 'fd',
+	message: 'must be "stdin"',
+});
 test('.pipe() "from" option cannot be a float', testPipeError, {
-	from: 1.5,
+	from: 'fd1.5',
 	message: 'must be "stdout", "stderr", "all"',
 });
 test('.duplex() "from" option cannot be a float', testNodeStream, {
-	from: 1.5,
+	from: 'fd1.5',
 	message: 'must be "stdout", "stderr", "all"',
 });
 test('.pipe() "to" option cannot be a float', testPipeError, {
-	to: 1.5,
+	to: 'fd1.5',
 	message: 'must be "stdin"',
 });
 test('.duplex() "to" option cannot be a float', testNodeStream, {
-	to: 1.5,
+	to: 'fd1.5',
 	message: 'must be "stdin"',
 });
 test('.pipe() "from" option cannot be a negative number', testPipeError, {
-	from: -1,
+	from: 'fd-1',
 	message: 'must be "stdout", "stderr", "all"',
 });
 test('.duplex() "from" option cannot be a negative number', testNodeStream, {
-	from: -1,
+	from: 'fd-1',
 	message: 'must be "stdout", "stderr", "all"',
 });
 test('.pipe() "to" option cannot be a negative number', testPipeError, {
-	to: -1,
+	to: 'fd-1',
 	message: 'must be "stdin"',
 });
 test('.duplex() "to" option cannot be a negative number', testNodeStream, {
-	to: -1,
+	to: 'fd-1',
 	message: 'must be "stdin"',
 });
 test('.pipe() "from" option cannot be a non-existing file descriptor', testPipeError, {
-	from: 3,
+	from: 'fd3',
 	message: 'file descriptor does not exist',
 });
 test('.duplex() "from" cannot be a non-existing file descriptor', testNodeStream, {
-	from: 3,
+	from: 'fd3',
 	message: 'file descriptor does not exist',
 });
 test('.pipe() "to" option cannot be a non-existing file descriptor', testPipeError, {
-	to: 3,
+	to: 'fd3',
 	message: 'file descriptor does not exist',
 });
 test('.duplex() "to" cannot be a non-existing file descriptor', testNodeStream, {
-	to: 3,
+	to: 'fd3',
 	message: 'file descriptor does not exist',
 });
 test('.pipe() "from" option cannot be an input file descriptor', testPipeError, {
 	sourceOptions: getStdio(3, new Uint8Array()),
-	from: 3,
+	from: 'fd3',
 	message: 'must be a readable stream',
 });
 test('.duplex() "from" option cannot be an input file descriptor', testNodeStream, {
 	sourceOptions: getStdio(3, new Uint8Array()),
-	from: 3,
+	from: 'fd3',
 	message: 'must be a readable stream',
 });
 test('.pipe() "to" option cannot be an output file descriptor', testPipeError, {
 	destinationOptions: fullStdio,
-	to: 3,
+	to: 'fd3',
 	message: 'must be a writable stream',
 });
 test('.duplex() "to" option cannot be an output file descriptor', testNodeStream, {
 	sourceOptions: fullStdio,
-	to: 3,
+	to: 'fd3',
+	message: 'must be a writable stream',
+});
+test('.pipe() "to" option cannot be "all"', testPipeError, {
+	destinationOptions: fullStdio,
+	to: 'all',
+	message: 'must be a writable stream',
+});
+test('.duplex() "to" option cannot be "all"', testNodeStream, {
+	sourceOptions: fullStdio,
+	to: 'all',
 	message: 'must be a writable stream',
 });
 test('Cannot set "stdout" option to "ignore" to use .pipe()', testPipeError, {
@@ -220,23 +262,23 @@ test('Cannot set "stdin" option to "ignore" to use .duplex()', testNodeStream, {
 });
 test('Cannot set "stdout" option to "ignore" to use .pipe(1)', testPipeError, {
 	sourceOptions: {stdout: 'ignore'},
-	from: 1,
+	from: 'fd1',
 	message: ['stdout', '\'ignore\''],
 });
 test('Cannot set "stdout" option to "ignore" to use .duplex(1)', testNodeStream, {
 	sourceOptions: {stdout: 'ignore'},
-	from: 1,
+	from: 'fd1',
 	message: ['stdout', '\'ignore\''],
 });
 test('Cannot set "stdin" option to "ignore" to use .pipe(0)', testPipeError, {
 	destinationOptions: {stdin: 'ignore'},
 	message: ['stdin', '\'ignore\''],
-	to: 0,
+	to: 'fd0',
 });
 test('Cannot set "stdin" option to "ignore" to use .duplex(0)', testNodeStream, {
 	sourceOptions: {stdin: 'ignore'},
 	message: ['stdin', '\'ignore\''],
-	to: 0,
+	to: 'fd0',
 });
 test('Cannot set "stdout" option to "ignore" to use .pipe("stdout")', testPipeError, {
 	sourceOptions: {stdout: 'ignore'},
@@ -268,12 +310,12 @@ test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex()', testN
 });
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe(1)', testPipeError, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
-	from: 1,
+	from: 'fd1',
 	message: ['stdout', '\'ignore\''],
 });
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex(1)', testNodeStream, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
-	from: 1,
+	from: 'fd1',
 	message: ['stdout', '\'ignore\''],
 });
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe("stdout")', testPipeError, {
@@ -305,23 +347,23 @@ test('Cannot set "stdio[0]" option to "ignore" to use .duplex()', testNodeStream
 });
 test('Cannot set "stdio[1]" option to "ignore" to use .pipe(1)', testPipeError, {
 	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
-	from: 1,
+	from: 'fd1',
 	message: ['stdio[1]', '\'ignore\''],
 });
 test('Cannot set "stdio[1]" option to "ignore" to use .duplex(1)', testNodeStream, {
 	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
-	from: 1,
+	from: 'fd1',
 	message: ['stdio[1]', '\'ignore\''],
 });
 test('Cannot set "stdio[0]" option to "ignore" to use .pipe(0)', testPipeError, {
 	destinationOptions: {stdio: ['ignore', 'pipe', 'pipe']},
 	message: ['stdio[0]', '\'ignore\''],
-	to: 0,
+	to: 'fd0',
 });
 test('Cannot set "stdio[0]" option to "ignore" to use .duplex(0)', testNodeStream, {
 	sourceOptions: {stdio: ['ignore', 'pipe', 'pipe']},
 	message: ['stdio[0]', '\'ignore\''],
-	to: 0,
+	to: 'fd0',
 });
 test('Cannot set "stdio[1]" option to "ignore" to use .pipe("stdout")', testPipeError, {
 	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
@@ -345,12 +387,12 @@ test('Cannot set "stdio[0]" option to "ignore" to use .duplex("stdin")', testNod
 });
 test('Cannot set "stderr" option to "ignore" to use .pipe(2)', testPipeError, {
 	sourceOptions: {stderr: 'ignore'},
-	from: 2,
+	from: 'fd2',
 	message: ['stderr', '\'ignore\''],
 });
 test('Cannot set "stderr" option to "ignore" to use .duplex(2)', testNodeStream, {
 	sourceOptions: {stderr: 'ignore'},
-	from: 2,
+	from: 'fd2',
 	message: ['stderr', '\'ignore\''],
 });
 test('Cannot set "stderr" option to "ignore" to use .pipe("stderr")', testPipeError, {
@@ -365,12 +407,12 @@ test('Cannot set "stderr" option to "ignore" to use .duplex("stderr")', testNode
 });
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe(2)', testPipeError, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
-	from: 2,
+	from: 'fd2',
 	message: ['stderr', '\'ignore\''],
 });
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex(2)', testNodeStream, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
-	from: 2,
+	from: 'fd2',
 	message: ['stderr', '\'ignore\''],
 });
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe("stderr")', testPipeError, {
@@ -385,12 +427,12 @@ test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex("stderr")
 });
 test('Cannot set "stdio[2]" option to "ignore" to use .pipe(2)', testPipeError, {
 	sourceOptions: {stdio: ['pipe', 'pipe', 'ignore']},
-	from: 2,
+	from: 'fd2',
 	message: ['stdio[2]', '\'ignore\''],
 });
 test('Cannot set "stdio[2]" option to "ignore" to use .duplex(2)', testNodeStream, {
 	sourceOptions: {stdio: ['pipe', 'pipe', 'ignore']},
-	from: 2,
+	from: 'fd2',
 	message: ['stdio[2]', '\'ignore\''],
 });
 test('Cannot set "stdio[2]" option to "ignore" to use .pipe("stderr")', testPipeError, {
@@ -405,12 +447,12 @@ test('Cannot set "stdio[2]" option to "ignore" to use .duplex("stderr")', testNo
 });
 test('Cannot set "stdio[3]" option to "ignore" to use .pipe(3)', testPipeError, {
 	sourceOptions: getStdio(3, 'ignore'),
-	from: 3,
+	from: 'fd3',
 	message: ['stdio[3]', '\'ignore\''],
 });
 test('Cannot set "stdio[3]" option to "ignore" to use .duplex(3)', testNodeStream, {
 	sourceOptions: getStdio(3, 'ignore'),
-	from: 3,
+	from: 'fd3',
 	message: ['stdio[3]', '\'ignore\''],
 });
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe("all")', testPipeError, {
@@ -504,22 +546,22 @@ test('Cannot set "stdin" option to Node.js streams to use .duplex()', testNodeSt
 test('Cannot set "stdio[3]" option to Node.js Writable streams to use .pipe()', testPipeError, {
 	sourceOptions: getStdio(3, process.stdout),
 	message: ['stdio[3]', 'Stream'],
-	from: 3,
+	from: 'fd3',
 });
 test('Cannot set "stdio[3]" option to Node.js Writable streams to use .duplex()', testNodeStream, {
 	sourceOptions: getStdio(3, process.stdout),
 	message: ['stdio[3]', 'Stream'],
-	from: 3,
+	from: 'fd3',
 });
 test('Cannot set "stdio[3]" option to Node.js Readable streams to use .pipe()', testPipeError, {
 	destinationOptions: getStdio(3, process.stdin),
 	message: ['stdio[3]', 'Stream'],
-	to: 3,
+	to: 'fd3',
 });
 test('Cannot set "stdio[3]" option to Node.js Readable streams to use .duplex()', testNodeStream, {
 	sourceOptions: getStdio(3, process.stdin),
 	message: ['stdio[3]', 'Stream'],
-	to: 3,
+	to: 'fd3',
 });
 
 test('Destination stream is ended when first argument is invalid', async t => {


### PR DESCRIPTION
Fixes #918.