### PR TITLE
Prevent handling binary data like text data

### DIFF
--- a/docs/transform.md
+++ b/docs/transform.md
@@ -18,7 +18,8 @@ console.log(stdout); // HELLO
 
 ## Encoding
 
-The `line` argument passed to the transform is a string. If the [`encoding`](../readme.md#encoding) option is `buffer`, it is an `Uint8Array` instead.
+The `line` argument passed to the transform is a string by default.\
+However, if either a `{transform, binary: true}` plain object is passed, or if the [`encoding`](../readme.md#encoding) option is `buffer`, it is an `Uint8Array` instead.
 
 The transform can `yield` either a `string` or an `Uint8Array`, regardless of the `line` argument's type.
 
@@ -42,7 +43,7 @@ console.log(stdout); // ''
 ## Binary data
 
 The transform iterates over lines by default.\
-However, if a `{transform, binary: true}` plain object is passed, it iterates over arbitrary chunks of data instead.
+However, if either a `{transform, binary: true}` plain object is passed, or if the [`encoding`](../readme.md#encoding) option is `buffer`, it iterates over arbitrary chunks of data instead.
 
 ```js
 await execa('./binary.js', {stdout: {transform, binary: true}});
@@ -116,7 +117,8 @@ await execa('./run.js', {stdout: {transform, preserveNewlines: true}});
 
 ## Object mode
 
-By default, `stdout` and `stderr`'s transforms must return a string or an `Uint8Array`. However, if a `{transform, objectMode: true}` plain object is passed, any type can be returned instead, except `null` or `undefined`. The subprocess' [`stdout`](../readme.md#stdout)/[`stderr`](../readme.md#stderr) will be an array of values.
+By default, `stdout` and `stderr`'s transforms must return a string or an `Uint8Array`.\
+However, if a `{transform, objectMode: true}` plain object is passed, any type can be returned instead, except `null` or `undefined`. The subprocess' [`stdout`](../readme.md#stdout)/[`stderr`](../readme.md#stderr) will be an array of values.
 
 ```js
 const transform = function * (line) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -24,7 +24,7 @@ import {
 const fileUrl = new URL('file:///test');
 
 type AnySyncChunk = string | Uint8Array | undefined;
-type AnyChunk = AnySyncChunk | string[] | Uint8Array[] | unknown[];
+type AnyChunk = AnySyncChunk | string[] | unknown[];
 expectType<Writable | null>({} as ExecaSubprocess['stdin']);
 expectType<Readable | null>({} as ExecaSubprocess['stdout']);
 expectType<Readable | null>({} as ExecaSubprocess['stderr']);
@@ -298,7 +298,7 @@ try {
 		}
 
 		for await (const line of execaBufferPromise.iterable({binary: false})) {
-			expectType<string>(line);
+			expectType<Uint8Array>(line);
 		}
 
 		for await (const line of execaBufferPromise.iterable({binary: true})) {
@@ -306,19 +306,19 @@ try {
 		}
 
 		for await (const line of execaBufferPromise.iterable({} as {binary: boolean})) {
-			expectType<string | Uint8Array>(line);
+			expectType<Uint8Array>(line);
 		}
 	};
 
 	await asyncIteration();
-	expectAssignable<AsyncIterable<string>>(scriptPromise.iterable());
-	expectAssignable<AsyncIterable<string>>(scriptPromise.iterable({binary: false}));
-	expectAssignable<AsyncIterable<Uint8Array>>(scriptPromise.iterable({binary: true}));
-	expectAssignable<AsyncIterable<string | Uint8Array>>(scriptPromise.iterable({} as {binary: boolean}));
-	expectAssignable<AsyncIterable<Uint8Array>>(execaBufferPromise.iterable());
-	expectAssignable<AsyncIterable<string>>(execaBufferPromise.iterable({binary: false}));
-	expectAssignable<AsyncIterable<Uint8Array>>(execaBufferPromise.iterable({binary: true}));
-	expectAssignable<AsyncIterable<string | Uint8Array>>(execaBufferPromise.iterable({} as {binary: boolean}));
+	expectType<AsyncIterableIterator<string>>(scriptPromise.iterable());
+	expectType<AsyncIterableIterator<string>>(scriptPromise.iterable({binary: false}));
+	expectType<AsyncIterableIterator<Uint8Array>>(scriptPromise.iterable({binary: true}));
+	expectType<AsyncIterableIterator<string | Uint8Array>>(scriptPromise.iterable({} as {binary: boolean}));
+	expectType<AsyncIterableIterator<Uint8Array>>(execaBufferPromise.iterable());
+	expectType<AsyncIterableIterator<Uint8Array>>(execaBufferPromise.iterable({binary: false}));
+	expectType<AsyncIterableIterator<Uint8Array>>(execaBufferPromise.iterable({binary: true}));
+	expectType<AsyncIterableIterator<Uint8Array>>(execaBufferPromise.iterable({} as {binary: boolean}));
 
 	expectType<Readable>(scriptPromise.readable());
 	expectType<Writable>(scriptPromise.writable());
@@ -430,11 +430,11 @@ try {
 	expectType<string[]>(linesResult.all);
 
 	const linesBufferResult = await execa('unicorns', {lines: true, encoding: 'buffer', all: true});
-	expectType<Uint8Array[]>(linesBufferResult.stdout);
-	expectType<Uint8Array[]>(linesBufferResult.stdio[1]);
-	expectType<Uint8Array[]>(linesBufferResult.stderr);
-	expectType<Uint8Array[]>(linesBufferResult.stdio[2]);
-	expectType<Uint8Array[]>(linesBufferResult.all);
+	expectType<Uint8Array>(linesBufferResult.stdout);
+	expectType<Uint8Array>(linesBufferResult.stdio[1]);
+	expectType<Uint8Array>(linesBufferResult.stderr);
+	expectType<Uint8Array>(linesBufferResult.stdio[2]);
+	expectType<Uint8Array>(linesBufferResult.all);
 
 	const noBufferPromise = execa('unicorns', {buffer: false, all: true});
 	expectType<Writable>(noBufferPromise.stdin);
@@ -631,7 +631,7 @@ try {
 	expectType<string[]>(linesFd3Result.stdio[3]);
 
 	const linesBufferFd3Result = await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', 'pipe'], lines: true, encoding: 'buffer'});
-	expectType<Uint8Array[]>(linesBufferFd3Result.stdio[3]);
+	expectType<Uint8Array>(linesBufferFd3Result.stdio[3]);
 
 	const noBufferFd3Result = await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', 'pipe'], buffer: false});
 	expectType<undefined>(noBufferFd3Result.stdio[3]);
@@ -749,11 +749,11 @@ try {
 	expectType<string[]>(execaLinesError.all);
 
 	const execaLinesBufferError = error as ExecaError<{lines: true; encoding: 'buffer'; all: true}>;
-	expectType<Uint8Array[]>(execaLinesBufferError.stdout);
-	expectType<Uint8Array[]>(execaLinesBufferError.stdio[1]);
-	expectType<Uint8Array[]>(execaLinesBufferError.stderr);
-	expectType<Uint8Array[]>(execaLinesBufferError.stdio[2]);
-	expectType<Uint8Array[]>(execaLinesBufferError.all);
+	expectType<Uint8Array>(execaLinesBufferError.stdout);
+	expectType<Uint8Array>(execaLinesBufferError.stdio[1]);
+	expectType<Uint8Array>(execaLinesBufferError.stderr);
+	expectType<Uint8Array>(execaLinesBufferError.stdio[2]);
+	expectType<Uint8Array>(execaLinesBufferError.all);
 
 	const noBufferError = error as ExecaError<{buffer: false; all: true}>;
 	expectType<undefined>(noBufferError.stdout);

--- a/lib/convert/add.js
+++ b/lib/convert/add.js
@@ -4,11 +4,12 @@ import {createWritable} from './writable.js';
 import {createDuplex} from './duplex.js';
 import {createIterable} from './iterable.js';
 
-export const addConvertedStreams = (subprocess, options) => {
+export const addConvertedStreams = (subprocess, {encoding}) => {
 	const concurrentStreams = initializeConcurrentStreams();
-	subprocess.readable = createReadable.bind(undefined, {subprocess, concurrentStreams});
+	const isBuffer = encoding === 'buffer';
+	subprocess.readable = createReadable.bind(undefined, {subprocess, concurrentStreams, isBuffer});
 	subprocess.writable = createWritable.bind(undefined, {subprocess, concurrentStreams});
-	subprocess.duplex = createDuplex.bind(undefined, {subprocess, concurrentStreams});
-	subprocess.iterable = createIterable.bind(undefined, subprocess, options);
-	subprocess[Symbol.asyncIterator] = createIterable.bind(undefined, subprocess, options, {});
+	subprocess.duplex = createDuplex.bind(undefined, {subprocess, concurrentStreams, isBuffer});
+	subprocess.iterable = createIterable.bind(undefined, subprocess, isBuffer);
+	subprocess[Symbol.asyncIterator] = createIterable.bind(undefined, subprocess, isBuffer, {});
 };

--- a/lib/convert/duplex.js
+++ b/lib/convert/duplex.js
@@ -15,7 +15,8 @@ import {
 } from './writable.js';
 
 // Create a `Duplex` stream combining both
-export const createDuplex = ({subprocess, concurrentStreams}, {from, to, binary = true, preserveNewlines = true} = {}) => {
+export const createDuplex = ({subprocess, concurrentStreams, isBuffer}, {from, to, binary: binaryOption = true, preserveNewlines = true} = {}) => {
+	const binary = binaryOption || isBuffer;
 	const {subprocessStdout, waitReadableDestroy} = getSubprocessStdout(subprocess, from, concurrentStreams);
 	const {subprocessStdin, waitWritableFinal, waitWritableDestroy} = getSubprocessStdin(subprocess, to, concurrentStreams);
 	const {readableEncoding, readableObjectMode, readableHighWaterMark} = getReadableOptions(subprocessStdout, binary);

--- a/lib/convert/iterable.js
+++ b/lib/convert/iterable.js
@@ -1,11 +1,12 @@
 import {getReadable} from '../pipe/validate.js';
 import {iterateOnStdout} from './loop.js';
 
-export const createIterable = (subprocess, {encoding}, {
+export const createIterable = (subprocess, isBuffer, {
 	from,
-	binary = encoding === 'buffer',
+	binary: binaryOption = false,
 	preserveNewlines = false,
 } = {}) => {
+	const binary = binaryOption || isBuffer;
 	const subprocessStdout = getReadable(subprocess, from);
 	const onStdoutData = iterateOnStdout({subprocessStdout, subprocess, binary, preserveNewlines, isStream: false});
 	return iterateOnStdoutData(onStdoutData, subprocessStdout, subprocess);

--- a/lib/convert/loop.js
+++ b/lib/convert/loop.js
@@ -66,19 +66,17 @@ const getTransforms = ({subprocessStdout, binary, preserveNewlines, isStream}) =
 		return getTextTransforms(binary, preserveNewlines, writableObjectMode);
 	}
 
-	return isStream ? {} : getBinaryTransforms(writableObjectMode);
+	return isStream ? {} : getBinaryTransforms(binary, writableObjectMode);
 };
 
 const getTextTransforms = (binary, preserveNewlines, writableObjectMode) => {
-	const encoding = 'utf8';
-	const {transform: encodeChunk, final: encodeChunkFinal} = getEncodingTransformGenerator(encoding, writableObjectMode, false);
-	const {transform: splitLines, final: splitLinesFinal} = getSplitLinesGenerator({encoding, binary, preserveNewlines, writableObjectMode, state: {}});
+	const {transform: encodeChunk, final: encodeChunkFinal} = getEncodingTransformGenerator(binary, writableObjectMode, false);
+	const {transform: splitLines, final: splitLinesFinal} = getSplitLinesGenerator({binary, preserveNewlines, writableObjectMode, state: {}});
 	return {encodeChunk, encodeChunkFinal, splitLines, splitLinesFinal};
 };
 
-const getBinaryTransforms = writableObjectMode => {
-	const encoding = 'buffer';
-	const {transform: encodeChunk} = getEncodingTransformGenerator(encoding, writableObjectMode, false);
+const getBinaryTransforms = (binary, writableObjectMode) => {
+	const {transform: encodeChunk} = getEncodingTransformGenerator(binary, writableObjectMode, false);
 	return {encodeChunk};
 };
 

--- a/lib/convert/readable.js
+++ b/lib/convert/readable.js
@@ -12,7 +12,8 @@ import {
 import {iterateOnStdout, DEFAULT_OBJECT_HIGH_WATER_MARK} from './loop.js';
 
 // Create a `Readable` stream that forwards from `stdout` and awaits the subprocess
-export const createReadable = ({subprocess, concurrentStreams}, {from, binary = true, preserveNewlines = true} = {}) => {
+export const createReadable = ({subprocess, concurrentStreams, isBuffer}, {from, binary: binaryOption = true, preserveNewlines = true} = {}) => {
+	const binary = binaryOption || isBuffer;
 	const {subprocessStdout, waitReadableDestroy} = getSubprocessStdout(subprocess, from, concurrentStreams);
 	const {readableEncoding, readableObjectMode, readableHighWaterMark} = getReadableOptions(subprocessStdout, binary);
 	const {read, onStdoutDataDone} = getReadableMethods({subprocessStdout, subprocess, binary, preserveNewlines});

--- a/lib/stdio/encoding-final.js
+++ b/lib/stdio/encoding-final.js
@@ -26,7 +26,6 @@ export const handleStreamsEncoding = (stdioStreams, {encoding}, isSync) => {
 				final: encodingStringFinal.bind(undefined, stringDecoder),
 				binary: true,
 			},
-			encoding: 'buffer',
 		},
 	];
 };

--- a/lib/stdio/encoding-transform.js
+++ b/lib/stdio/encoding-transform.js
@@ -12,13 +12,13 @@ However, those are converted to Buffer:
 - on writes: `Duplex.writable` `decodeStrings: true` default option
 - on reads: `Duplex.readable` `readableEncoding: null` default option
 */
-export const getEncodingTransformGenerator = (encoding, writableObjectMode, forceEncoding) => {
+export const getEncodingTransformGenerator = (binary, writableObjectMode, forceEncoding) => {
 	if (writableObjectMode && !forceEncoding) {
 		return;
 	}
 
-	if (encoding === 'buffer') {
-		return {transform: encodingBufferGenerator};
+	if (binary) {
+		return {transform: encodingUint8ArrayGenerator};
 	}
 
 	const textDecoder = new TextDecoder();
@@ -28,7 +28,7 @@ export const getEncodingTransformGenerator = (encoding, writableObjectMode, forc
 	};
 };
 
-const encodingBufferGenerator = function * (chunk) {
+const encodingUint8ArrayGenerator = function * (chunk) {
 	yield Buffer.isBuffer(chunk) ? new Uint8Array(chunk) : chunk;
 };
 

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -5,21 +5,28 @@ import {pipeStreams} from './pipeline.js';
 import {isGeneratorOptions, isAsyncGenerator} from './type.js';
 import {getValidateTransformReturn} from './validate.js';
 
-export const normalizeGenerators = stdioStreams => {
+export const normalizeGenerators = (stdioStreams, options) => {
 	const nonGenerators = stdioStreams.filter(({type}) => type !== 'generator');
 	const generators = stdioStreams.filter(({type}) => type === 'generator');
 
 	const newGenerators = Array.from({length: generators.length});
 
 	for (const [index, stdioStream] of Object.entries(generators)) {
-		newGenerators[index] = normalizeGenerator(stdioStream, Number(index), newGenerators);
+		newGenerators[index] = normalizeGenerator(stdioStream, Number(index), newGenerators, options);
 	}
 
 	return [...nonGenerators, ...sortGenerators(newGenerators)];
 };
 
-const normalizeGenerator = ({value, ...stdioStream}, index, newGenerators) => {
-	const {transform, final, binary = false, preserveNewlines = false, objectMode} = isGeneratorOptions(value) ? value : {transform: value};
+const normalizeGenerator = ({value, ...stdioStream}, index, newGenerators, {encoding}) => {
+	const {
+		transform,
+		final,
+		binary: binaryOption = false,
+		preserveNewlines = false,
+		objectMode,
+	} = isGeneratorOptions(value) ? value : {transform: value};
+	const binary = binaryOption || encoding === 'buffer';
 	const objectModes = stdioStream.direction === 'output'
 		? getOutputObjectModes(objectMode, index, newGenerators)
 		: getInputObjectModes(objectMode, index, newGenerators);
@@ -69,14 +76,13 @@ Chunks are currently processed serially. We could add a `concurrency` option to 
 */
 export const generatorToDuplexStream = ({
 	value: {transform, final, binary, writableObjectMode, readableObjectMode, preserveNewlines},
-	encoding,
 	forceEncoding,
 	optionName,
 }) => {
 	const state = {};
 	const generators = [
-		getEncodingTransformGenerator(encoding, writableObjectMode, forceEncoding),
-		getSplitLinesGenerator({encoding, binary, preserveNewlines, writableObjectMode, state}),
+		getEncodingTransformGenerator(binary, writableObjectMode, forceEncoding),
+		getSplitLinesGenerator({binary, preserveNewlines, writableObjectMode, state}),
 		{transform, final},
 		{transform: getValidateTransformReturn(readableObjectMode, optionName)},
 		getAppendNewlineGenerator({binary, preserveNewlines, readableObjectMode, state}),

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -20,7 +20,7 @@ export const handleInput = (addProperties, options, verboseInfo, isSync) => {
 		.map(stdioStreams => handleStreamsVerbose({stdioStreams, options, isSync, stdioState, verboseInfo}))
 		.map(stdioStreams => handleStreamsLines(stdioStreams, options, isSync))
 		.map(stdioStreams => handleStreamsEncoding(stdioStreams, options, isSync))
-		.map(stdioStreams => normalizeGenerators(stdioStreams))
+		.map(stdioStreams => normalizeGenerators(stdioStreams, options))
 		.map(stdioStreams => addStreamsProperties(stdioStreams, addProperties));
 	options.stdio = forwardStdio(stdioStreamsGroups);
 	return {stdioStreamsGroups, stdioState};

--- a/lib/stdio/lines.js
+++ b/lib/stdio/lines.js
@@ -2,7 +2,7 @@ import {willPipeStreams} from './forward.js';
 
 // Split chunks line-wise for streams exposed to users like `subprocess.stdout`.
 // Appending a noop transform in object mode is enough to do this, since every non-binary transform iterates line-wise.
-export const handleStreamsLines = (stdioStreams, {lines, stripFinalNewline}, isSync) => shouldSplitLines(stdioStreams, lines, isSync)
+export const handleStreamsLines = (stdioStreams, {lines, encoding, stripFinalNewline}, isSync) => shouldSplitLines({stdioStreams, lines, encoding, isSync})
 	? [
 		...stdioStreams,
 		{
@@ -13,8 +13,9 @@ export const handleStreamsLines = (stdioStreams, {lines, stripFinalNewline}, isS
 	]
 	: stdioStreams;
 
-const shouldSplitLines = (stdioStreams, lines, isSync) => stdioStreams[0].direction === 'output'
+const shouldSplitLines = ({stdioStreams, lines, encoding, isSync}) => stdioStreams[0].direction === 'output'
 	&& lines
+	&& encoding !== 'buffer'
 	&& !isSync
 	&& willPipeStreams(stdioStreams);
 

--- a/lib/stdio/split.js
+++ b/lib/stdio/split.js
@@ -1,65 +1,29 @@
-import {isUint8Array} from '../utils.js';
-
 // Split chunks line-wise for generators passed to the `std*` options
-export const getSplitLinesGenerator = ({encoding, binary, preserveNewlines, writableObjectMode, state}) => {
+export const getSplitLinesGenerator = ({binary, preserveNewlines, writableObjectMode, state}) => {
 	if (binary || writableObjectMode) {
 		return;
 	}
 
-	const info = encoding === 'buffer' ? linesUint8ArrayInfo : linesStringInfo;
-	state.previousChunks = info.emptyValue;
+	state.previousChunks = '';
 	return {
-		transform: splitGenerator.bind(undefined, state, preserveNewlines, info),
+		transform: splitGenerator.bind(undefined, state, preserveNewlines),
 		final: linesFinal.bind(undefined, state),
 	};
 };
 
-const concatUint8Array = (firstChunk, secondChunk) => {
-	const chunk = new Uint8Array(firstChunk.length + secondChunk.length);
-	chunk.set(firstChunk, 0);
-	chunk.set(secondChunk, firstChunk.length);
-	return chunk;
-};
-
-const linesUint8ArrayInfo = {
-	emptyValue: new Uint8Array(0),
-	windowsNewline: new Uint8Array([0x0D, 0x0A]),
-	unixNewline: new Uint8Array([0x0A]),
-	CR: 0x0D,
-	LF: 0x0A,
-	concatBytes: concatUint8Array,
-	isValidType: isUint8Array,
-};
-
-const concatString = (firstChunk, secondChunk) => `${firstChunk}${secondChunk}`;
-const isString = chunk => typeof chunk === 'string';
-
-const linesStringInfo = {
-	emptyValue: '',
-	windowsNewline: '\r\n',
-	unixNewline: '\n',
-	CR: '\r',
-	LF: '\n',
-	concatBytes: concatString,
-	isValidType: isString,
-};
-
-const linesInfo = [linesStringInfo, linesUint8ArrayInfo];
-
 // This imperative logic is much faster than using `String.split()` and uses very low memory.
-// Also, it allows sharing it with `Uint8Array`.
-const splitGenerator = function * (state, preserveNewlines, {emptyValue, CR, LF, concatBytes}, chunk) {
+const splitGenerator = function * (state, preserveNewlines, chunk) {
 	let {previousChunks} = state;
 	let start = -1;
 
 	for (let end = 0; end < chunk.length; end += 1) {
-		if (chunk[end] === LF) {
-			const newlineLength = getNewlineLength({chunk, end, CR, preserveNewlines, state});
+		if (chunk[end] === '\n') {
+			const newlineLength = getNewlineLength(chunk, end, preserveNewlines, state);
 			let line = chunk.slice(start + 1, end + 1 - newlineLength);
 
 			if (previousChunks.length > 0) {
-				line = concatBytes(previousChunks, line);
-				previousChunks = emptyValue;
+				line = concatString(previousChunks, line);
+				previousChunks = '';
 			}
 
 			yield line;
@@ -68,18 +32,18 @@ const splitGenerator = function * (state, preserveNewlines, {emptyValue, CR, LF,
 	}
 
 	if (start !== chunk.length - 1) {
-		previousChunks = concatBytes(previousChunks, chunk.slice(start + 1));
+		previousChunks = concatString(previousChunks, chunk.slice(start + 1));
 	}
 
 	state.previousChunks = previousChunks;
 };
 
-const getNewlineLength = ({chunk, end, CR, preserveNewlines, state}) => {
+const getNewlineLength = (chunk, end, preserveNewlines, state) => {
 	if (preserveNewlines) {
 		return 0;
 	}
 
-	state.isWindowsNewline = end !== 0 && chunk[end - 1] === CR;
+	state.isWindowsNewline = end !== 0 && chunk[end - 1] === '\r';
 	return state.isWindowsNewline ? 2 : 1;
 };
 
@@ -96,7 +60,7 @@ export const getAppendNewlineGenerator = ({binary, preserveNewlines, readableObj
 	: {transform: appendNewlineGenerator.bind(undefined, state)};
 
 const appendNewlineGenerator = function * ({isWindowsNewline = false}, chunk) {
-	const {unixNewline, windowsNewline, LF, concatBytes} = linesInfo.find(({isValidType}) => isValidType(chunk));
+	const {unixNewline, windowsNewline, LF, concatBytes} = typeof chunk === 'string' ? linesStringInfo : linesUint8ArrayInfo;
 
 	if (chunk.at(-1) === LF) {
 		yield chunk;
@@ -105,4 +69,27 @@ const appendNewlineGenerator = function * ({isWindowsNewline = false}, chunk) {
 
 	const newline = isWindowsNewline ? windowsNewline : unixNewline;
 	yield concatBytes(chunk, newline);
+};
+
+const concatString = (firstChunk, secondChunk) => `${firstChunk}${secondChunk}`;
+
+const linesStringInfo = {
+	windowsNewline: '\r\n',
+	unixNewline: '\n',
+	LF: '\n',
+	concatBytes: concatString,
+};
+
+const concatUint8Array = (firstChunk, secondChunk) => {
+	const chunk = new Uint8Array(firstChunk.length + secondChunk.length);
+	chunk.set(firstChunk, 0);
+	chunk.set(secondChunk, firstChunk.length);
+	return chunk;
+};
+
+const linesUint8ArrayInfo = {
+	windowsNewline: new Uint8Array([0x0D, 0x0A]),
+	unixNewline: new Uint8Array([0x0A]),
+	LF: 0x0A,
+	concatBytes: concatUint8Array,
 };

--- a/lib/stream/all.js
+++ b/lib/stream/all.js
@@ -23,11 +23,16 @@ export const waitForAllStream = ({subprocess, encoding, buffer, maxBuffer, strea
 //  - `getStreamAsArrayBuffer()` or `getStream()` for the chunks not in objectMode, to convert them from Buffers to string or Uint8Array
 // We do this by emulating the Buffer -> string|Uint8Array conversion performed by `get-stream` with our own, which is identical.
 const getAllStream = ({all, stdout, stderr}, encoding) => all && stdout && stderr && stdout.readableObjectMode !== stderr.readableObjectMode
-	? all.pipe(generatorToDuplexStream({value: allStreamGenerator, encoding, forceEncoding: true}).value)
+	? all.pipe(generatorToDuplexStream(getAllStreamTransform(encoding)).value)
 	: all;
 
-const allStreamGenerator = {
-	* final() {},
-	writableObjectMode: true,
-	readableObjectMode: true,
-};
+const getAllStreamTransform = encoding => ({
+	value: {
+		* final() {},
+		binary: encoding === 'buffer',
+		writableObjectMode: true,
+		readableObjectMode: true,
+		preserveNewlines: true,
+	},
+	forceEncoding: true,
+});

--- a/readme.md
+++ b/readme.md
@@ -513,13 +513,14 @@ Which stream to read from the subprocess. A file descriptor like `"fd3"` can als
 
 ##### readableOptions.binary
 
-Type: `boolean`
+Type: `boolean`\
+Default: `false` with [`.iterable()`](#iterablereadableoptions), `true` with [`.readable()`](#readablereadableoptions)/[`.duplex()`](#duplexduplexoptions)
 
 If `false`, the stream iterates over lines. Each line is a string. Also, the stream is in [object mode](https://nodejs.org/api/stream.html#object-mode).
 
 If `true`, the stream iterates over arbitrary chunks of data. Each line is an `Uint8Array` (with [`.iterable()`](#iterablereadableoptions)) or a [`Buffer`](https://nodejs.org/api/buffer.html#class-buffer) (otherwise).
 
-With [`.readable()`](#readablereadableoptions)/[`.duplex()`](#duplexduplexoptions), the default value is `true`. With [`.iterable()`](#iterablereadableoptions), the default value is `true` if the [`encoding` option](#encoding) is `buffer`, otherwise it is `false`.
+This is always `true` if the [`encoding` option](#encoding) is `'buffer'`.
 
 ##### readableOptions.preserveNewlines
 
@@ -947,6 +948,8 @@ Split `stdout` and `stderr` into lines.
 - [`result.stdout`](#stdout), [`result.stderr`](#stderr), [`result.all`](#all-1) and [`result.stdio`](#stdio) are arrays of lines.
 - [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), [`subprocess.all`](#all), [`subprocess.stdio`](https://nodejs.org/api/child_process.html#subprocessstdio), [`subprocess.readable()`](#readablereadableoptions) and [`subprocess.duplex`](#duplexduplexoptions) iterate over lines instead of arbitrary chunks.
 - Any stream passed to the [`stdout`](#stdout-1), [`stderr`](#stderr-1) or [`stdio`](#stdio-1) option receives lines instead of arbitrary chunks.
+
+This cannot be used if the [`encoding` option](#encoding) is `'buffer'`.
 
 #### encoding
 

--- a/test/convert/loop.js
+++ b/test/convert/loop.js
@@ -57,22 +57,25 @@ const testText = async (t, expectedChunks, methodName, binary, preserveNewlines,
 	await assertSubprocessOutput(t, subprocess, stringToUint8Arrays(complexFull, isUint8Array));
 };
 
-test('.iterable() can use "binary: true"', testText, singleComplexUint8Array, 'iterable', true, undefined, false);
+test('.iterable() can use "binary: true"', testText, [singleComplexUint8Array], 'iterable', true, undefined, false);
 test('.iterable() can use "binary: undefined"', testText, complexChunks, 'iterable', undefined, undefined, false);
-test('.iterable() can use "binary: undefined" + "encoding: buffer"', testText, singleComplexUint8Array, 'iterable', undefined, undefined, true);
+test('.iterable() can use "binary: undefined" + "encoding: buffer"', testText, [singleComplexUint8Array], 'iterable', undefined, undefined, true);
 test('.iterable() can use "binary: false"', testText, complexChunks, 'iterable', false, undefined, false);
+test('.iterable() can use "binary: false" + "encoding: buffer"', testText, [singleComplexUint8Array], 'iterable', false, undefined, true);
 test('.iterable() can use "binary: false" + "preserveNewlines: true"', testText, complexChunksEnd, 'iterable', false, true, false);
 test('.iterable() can use "binary: false" + "preserveNewlines: false"', testText, complexChunks, 'iterable', false, false, false);
 test('.readable() can use "binary: true"', testText, singleComplexBuffer, 'readable', true, undefined, false);
 test('.readable() can use "binary: undefined"', testText, singleComplexBuffer, 'readable', undefined, undefined, false);
 test('.readable() can use "binary: undefined" + "encoding: buffer"', testText, singleComplexBuffer, 'readable', undefined, undefined, true);
 test('.readable() can use "binary: false"', testText, complexChunksEnd, 'readable', false, undefined, false);
+test('.readable() can use "binary: false" + "encoding: buffer"', testText, singleComplexBuffer, 'readable', false, undefined, true);
 test('.readable() can use "binary: false" + "preserveNewlines: true"', testText, complexChunksEnd, 'readable', false, true, false);
 test('.readable() can use "binary: false" + "preserveNewlines: false"', testText, complexChunks, 'readable', false, false, false);
 test('.duplex() can use "binary: true"', testText, singleComplexBuffer, 'duplex', true, undefined, false);
 test('.duplex() can use "binary: undefined"', testText, singleComplexBuffer, 'duplex', undefined, undefined, false);
 test('.duplex() can use "binary: undefined" + "encoding: "buffer"', testText, singleComplexBuffer, 'duplex', undefined, undefined, true);
 test('.duplex() can use "binary: false"', testText, complexChunksEnd, 'duplex', false, undefined, false);
+test('.duplex() can use "binary: false" + "encoding: buffer"', testText, singleComplexBuffer, 'duplex', false, undefined, true);
 test('.duplex() can use "binary: false" + "preserveNewlines: true"', testText, complexChunksEnd, 'duplex', false, true, false);
 test('.duplex() can use "binary: false" + "preserveNewlines: false"', testText, complexChunks, 'duplex', false, false, false);
 
@@ -118,13 +121,13 @@ const testObjectMode = async (t, expectedChunks, methodName, encoding, initialOb
 	await subprocess;
 };
 
-test('.iterable() uses Buffers with "binary: true"', testObjectMode, simpleChunksUint8Array, 'iterable', null, false, false, true);
+test('.iterable() uses Uint8Arrays with "binary: true"', testObjectMode, simpleChunksUint8Array, 'iterable', null, false, false, true);
 test('.iterable() uses strings with "binary: true" and .setEncoding("utf8")', testObjectMode, simpleChunks, 'iterable', 'utf8', false, false, true);
 test('.iterable() uses strings with "binary: true" and "encoding: buffer"', testObjectMode, simpleChunks, 'iterable', 'utf8', false, false, true, {encoding: 'buffer'});
 test('.iterable() uses strings in objectMode with "binary: true" and object transforms', testObjectMode, foobarObjectChunks, 'iterable', null, true, true, true, {stdout: outputObjectGenerator});
 test('.iterable() uses strings in objectMode with "binary: false"', testObjectMode, simpleLines, 'iterable', null, false, true, false);
 test('.iterable() uses strings in objectMode with "binary: false" and .setEncoding("utf8")', testObjectMode, simpleLines, 'iterable', 'utf8', false, true, false);
-test('.iterable() uses strings in objectMode with "binary: false" and "encoding: buffer"', testObjectMode, simpleLines, 'iterable', 'utf8', false, true, false, {encoding: 'buffer'});
+test('.iterable() uses strings in objectMode with "binary: false" and "encoding: buffer"', testObjectMode, simpleChunks, 'iterable', 'utf8', false, true, false, {encoding: 'buffer'});
 test('.iterable() uses strings in objectMode with "binary: false" and object transforms', testObjectMode, foobarObjectChunks, 'iterable', null, true, true, false, {stdout: outputObjectGenerator});
 test('.readable() uses Buffers with "binary: true"', testObjectMode, simpleChunksBuffer, 'readable', null, false, false, true);
 test('.readable() uses strings with "binary: true" and .setEncoding("utf8")', testObjectMode, simpleChunks, 'readable', 'utf8', false, false, true);
@@ -132,7 +135,7 @@ test('.readable() uses strings with "binary: true" and "encoding: buffer"', test
 test('.readable() uses strings in objectMode with "binary: true" and object transforms', testObjectMode, foobarObjectChunks, 'readable', null, true, true, true, {stdout: outputObjectGenerator});
 test('.readable() uses strings in objectMode with "binary: false"', testObjectMode, simpleLines, 'readable', null, false, true, false);
 test('.readable() uses strings in objectMode with "binary: false" and .setEncoding("utf8")', testObjectMode, simpleLines, 'readable', 'utf8', false, true, false);
-test('.readable() uses strings in objectMode with "binary: false" and "encoding: buffer"', testObjectMode, simpleLines, 'readable', 'utf8', false, true, false, {encoding: 'buffer'});
+test('.readable() uses strings in objectMode with "binary: false" and "encoding: buffer"', testObjectMode, simpleChunks, 'readable', 'utf8', false, false, false, {encoding: 'buffer'});
 test('.readable() uses strings in objectMode with "binary: false" and object transforms', testObjectMode, foobarObjectChunks, 'readable', null, true, true, false, {stdout: outputObjectGenerator});
 test('.duplex() uses Buffers with "binary: true"', testObjectMode, simpleChunksBuffer, 'duplex', null, false, false, true);
 test('.duplex() uses strings with "binary: true" and .setEncoding("utf8")', testObjectMode, simpleChunks, 'duplex', 'utf8', false, false, true);
@@ -140,7 +143,7 @@ test('.duplex() uses strings with "binary: true" and "encoding: buffer"', testOb
 test('.duplex() uses strings in objectMode with "binary: true" and object transforms', testObjectMode, foobarObjectChunks, 'duplex', null, true, true, true, {stdout: outputObjectGenerator});
 test('.duplex() uses strings in objectMode with "binary: false"', testObjectMode, simpleLines, 'duplex', null, false, true, false);
 test('.duplex() uses strings in objectMode with "binary: false" and .setEncoding("utf8")', testObjectMode, simpleLines, 'duplex', 'utf8', false, true, false);
-test('.duplex() uses strings in objectMode with "binary: false" and "encoding: buffer"', testObjectMode, simpleLines, 'duplex', 'utf8', false, true, false, {encoding: 'buffer'});
+test('.duplex() uses strings in objectMode with "binary: false" and "encoding: buffer"', testObjectMode, simpleChunks, 'duplex', 'utf8', false, false, false, {encoding: 'buffer'});
 test('.duplex() uses strings in objectMode with "binary: false" and object transforms', testObjectMode, foobarObjectChunks, 'duplex', null, true, true, false, {stdout: outputObjectGenerator});
 
 const testObjectSplit = async (t, methodName) => {

--- a/test/helpers/generator.js
+++ b/test/helpers/generator.js
@@ -13,12 +13,13 @@ export const addNoopGenerator = (transform, addNoopTransform) => addNoopTransfor
 	? [transform, noopGenerator(undefined, true)]
 	: [transform];
 
-export const noopGenerator = (objectMode, binary) => ({
+export const noopGenerator = (objectMode, binary, preserveNewlines) => ({
 	* transform(line) {
 		yield line;
 	},
 	objectMode,
 	binary,
+	preserveNewlines,
 });
 
 export const serializeGenerator = (objectMode, binary) => ({

--- a/test/helpers/lines.js
+++ b/test/helpers/lines.js
@@ -1,38 +1,24 @@
 import {Buffer} from 'node:buffer';
 
 const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
 
-export const getEncoding = isUint8Array => isUint8Array ? 'buffer' : 'utf8';
-
-export const stringsToUint8Arrays = (strings, isUint8Array) => strings.map(string => stringToUint8Arrays(string, isUint8Array));
+export const stringsToUint8Arrays = strings => strings.map(string => stringToUint8Arrays(string, true));
 
 export const stringToUint8Arrays = (string, isUint8Array) => isUint8Array
 	? textEncoder.encode(string)
 	: string;
 
-export const stringsToBuffers = (strings, isUint8Array) => isUint8Array
-	? strings.map(string => Buffer.from(string))
-	: strings;
-
-export const serializeResult = (result, isUint8Array) => Array.isArray(result)
-	? result.map(resultItem => serializeResultItem(resultItem, isUint8Array))
-	: serializeResultItem(result, isUint8Array);
-
-const serializeResultItem = (resultItem, isUint8Array) => isUint8Array
-	? textDecoder.decode(resultItem)
-	: resultItem;
-
 export const simpleFull = 'aaa\nbbb\nccc';
 export const simpleChunks = [simpleFull];
+export const simpleFullUint8Array = textEncoder.encode(simpleFull);
+export const simpleChunksUint8Array = [simpleFullUint8Array];
 export const simpleChunksBuffer = [Buffer.from(simpleFull)];
-export const simpleChunksUint8Array = stringsToUint8Arrays(simpleChunks, true);
 export const simpleLines = ['aaa\n', 'bbb\n', 'ccc'];
 export const simpleFullEndLines = ['aaa\n', 'bbb\n', 'ccc\n'];
 export const noNewlinesFull = 'aaabbbccc';
 export const noNewlinesChunks = ['aaa', 'bbb', 'ccc'];
 export const complexFull = '\naaa\r\nbbb\n\nccc';
 export const singleComplexBuffer = [Buffer.from(complexFull)];
-export const singleComplexUint8Array = stringsToUint8Arrays([complexFull], true);
+export const singleComplexUint8Array = textEncoder.encode(complexFull);
 export const complexChunksEnd = ['\n', 'aaa\r\n', 'bbb\n', '\n', 'ccc'];
 export const complexChunks = ['', 'aaa', 'bbb', '', 'ccc'];

--- a/test/return/output.js
+++ b/test/return/output.js
@@ -137,6 +137,6 @@ test('stripFinalNewline: true with stdio[*] - sync', testStripFinalNewline, 3, t
 test('stripFinalNewline: false with stdio[*] - sync', testStripFinalNewline, 3, false, execaSync);
 
 test('stripFinalNewline is not used in objectMode', async t => {
-	const {stdout} = await execa('noop-fd.js', ['1', 'foobar\n'], {stripFinalNewline: true, stdout: noopGenerator(true, true)});
+	const {stdout} = await execa('noop-fd.js', ['1', 'foobar\n'], {stripFinalNewline: true, stdout: noopGenerator(true, false, true)});
 	t.deepEqual(stdout, ['foobar\n']);
 });

--- a/test/stdio/lines.js
+++ b/test/stdio/lines.js
@@ -9,41 +9,35 @@ import {foobarObject} from '../helpers/input.js';
 import {
 	simpleFull,
 	simpleChunks,
+	simpleFullUint8Array,
 	simpleLines,
 	simpleFullEndLines,
 	noNewlinesChunks,
-	getEncoding,
-	stringsToUint8Arrays,
-	stringsToBuffers,
-	serializeResult,
 } from '../helpers/lines.js';
 
 setFixtureDir();
 
+test('"lines: true" is a noop when using "encoding: buffer"', async t => {
+	const {stdout} = await execa('noop-fd.js', ['1', simpleFull], {lines: true, encoding: 'buffer'});
+	t.deepEqual(stdout, simpleFullUint8Array);
+});
+
 // eslint-disable-next-line max-params
-const testStreamLines = async (t, fdNumber, input, expectedOutput, isUint8Array, stripFinalNewline) => {
+const testStreamLines = async (t, fdNumber, input, expectedOutput, stripFinalNewline) => {
 	const {stdio} = await execa('noop-fd.js', [`${fdNumber}`, input], {
 		...fullStdio,
 		lines: true,
-		encoding: getEncoding(isUint8Array),
 		stripFinalNewline,
 	});
-	const output = serializeResult(stdio[fdNumber], isUint8Array);
-	t.deepEqual(output, expectedOutput);
+	t.deepEqual(stdio[fdNumber], expectedOutput);
 };
 
-test('"lines: true" splits lines, stdout, string', testStreamLines, 1, simpleFull, simpleLines, false, false);
-test('"lines: true" splits lines, stdout, Uint8Array', testStreamLines, 1, simpleFull, simpleLines, true, false);
-test('"lines: true" splits lines, stderr, string', testStreamLines, 2, simpleFull, simpleLines, false, false);
-test('"lines: true" splits lines, stderr, Uint8Array', testStreamLines, 2, simpleFull, simpleLines, true, false);
-test('"lines: true" splits lines, stdio[*], string', testStreamLines, 3, simpleFull, simpleLines, false, false);
-test('"lines: true" splits lines, stdio[*], Uint8Array', testStreamLines, 3, simpleFull, simpleLines, true, false);
-test('"lines: true" splits lines, stdout, string, stripFinalNewline', testStreamLines, 1, simpleFull, noNewlinesChunks, false, true);
-test('"lines: true" splits lines, stdout, Uint8Array, stripFinalNewline', testStreamLines, 1, simpleFull, noNewlinesChunks, true, true);
-test('"lines: true" splits lines, stderr, string, stripFinalNewline', testStreamLines, 2, simpleFull, noNewlinesChunks, false, true);
-test('"lines: true" splits lines, stderr, Uint8Array, stripFinalNewline', testStreamLines, 2, simpleFull, noNewlinesChunks, true, true);
-test('"lines: true" splits lines, stdio[*], string, stripFinalNewline', testStreamLines, 3, simpleFull, noNewlinesChunks, false, true);
-test('"lines: true" splits lines, stdio[*], Uint8Array, stripFinalNewline', testStreamLines, 3, simpleFull, noNewlinesChunks, true, true);
+test('"lines: true" splits lines, stdout, string', testStreamLines, 1, simpleFull, simpleLines, false);
+test('"lines: true" splits lines, stderr, string', testStreamLines, 2, simpleFull, simpleLines, false);
+test('"lines: true" splits lines, stdio[*], string', testStreamLines, 3, simpleFull, simpleLines, false);
+test('"lines: true" splits lines, stdout, string, stripFinalNewline', testStreamLines, 1, simpleFull, noNewlinesChunks, true);
+test('"lines: true" splits lines, stderr, string, stripFinalNewline', testStreamLines, 2, simpleFull, noNewlinesChunks, true);
+test('"lines: true" splits lines, stdio[*], string, stripFinalNewline', testStreamLines, 3, simpleFull, noNewlinesChunks, true);
 
 const testStreamLinesNoop = async (t, lines, execaMethod) => {
 	const {stdout} = await execaMethod('noop-fd.js', ['1', simpleFull], {lines});
@@ -101,36 +95,31 @@ const testOtherEncoding = async (t, stripFinalNewline, strippedLine) => {
 test('"lines: true" does not work with other encodings', testOtherEncoding, false, singleLine);
 test('"lines: true" does not work with other encodings, stripFinalNewline', testOtherEncoding, true, singleLineStrip);
 
-const getSimpleChunkSubprocess = (isUint8Array, stripFinalNewline, options) => execa('noop-fd.js', ['1', ...simpleChunks], {
+const getSimpleChunkSubprocess = (stripFinalNewline, options) => execa('noop-fd.js', ['1', ...simpleChunks], {
 	lines: true,
-	encoding: getEncoding(isUint8Array),
 	stripFinalNewline,
 	...options,
 });
 
-const testAsyncIteration = async (t, expectedOutput, isUint8Array, stripFinalNewline) => {
-	const subprocess = getSimpleChunkSubprocess(isUint8Array, stripFinalNewline);
+const testAsyncIteration = async (t, expectedOutput, stripFinalNewline) => {
+	const subprocess = getSimpleChunkSubprocess(stripFinalNewline);
 	const [stdout] = await Promise.all([subprocess.stdout.toArray(), subprocess]);
-	t.deepEqual(stdout, stringsToUint8Arrays(expectedOutput, isUint8Array));
+	t.deepEqual(stdout, expectedOutput);
 };
 
-test('"lines: true" works with stream async iteration, string', testAsyncIteration, simpleLines, false, false);
-test('"lines: true" works with stream async iteration, Uint8Array', testAsyncIteration, simpleLines, true, false);
-test('"lines: true" works with stream async iteration, string, stripFinalNewline', testAsyncIteration, noNewlinesChunks, false, true);
-test('"lines: true" works with stream async iteration, Uint8Array, stripFinalNewline', testAsyncIteration, noNewlinesChunks, true, true);
+test('"lines: true" works with stream async iteration, string', testAsyncIteration, simpleLines, false);
+test('"lines: true" works with stream async iteration, string, stripFinalNewline', testAsyncIteration, noNewlinesChunks, true);
 
-const testDataEvents = async (t, expectedOutput, isUint8Array, stripFinalNewline) => {
-	const subprocess = getSimpleChunkSubprocess(isUint8Array, stripFinalNewline);
+const testDataEvents = async (t, [expectedFirstLine], stripFinalNewline) => {
+	const subprocess = getSimpleChunkSubprocess(stripFinalNewline);
 	const [[firstLine]] = await Promise.all([once(subprocess.stdout, 'data'), subprocess]);
-	t.deepEqual(firstLine, stringsToUint8Arrays(expectedOutput, isUint8Array)[0]);
+	t.deepEqual(firstLine, expectedFirstLine);
 };
 
-test('"lines: true" works with stream "data" events, string', testDataEvents, simpleLines, false, false);
-test('"lines: true" works with stream "data" events, Uint8Array', testDataEvents, simpleLines, true, false);
-test('"lines: true" works with stream "data" events, string, stripFinalNewline', testDataEvents, noNewlinesChunks, false, true);
-test('"lines: true" works with stream "data" events, Uint8Array, stripFinalNewline', testDataEvents, noNewlinesChunks, true, true);
+test('"lines: true" works with stream "data" events, string', testDataEvents, simpleLines, false);
+test('"lines: true" works with stream "data" events, string, stripFinalNewline', testDataEvents, noNewlinesChunks, true);
 
-const testWritableStream = async (t, expectedOutput, isUint8Array, stripFinalNewline) => {
+const testWritableStream = async (t, expectedOutput, stripFinalNewline) => {
 	const lines = [];
 	const writable = new Writable({
 		write(line, encoding, done) {
@@ -139,11 +128,9 @@ const testWritableStream = async (t, expectedOutput, isUint8Array, stripFinalNew
 		},
 		decodeStrings: false,
 	});
-	await getSimpleChunkSubprocess(isUint8Array, stripFinalNewline, {stdout: ['pipe', writable]});
-	t.deepEqual(lines, stringsToBuffers(expectedOutput, isUint8Array));
+	await getSimpleChunkSubprocess(stripFinalNewline, {stdout: ['pipe', writable]});
+	t.deepEqual(lines, expectedOutput);
 };
 
-test('"lines: true" works with writable streams targets, string', testWritableStream, simpleLines, false, false);
-test('"lines: true" works with writable streams targets, Uint8Array', testWritableStream, simpleLines, true, false);
-test('"lines: true" works with writable streams targets, string, stripFinalNewline', testWritableStream, noNewlinesChunks, false, true);
-test('"lines: true" works with writable streams targets, Uint8Array, stripFinalNewline', testWritableStream, noNewlinesChunks, true, true);
+test('"lines: true" works with writable streams targets, string', testWritableStream, simpleLines, false);
+test('"lines: true" works with writable streams targets, string, stripFinalNewline', testWritableStream, noNewlinesChunks, true);

--- a/test/stdio/transform.js
+++ b/test/stdio/transform.js
@@ -66,11 +66,11 @@ const testHighWaterMark = async (t, passThrough, binary, objectMode) => {
 			...(objectMode ? [outputObjectGenerator] : []),
 			writerGenerator,
 			...(passThrough ? [noopGenerator(false, binary)] : []),
-			{transform: getLengthGenerator.bind(undefined, t), binary: true, objectMode: true},
+			{transform: getLengthGenerator.bind(undefined, t), preserveNewlines: true, objectMode: true},
 		],
 	});
 	t.is(stdout.length, repeatCount);
-	t.true(stdout.every(chunk => chunk.toString() === '\n'));
+	t.true(stdout.every(chunk => chunk === '\n'));
 };
 
 test('Synchronous yields are not buffered, no passThrough', testHighWaterMark, false, false, false);


### PR DESCRIPTION
Using the `encoding: 'buffer'` option means the subprocess' output is binary.

Some of our logic splits the subprocess' output into lines. This does not make sense for binary data, only text data. Binary data is very rarely divided into newline-delimited chunks of data.

Based on this, if the `encoding: 'buffer'` option is used, we should not attempt to split the subprocess' output into lines, or iterate over lines. Furthermore, we should use `Uint8Array` instead of strings. This means:
  - Transforms and `subprocess.iterable()` should pass `Uint8Array` as arguments (instead of strings)
  - `subprocess.readable()` and `subprocess.duplex()` should not set the encoding to `utf8`, i.e. its chunks should be `Buffer` (instead of string)
  - Transforms, `subprocess.iterable()`, `subprocess.readable()` and `subprocess.duplex()` should iterate over arbitrary chunks of data (instead of lines)
  - The `lines` option should be `false`

This PR implements the above points.