### PR TITLE
Make subprocess async iterable

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -461,6 +461,33 @@ await cat
 await $({inputFile: 'file.txt'})`cat`
 ```
 
+### Iterate over output lines
+
+```sh
+# Bash
+while read
+do
+	if [[ "$REPLY" == *ERROR* ]]
+	then
+		echo "$REPLY"
+	fi
+done < <(npm run build)
+```
+
+```js
+// zx does not allow proper iteration.
+// For example, the iteration does not handle subprocess errors.
+```
+
+```js
+// Execa
+for await (const line of $`npm run build`) {
+	if (line.includes('ERROR')) {
+		console.log(line);
+	}
+}
+```
+
 ### Errors
 
 ```sh

--- a/docs/transform.md
+++ b/docs/transform.md
@@ -12,7 +12,7 @@ const transform = function * (line) {
 	yield `${prefix}: ${line}`;
 };
 
-const {stdout} = await execa('echo', ['hello'], {stdout: transform});
+const {stdout} = await execa('./run.js', {stdout: transform});
 console.log(stdout); // HELLO
 ```
 
@@ -185,4 +185,17 @@ This also allows using multiple transforms.
 
 ```js
 await execa('echo', ['hello'], {stdout: [transform, otherTransform]});
+```
+
+## Async iteration
+
+In some cases, [iterating](../readme.md#iterablereadableoptions) over the subprocess can be an alternative to transforms.
+
+```js
+import {execa} from 'execa';
+
+for await (const line of execa('./run.js')) {
+	const prefix = line.includes('error') ? 'ERROR' : 'INFO';
+	console.log(`${prefix}: ${line}`);
+}
 ```

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -268,10 +268,77 @@ try {
 	const ignoreShortcutScriptPipeResult = await scriptPromise.pipe('stdin', {stdout: 'ignore'});
 	expectType<undefined>(ignoreShortcutScriptPipeResult.stdout);
 
+	const asyncIteration = async () => {
+		for await (const line of scriptPromise) {
+			expectType<string>(line);
+		}
+
+		for await (const line of scriptPromise.iterable()) {
+			expectType<string>(line);
+		}
+
+		for await (const line of scriptPromise.iterable({binary: false})) {
+			expectType<string>(line);
+		}
+
+		for await (const line of scriptPromise.iterable({binary: true})) {
+			expectType<Uint8Array>(line);
+		}
+
+		for await (const line of scriptPromise.iterable({} as {binary: boolean})) {
+			expectType<string | Uint8Array>(line);
+		}
+
+		for await (const line of execaBufferPromise) {
+			expectType<Uint8Array>(line);
+		}
+
+		for await (const line of execaBufferPromise.iterable()) {
+			expectType<Uint8Array>(line);
+		}
+
+		for await (const line of execaBufferPromise.iterable({binary: false})) {
+			expectType<string>(line);
+		}
+
+		for await (const line of execaBufferPromise.iterable({binary: true})) {
+			expectType<Uint8Array>(line);
+		}
+
+		for await (const line of execaBufferPromise.iterable({} as {binary: boolean})) {
+			expectType<string | Uint8Array>(line);
+		}
+	};
+
+	await asyncIteration();
+	expectAssignable<AsyncIterable<string>>(scriptPromise.iterable());
+	expectAssignable<AsyncIterable<string>>(scriptPromise.iterable({binary: false}));
+	expectAssignable<AsyncIterable<Uint8Array>>(scriptPromise.iterable({binary: true}));
+	expectAssignable<AsyncIterable<string | Uint8Array>>(scriptPromise.iterable({} as {binary: boolean}));
+	expectAssignable<AsyncIterable<Uint8Array>>(execaBufferPromise.iterable());
+	expectAssignable<AsyncIterable<string>>(execaBufferPromise.iterable({binary: false}));
+	expectAssignable<AsyncIterable<Uint8Array>>(execaBufferPromise.iterable({binary: true}));
+	expectAssignable<AsyncIterable<string | Uint8Array>>(execaBufferPromise.iterable({} as {binary: boolean}));
+
 	expectType<Readable>(scriptPromise.readable());
 	expectType<Writable>(scriptPromise.writable());
 	expectType<Duplex>(scriptPromise.duplex());
 
+	scriptPromise.iterable({});
+	scriptPromise.iterable({from: 'stdout'});
+	scriptPromise.iterable({from: 'stderr'});
+	scriptPromise.iterable({from: 'all'});
+	scriptPromise.iterable({from: 'fd3'});
+	scriptPromise.iterable({binary: false});
+	scriptPromise.iterable({preserveNewlines: false});
+	expectError(scriptPromise.iterable('stdout'));
+	expectError(scriptPromise.iterable({from: 'stdin'}));
+	expectError(scriptPromise.iterable({from: 'fd'}));
+	expectError(scriptPromise.iterable({from: 'fdNotANumber'}));
+	expectError(scriptPromise.iterable({binary: 'false'}));
+	expectError(scriptPromise.iterable({preserveNewlines: 'false'}));
+	expectError(scriptPromise.iterable({to: 'stdin'}));
+	expectError(scriptPromise.iterable({other: 'stdout'}));
 	scriptPromise.readable({});
 	scriptPromise.readable({from: 'stdout'});
 	scriptPromise.readable({from: 'stderr'});

--- a/lib/async.js
+++ b/lib/async.js
@@ -65,7 +65,7 @@ const spawnSubprocessAsync = ({file, args, options, startTime, verboseInfo, comm
 
 	subprocess.kill = subprocessKill.bind(undefined, {kill: subprocess.kill.bind(subprocess), subprocess, options, controller});
 	subprocess.all = makeAllStream(subprocess, options);
-	addConvertedStreams(subprocess);
+	addConvertedStreams(subprocess, options);
 
 	const promise = handlePromise({subprocess, options, startTime, verboseInfo, stdioStreamsGroups, originalStreams, command, escapedCommand, controller});
 	return {subprocess, promise};

--- a/lib/convert/add.js
+++ b/lib/convert/add.js
@@ -2,10 +2,13 @@ import {initializeConcurrentStreams} from './concurrent.js';
 import {createReadable} from './readable.js';
 import {createWritable} from './writable.js';
 import {createDuplex} from './duplex.js';
+import {createIterable} from './iterable.js';
 
-export const addConvertedStreams = subprocess => {
+export const addConvertedStreams = (subprocess, options) => {
 	const concurrentStreams = initializeConcurrentStreams();
 	subprocess.readable = createReadable.bind(undefined, {subprocess, concurrentStreams});
 	subprocess.writable = createWritable.bind(undefined, {subprocess, concurrentStreams});
 	subprocess.duplex = createDuplex.bind(undefined, {subprocess, concurrentStreams});
+	subprocess.iterable = createIterable.bind(undefined, subprocess, options);
+	subprocess[Symbol.asyncIterator] = createIterable.bind(undefined, subprocess, options, {});
 };

--- a/lib/convert/iterable.js
+++ b/lib/convert/iterable.js
@@ -1,0 +1,24 @@
+import {getReadable} from '../pipe/validate.js';
+import {iterateOnStdout} from './loop.js';
+
+export const createIterable = (subprocess, {encoding}, {
+	from,
+	binary = encoding === 'buffer',
+	preserveNewlines = false,
+} = {}) => {
+	const subprocessStdout = getReadable(subprocess, from);
+	const onStdoutData = iterateOnStdout({subprocessStdout, subprocess, binary, preserveNewlines, isStream: false});
+	return iterateOnStdoutData(onStdoutData, subprocessStdout, subprocess);
+};
+
+const iterateOnStdoutData = async function * (onStdoutData, subprocessStdout, subprocess) {
+	try {
+		yield * onStdoutData;
+	} finally {
+		if (subprocessStdout.readable) {
+			subprocessStdout.destroy();
+		}
+
+		await subprocess;
+	}
+};

--- a/lib/convert/loop.js
+++ b/lib/convert/loop.js
@@ -2,7 +2,7 @@ import {on} from 'node:events';
 import {getEncodingTransformGenerator} from '../stdio/encoding-transform.js';
 import {getSplitLinesGenerator} from '../stdio/split.js';
 
-export const iterateOnStdout = ({subprocessStdout, subprocess, binary, preserveNewlines}) => {
+export const iterateOnStdout = ({subprocessStdout, subprocess, binary, preserveNewlines, isStream}) => {
 	const controller = new AbortController();
 	stopReadingOnExit(subprocess, controller);
 	const onStdoutChunk = on(subprocessStdout, 'data', {
@@ -13,7 +13,7 @@ export const iterateOnStdout = ({subprocessStdout, subprocess, binary, preserveN
 		// @todo Remove after removing support for Node 21
 		highWatermark: HIGH_WATER_MARK,
 	});
-	const onStdoutData = iterateOnData({subprocessStdout, onStdoutChunk, controller, binary, preserveNewlines});
+	const onStdoutData = iterateOnData({subprocessStdout, onStdoutChunk, controller, binary, preserveNewlines, isStream});
 	return onStdoutData;
 };
 
@@ -34,13 +34,13 @@ export const DEFAULT_OBJECT_HIGH_WATER_MARK = 16;
 // Note: this option does not exist on Node 18, but this is ok since the logic works without it. It just consumes more memory.
 const HIGH_WATER_MARK = DEFAULT_OBJECT_HIGH_WATER_MARK;
 
-const iterateOnData = async function * ({subprocessStdout, onStdoutChunk, controller, binary, preserveNewlines}) {
+const iterateOnData = async function * ({subprocessStdout, onStdoutChunk, controller, binary, preserveNewlines, isStream}) {
 	const {
 		encodeChunk = identityGenerator,
 		encodeChunkFinal = noopGenerator,
 		splitLines = identityGenerator,
 		splitLinesFinal = noopGenerator,
-	} = getTransforms({subprocessStdout, binary, preserveNewlines});
+	} = getTransforms({subprocessStdout, binary, preserveNewlines, isStream});
 
 	try {
 		for await (const [chunk] of onStdoutChunk) {
@@ -55,7 +55,7 @@ const iterateOnData = async function * ({subprocessStdout, onStdoutChunk, contro
 	}
 };
 
-const getTransforms = ({subprocessStdout, binary, preserveNewlines}) => {
+const getTransforms = ({subprocessStdout, binary, preserveNewlines, isStream}) => {
 	if (subprocessStdout.readableObjectMode) {
 		return {};
 	}
@@ -66,7 +66,7 @@ const getTransforms = ({subprocessStdout, binary, preserveNewlines}) => {
 		return getTextTransforms(binary, preserveNewlines, writableObjectMode);
 	}
 
-	return {};
+	return isStream ? {} : getBinaryTransforms(writableObjectMode);
 };
 
 const getTextTransforms = (binary, preserveNewlines, writableObjectMode) => {
@@ -76,6 +76,12 @@ const getTextTransforms = (binary, preserveNewlines, writableObjectMode) => {
 	return {encodeChunk, encodeChunkFinal, splitLines, splitLinesFinal};
 };
 
+const getBinaryTransforms = writableObjectMode => {
+	const encoding = 'buffer';
+	const {transform: encodeChunk} = getEncodingTransformGenerator(encoding, writableObjectMode, false);
+	return {encodeChunk};
+};
+
 const identityGenerator = function * (chunk) {
 	yield chunk;
 };
@@ -83,14 +89,14 @@ const identityGenerator = function * (chunk) {
 const noopGenerator = function * () {};
 
 const handleChunk = function * (encodeChunk, splitLines, chunk) {
-	for (const chunkString of encodeChunk(chunk)) {
-		yield * splitLines(chunkString);
+	for (const encodedChunk of encodeChunk(chunk)) {
+		yield * splitLines(encodedChunk);
 	}
 };
 
 const handleFinalChunks = function * (encodeChunkFinal, splitLines, splitLinesFinal) {
-	for (const chunkString of encodeChunkFinal()) {
-		yield * splitLines(chunkString);
+	for (const encodedChunk of encodeChunkFinal()) {
+		yield * splitLines(encodedChunk);
 	}
 
 	yield * splitLinesFinal();

--- a/lib/convert/readable.js
+++ b/lib/convert/readable.js
@@ -40,7 +40,7 @@ export const getReadableOptions = ({readableEncoding, readableObjectMode, readab
 
 export const getReadableMethods = ({subprocessStdout, subprocess, binary, preserveNewlines}) => {
 	const onStdoutDataDone = createDeferred();
-	const onStdoutData = iterateOnStdout({subprocessStdout, subprocess, binary, preserveNewlines});
+	const onStdoutData = iterateOnStdout({subprocessStdout, subprocess, binary, preserveNewlines, isStream: true});
 
 	return {
 		read() {

--- a/test/convert/iterable.js
+++ b/test/convert/iterable.js
@@ -1,0 +1,154 @@
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {foobarString} from '../helpers/input.js';
+import {fullStdio, assertEpipe} from '../helpers/stdio.js';
+import {
+	arrayFromAsync,
+	assertWritableAborted,
+	assertReadableAborted,
+	assertProcessNormalExit,
+} from '../helpers/convert.js';
+import {simpleFull, noNewlinesChunks} from '../helpers/lines.js';
+
+setFixtureDir();
+
+const partialArrayFromAsync = async (asyncIterable, lines = []) => {
+	// eslint-disable-next-line no-unreachable-loop
+	for await (const line of asyncIterable) {
+		lines.push(line);
+		break;
+	}
+
+	return lines;
+};
+
+const errorArrayFromAsync = async (t, cause, asyncIterable, lines = []) => {
+	const {value} = await asyncIterable.next();
+	lines.push(value);
+	await asyncIterable.throw(cause);
+};
+
+const throwsAsync = async (t, asyncIterable, arrayFromAsyncMethod) => {
+	const lines = [];
+	const error = await t.throwsAsync(arrayFromAsyncMethod(asyncIterable, lines));
+	return {error, lines};
+};
+
+const assertStdoutAbort = (t, subprocess, error, cause) => {
+	assertProcessNormalExit(t, error, 1);
+	assertEpipe(t, error.stderr);
+	assertWritableAborted(t, subprocess.stdin);
+	t.true(subprocess.stderr.readableEnded);
+
+	if (cause === undefined) {
+		assertReadableAborted(t, subprocess.stdout);
+	} else {
+		t.is(subprocess.stdout.errored, cause);
+	}
+};
+
+const testSuccess = async (t, fdNumber, from, options = {}) => {
+	const lines = await arrayFromAsync(execa('noop-fd.js', [`${fdNumber}`, simpleFull], options).iterable({from}));
+	t.deepEqual(lines, noNewlinesChunks);
+};
+
+test('Uses stdout by default', testSuccess, 1, undefined);
+test('Can iterate successfully on stdout', testSuccess, 1, 'stdout');
+test('Can iterate successfully on stderr', testSuccess, 2, 'stderr');
+test('Can iterate successfully on stdio[*]', testSuccess, 3, 'fd3', fullStdio);
+
+test('Can iterate successfully on all', async t => {
+	const lines = await arrayFromAsync(execa('noop-both.js', [simpleFull], {all: true}).iterable({from: 'all'}));
+	t.deepEqual(lines, [...noNewlinesChunks, ...noNewlinesChunks]);
+});
+
+test('Can iterate using Symbol.asyncIterator', async t => {
+	const lines = await arrayFromAsync(execa('noop-fd.js', ['1', simpleFull]));
+	t.deepEqual(lines, noNewlinesChunks);
+});
+
+const assertMultipleCalls = async (t, iterable, iterableTwo) => {
+	t.not(iterable, iterableTwo);
+	const lines = await arrayFromAsync(iterable);
+	const linesTwo = await arrayFromAsync(iterableTwo);
+	t.deepEqual(lines, linesTwo);
+	t.deepEqual(lines, noNewlinesChunks);
+};
+
+test('Can be called multiple times', async t => {
+	const subprocess = execa('noop-fd.js', ['1', simpleFull]);
+	const iterable = subprocess.iterable();
+	const iterableTwo = subprocess.iterable();
+	await assertMultipleCalls(t, iterable, iterableTwo);
+});
+
+test('Can be called on different file descriptors', async t => {
+	const subprocess = execa('noop-both.js', [simpleFull]);
+	const iterable = subprocess.iterable();
+	const iterableTwo = subprocess.iterable({from: 'stderr'});
+	await assertMultipleCalls(t, iterable, iterableTwo);
+});
+
+test('Wait for the subprocess exit', async t => {
+	const subprocess = execa('noop-delay.js', ['1', simpleFull]);
+	const linesPromise = arrayFromAsync(subprocess);
+	t.is(await Promise.race([linesPromise, subprocess]), await subprocess);
+	t.deepEqual(await linesPromise, noNewlinesChunks);
+});
+
+test('Wait for the subprocess exit on iterator.return()', async t => {
+	const subprocess = execa('noop-delay.js', ['1', simpleFull]);
+	const linesPromise = partialArrayFromAsync(subprocess);
+	t.is(await Promise.race([linesPromise, subprocess]), await subprocess);
+	t.deepEqual(await linesPromise, [noNewlinesChunks[0]]);
+});
+
+test('Wait for the subprocess exit on iterator.throw()', async t => {
+	const subprocess = execa('noop-delay.js', ['1', simpleFull]);
+	const cause = new Error(foobarString);
+	const lines = [];
+	const linesPromise = t.throwsAsync(errorArrayFromAsync(t, cause, subprocess.iterable(), lines));
+	t.is(await Promise.race([linesPromise, subprocess]), await subprocess);
+	t.deepEqual(lines, [noNewlinesChunks[0]]);
+});
+
+test('Abort stdout on iterator.return()', async t => {
+	const subprocess = execa('noop-repeat.js', ['1', simpleFull]);
+	const {error, lines} = await throwsAsync(t, subprocess, partialArrayFromAsync);
+	t.deepEqual(lines, [noNewlinesChunks[0]]);
+	assertStdoutAbort(t, subprocess, error);
+	t.is(error, await t.throwsAsync(subprocess));
+});
+
+test('Abort stdout on iterator.throw()', async t => {
+	const subprocess = execa('noop-repeat.js', ['1', simpleFull]);
+	const cause = new Error(foobarString);
+	const {error, lines} = await throwsAsync(t, subprocess.iterable(), errorArrayFromAsync.bind(undefined, t, cause));
+	t.deepEqual(lines, [noNewlinesChunks[0]]);
+	assertStdoutAbort(t, subprocess, error);
+	t.is(error, await t.throwsAsync(subprocess));
+});
+
+test('Propagate subprocess failure', async t => {
+	const subprocess = execa('noop-fail.js', ['1', simpleFull]);
+	const {error, lines} = await throwsAsync(t, subprocess, arrayFromAsync);
+	t.is(error, await t.throwsAsync(subprocess));
+	t.deepEqual(lines, noNewlinesChunks);
+});
+
+const testStdoutError = async (t, destroyStdout, isAbort, cause) => {
+	const subprocess = execa('noop-repeat.js', ['1', simpleFull]);
+	subprocess.stdout.once('data', () => {
+		destroyStdout(subprocess.stdout, cause);
+	});
+
+	const {error} = await throwsAsync(t, subprocess, arrayFromAsync);
+	t.is(error.cause, cause);
+	assertStdoutAbort(t, subprocess, error, isAbort ? undefined : cause);
+	t.is(error, await t.throwsAsync(subprocess));
+};
+
+test('Propagate stdout abort', testStdoutError, subprocessStdout => subprocessStdout.destroy(), true);
+test('Propagate stdout error', testStdoutError, (subprocessStdout, cause) => subprocessStdout.destroy(cause), false, new Error(foobarString));
+test('Propagate stdout "error" event', testStdoutError, (subprocessStdout, cause) => subprocessStdout.emit('error', cause), true, new Error(foobarString));

--- a/test/fixtures/noop-delay.js
+++ b/test/fixtures/noop-delay.js
@@ -5,5 +5,6 @@ import {getWriteStream} from '../helpers/fs.js';
 import {foobarString} from '../helpers/input.js';
 
 const fdNumber = Number(process.argv[2]);
-getWriteStream(fdNumber).write(foobarString);
+const bytes = process.argv[3] || foobarString;
+getWriteStream(fdNumber).write(bytes);
 await setTimeout(100);

--- a/test/helpers/convert.js
+++ b/test/helpers/convert.js
@@ -4,6 +4,14 @@ import isPlainObj from 'is-plain-obj';
 import {execa} from '../../index.js';
 import {foobarString} from '../helpers/input.js';
 
+export const arrayFromAsync = async (asyncIterable, lines = []) => {
+	for await (const line of asyncIterable) {
+		lines.push(line);
+	}
+
+	return lines;
+};
+
 export const finishedStream = stream => finished(stream, {cleanup: true});
 
 export const assertWritableAborted = (t, writable) => {
@@ -25,6 +33,10 @@ export const assertProcessNormalExit = (t, error, exitCode = 0) => {
 
 export const assertStreamOutput = async (t, stream, expectedOutput = foobarString) => {
 	t.is(await text(stream), expectedOutput);
+};
+
+export const assertIterableChunks = async (t, asyncIterable, expectedChunks) => {
+	t.deepEqual(await arrayFromAsync(asyncIterable), expectedChunks);
 };
 
 export const assertStreamChunks = async (t, stream, expectedOutput) => {

--- a/test/helpers/lines.js
+++ b/test/helpers/lines.js
@@ -1,25 +1,15 @@
 import {Buffer} from 'node:buffer';
 
-export const simpleFull = 'aaa\nbbb\nccc';
-export const simpleChunks = [simpleFull];
-export const simpleChunksBuffer = [Buffer.from(simpleFull)];
-export const simpleLines = ['aaa\n', 'bbb\n', 'ccc'];
-export const simpleFullEndLines = ['aaa\n', 'bbb\n', 'ccc\n'];
-export const noNewlinesFull = 'aaabbbccc';
-export const noNewlinesChunks = ['aaa', 'bbb', 'ccc'];
-export const complexFull = '\naaa\r\nbbb\n\nccc';
-export const singleComplexBuffer = [Buffer.from(complexFull)];
-export const complexChunksEnd = ['\n', 'aaa\r\n', 'bbb\n', '\n', 'ccc'];
-export const complexChunks = ['', 'aaa', 'bbb', '', 'ccc'];
-
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
 export const getEncoding = isUint8Array => isUint8Array ? 'buffer' : 'utf8';
 
-export const stringsToUint8Arrays = (strings, isUint8Array) => isUint8Array
-	? strings.map(string => textEncoder.encode(string))
-	: strings;
+export const stringsToUint8Arrays = (strings, isUint8Array) => strings.map(string => stringToUint8Arrays(string, isUint8Array));
+
+export const stringToUint8Arrays = (string, isUint8Array) => isUint8Array
+	? textEncoder.encode(string)
+	: string;
 
 export const stringsToBuffers = (strings, isUint8Array) => isUint8Array
 	? strings.map(string => Buffer.from(string))
@@ -32,3 +22,17 @@ export const serializeResult = (result, isUint8Array) => Array.isArray(result)
 const serializeResultItem = (resultItem, isUint8Array) => isUint8Array
 	? textDecoder.decode(resultItem)
 	: resultItem;
+
+export const simpleFull = 'aaa\nbbb\nccc';
+export const simpleChunks = [simpleFull];
+export const simpleChunksBuffer = [Buffer.from(simpleFull)];
+export const simpleChunksUint8Array = stringsToUint8Arrays(simpleChunks, true);
+export const simpleLines = ['aaa\n', 'bbb\n', 'ccc'];
+export const simpleFullEndLines = ['aaa\n', 'bbb\n', 'ccc\n'];
+export const noNewlinesFull = 'aaabbbccc';
+export const noNewlinesChunks = ['aaa', 'bbb', 'ccc'];
+export const complexFull = '\naaa\r\nbbb\n\nccc';
+export const singleComplexBuffer = [Buffer.from(complexFull)];
+export const singleComplexUint8Array = stringsToUint8Arrays([complexFull], true);
+export const complexChunksEnd = ['\n', 'aaa\r\n', 'bbb\n', '\n', 'ccc'];
+export const complexChunks = ['', 'aaa', 'bbb', '', 'ccc'];

--- a/test/helpers/stdio.js
+++ b/test/helpers/stdio.js
@@ -1,4 +1,4 @@
-import process from 'node:process';
+import process, {platform} from 'node:process';
 import {noopReadable} from './stream.js';
 
 export const identity = value => value;
@@ -19,3 +19,11 @@ export const fullReadableStdio = () => getStdio(3, ['pipe', noopReadable()]);
 export const STANDARD_STREAMS = [process.stdin, process.stdout, process.stderr];
 
 export const prematureClose = {code: 'ERR_STREAM_PREMATURE_CLOSE'};
+
+const isWindows = platform === 'win32';
+
+export const assertEpipe = (t, stderr, fdNumber = 1) => {
+	if (fdNumber === 1 && !isWindows) {
+		t.true(stderr.includes('EPIPE'));
+	}
+};

--- a/test/pipe/validate.js
+++ b/test/pipe/validate.js
@@ -75,11 +75,27 @@ const assertNodeStream = ({t, message, getSource, from, to, methodName}) => {
 	t.true(error.message.includes(getMessage(message)));
 };
 
+const testIterable = async (t, {
+	message,
+	sourceOptions = {},
+	getSource = () => execa('empty.js', sourceOptions),
+	from,
+}) => {
+	const error = t.throws(() => {
+		getSource().iterable({from});
+	});
+	t.true(error.message.includes(getMessage(message)));
+};
+
 test('Must set "all" option to "true" to use .pipe("all")', testPipeError, {
 	from: 'all',
 	message: '"all" option must be true',
 });
 test('Must set "all" option to "true" to use .duplex("all")', testNodeStream, {
+	from: 'all',
+	message: '"all" option must be true',
+});
+test('Must set "all" option to "true" to use .iterable("all")', testIterable, {
 	from: 'all',
 	message: '"all" option must be true',
 });
@@ -96,6 +112,10 @@ test('.pipe() "from" option cannot be "stdin"', testPipeError, {
 	message: '"from" must not be',
 });
 test('.duplex() "from" option cannot be "stdin"', testNodeStream, {
+	from: 'stdin',
+	message: '"from" must not be',
+});
+test('.iterable() "from" option cannot be "stdin"', testIterable, {
 	from: 'stdin',
 	message: '"from" must not be',
 });
@@ -125,6 +145,10 @@ test('.duplex() "from" option cannot be any string', testNodeStream, {
 	from: 'other',
 	message: 'must be "stdout", "stderr", "all"',
 });
+test('.iterable() "from" option cannot be any string', testIterable, {
+	from: 'other',
+	message: 'must be "stdout", "stderr", "all"',
+});
 test('.pipe() "to" option cannot be any string', testPipeError, {
 	to: 'other',
 	message: 'must be "stdin"',
@@ -138,6 +162,10 @@ test('.pipe() "from" option cannot be a number without "fd"', testPipeError, {
 	message: 'must be "stdout", "stderr", "all"',
 });
 test('.duplex() "from" option cannot be a number without "fd"', testNodeStream, {
+	from: '1',
+	message: 'must be "stdout", "stderr", "all"',
+});
+test('.iterable() "from" option cannot be a number without "fd"', testIterable, {
 	from: '1',
 	message: 'must be "stdout", "stderr", "all"',
 });
@@ -157,6 +185,10 @@ test('.duplex() "from" option cannot be just "fd"', testNodeStream, {
 	from: 'fd',
 	message: 'must be "stdout", "stderr", "all"',
 });
+test('.iterable() "from" option cannot be just "fd"', testIterable, {
+	from: 'fd',
+	message: 'must be "stdout", "stderr", "all"',
+});
 test('.pipe() "to" option cannot be just "fd"', testPipeError, {
 	to: 'fd',
 	message: 'must be "stdin"',
@@ -170,6 +202,10 @@ test('.pipe() "from" option cannot be a float', testPipeError, {
 	message: 'must be "stdout", "stderr", "all"',
 });
 test('.duplex() "from" option cannot be a float', testNodeStream, {
+	from: 'fd1.5',
+	message: 'must be "stdout", "stderr", "all"',
+});
+test('.iterable() "from" option cannot be a float', testIterable, {
 	from: 'fd1.5',
 	message: 'must be "stdout", "stderr", "all"',
 });
@@ -189,6 +225,10 @@ test('.duplex() "from" option cannot be a negative number', testNodeStream, {
 	from: 'fd-1',
 	message: 'must be "stdout", "stderr", "all"',
 });
+test('.iterable() "from" option cannot be a negative number', testIterable, {
+	from: 'fd-1',
+	message: 'must be "stdout", "stderr", "all"',
+});
 test('.pipe() "to" option cannot be a negative number', testPipeError, {
 	to: 'fd-1',
 	message: 'must be "stdin"',
@@ -202,6 +242,10 @@ test('.pipe() "from" option cannot be a non-existing file descriptor', testPipeE
 	message: 'file descriptor does not exist',
 });
 test('.duplex() "from" cannot be a non-existing file descriptor', testNodeStream, {
+	from: 'fd3',
+	message: 'file descriptor does not exist',
+});
+test('.iterable() "from" cannot be a non-existing file descriptor', testIterable, {
 	from: 'fd3',
 	message: 'file descriptor does not exist',
 });
@@ -219,6 +263,11 @@ test('.pipe() "from" option cannot be an input file descriptor', testPipeError, 
 	message: 'must be a readable stream',
 });
 test('.duplex() "from" option cannot be an input file descriptor', testNodeStream, {
+	sourceOptions: getStdio(3, new Uint8Array()),
+	from: 'fd3',
+	message: 'must be a readable stream',
+});
+test('.iterable() "from" option cannot be an input file descriptor', testIterable, {
 	sourceOptions: getStdio(3, new Uint8Array()),
 	from: 'fd3',
 	message: 'must be a readable stream',
@@ -251,6 +300,10 @@ test('Cannot set "stdout" option to "ignore" to use .duplex()', testNodeStream, 
 	sourceOptions: {stdout: 'ignore'},
 	message: ['stdout', '\'ignore\''],
 });
+test('Cannot set "stdout" option to "ignore" to use .iterable()', testIterable, {
+	sourceOptions: {stdout: 'ignore'},
+	message: ['stdout', '\'ignore\''],
+});
 test('Cannot set "stdin" option to "ignore" to use .pipe()', testPipeError, {
 	destinationOptions: {stdin: 'ignore'},
 	message: ['stdin', '\'ignore\''],
@@ -266,6 +319,11 @@ test('Cannot set "stdout" option to "ignore" to use .pipe(1)', testPipeError, {
 	message: ['stdout', '\'ignore\''],
 });
 test('Cannot set "stdout" option to "ignore" to use .duplex(1)', testNodeStream, {
+	sourceOptions: {stdout: 'ignore'},
+	from: 'fd1',
+	message: ['stdout', '\'ignore\''],
+});
+test('Cannot set "stdout" option to "ignore" to use .iterable(1)', testIterable, {
 	sourceOptions: {stdout: 'ignore'},
 	from: 'fd1',
 	message: ['stdout', '\'ignore\''],
@@ -290,6 +348,11 @@ test('Cannot set "stdout" option to "ignore" to use .duplex("stdout")', testNode
 	from: 'stdout',
 	message: ['stdout', '\'ignore\''],
 });
+test('Cannot set "stdout" option to "ignore" to use .iterable("stdout")', testIterable, {
+	sourceOptions: {stdout: 'ignore'},
+	from: 'stdout',
+	message: ['stdout', '\'ignore\''],
+});
 test('Cannot set "stdin" option to "ignore" to use .pipe("stdin")', testPipeError, {
 	destinationOptions: {stdin: 'ignore'},
 	message: ['stdin', '\'ignore\''],
@@ -308,12 +371,21 @@ test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex()', testN
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
 	message: ['stdout', '\'ignore\''],
 });
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .iterable()', testIterable, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
+	message: ['stdout', '\'ignore\''],
+});
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe(1)', testPipeError, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
 	from: 'fd1',
 	message: ['stdout', '\'ignore\''],
 });
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex(1)', testNodeStream, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
+	from: 'fd1',
+	message: ['stdout', '\'ignore\''],
+});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .iterable(1)', testIterable, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
 	from: 'fd1',
 	message: ['stdout', '\'ignore\''],
@@ -328,11 +400,20 @@ test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex("stdout")
 	from: 'stdout',
 	message: ['stdout', '\'ignore\''],
 });
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .iterable("stdout")', testIterable, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
+	from: 'stdout',
+	message: ['stdout', '\'ignore\''],
+});
 test('Cannot set "stdio[1]" option to "ignore" to use .pipe()', testPipeError, {
 	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
 	message: ['stdio[1]', '\'ignore\''],
 });
 test('Cannot set "stdio[1]" option to "ignore" to use .duplex()', testNodeStream, {
+	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
+	message: ['stdio[1]', '\'ignore\''],
+});
+test('Cannot set "stdio[1]" option to "ignore" to use .iterable()', testIterable, {
 	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
 	message: ['stdio[1]', '\'ignore\''],
 });
@@ -351,6 +432,11 @@ test('Cannot set "stdio[1]" option to "ignore" to use .pipe(1)', testPipeError, 
 	message: ['stdio[1]', '\'ignore\''],
 });
 test('Cannot set "stdio[1]" option to "ignore" to use .duplex(1)', testNodeStream, {
+	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
+	from: 'fd1',
+	message: ['stdio[1]', '\'ignore\''],
+});
+test('Cannot set "stdio[1]" option to "ignore" to use .iterable(1)', testIterable, {
 	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
 	from: 'fd1',
 	message: ['stdio[1]', '\'ignore\''],
@@ -375,6 +461,11 @@ test('Cannot set "stdio[1]" option to "ignore" to use .duplex("stdout")', testNo
 	from: 'stdout',
 	message: ['stdio[1]', '\'ignore\''],
 });
+test('Cannot set "stdio[1]" option to "ignore" to use .iterable("stdout")', testIterable, {
+	sourceOptions: {stdio: ['pipe', 'ignore', 'pipe']},
+	from: 'stdout',
+	message: ['stdio[1]', '\'ignore\''],
+});
 test('Cannot set "stdio[0]" option to "ignore" to use .pipe("stdin")', testPipeError, {
 	destinationOptions: {stdio: ['ignore', 'pipe', 'pipe']},
 	message: ['stdio[0]', '\'ignore\''],
@@ -395,12 +486,22 @@ test('Cannot set "stderr" option to "ignore" to use .duplex(2)', testNodeStream,
 	from: 'fd2',
 	message: ['stderr', '\'ignore\''],
 });
+test('Cannot set "stderr" option to "ignore" to use .iterable(2)', testIterable, {
+	sourceOptions: {stderr: 'ignore'},
+	from: 'fd2',
+	message: ['stderr', '\'ignore\''],
+});
 test('Cannot set "stderr" option to "ignore" to use .pipe("stderr")', testPipeError, {
 	sourceOptions: {stderr: 'ignore'},
 	from: 'stderr',
 	message: ['stderr', '\'ignore\''],
 });
 test('Cannot set "stderr" option to "ignore" to use .duplex("stderr")', testNodeStream, {
+	sourceOptions: {stderr: 'ignore'},
+	from: 'stderr',
+	message: ['stderr', '\'ignore\''],
+});
+test('Cannot set "stderr" option to "ignore" to use .iterable("stderr")', testIterable, {
 	sourceOptions: {stderr: 'ignore'},
 	from: 'stderr',
 	message: ['stderr', '\'ignore\''],
@@ -415,12 +516,22 @@ test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex(2)', test
 	from: 'fd2',
 	message: ['stderr', '\'ignore\''],
 });
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .iterable(2)', testIterable, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
+	from: 'fd2',
+	message: ['stderr', '\'ignore\''],
+});
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe("stderr")', testPipeError, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
 	from: 'stderr',
 	message: ['stderr', '\'ignore\''],
 });
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex("stderr")', testNodeStream, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
+	from: 'stderr',
+	message: ['stderr', '\'ignore\''],
+});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .iterable("stderr")', testIterable, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore'},
 	from: 'stderr',
 	message: ['stderr', '\'ignore\''],
@@ -435,12 +546,22 @@ test('Cannot set "stdio[2]" option to "ignore" to use .duplex(2)', testNodeStrea
 	from: 'fd2',
 	message: ['stdio[2]', '\'ignore\''],
 });
+test('Cannot set "stdio[2]" option to "ignore" to use .iterable(2)', testIterable, {
+	sourceOptions: {stdio: ['pipe', 'pipe', 'ignore']},
+	from: 'fd2',
+	message: ['stdio[2]', '\'ignore\''],
+});
 test('Cannot set "stdio[2]" option to "ignore" to use .pipe("stderr")', testPipeError, {
 	sourceOptions: {stdio: ['pipe', 'pipe', 'ignore']},
 	from: 'stderr',
 	message: ['stdio[2]', '\'ignore\''],
 });
 test('Cannot set "stdio[2]" option to "ignore" to use .duplex("stderr")', testNodeStream, {
+	sourceOptions: {stdio: ['pipe', 'pipe', 'ignore']},
+	from: 'stderr',
+	message: ['stdio[2]', '\'ignore\''],
+});
+test('Cannot set "stdio[2]" option to "ignore" to use .iterable("stderr")', testIterable, {
 	sourceOptions: {stdio: ['pipe', 'pipe', 'ignore']},
 	from: 'stderr',
 	message: ['stdio[2]', '\'ignore\''],
@@ -455,12 +576,22 @@ test('Cannot set "stdio[3]" option to "ignore" to use .duplex(3)', testNodeStrea
 	from: 'fd3',
 	message: ['stdio[3]', '\'ignore\''],
 });
+test('Cannot set "stdio[3]" option to "ignore" to use .iterable(3)', testIterable, {
+	sourceOptions: getStdio(3, 'ignore'),
+	from: 'fd3',
+	message: ['stdio[3]', '\'ignore\''],
+});
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .pipe("all")', testPipeError, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore', all: true},
 	from: 'all',
 	message: ['stdout', '\'ignore\''],
 });
 test('Cannot set "stdout" + "stderr" option to "ignore" to use .duplex("all")', testNodeStream, {
+	sourceOptions: {stdout: 'ignore', stderr: 'ignore', all: true},
+	from: 'all',
+	message: ['stdout', '\'ignore\''],
+});
+test('Cannot set "stdout" + "stderr" option to "ignore" to use .iterable("all")', testIterable, {
 	sourceOptions: {stdout: 'ignore', stderr: 'ignore', all: true},
 	from: 'all',
 	message: ['stdout', '\'ignore\''],
@@ -475,11 +606,20 @@ test('Cannot set "stdio[1]" + "stdio[2]" option to "ignore" to use .duplex("all"
 	from: 'all',
 	message: ['stdio[1]', '\'ignore\''],
 });
+test('Cannot set "stdio[1]" + "stdio[2]" option to "ignore" to use .iterable("all")', testIterable, {
+	sourceOptions: {stdio: ['pipe', 'ignore', 'ignore'], all: true},
+	from: 'all',
+	message: ['stdio[1]', '\'ignore\''],
+});
 test('Cannot set "stdout" option to "inherit" to use .pipe()', testPipeError, {
 	sourceOptions: {stdout: 'inherit'},
 	message: ['stdout', '\'inherit\''],
 });
 test('Cannot set "stdout" option to "inherit" to use .duplex()', testNodeStream, {
+	sourceOptions: {stdout: 'inherit'},
+	message: ['stdout', '\'inherit\''],
+});
+test('Cannot set "stdout" option to "inherit" to use .iterable()', testIterable, {
 	sourceOptions: {stdout: 'inherit'},
 	message: ['stdout', '\'inherit\''],
 });
@@ -500,6 +640,10 @@ test('Cannot set "stdout" option to "ipc" to use .duplex()', testNodeStream, {
 	sourceOptions: {stdout: 'ipc'},
 	message: ['stdout', '\'ipc\''],
 });
+test('Cannot set "stdout" option to "ipc" to use .iterable()', testIterable, {
+	sourceOptions: {stdout: 'ipc'},
+	message: ['stdout', '\'ipc\''],
+});
 test('Cannot set "stdin" option to "ipc" to use .pipe()', testPipeError, {
 	destinationOptions: {stdin: 'ipc'},
 	message: ['stdin', '\'ipc\''],
@@ -514,6 +658,10 @@ test('Cannot set "stdout" option to file descriptors to use .pipe()', testPipeEr
 	message: ['stdout', '1'],
 });
 test('Cannot set "stdout" option to file descriptors to use .duplex()', testNodeStream, {
+	sourceOptions: {stdout: 1},
+	message: ['stdout', '1'],
+});
+test('Cannot set "stdout" option to file descriptors to use .iterable()', testIterable, {
 	sourceOptions: {stdout: 1},
 	message: ['stdout', '1'],
 });
@@ -534,6 +682,10 @@ test('Cannot set "stdout" option to Node.js streams to use .duplex()', testNodeS
 	sourceOptions: {stdout: process.stdout},
 	message: ['stdout', 'Stream'],
 });
+test('Cannot set "stdout" option to Node.js streams to use .iterable()', testIterable, {
+	sourceOptions: {stdout: process.stdout},
+	message: ['stdout', 'Stream'],
+});
 test('Cannot set "stdin" option to Node.js streams to use .pipe()', testPipeError, {
 	destinationOptions: {stdin: process.stdin},
 	message: ['stdin', 'Stream'],
@@ -549,6 +701,11 @@ test('Cannot set "stdio[3]" option to Node.js Writable streams to use .pipe()', 
 	from: 'fd3',
 });
 test('Cannot set "stdio[3]" option to Node.js Writable streams to use .duplex()', testNodeStream, {
+	sourceOptions: getStdio(3, process.stdout),
+	message: ['stdio[3]', 'Stream'],
+	from: 'fd3',
+});
+test('Cannot set "stdio[3]" option to Node.js Writable streams to use .iterable()', testIterable, {
 	sourceOptions: getStdio(3, process.stdout),
 	message: ['stdio[3]', 'Stream'],
 	from: 'fd3',

--- a/test/stream/subprocess.js
+++ b/test/stream/subprocess.js
@@ -1,14 +1,11 @@
-import {platform} from 'node:process';
 import {setTimeout} from 'node:timers/promises';
 import test from 'ava';
 import {execa} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
-import {fullStdio, getStdio, prematureClose} from '../helpers/stdio.js';
+import {fullStdio, getStdio, prematureClose, assertEpipe} from '../helpers/stdio.js';
 import {infiniteGenerator} from '../helpers/generator.js';
 
 setFixtureDir();
-
-const isWindows = platform === 'win32';
 
 const getStreamInputSubprocess = fdNumber => execa('stdin-fd.js', [`${fdNumber}`], fdNumber === 3
 	? getStdio(3, [new Uint8Array(), infiniteGenerator])
@@ -31,9 +28,7 @@ const assertStreamOutputError = (t, fdNumber, {exitCode, signal, isTerminated, f
 	t.false(isTerminated);
 	t.true(failed);
 
-	if (fdNumber === 1 && !isWindows) {
-		t.true(stderr.includes('EPIPE'));
-	}
+	assertEpipe(t, stderr, fdNumber);
 };
 
 const testStreamInputAbort = async (t, fdNumber) => {

--- a/test/stream/wait.js
+++ b/test/stream/wait.js
@@ -1,16 +1,13 @@
-import {platform} from 'node:process';
 import {setImmediate} from 'node:timers/promises';
 import test from 'ava';
 import {execa} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
-import {getStdio, prematureClose} from '../helpers/stdio.js';
+import {getStdio, prematureClose, assertEpipe} from '../helpers/stdio.js';
 import {foobarString} from '../helpers/input.js';
 import {noopGenerator} from '../helpers/generator.js';
 import {noopReadable, noopWritable, noopDuplex} from '../helpers/stream.js';
 
 setFixtureDir();
-
-const isWindows = platform === 'win32';
 
 const noop = () => {};
 
@@ -127,9 +124,7 @@ const testStreamEpipeFail = async (t, streamMethod, stream, fdNumber, useTransfo
 	t.is(exitCode, 1);
 	t.is(stdio[fdNumber], '');
 	t.true(stream.destroyed);
-	if (fdNumber !== 2 && !isWindows) {
-		t.true(stderr.includes('EPIPE'));
-	}
+	assertEpipe(t, stderr, fdNumber);
 };
 
 test('Throws EPIPE when stdout option ends with more writes', testStreamEpipeFail, endOptionStream, noopWritable(), 1, false);


### PR DESCRIPTION
This makes subprocesses async iterable. 

```js
for await (const line of $`npm run build`) {
  if (line.includes('ERROR')) {
    console.log(line);
  }
}
```

A `subprocess.iterable(options)` method is also available to pass options. The options are the same as `subprocess.readable()`: `{from?: string, binary?: boolean, preserveNewlines?: boolean}`.

```js
for await (const line of $`npm run build`.iterable({from: 'stderr'})) {
  // ...
}
```

## Advantages over `subprocess.readable()`

Since streams are async iterable, this is similar to:

```js
for await (const line of $`npm run build`.readable(options)) {
  // ...
}
```

However, it is better than `subprocess.readable()` when the user _just wants to iterate_ over output lines:
  - It uses `Symbol.asyncIterator`, which results in a simpler syntax (first example above).
  - It defaults to iterating over line strings (with newlines stripped) instead of arbitrary chunks of data. That's because we know the user only wants to iterate. We do not know this with `subprocess.readable()` (since streams can be used in other ways), which means the user must explicitly opt-in to line iteration using `subprocess.readable({binary: false, preserveNewlines: false})`.
  - It does not involve streams. 
     - Iterating over `subprocess.readable()` actually adds a few additional layers. First, a stream is created, with some state that must be synced with the subprocess (which is not simple). Then, that stream consumes the underlying async iterable in its `.read()` method. Then, the `Readable` iteration calls `.read()` repeatedly, in a different async iterable. 
     - This results in: `subprocess.stdout` (stream) -> `on(stream, 'data')` (iterable) -> `subprocess.readable()` (stream) -> `Readable.iterator()` (iterable). 
     - Between each of those layers, some buffering applies. 
     - This PR uses the underlying async iterable directly instead. This is simpler, i.e. more efficient and probably more stable.

## Advantages over iterating over `subprocess.stdout`

Just like `subprocess.readable()`, `subprocess.iterable()` is better than just iterating over `subprocess.stdout`.

```js
for await (const line of $`npm run build`.stdout) {
  // ...
}
```

Because:
  - It iterates over lines, with newlines stripped (by default)
  - Each chunk is a string (by default)
  - It waits for the subprocess to complete
  - It throws if the subprocess fails (as opposed to only catching `subprocess.stdout` failures, which rarely happens)
  - It allows for multiple readers at once

## Difference with Execa transforms

Unlike Execa transforms:
  - This is not intended for mapping the subprocess output
  - It only applies to output, not input
  - It does not modify `subprocess.stdout`, which can be either good or bad, depending on the use case