### PR TITLE
Improve documentation of `maxBuffer`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -491,7 +491,13 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 	readonly timeout?: number;
 
 	/**
-	Largest amount of data in bytes allowed on `stdout`, `stderr` and `stdio`. Default: 100 MB.
+	Largest amount of data allowed on `stdout`, `stderr` and `stdio`.
+
+	This is measured:
+	- By default: in [characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length).
+	- If the `encoding` option is `'buffer'`: in bytes.
+	- If the `lines` option is `true`: in lines.
+	- If a transform in object mode is used: in objects.
 
 	@default 100_000_000
 	*/

--- a/readme.md
+++ b/readme.md
@@ -921,9 +921,15 @@ Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from 
 #### maxBuffer
 
 Type: `number`\
-Default: `100_000_000` (100 MB)
+Default: `100_000_000`
 
-Largest amount of data in bytes allowed on [`stdout`](#stdout), [`stderr`](#stderr) and [`stdio`](#stdio).
+Largest amount of data allowed on [`stdout`](#stdout), [`stderr`](#stderr) and [`stdio`](#stdio).
+
+This is measured:
+- By default: in [characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length).
+- If the [`encoding` option](#encoding) is `'buffer'`: in bytes.
+- If the [`lines` option](#lines) is `true`: in lines.
+- If a [transform in object mode](docs/transform.md#object-mode) is used: in objects.
 
 #### ipc
 


### PR DESCRIPTION
This PR fixes some inaccuracies in the documentation of the `maxBuffer` option, and clarifies it.