### PR TITLE
Add `binary` and `preserveNewlines` options to `subprocess.readable()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -978,23 +978,43 @@ type PipableSubprocess = {
 	Promise<Awaited<Destination>> & PipableSubprocess;
 };
 
-type ReadableStreamOptions = {
+type ReadableOptions = {
 	/**
 	Which stream to read from the subprocess. A file descriptor like `"fd3"` can also be passed.
 
 	`"all"` reads both `stdout` and `stderr`. This requires the `all` option to be `true`.
+
+	@default 'stdout'
 	*/
 	readonly from?: FromOption;
+
+	/**
+	If `false`, the stream iterates over lines. Each line is a string. Also, the stream is in [object mode](https://nodejs.org/api/stream.html#object-mode).
+
+	If `true`, the stream iterates over arbitrary chunks of data. Each line is a [`Buffer`](https://nodejs.org/api/buffer.html#class-buffer).
+
+	@default true
+	*/
+	readonly binary?: boolean;
+
+	/**
+	If both this option and the `binary` option is `false`, newlines are stripped from each line.
+
+	@default true
+	*/
+	readonly preserveNewlines?: boolean;
 };
 
-type WritableStreamOptions = {
+type WritableOptions = {
 	/**
 	Which stream to write to the subprocess. A file descriptor like `"fd3"` can also be passed.
+
+	@default 'stdin'
 	*/
 	readonly to?: ToOption;
 };
 
-type DuplexStreamOptions = ReadableStreamOptions & WritableStreamOptions;
+type DuplexOptions = ReadableOptions & WritableOptions;
 
 export type ExecaResultPromise<OptionsType extends Options = Options> = {
 	stdin: StreamUnlessIgnored<'0', OptionsType>;
@@ -1035,7 +1055,7 @@ export type ExecaResultPromise<OptionsType extends Options = Options> = {
 
 	Before using this method, please first consider the `stdin`/`stdout`/`stderr`/`stdio` options or the `subprocess.pipe()` method.
 	*/
-	readable(streamOptions?: ReadableStreamOptions): Readable;
+	readable(readableOptions?: ReadableOptions): Readable;
 
 	/**
 	Converts the subprocess to a writable stream.
@@ -1044,7 +1064,7 @@ export type ExecaResultPromise<OptionsType extends Options = Options> = {
 
 	Before using this method, please first consider the `stdin`/`stdout`/`stderr`/`stdio` options or the `subprocess.pipe()` method.
 	*/
-	writable(streamOptions?: WritableStreamOptions): Writable;
+	writable(writableOptions?: WritableOptions): Writable;
 
 	/**
 	Converts the subprocess to a duplex stream.
@@ -1053,7 +1073,7 @@ export type ExecaResultPromise<OptionsType extends Options = Options> = {
 
 	Before using this method, please first consider the `stdin`/`stdout`/`stderr`/`stdio` options or the `subprocess.pipe()` method.
 	*/
-	duplex(streamOptions?: DuplexStreamOptions): Duplex;
+	duplex(duplexOptions?: DuplexOptions): Duplex;
 } & PipableSubprocess;
 
 export type ExecaSubprocess<OptionsType extends Options = Options> = ChildProcess &

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -277,10 +277,15 @@ try {
 	scriptPromise.readable({from: 'stderr'});
 	scriptPromise.readable({from: 'all'});
 	scriptPromise.readable({from: 'fd3'});
+	scriptPromise.readable({binary: false});
+	scriptPromise.readable({preserveNewlines: false});
 	expectError(scriptPromise.readable('stdout'));
 	expectError(scriptPromise.readable({from: 'stdin'}));
 	expectError(scriptPromise.readable({from: 'fd'}));
 	expectError(scriptPromise.readable({from: 'fdNotANumber'}));
+	expectError(scriptPromise.readable({binary: 'false'}));
+	expectError(scriptPromise.readable({preserveNewlines: 'false'}));
+	expectError(scriptPromise.readable({to: 'stdin'}));
 	expectError(scriptPromise.readable({other: 'stdout'}));
 	scriptPromise.writable({});
 	scriptPromise.writable({to: 'stdin'});
@@ -289,6 +294,9 @@ try {
 	expectError(scriptPromise.writable({to: 'stdout'}));
 	expectError(scriptPromise.writable({to: 'fd'}));
 	expectError(scriptPromise.writable({to: 'fdNotANumber'}));
+	expectError(scriptPromise.writable({from: 'stdout'}));
+	expectError(scriptPromise.writable({binary: false}));
+	expectError(scriptPromise.writable({preserveNewlines: false}));
 	expectError(scriptPromise.writable({other: 'stdin'}));
 	scriptPromise.duplex({});
 	scriptPromise.duplex({from: 'stdout'});
@@ -297,6 +305,8 @@ try {
 	scriptPromise.duplex({from: 'fd3'});
 	scriptPromise.duplex({from: 'stdout', to: 'stdin'});
 	scriptPromise.duplex({from: 'stdout', to: 'fd3'});
+	scriptPromise.duplex({binary: false});
+	scriptPromise.duplex({preserveNewlines: false});
 	expectError(scriptPromise.duplex('stdout'));
 	expectError(scriptPromise.duplex({from: 'stdin'}));
 	expectError(scriptPromise.duplex({from: 'stderr', to: 'stdout'}));
@@ -304,6 +314,8 @@ try {
 	expectError(scriptPromise.duplex({from: 'fdNotANumber'}));
 	expectError(scriptPromise.duplex({to: 'fd'}));
 	expectError(scriptPromise.duplex({to: 'fdNotANumber'}));
+	expectError(scriptPromise.duplex({binary: 'false'}));
+	expectError(scriptPromise.duplex({preserveNewlines: 'false'}));
 	expectError(scriptPromise.duplex({other: 'stdout'}));
 
 	expectType<Readable>(execaPromise.all);

--- a/lib/convert/concurrent.js
+++ b/lib/convert/concurrent.js
@@ -1,3 +1,5 @@
+import {createDeferred} from './shared.js';
+
 // When using multiple `.readable()`/`.writable()`/`.duplex()`, `final` and `destroy` should wait for other streams
 export const initializeConcurrentStreams = () => ({
 	readableDestroy: new WeakMap(),
@@ -18,14 +20,6 @@ export const addConcurrentStream = (concurrentStreams, stream, waitName) => {
 	promises.push(promise);
 	const resolve = promise.resolve.bind(promise);
 	return {resolve, promises};
-};
-
-const createDeferred = () => {
-	let resolve;
-	const promise = new Promise(resolve_ => {
-		resolve = resolve_;
-	});
-	return Object.assign(promise, {resolve});
 };
 
 // Wait for other streams, but stop waiting when subprocess ends

--- a/lib/convert/duplex.js
+++ b/lib/convert/duplex.js
@@ -2,6 +2,7 @@ import {Duplex} from 'node:stream';
 import {callbackify} from 'node:util';
 import {
 	getSubprocessStdout,
+	getReadableOptions,
 	getReadableMethods,
 	onStdoutFinished,
 	onReadableDestroy,
@@ -14,20 +15,22 @@ import {
 } from './writable.js';
 
 // Create a `Duplex` stream combining both
-export const createDuplex = ({subprocess, concurrentStreams}, {from, to} = {}) => {
+export const createDuplex = ({subprocess, concurrentStreams}, {from, to, binary = true, preserveNewlines = true} = {}) => {
 	const {subprocessStdout, waitReadableDestroy} = getSubprocessStdout(subprocess, from, concurrentStreams);
 	const {subprocessStdin, waitWritableFinal, waitWritableDestroy} = getSubprocessStdin(subprocess, to, concurrentStreams);
+	const {readableEncoding, readableObjectMode, readableHighWaterMark} = getReadableOptions(subprocessStdout, binary);
+	const {read, onStdoutDataDone} = getReadableMethods({subprocessStdout, subprocess, binary, preserveNewlines});
 	const duplex = new Duplex({
-		...getReadableMethods(subprocessStdout, subprocess),
+		read,
 		...getWritableMethods(subprocessStdin, subprocess, waitWritableFinal),
 		destroy: callbackify(onDuplexDestroy.bind(undefined, {subprocessStdout, subprocessStdin, subprocess, waitReadableDestroy, waitWritableFinal, waitWritableDestroy})),
-		readableHighWaterMark: subprocessStdout.readableHighWaterMark,
+		readableHighWaterMark,
 		writableHighWaterMark: subprocessStdin.writableHighWaterMark,
-		readableObjectMode: subprocessStdout.readableObjectMode,
+		readableObjectMode,
 		writableObjectMode: subprocessStdin.writableObjectMode,
-		encoding: subprocessStdout.readableEncoding,
+		encoding: readableEncoding,
 	});
-	onStdoutFinished(subprocessStdout, duplex, subprocess, subprocessStdin);
+	onStdoutFinished({subprocessStdout, onStdoutDataDone, readable: duplex, subprocess, subprocessStdin});
 	onStdinFinished(subprocessStdin, duplex, subprocessStdout);
 	return duplex;
 };

--- a/lib/convert/loop.js
+++ b/lib/convert/loop.js
@@ -1,0 +1,97 @@
+import {on} from 'node:events';
+import {getEncodingTransformGenerator} from '../stdio/encoding-transform.js';
+import {getSplitLinesGenerator} from '../stdio/split.js';
+
+export const iterateOnStdout = ({subprocessStdout, subprocess, binary, preserveNewlines}) => {
+	const controller = new AbortController();
+	stopReadingOnExit(subprocess, controller);
+	const onStdoutChunk = on(subprocessStdout, 'data', {
+		signal: controller.signal,
+		highWaterMark: HIGH_WATER_MARK,
+		// Backward compatibility with older name for this option
+		// See https://github.com/nodejs/node/pull/52080#discussion_r1525227861
+		// @todo Remove after removing support for Node 21
+		highWatermark: HIGH_WATER_MARK,
+	});
+	const onStdoutData = iterateOnData({subprocessStdout, onStdoutChunk, controller, binary, preserveNewlines});
+	return onStdoutData;
+};
+
+const stopReadingOnExit = async (subprocess, controller) => {
+	try {
+		await subprocess;
+	} catch {} finally {
+		controller.abort();
+	}
+};
+
+// @todo: replace with `getDefaultHighWaterMark(true)` after dropping support for Node <18.17.0
+export const DEFAULT_OBJECT_HIGH_WATER_MARK = 16;
+
+// The `highWaterMark` of `events.on()` is measured in number of events, not in bytes.
+// Not knowing the average amount of bytes per `data` event, we use the same heuristic as streams in objectMode, since they have the same issue.
+// Therefore, we use the value of `getDefaultHighWaterMark(true)`.
+// Note: this option does not exist on Node 18, but this is ok since the logic works without it. It just consumes more memory.
+const HIGH_WATER_MARK = DEFAULT_OBJECT_HIGH_WATER_MARK;
+
+const iterateOnData = async function * ({subprocessStdout, onStdoutChunk, controller, binary, preserveNewlines}) {
+	const {
+		encodeChunk = identityGenerator,
+		encodeChunkFinal = noopGenerator,
+		splitLines = identityGenerator,
+		splitLinesFinal = noopGenerator,
+	} = getTransforms({subprocessStdout, binary, preserveNewlines});
+
+	try {
+		for await (const [chunk] of onStdoutChunk) {
+			yield * handleChunk(encodeChunk, splitLines, chunk);
+		}
+	} catch (error) {
+		if (!controller.signal.aborted) {
+			throw error;
+		}
+	} finally {
+		yield * handleFinalChunks(encodeChunkFinal, splitLines, splitLinesFinal);
+	}
+};
+
+const getTransforms = ({subprocessStdout, binary, preserveNewlines}) => {
+	if (subprocessStdout.readableObjectMode) {
+		return {};
+	}
+
+	const writableObjectMode = false;
+
+	if (!binary) {
+		return getTextTransforms(binary, preserveNewlines, writableObjectMode);
+	}
+
+	return {};
+};
+
+const getTextTransforms = (binary, preserveNewlines, writableObjectMode) => {
+	const encoding = 'utf8';
+	const {transform: encodeChunk, final: encodeChunkFinal} = getEncodingTransformGenerator(encoding, writableObjectMode, false);
+	const {transform: splitLines, final: splitLinesFinal} = getSplitLinesGenerator({encoding, binary, preserveNewlines, writableObjectMode, state: {}});
+	return {encodeChunk, encodeChunkFinal, splitLines, splitLinesFinal};
+};
+
+const identityGenerator = function * (chunk) {
+	yield chunk;
+};
+
+const noopGenerator = function * () {};
+
+const handleChunk = function * (encodeChunk, splitLines, chunk) {
+	for (const chunkString of encodeChunk(chunk)) {
+		yield * splitLines(chunkString);
+	}
+};
+
+const handleFinalChunks = function * (encodeChunkFinal, splitLines, splitLinesFinal) {
+	for (const chunkString of encodeChunkFinal()) {
+		yield * splitLines(chunkString);
+	}
+
+	yield * splitLinesFinal();
+};

--- a/lib/convert/readable.js
+++ b/lib/convert/readable.js
@@ -1,26 +1,29 @@
-import {on} from 'node:events';
 import {Readable} from 'node:stream';
 import {callbackify} from 'node:util';
 import {getReadable} from '../pipe/validate.js';
 import {addConcurrentStream, waitForConcurrentStreams} from './concurrent.js';
 import {
+	createDeferred,
 	safeWaitForSubprocessStdin,
 	waitForSubprocessStdout,
 	waitForSubprocess,
 	destroyOtherStream,
 } from './shared.js';
+import {iterateOnStdout, DEFAULT_OBJECT_HIGH_WATER_MARK} from './loop.js';
 
 // Create a `Readable` stream that forwards from `stdout` and awaits the subprocess
-export const createReadable = ({subprocess, concurrentStreams}, {from} = {}) => {
+export const createReadable = ({subprocess, concurrentStreams}, {from, binary = true, preserveNewlines = true} = {}) => {
 	const {subprocessStdout, waitReadableDestroy} = getSubprocessStdout(subprocess, from, concurrentStreams);
+	const {readableEncoding, readableObjectMode, readableHighWaterMark} = getReadableOptions(subprocessStdout, binary);
+	const {read, onStdoutDataDone} = getReadableMethods({subprocessStdout, subprocess, binary, preserveNewlines});
 	const readable = new Readable({
-		...getReadableMethods(subprocessStdout, subprocess),
+		read,
 		destroy: callbackify(onReadableDestroy.bind(undefined, {subprocessStdout, subprocess, waitReadableDestroy})),
-		highWaterMark: subprocessStdout.readableHighWaterMark,
-		objectMode: subprocessStdout.readableObjectMode,
-		encoding: subprocessStdout.readableEncoding,
+		highWaterMark: readableHighWaterMark,
+		objectMode: readableObjectMode,
+		encoding: readableEncoding,
 	});
-	onStdoutFinished(subprocessStdout, readable, subprocess);
+	onStdoutFinished({subprocessStdout, onStdoutDataDone, readable, subprocess});
 	return readable;
 };
 
@@ -31,56 +34,42 @@ export const getSubprocessStdout = (subprocess, from, concurrentStreams) => {
 	return {subprocessStdout, waitReadableDestroy};
 };
 
-export const getReadableMethods = (subprocessStdout, subprocess) => {
-	const controller = new AbortController();
-	stopReadingOnExit(subprocess, controller);
-	const onStdoutData = on(subprocessStdout, 'data', {
-		signal: controller.signal,
-		highWaterMark: HIGH_WATER_MARK,
-		// Backward compatibility with older name for this option
-		// See https://github.com/nodejs/node/pull/52080#discussion_r1525227861
-		// @todo Remove after removing support for Node 21
-		highWatermark: HIGH_WATER_MARK,
-	});
+export const getReadableOptions = ({readableEncoding, readableObjectMode, readableHighWaterMark}, binary) => binary
+	? {readableEncoding, readableObjectMode, readableHighWaterMark}
+	: {readableEncoding, readableObjectMode: true, readableHighWaterMark: DEFAULT_OBJECT_HIGH_WATER_MARK};
+
+export const getReadableMethods = ({subprocessStdout, subprocess, binary, preserveNewlines}) => {
+	const onStdoutDataDone = createDeferred();
+	const onStdoutData = iterateOnStdout({subprocessStdout, subprocess, binary, preserveNewlines});
 
 	return {
 		read() {
-			onRead(this, onStdoutData);
+			onRead(this, onStdoutData, onStdoutDataDone);
 		},
+		onStdoutDataDone,
 	};
 };
 
-const stopReadingOnExit = async (subprocess, controller) => {
-	try {
-		await subprocess;
-	} catch {} finally {
-		controller.abort();
-	}
-};
-
-// The `highWaterMark` of `events.on()` is measured in number of events, not in bytes.
-// Not knowing the average amount of bytes per `data` event, we use the same heuristic as streams in objectMode, since they have the same issue.
-// Therefore, we use the value of `getDefaultHighWaterMark(true)`.
-// Note: this option does not exist on Node 18, but this is ok since the logic works without it. It just consumes more memory.
-const HIGH_WATER_MARK = 16;
-
 // Forwards data from `stdout` to `readable`
-const onRead = async (readable, onStdoutData) => {
+const onRead = async (readable, onStdoutData, onStdoutDataDone) => {
 	try {
 		const {value, done} = await onStdoutData.next();
-		if (!done) {
-			readable.push(value[0]);
+		if (done) {
+			onStdoutDataDone.resolve();
+		} else {
+			readable.push(value);
 		}
 	} catch {}
 };
 
 // When `subprocess.stdout` ends/aborts/errors, do the same on `readable`.
 // Await the subprocess, for the same reason as above.
-export const onStdoutFinished = async (subprocessStdout, readable, subprocess, subprocessStdin) => {
+export const onStdoutFinished = async ({subprocessStdout, onStdoutDataDone, readable, subprocess, subprocessStdin}) => {
 	try {
 		await waitForSubprocessStdout(subprocessStdout);
 		await subprocess;
 		await safeWaitForSubprocessStdin(subprocessStdin);
+		await onStdoutDataDone;
 
 		if (readable.readable) {
 			readable.push(null);

--- a/lib/convert/shared.js
+++ b/lib/convert/shared.js
@@ -44,3 +44,11 @@ export const destroyOtherStream = (stream, isOpen, error) => {
 		stream.destroy();
 	}
 };
+
+export const createDeferred = () => {
+	let resolve;
+	const promise = new Promise(resolve_ => {
+		resolve = resolve_;
+	});
+	return Object.assign(promise, {resolve});
+};

--- a/readme.md
+++ b/readme.md
@@ -438,9 +438,9 @@ When an error is passed as argument, it is set to the subprocess' [`error.cause`
 
 [More info.](https://nodejs.org/api/child_process.html#subprocesskillsignal)
 
-#### readable(streamOptions?)
+#### readable(readableOptions?)
 
-`streamOptions`: [`StreamOptions`](#streamoptions)\
+`readableOptions`: [`ReadableOptions`](#readableoptions)\
 _Returns_: [`Readable`](https://nodejs.org/api/stream.html#class-streamreadable) Node.js stream
 
 Converts the subprocess to a readable stream.
@@ -449,9 +449,9 @@ Unlike [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subproces
 
 Before using this method, please first consider the [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1)/[`stdio`](#stdio-1) options or the [`subprocess.pipe()`](#pipefile-arguments-options) method.
 
-#### writable(streamOptions?)
+#### writable(writableOptions?)
 
-`streamOptions`: [`StreamOptions`](#streamoptions)\
+`writableOptions`: [`WritableOptions`](#writableoptions)\
 _Returns_: [`Writable`](https://nodejs.org/api/stream.html#class-streamwritable) Node.js stream
 
 Converts the subprocess to a writable stream.
@@ -460,9 +460,9 @@ Unlike [`subprocess.stdin`](https://nodejs.org/api/child_process.html#subprocess
 
 Before using this method, please first consider the [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1)/[`stdio`](#stdio-1) options or the [`subprocess.pipe()`](#pipefile-arguments-options) method.
 
-#### duplex(streamOptions?)
+#### duplex(duplexOptions?)
 
-`streamOptions`: [`StreamOptions`](#streamoptions)\
+`duplexOptions`: [`ReadableOptions | WritableOptions`](#readableoptions)\
 _Returns_: [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) Node.js stream
 
 Converts the subprocess to a duplex stream.
@@ -471,11 +471,11 @@ The stream waits for the subprocess to end and emits an [`error`](https://nodejs
 
 Before using this method, please first consider the [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1)/[`stdio`](#stdio-1) options or the [`subprocess.pipe()`](#pipefile-arguments-options) method.
 
-##### streamOptions
+##### readableOptions
 
 Type: `object`
 
-##### streamOptions.from
+##### readableOptions.from
 
 Type: `"stdout" | "stderr" | "all" | "fd3" | "fd4" | ...`\
 Default: `"stdout"`
@@ -484,16 +484,32 @@ Which stream to read from the subprocess. A file descriptor like `"fd3"` can als
 
 `"all"` reads both `stdout` and `stderr`. This requires the [`all` option](#all-2) to be `true`.
 
-Only available with [`.readable()`](#readablestreamoptions) and [`.duplex()`](#duplexstreamoptions), not [`.writable()`](#writablestreamoptions).
+##### readableOptions.binary
 
-##### streamOptions.to
+Type: `boolean`\
+Default: `true`
+
+If `false`, the stream iterates over lines. Each line is a string. Also, the stream is in [object mode](https://nodejs.org/api/stream.html#object-mode).
+
+If `true`, the stream iterates over arbitrary chunks of data. Each line is a [`Buffer`](https://nodejs.org/api/buffer.html#class-buffer).
+
+##### readableOptions.preserveNewlines
+
+Type: `boolean`\
+Default: `true`
+
+If both this option and the [`binary` option](#readableoptionsbinary) is `false`, newlines are stripped from each line.
+
+##### writableOptions
+
+Type: `object`
+
+##### writableOptions.to
 
 Type: `"stdin" | "fd3" | "fd4" | ...`\
 Default: `"stdin"`
 
 Which stream to write to the subprocess. A file descriptor like `"fd3"` can also be passed.
-
-Only available with [`.writable()`](#writablestreamoptions) and [`.duplex()`](#duplexstreamoptions), not [`.readable()`](#readablestreamoptions).
 
 ### SubprocessResult
 
@@ -901,7 +917,7 @@ Default: `false`
 
 Split `stdout` and `stderr` into lines.
 - [`result.stdout`](#stdout), [`result.stderr`](#stderr), [`result.all`](#all-1) and [`result.stdio`](#stdio) are arrays of lines.
-- [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), [`subprocess.all`](#all), [`subprocess.stdio`](https://nodejs.org/api/child_process.html#subprocessstdio), [`subprocess.readable()`](#readablestreamoptions) and [`subprocess.duplex`](#duplexstreamoptions) iterate over lines instead of arbitrary chunks.
+- [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), [`subprocess.all`](#all), [`subprocess.stdio`](https://nodejs.org/api/child_process.html#subprocessstdio), [`subprocess.readable()`](#readablereadableoptions) and [`subprocess.duplex`](#duplexduplexoptions) iterate over lines instead of arbitrary chunks.
 - Any stream passed to the [`stdout`](#stdout-1), [`stderr`](#stderr-1) or [`stdio`](#stdio-1) option receives lines instead of arbitrary chunks.
 
 #### encoding

--- a/test/convert/loop.js
+++ b/test/convert/loop.js
@@ -1,0 +1,137 @@
+import {once} from 'node:events';
+import {getDefaultHighWaterMark} from 'node:stream';
+import test from 'ava';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {
+	assertStreamOutput,
+	assertStreamChunks,
+	assertSubprocessOutput,
+	getReadableSubprocess,
+	getReadWriteSubprocess,
+} from '../helpers/convert.js';
+import {
+	simpleFull,
+	simpleChunks,
+	simpleChunksBuffer,
+	simpleLines,
+	noNewlinesFull,
+	complexFull,
+	singleComplexBuffer,
+	complexChunks,
+	complexChunksEnd,
+} from '../helpers/lines.js';
+import {outputObjectGenerator, getOutputGenerator} from '../helpers/generator.js';
+import {foobarString, foobarObject} from '../helpers/input.js';
+import {multibyteChar, multibyteUint8Array, breakingLength, brokenSymbol} from '../helpers/encoding.js';
+
+setFixtureDir();
+
+const foobarObjectChunks = [foobarObject, foobarObject, foobarObject];
+
+const getSubprocess = (methodName, output, options) => {
+	if (methodName !== 'duplex') {
+		return getReadableSubprocess(output, options);
+	}
+
+	const subprocess = getReadWriteSubprocess(options);
+	subprocess.stdin.end(output);
+	return subprocess;
+};
+
+// eslint-disable-next-line max-params
+const testText = async (t, expectedChunks, methodName, binary, preserveNewlines) => {
+	const subprocess = getSubprocess(methodName, complexFull);
+	const stream = subprocess[methodName]({binary, preserveNewlines});
+
+	await assertStreamChunks(t, stream, expectedChunks);
+	await assertSubprocessOutput(t, subprocess, complexFull);
+};
+
+test('.readable() can use "binary: true"', testText, singleComplexBuffer, 'readable', true, undefined);
+test('.readable() can use "binary: undefined"', testText, singleComplexBuffer, 'readable', undefined, undefined);
+test('.readable() can use "binary: false"', testText, complexChunksEnd, 'readable', false, undefined);
+test('.readable() can use "binary: false" + "preserveNewlines: true"', testText, complexChunksEnd, 'readable', false, true);
+test('.readable() can use "binary: false" + "preserveNewlines: false"', testText, complexChunks, 'readable', false, false);
+test('.duplex() can use "binary: true"', testText, singleComplexBuffer, 'duplex', true, undefined);
+test('.duplex() can use "binary: undefined"', testText, singleComplexBuffer, 'duplex', undefined, undefined);
+test('.duplex() can use "binary: false"', testText, complexChunksEnd, 'duplex', false, undefined);
+test('.duplex() can use "binary: false" + "preserveNewlines: true"', testText, complexChunksEnd, 'duplex', false, true);
+test('.duplex() can use "binary: false" + "preserveNewlines: false"', testText, complexChunks, 'duplex', false, false);
+
+const testTextOutput = async (t, expectedOutput, methodName, preserveNewlines) => {
+	const subprocess = getSubprocess(methodName, complexFull);
+	const stream = subprocess[methodName]({binary: false, preserveNewlines});
+
+	await assertStreamOutput(t, stream, expectedOutput);
+	await assertSubprocessOutput(t, subprocess, complexFull);
+};
+
+test('.readable() "binary: false" keeps output as is', testTextOutput, complexFull, 'readable', undefined);
+test('.readable() "binary: false" + "preserveNewlines: true" keeps output as is', testTextOutput, complexFull, 'readable', true);
+test('.readable() "binary: false" + "preserveNewlines: false" removes all newlines', testTextOutput, noNewlinesFull, 'readable', false);
+test('.duplex() "binary: false" keeps output as is', testTextOutput, complexFull, 'duplex', undefined);
+test('.duplex() "binary: false" + "preserveNewlines: true" keeps output as is', testTextOutput, complexFull, 'duplex', true);
+test('.duplex() "binary: false" + "preserveNewlines: false" removes all newlines', testTextOutput, noNewlinesFull, 'duplex', false);
+
+// eslint-disable-next-line max-params
+const testObjectMode = async (t, expectedChunks, methodName, encoding, initialObjectMode, finalObjectMode, binary, options) => {
+	const subprocess = getSubprocess(methodName, simpleFull, options);
+	if (encoding !== null) {
+		subprocess.stdout.setEncoding(encoding);
+	}
+
+	t.is(subprocess.stdout.readableEncoding, encoding);
+	t.is(subprocess.stdout.readableObjectMode, initialObjectMode);
+	t.is(subprocess.stdout.readableHighWaterMark, getDefaultHighWaterMark(initialObjectMode));
+
+	const stream = subprocess[methodName]({binary, preserveNewlines: true});
+	t.is(stream.readableEncoding, encoding);
+	t.is(stream.readableObjectMode, finalObjectMode);
+	t.is(stream.readableHighWaterMark, getDefaultHighWaterMark(finalObjectMode));
+	t.is(subprocess.stdout.readableEncoding, encoding);
+	t.is(subprocess.stdout.readableObjectMode, initialObjectMode);
+	t.is(subprocess.stdout.readableHighWaterMark, getDefaultHighWaterMark(initialObjectMode));
+
+	await assertStreamChunks(t, stream, expectedChunks);
+	await subprocess;
+};
+
+test('.readable() uses Buffers with "binary: true"', testObjectMode, simpleChunksBuffer, 'readable', null, false, false, true);
+test('.readable() uses strings with "binary: true" and .setEncoding("utf8")', testObjectMode, simpleChunks, 'readable', 'utf8', false, false, true);
+test('.readable() uses strings with "binary: true" and "encoding: buffer"', testObjectMode, simpleChunks, 'readable', 'utf8', false, false, true, {encoding: 'buffer'});
+test('.readable() uses strings in objectMode with "binary: true" and object transforms', testObjectMode, foobarObjectChunks, 'readable', null, true, true, true, {stdout: outputObjectGenerator});
+test('.readable() uses strings in objectMode with "binary: false"', testObjectMode, simpleLines, 'readable', null, false, true, false);
+test('.readable() uses strings in objectMode with "binary: false" and .setEncoding("utf8")', testObjectMode, simpleLines, 'readable', 'utf8', false, true, false);
+test('.readable() uses strings in objectMode with "binary: false" and "encoding: buffer"', testObjectMode, simpleLines, 'readable', 'utf8', false, true, false, {encoding: 'buffer'});
+test('.readable() uses strings in objectMode with "binary: false" and object transforms', testObjectMode, foobarObjectChunks, 'readable', null, true, true, false, {stdout: outputObjectGenerator});
+test('.duplex() uses Buffers with "binary: true"', testObjectMode, simpleChunksBuffer, 'duplex', null, false, false, true);
+test('.duplex() uses strings with "binary: true" and .setEncoding("utf8")', testObjectMode, simpleChunks, 'duplex', 'utf8', false, false, true);
+test('.duplex() uses strings with "binary: true" and "encoding: buffer"', testObjectMode, simpleChunks, 'duplex', 'utf8', false, false, true, {encoding: 'buffer'});
+test('.duplex() uses strings in objectMode with "binary: true" and object transforms', testObjectMode, foobarObjectChunks, 'duplex', null, true, true, true, {stdout: outputObjectGenerator});
+test('.duplex() uses strings in objectMode with "binary: false"', testObjectMode, simpleLines, 'duplex', null, false, true, false);
+test('.duplex() uses strings in objectMode with "binary: false" and .setEncoding("utf8")', testObjectMode, simpleLines, 'duplex', 'utf8', false, true, false);
+test('.duplex() uses strings in objectMode with "binary: false" and "encoding: buffer"', testObjectMode, simpleLines, 'duplex', 'utf8', false, true, false, {encoding: 'buffer'});
+test('.duplex() uses strings in objectMode with "binary: false" and object transforms', testObjectMode, foobarObjectChunks, 'duplex', null, true, true, false, {stdout: outputObjectGenerator});
+
+const testObjectSplit = async (t, methodName) => {
+	const subprocess = getSubprocess(methodName, foobarString, {stdout: getOutputGenerator(simpleFull, true)});
+	const stream = subprocess[methodName]({binary: false});
+	await assertStreamChunks(t, stream, [simpleFull]);
+	await subprocess;
+};
+
+test('.readable() "binary: false" does not split lines of strings produced by object transforms', testObjectSplit, 'readable');
+test('.duplex() "binary: false" does not split lines of strings produced by object transforms', testObjectSplit, 'duplex');
+
+const testMultibyteCharacters = async (t, methodName) => {
+	const subprocess = getReadWriteSubprocess();
+	const stream = subprocess[methodName]({binary: false});
+	const assertPromise = assertStreamOutput(t, stream, `${multibyteChar}${brokenSymbol}`);
+	subprocess.stdin.write(multibyteUint8Array.slice(0, breakingLength));
+	await once(subprocess.stdout, 'data');
+	subprocess.stdin.end();
+	await assertPromise;
+};
+
+test('.readable() "binary: false" handles partial multibyte characters', testMultibyteCharacters, 'readable');
+test('.duplex() "binary: false" handles partial multibyte characters', testMultibyteCharacters, 'duplex');

--- a/test/helpers/convert.js
+++ b/test/helpers/convert.js
@@ -27,6 +27,10 @@ export const assertStreamOutput = async (t, stream, expectedOutput = foobarStrin
 	t.is(await text(stream), expectedOutput);
 };
 
+export const assertStreamChunks = async (t, stream, expectedOutput) => {
+	t.deepEqual(await stream.toArray(), expectedOutput);
+};
+
 export const assertSubprocessOutput = async (t, subprocess, expectedOutput = foobarString, fdNumber = 1) => {
 	const result = await subprocess;
 	t.deepEqual(result.stdio[fdNumber], expectedOutput);
@@ -50,7 +54,7 @@ export const assertPromiseError = async (t, promise, error) => {
 	return thrownError;
 };
 
-export const getReadableSubprocess = () => execa('noop-fd.js', ['1', foobarString]);
+export const getReadableSubprocess = (output = foobarString, options = {}) => execa('noop-fd.js', ['1', output], options);
 
 export const getWritableSubprocess = () => execa('noop-stdin-fd.js', ['2']);
 

--- a/test/helpers/encoding.js
+++ b/test/helpers/encoding.js
@@ -1,0 +1,7 @@
+const textEncoder = new TextEncoder();
+
+export const multibyteChar = '\u{1F984}';
+export const multibyteString = `${multibyteChar}${multibyteChar}`;
+export const multibyteUint8Array = textEncoder.encode(multibyteString);
+export const breakingLength = multibyteUint8Array.length * 0.75;
+export const brokenSymbol = '\uFFFD';

--- a/test/helpers/lines.js
+++ b/test/helpers/lines.js
@@ -2,9 +2,15 @@ import {Buffer} from 'node:buffer';
 
 export const simpleFull = 'aaa\nbbb\nccc';
 export const simpleChunks = [simpleFull];
+export const simpleChunksBuffer = [Buffer.from(simpleFull)];
 export const simpleLines = ['aaa\n', 'bbb\n', 'ccc'];
 export const simpleFullEndLines = ['aaa\n', 'bbb\n', 'ccc\n'];
+export const noNewlinesFull = 'aaabbbccc';
 export const noNewlinesChunks = ['aaa', 'bbb', 'ccc'];
+export const complexFull = '\naaa\r\nbbb\n\nccc';
+export const singleComplexBuffer = [Buffer.from(complexFull)];
+export const complexChunksEnd = ['\n', 'aaa\r\n', 'bbb\n', '\n', 'ccc'];
+export const complexChunks = ['', 'aaa', 'bbb', '', 'ccc'];
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();

--- a/test/stdio/encoding-transform.js
+++ b/test/stdio/encoding-transform.js
@@ -6,10 +6,9 @@ import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {getStdio} from '../helpers/stdio.js';
 import {foobarString, foobarUint8Array, foobarBuffer, foobarObject} from '../helpers/input.js';
 import {noopGenerator, getOutputGenerator, convertTransformToFinal} from '../helpers/generator.js';
+import {multibyteChar, multibyteString, multibyteUint8Array, breakingLength, brokenSymbol} from '../helpers/encoding.js';
 
 setFixtureDir();
-
-const textEncoder = new TextEncoder();
 
 const getTypeofGenerator = (objectMode, binary) => ({
 	* transform(line) {
@@ -154,12 +153,6 @@ test('Generator can return final string with encoding "buffer", objectMode, fail
 test('Generator can return final Uint8Array with encoding "buffer", objectMode, failure', testGeneratorReturnType, foobarUint8Array, 'buffer', false, true, true);
 test('Generator can return final string with encoding "hex", objectMode, failure', testGeneratorReturnType, foobarString, 'hex', false, true, true);
 test('Generator can return final Uint8Array with encoding "hex", objectMode, failure', testGeneratorReturnType, foobarUint8Array, 'hex', false, true, true);
-
-const multibyteChar = '\u{1F984}';
-const multibyteString = `${multibyteChar}${multibyteChar}`;
-const multibyteUint8Array = textEncoder.encode(multibyteString);
-const breakingLength = multibyteUint8Array.length * 0.75;
-const brokenSymbol = '\uFFFD';
 
 const testMultibyte = async (t, objectMode) => {
 	const subprocess = execa('stdin.js', {stdin: noopGenerator(objectMode, true)});

--- a/test/stdio/split.js
+++ b/test/stdio/split.js
@@ -14,6 +14,7 @@ import {
 	simpleChunks,
 	simpleLines,
 	simpleFullEndLines,
+	noNewlinesFull,
 	noNewlinesChunks,
 	getEncoding,
 	stringsToUint8Arrays,
@@ -28,7 +29,6 @@ const windowsFull = 'aaa\r\nbbb\r\nccc';
 const windowsFullEnd = `${windowsFull}\r\n`;
 const windowsChunks = [windowsFull];
 const windowsLines = ['aaa\r\n', 'bbb\r\n', 'ccc'];
-const noNewlinesFull = 'aaabbbccc';
 const noNewlinesFullEnd = `${noNewlinesFull}\n`;
 const noNewlinesLines = ['aaabbbccc'];
 const singleFull = 'aaa';


### PR DESCRIPTION
This PR adds the `binary` and `preserveNewlines` options to `subprocess.readable()` and `subprocess.duplex()`. Those are the same options as for transforms (added by #919). It has the same behavior and re-uses the same logic.

This allows streams created by `subprocess.readable()`/`subprocess.duplex()` to operate one line at a time, instead of operating on arbitrary chunks of data.

Unlike transforms, this is disabled by default because:
  - `binary: false` requires the stream to be in object mode. Otherwise, Node.js would merge lines together. Object mode has its own quirks, so should not be a default behavior.
  - `binary: false` splits the stream into lines, which produces smaller chunks. Also, it converts `Buffer` to strings. Both of those have a small performance impact.
  - `preserveNewlines: false` strips newlines, which is helpful when operating on each line. However, if the stream's full output is concatenated (for example, by redirecting it to a file), all newlines will be gone, which is most likely not wanted.