### PR TITLE
Refactor `stdio` option

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -16,11 +16,11 @@ import {getSubprocessResult} from './stream/resolve.js';
 import {mergePromise} from './promise.js';
 
 export const execa = (rawFile, rawArgs, rawOptions) => {
-	const {file, args, command, escapedCommand, startTime, verboseInfo, options, stdioStreamsGroups, stdioState} = handleAsyncArguments(rawFile, rawArgs, rawOptions);
-	const {subprocess, promise} = spawnSubprocessAsync({file, args, options, startTime, verboseInfo, command, escapedCommand, stdioStreamsGroups, stdioState});
+	const {file, args, command, escapedCommand, startTime, verboseInfo, options, fileDescriptors, stdioState} = handleAsyncArguments(rawFile, rawArgs, rawOptions);
+	const {subprocess, promise} = spawnSubprocessAsync({file, args, options, startTime, verboseInfo, command, escapedCommand, fileDescriptors, stdioState});
 	subprocess.pipe = pipeToSubprocess.bind(undefined, {source: subprocess, sourcePromise: promise, boundOptions: {}});
 	mergePromise(subprocess, promise);
-	SUBPROCESS_OPTIONS.set(subprocess, {options, stdioStreamsGroups});
+	SUBPROCESS_OPTIONS.set(subprocess, {options, fileDescriptors});
 	return subprocess;
 };
 
@@ -31,8 +31,8 @@ const handleAsyncArguments = (rawFile, rawArgs, rawOptions) => {
 	try {
 		const {file, args, options: normalizedOptions} = handleArguments(rawFile, rawArgs, rawOptions);
 		const options = handleAsyncOptions(normalizedOptions);
-		const {stdioStreamsGroups, stdioState} = handleInputAsync(options, verboseInfo);
-		return {file, args, command, escapedCommand, startTime, verboseInfo, options, stdioStreamsGroups, stdioState};
+		const {fileDescriptors, stdioState} = handleInputAsync(options, verboseInfo);
+		return {file, args, command, escapedCommand, startTime, verboseInfo, options, fileDescriptors, stdioState};
 	} catch (error) {
 		logEarlyResult(error, startTime, verboseInfo);
 		throw error;
@@ -48,30 +48,30 @@ const handleAsyncOptions = ({timeout, signal, cancelSignal, ...options}) => {
 	return {...options, timeoutDuration: timeout, signal: cancelSignal};
 };
 
-const spawnSubprocessAsync = ({file, args, options, startTime, verboseInfo, command, escapedCommand, stdioStreamsGroups, stdioState}) => {
+const spawnSubprocessAsync = ({file, args, options, startTime, verboseInfo, command, escapedCommand, fileDescriptors, stdioState}) => {
 	let subprocess;
 	try {
 		subprocess = spawn(file, args, options);
 	} catch (error) {
-		return handleEarlyError({error, command, escapedCommand, stdioStreamsGroups, options, startTime, verboseInfo});
+		return handleEarlyError({error, command, escapedCommand, fileDescriptors, options, startTime, verboseInfo});
 	}
 
 	const controller = new AbortController();
 	setMaxListeners(Number.POSITIVE_INFINITY, controller.signal);
 
 	const originalStreams = [...subprocess.stdio];
-	pipeOutputAsync(subprocess, stdioStreamsGroups, stdioState, controller);
+	pipeOutputAsync(subprocess, fileDescriptors, stdioState, controller);
 	cleanupOnExit(subprocess, options, controller);
 
 	subprocess.kill = subprocessKill.bind(undefined, {kill: subprocess.kill.bind(subprocess), subprocess, options, controller});
 	subprocess.all = makeAllStream(subprocess, options);
 	addConvertedStreams(subprocess, options);
 
-	const promise = handlePromise({subprocess, options, startTime, verboseInfo, stdioStreamsGroups, originalStreams, command, escapedCommand, controller});
+	const promise = handlePromise({subprocess, options, startTime, verboseInfo, fileDescriptors, originalStreams, command, escapedCommand, controller});
 	return {subprocess, promise};
 };
 
-const handlePromise = async ({subprocess, options, startTime, verboseInfo, stdioStreamsGroups, originalStreams, command, escapedCommand, controller}) => {
+const handlePromise = async ({subprocess, options, startTime, verboseInfo, fileDescriptors, originalStreams, command, escapedCommand, controller}) => {
 	const context = {timedOut: false};
 
 	const [
@@ -79,7 +79,7 @@ const handlePromise = async ({subprocess, options, startTime, verboseInfo, stdio
 		[exitCode, signal],
 		stdioResults,
 		allResult,
-	] = await getSubprocessResult({subprocess, options, context, stdioStreamsGroups, originalStreams, controller});
+	] = await getSubprocessResult({subprocess, options, context, fileDescriptors, originalStreams, controller});
 	controller.abort();
 
 	const stdio = stdioResults.map(stdioResult => handleOutput(options, stdioResult));

--- a/lib/pipe/abort.js
+++ b/lib/pipe/abort.js
@@ -5,9 +5,9 @@ export const unpipeOnAbort = (unpipeSignal, ...args) => unpipeSignal === undefin
 	? []
 	: [unpipeOnSignalAbort(unpipeSignal, ...args)];
 
-const unpipeOnSignalAbort = async (unpipeSignal, {sourceStream, mergedStream, stdioStreamsGroups, sourceOptions, startTime}) => {
+const unpipeOnSignalAbort = async (unpipeSignal, {sourceStream, mergedStream, fileDescriptors, sourceOptions, startTime}) => {
 	await aborted(unpipeSignal, sourceStream);
 	await mergedStream.remove(sourceStream);
 	const error = new Error('Pipe cancelled by `unpipeSignal` option.');
-	throw createNonCommandError({error, stdioStreamsGroups, sourceOptions, startTime});
+	throw createNonCommandError({error, fileDescriptors, sourceOptions, startTime});
 };

--- a/lib/pipe/setup.js
+++ b/lib/pipe/setup.js
@@ -29,7 +29,7 @@ const handlePipePromise = async ({
 	destinationStream,
 	destinationError,
 	unpipeSignal,
-	stdioStreamsGroups,
+	fileDescriptors,
 	startTime,
 }) => {
 	const subprocessPromises = getSubprocessPromises(sourcePromise, destination);
@@ -38,7 +38,7 @@ const handlePipePromise = async ({
 		sourceError,
 		destinationStream,
 		destinationError,
-		stdioStreamsGroups,
+		fileDescriptors,
 		sourceOptions,
 		startTime,
 	});
@@ -47,7 +47,7 @@ const handlePipePromise = async ({
 		const mergedStream = pipeSubprocessStream(sourceStream, destinationStream, maxListenersController);
 		return await Promise.race([
 			waitForBothSubprocesses(subprocessPromises),
-			...unpipeOnAbort(unpipeSignal, {sourceStream, mergedStream, sourceOptions, stdioStreamsGroups, startTime}),
+			...unpipeOnAbort(unpipeSignal, {sourceStream, mergedStream, sourceOptions, fileDescriptors, startTime}),
 		]);
 	} finally {
 		maxListenersController.abort();

--- a/lib/pipe/throw.js
+++ b/lib/pipe/throw.js
@@ -6,13 +6,13 @@ export const handlePipeArgumentsError = ({
 	sourceError,
 	destinationStream,
 	destinationError,
-	stdioStreamsGroups,
+	fileDescriptors,
 	sourceOptions,
 	startTime,
 }) => {
 	const error = getPipeArgumentsError({sourceStream, sourceError, destinationStream, destinationError});
 	if (error !== undefined) {
-		throw createNonCommandError({error, stdioStreamsGroups, sourceOptions, startTime});
+		throw createNonCommandError({error, fileDescriptors, sourceOptions, startTime});
 	}
 };
 
@@ -32,11 +32,11 @@ const getPipeArgumentsError = ({sourceStream, sourceError, destinationStream, de
 	}
 };
 
-export const createNonCommandError = ({error, stdioStreamsGroups, sourceOptions, startTime}) => makeEarlyError({
+export const createNonCommandError = ({error, fileDescriptors, sourceOptions, startTime}) => makeEarlyError({
 	error,
 	command: PIPE_COMMAND_MESSAGE,
 	escapedCommand: PIPE_COMMAND_MESSAGE,
-	stdioStreamsGroups,
+	fileDescriptors,
 	options: sourceOptions,
 	startTime,
 	isSync: false,

--- a/lib/pipe/validate.js
+++ b/lib/pipe/validate.js
@@ -14,7 +14,7 @@ export const normalizePipeArguments = ({source, sourcePromise, boundOptions}, ..
 		unpipeSignal,
 	} = getDestinationStream(boundOptions, args);
 	const {sourceStream, sourceError} = getSourceStream(source, from);
-	const {options: sourceOptions, stdioStreamsGroups} = SUBPROCESS_OPTIONS.get(source);
+	const {options: sourceOptions, fileDescriptors} = SUBPROCESS_OPTIONS.get(source);
 	return {
 		sourcePromise,
 		sourceStream,
@@ -24,7 +24,7 @@ export const normalizePipeArguments = ({source, sourcePromise, boundOptions}, ..
 		destinationStream,
 		destinationError,
 		unpipeSignal,
-		stdioStreamsGroups,
+		fileDescriptors,
 		startTime,
 	};
 };
@@ -75,8 +75,8 @@ export const SUBPROCESS_OPTIONS = new WeakMap();
 
 export const getWritable = (destination, to = 'stdin') => {
 	const isWritable = true;
-	const {options, stdioStreamsGroups} = SUBPROCESS_OPTIONS.get(destination);
-	const fdNumber = getFdNumber(stdioStreamsGroups, to, isWritable);
+	const {options, fileDescriptors} = SUBPROCESS_OPTIONS.get(destination);
+	const fdNumber = getFdNumber(fileDescriptors, to, isWritable);
 	const destinationStream = destination.stdio[fdNumber];
 
 	if (destinationStream === null) {
@@ -97,8 +97,8 @@ const getSourceStream = (source, from) => {
 
 export const getReadable = (source, from = 'stdout') => {
 	const isWritable = false;
-	const {options, stdioStreamsGroups} = SUBPROCESS_OPTIONS.get(source);
-	const fdNumber = getFdNumber(stdioStreamsGroups, from, isWritable);
+	const {options, fileDescriptors} = SUBPROCESS_OPTIONS.get(source);
+	const fdNumber = getFdNumber(fileDescriptors, from, isWritable);
 	const sourceStream = fdNumber === 'all' ? source.all : source.stdio[fdNumber];
 
 	if (sourceStream === null || sourceStream === undefined) {
@@ -108,9 +108,9 @@ export const getReadable = (source, from = 'stdout') => {
 	return sourceStream;
 };
 
-const getFdNumber = (stdioStreamsGroups, fdName, isWritable) => {
+const getFdNumber = (fileDescriptors, fdName, isWritable) => {
 	const fdNumber = parseFdNumber(fdName, isWritable);
-	validateFdNumber(fdNumber, fdName, isWritable, stdioStreamsGroups);
+	validateFdNumber(fdNumber, fdName, isWritable, fileDescriptors);
 	return fdNumber;
 };
 
@@ -138,19 +138,19 @@ It is optional and defaults to "${defaultValue}".`);
 
 const FD_REGEXP = /^fd(\d+)$/;
 
-const validateFdNumber = (fdNumber, fdName, isWritable, stdioStreamsGroups) => {
+const validateFdNumber = (fdNumber, fdName, isWritable, fileDescriptors) => {
 	const usedDescriptor = getUsedDescriptor(fdNumber);
-	const stdioStreams = stdioStreamsGroups[usedDescriptor];
-	if (stdioStreams === undefined) {
+	const fileDescriptor = fileDescriptors.find(fileDescriptor => fileDescriptor.fdNumber === usedDescriptor);
+	if (fileDescriptor === undefined) {
 		throw new TypeError(`"${getOptionName(isWritable)}" must not be ${fdName}. That file descriptor does not exist.
 Please set the "stdio" option to ensure that file descriptor exists.`);
 	}
 
-	if (stdioStreams[0].direction === 'input' && !isWritable) {
+	if (fileDescriptor.direction === 'input' && !isWritable) {
 		throw new TypeError(`"${getOptionName(isWritable)}" must not be ${fdName}. It must be a readable stream, not writable.`);
 	}
 
-	if (stdioStreams[0].direction !== 'input' && isWritable) {
+	if (fileDescriptor.direction !== 'input' && isWritable) {
 		throw new TypeError(`"${getOptionName(isWritable)}" must not be ${fdName}. It must be a writable stream, not readable.`);
 	}
 };

--- a/lib/return/early-error.js
+++ b/lib/return/early-error.js
@@ -1,28 +1,28 @@
 import {ChildProcess} from 'node:child_process';
 import {PassThrough, Readable, Writable, Duplex} from 'node:stream';
-import {cleanupStdioStreams} from '../stdio/async.js';
+import {cleanupCustomStreams} from '../stdio/async.js';
 import {makeEarlyError} from './error.js';
 import {handleResult} from './output.js';
 
 // When the subprocess fails to spawn.
 // We ensure the returned error is always both a promise and a subprocess.
-export const handleEarlyError = ({error, command, escapedCommand, stdioStreamsGroups, options, startTime, verboseInfo}) => {
-	cleanupStdioStreams(stdioStreamsGroups);
+export const handleEarlyError = ({error, command, escapedCommand, fileDescriptors, options, startTime, verboseInfo}) => {
+	cleanupCustomStreams(fileDescriptors);
 
 	const subprocess = new ChildProcess();
-	createDummyStreams(subprocess, stdioStreamsGroups);
+	createDummyStreams(subprocess, fileDescriptors);
 	Object.assign(subprocess, {readable, writable, duplex});
 
-	const earlyError = makeEarlyError({error, command, escapedCommand, stdioStreamsGroups, options, startTime, isSync: false});
+	const earlyError = makeEarlyError({error, command, escapedCommand, fileDescriptors, options, startTime, isSync: false});
 	const promise = handleDummyPromise(earlyError, verboseInfo, options);
 	return {subprocess, promise};
 };
 
-const createDummyStreams = (subprocess, stdioStreamsGroups) => {
+const createDummyStreams = (subprocess, fileDescriptors) => {
 	const stdin = createDummyStream();
 	const stdout = createDummyStream();
 	const stderr = createDummyStream();
-	const extraStdio = Array.from({length: stdioStreamsGroups.length - 3}, createDummyStream);
+	const extraStdio = Array.from({length: fileDescriptors.length - 3}, createDummyStream);
 	const all = createDummyStream();
 	const stdio = [stdin, stdout, stderr, ...extraStdio];
 	Object.assign(subprocess, {stdin, stdout, stderr, all, stdio});

--- a/lib/return/error.js
+++ b/lib/return/error.js
@@ -34,7 +34,7 @@ export const makeEarlyError = ({
 	error,
 	command,
 	escapedCommand,
-	stdioStreamsGroups,
+	fileDescriptors,
 	options,
 	startTime,
 	isSync,
@@ -45,7 +45,7 @@ export const makeEarlyError = ({
 	startTime,
 	timedOut: false,
 	isCanceled: false,
-	stdio: Array.from({length: stdioStreamsGroups.length}),
+	stdio: Array.from({length: fileDescriptors.length}),
 	options,
 	isSync,
 });

--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -18,36 +18,41 @@ const forbiddenIfAsync = ({type, optionName}) => {
 const addPropertiesAsync = {
 	input: {
 		generator: generatorToDuplexStream,
-		fileUrl: ({value}) => ({value: createReadStream(value)}),
-		filePath: ({value}) => ({value: createReadStream(value.file)}),
-		webStream: ({value}) => ({value: Readable.fromWeb(value)}),
-		iterable: ({value}) => ({value: Readable.from(value)}),
-		string: ({value}) => ({value: Readable.from(value)}),
-		uint8Array: ({value}) => ({value: Readable.from(Buffer.from(value))}),
+		fileUrl: ({value}) => ({stream: createReadStream(value)}),
+		filePath: ({value}) => ({stream: createReadStream(value.file)}),
+		webStream: ({value}) => ({stream: Readable.fromWeb(value)}),
+		nodeStream: ({value}) => ({stream: value}),
+		iterable: ({value}) => ({stream: Readable.from(value)}),
+		string: ({value}) => ({stream: Readable.from(value)}),
+		uint8Array: ({value}) => ({stream: Readable.from(Buffer.from(value))}),
+		native() {},
 	},
 	output: {
 		generator: generatorToDuplexStream,
-		fileUrl: ({value}) => ({value: createWriteStream(value)}),
-		filePath: ({value}) => ({value: createWriteStream(value.file)}),
-		webStream: ({value}) => ({value: Writable.fromWeb(value)}),
+		fileUrl: ({value}) => ({stream: createWriteStream(value)}),
+		filePath: ({value}) => ({stream: createWriteStream(value.file)}),
+		webStream: ({value}) => ({stream: Writable.fromWeb(value)}),
+		nodeStream: ({value}) => ({stream: value}),
 		iterable: forbiddenIfAsync,
+		string: forbiddenIfAsync,
 		uint8Array: forbiddenIfAsync,
+		native() {},
 	},
 };
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, after spawning, in async mode
 // When multiple input streams are used, we merge them to ensure the output stream ends only once each input stream has ended
-export const pipeOutputAsync = (subprocess, stdioStreamsGroups, stdioState, controller) => {
+export const pipeOutputAsync = (subprocess, fileDescriptors, stdioState, controller) => {
 	stdioState.subprocess = subprocess;
 	const inputStreamsGroups = {};
 
-	for (const stdioStreams of stdioStreamsGroups) {
-		for (const generatorStream of stdioStreams.filter(({type}) => type === 'generator')) {
-			pipeGenerator(subprocess, generatorStream);
+	for (const {stdioItems, direction, fdNumber} of fileDescriptors) {
+		for (const {stream} of stdioItems.filter(({type}) => type === 'generator')) {
+			pipeGenerator(subprocess, stream, direction, fdNumber);
 		}
 
-		for (const nonGeneratorStream of stdioStreams.filter(({type}) => type !== 'generator')) {
-			pipeStdioOption(subprocess, nonGeneratorStream, inputStreamsGroups, controller);
+		for (const {stream} of stdioItems.filter(({type}) => type !== 'generator')) {
+			pipeStdioItem({subprocess, stream, direction, fdNumber, inputStreamsGroups, controller});
 		}
 	}
 
@@ -57,17 +62,17 @@ export const pipeOutputAsync = (subprocess, stdioStreamsGroups, stdioState, cont
 	}
 };
 
-const pipeStdioOption = (subprocess, {type, value, direction, fdNumber}, inputStreamsGroups, controller) => {
-	if (type === 'native') {
+const pipeStdioItem = ({subprocess, stream, direction, fdNumber, inputStreamsGroups, controller}) => {
+	if (stream === undefined) {
 		return;
 	}
 
-	setStandardStreamMaxListeners(value, controller);
+	setStandardStreamMaxListeners(stream, controller);
 
 	if (direction === 'output') {
-		pipeStreams(subprocess.stdio[fdNumber], value);
+		pipeStreams(subprocess.stdio[fdNumber], stream);
 	} else {
-		inputStreamsGroups[fdNumber] = [...(inputStreamsGroups[fdNumber] ?? []), value];
+		inputStreamsGroups[fdNumber] = [...(inputStreamsGroups[fdNumber] ?? []), stream];
 	}
 };
 
@@ -88,10 +93,12 @@ const MAX_LISTENERS_INCREMENT = 2;
 // If the subprocess spawning fails (e.g. due to an invalid command), the streams need to be manually destroyed.
 // We need to create those streams before subprocess spawning, in case their creation fails, e.g. when passing an invalid generator as argument.
 // Like this, an exception would be thrown, which would prevent spawning a subprocess.
-export const cleanupStdioStreams = stdioStreamsGroups => {
-	for (const {value, type} of stdioStreamsGroups.flat()) {
-		if (type !== 'native' && !isStandardStream(value)) {
-			value.destroy();
+export const cleanupCustomStreams = fileDescriptors => {
+	for (const {stdioItems} of fileDescriptors) {
+		for (const {stream} of stdioItems) {
+			if (stream !== undefined && !isStandardStream(stream)) {
+				stream.destroy();
+			}
 		}
 	}
 };

--- a/lib/stdio/direction.js
+++ b/lib/stdio/direction.js
@@ -10,18 +10,17 @@ import {isWritableStream} from './type.js';
 // This allows us to know whether to pipe _into_ or _from_ the stream.
 // When `stdio[fdNumber]` is a single value, this guess is fairly straightforward.
 // However, when it is an array instead, we also need to make sure the different values are not incompatible with each other.
-export const addStreamDirection = stdioStreams => {
-	const directions = stdioStreams.map(stdioStream => getStreamDirection(stdioStream));
+export const getStreamDirection = (stdioItems, fdNumber, optionName) => {
+	const directions = stdioItems.map(stdioItem => getStdioItemDirection(stdioItem, fdNumber));
 
 	if (directions.includes('input') && directions.includes('output')) {
-		throw new TypeError(`The \`${stdioStreams[0].optionName}\` option must not be an array of both readable and writable values.`);
+		throw new TypeError(`The \`${optionName}\` option must not be an array of both readable and writable values.`);
 	}
 
-	const direction = directions.find(Boolean);
-	return stdioStreams.map(stdioStream => addDirection(stdioStream, direction));
+	return directions.find(Boolean) ?? DEFAULT_DIRECTION;
 };
 
-const getStreamDirection = ({fdNumber, type, value}) => KNOWN_DIRECTIONS[fdNumber] ?? guessStreamDirection[type](value);
+const getStdioItemDirection = ({type, value}, fdNumber) => KNOWN_DIRECTIONS[fdNumber] ?? guessStreamDirection[type](value);
 
 // `stdin`/`stdout`/`stderr` have a known direction
 const KNOWN_DIRECTIONS = ['input', 'output', 'output'];
@@ -36,42 +35,40 @@ const guessStreamDirection = {
 	filePath: anyDirection,
 	iterable: alwaysInput,
 	uint8Array: alwaysInput,
-	webStream: stdioOption => isWritableStream(stdioOption) ? 'output' : 'input',
-	nodeStream(stdioOption) {
-		const standardStreamDirection = getStandardStreamDirection(stdioOption);
+	webStream: value => isWritableStream(value) ? 'output' : 'input',
+	nodeStream(value) {
+		const standardStreamDirection = getStandardStreamDirection(value);
 		if (standardStreamDirection !== undefined) {
 			return standardStreamDirection;
 		}
 
-		if (!isNodeReadableStream(stdioOption, {checkOpen: false})) {
+		if (!isNodeReadableStream(value, {checkOpen: false})) {
 			return 'output';
 		}
 
-		return isNodeWritableStream(stdioOption, {checkOpen: false}) ? undefined : 'input';
+		return isNodeWritableStream(value, {checkOpen: false}) ? undefined : 'input';
 	},
-	native(stdioOption) {
-		const standardStreamDirection = getStandardStreamDirection(stdioOption);
+	native(value) {
+		const standardStreamDirection = getStandardStreamDirection(value);
 		if (standardStreamDirection !== undefined) {
 			return standardStreamDirection;
 		}
 
-		if (isNodeStream(stdioOption, {checkOpen: false})) {
-			return guessStreamDirection.nodeStream(stdioOption);
+		if (isNodeStream(value, {checkOpen: false})) {
+			return guessStreamDirection.nodeStream(value);
 		}
 	},
 };
 
-const getStandardStreamDirection = stdioOption => {
-	if ([0, process.stdin].includes(stdioOption)) {
+const getStandardStreamDirection = value => {
+	if ([0, process.stdin].includes(value)) {
 		return 'input';
 	}
 
-	if ([1, 2, process.stdout, process.stderr].includes(stdioOption)) {
+	if ([1, 2, process.stdout, process.stderr].includes(value)) {
 		return 'output';
 	}
 };
-
-const addDirection = (stdioStream, direction = DEFAULT_DIRECTION) => ({...stdioStream, direction});
 
 // When ambiguous, we initially keep the direction as `undefined`.
 // This allows arrays of `stdio` values to resolve the ambiguity.

--- a/lib/stdio/encoding-final.js
+++ b/lib/stdio/encoding-final.js
@@ -1,40 +1,34 @@
 import {StringDecoder} from 'node:string_decoder';
 import {isSimpleEncoding} from '../encoding.js';
-import {willPipeStreams} from './forward.js';
 
 // Apply the `encoding` option using an implicit generator.
 // This encodes the final output of `stdout`/`stderr`.
-export const handleStreamsEncoding = (stdioStreams, {encoding}, isSync) => {
-	const newStdioStreams = stdioStreams.map(stdioStream => ({...stdioStream, encoding}));
-	if (!shouldEncodeOutput(newStdioStreams, encoding, isSync)) {
-		return newStdioStreams;
-	}
-
-	const lastObjectStdioStream = newStdioStreams.findLast(({type, value}) => type === 'generator' && value.objectMode !== undefined);
-	const writableObjectMode = lastObjectStdioStream !== undefined && lastObjectStdioStream.value.objectMode;
-	if (writableObjectMode) {
-		return newStdioStreams;
+export const handleStreamsEncoding = ({stdioItems, options: {encoding}, isSync, direction, optionName}) => {
+	if (!shouldEncodeOutput({stdioItems, encoding, isSync, direction})) {
+		return [];
 	}
 
 	const stringDecoder = new StringDecoder(encoding);
-	return [
-		...newStdioStreams,
-		{
-			...newStdioStreams[0],
-			type: 'generator',
-			value: {
-				transform: encodingStringGenerator.bind(undefined, stringDecoder),
-				final: encodingStringFinal.bind(undefined, stringDecoder),
-				binary: true,
-			},
+	return [{
+		type: 'generator',
+		value: {
+			transform: encodingStringGenerator.bind(undefined, stringDecoder),
+			final: encodingStringFinal.bind(undefined, stringDecoder),
+			binary: true,
 		},
-	];
+		optionName,
+	}];
 };
 
-const shouldEncodeOutput = (stdioStreams, encoding, isSync) => stdioStreams[0].direction === 'output'
+const shouldEncodeOutput = ({stdioItems, encoding, isSync, direction}) => direction === 'output'
 	&& !isSimpleEncoding(encoding)
 	&& !isSync
-	&& willPipeStreams(stdioStreams);
+	&& !isWritableObjectMode(stdioItems);
+
+const isWritableObjectMode = stdioItems => {
+	const lastObjectStdioItem = stdioItems.findLast(({type, value}) => type === 'generator' && value.objectMode !== undefined);
+	return lastObjectStdioItem !== undefined && lastObjectStdioItem.value.objectMode;
+};
 
 const encodingStringGenerator = function * (stringDecoder, chunk) {
 	yield stringDecoder.write(chunk);

--- a/lib/stdio/forward.js
+++ b/lib/stdio/forward.js
@@ -1,18 +1,16 @@
-// When the `std*: Iterable | WebStream | URL | filePath`, `input` or `inputFile` option is used, we pipe to `subprocess.std*`.
-// When the `std*: Array` option is used, we emulate some of the native values ('inherit', Node.js stream and file descriptor integer). To do so, we also need to pipe to `subprocess.std*`.
-// Therefore the `std*` options must be either `pipe` or `overlapped`. Other values do not set `subprocess.std*`.
-export const forwardStdio = stdioStreamsGroups => stdioStreamsGroups.map(stdioStreams => forwardStdioItem(stdioStreams));
-
 // Whether `subprocess.std*` will be set
-export const willPipeStreams = stdioStreams => PIPED_STDIO_VALUES.has(forwardStdioItem(stdioStreams));
+export const willPipeFileDescriptor = stdioItems => PIPED_STDIO_VALUES.has(forwardStdio(stdioItems));
 
 export const PIPED_STDIO_VALUES = new Set(['pipe', 'overlapped', undefined, null]);
 
-const forwardStdioItem = stdioStreams => {
-	if (stdioStreams.length > 1) {
-		return stdioStreams.some(({value}) => value === 'overlapped') ? 'overlapped' : 'pipe';
+// When the `std*: Iterable | WebStream | URL | filePath`, `input` or `inputFile` option is used, we pipe to `subprocess.std*`.
+// When the `std*: Array` option is used, we emulate some of the native values ('inherit', Node.js stream and file descriptor integer). To do so, we also need to pipe to `subprocess.std*`.
+// Therefore the `std*` options must be either `pipe` or `overlapped`. Other values do not set `subprocess.std*`.
+export const forwardStdio = stdioItems => {
+	if (stdioItems.length > 1) {
+		return stdioItems.some(({value}) => value === 'overlapped') ? 'overlapped' : 'pipe';
 	}
 
-	const [stdioStream] = stdioStreams;
-	return stdioStream.type !== 'native' && stdioStream.value !== 'overlapped' ? 'pipe' : stdioStream.value;
+	const [{type, value}] = stdioItems;
+	return type === 'native' ? value : 'pipe';
 };

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -6,20 +6,20 @@ import {pipeStreams} from './pipeline.js';
 import {isGeneratorOptions, isAsyncGenerator} from './type.js';
 import {getValidateTransformReturn} from './validate.js';
 
-export const normalizeGenerators = (stdioStreams, options) => {
-	const nonGenerators = stdioStreams.filter(({type}) => type !== 'generator');
-	const generators = stdioStreams.filter(({type}) => type === 'generator');
+export const normalizeGenerators = (stdioItems, direction, {encoding}) => {
+	const nonGenerators = stdioItems.filter(({type}) => type !== 'generator');
+	const generators = stdioItems.filter(({type}) => type === 'generator');
 
 	const newGenerators = Array.from({length: generators.length});
 
-	for (const [index, stdioStream] of Object.entries(generators)) {
-		newGenerators[index] = normalizeGenerator(stdioStream, Number(index), newGenerators, options);
+	for (const [index, stdioItem] of Object.entries(generators)) {
+		newGenerators[index] = normalizeGenerator({stdioItem, index: Number(index), newGenerators, direction, encoding});
 	}
 
-	return [...nonGenerators, ...sortGenerators(newGenerators)];
+	return [...nonGenerators, ...sortGenerators(newGenerators, direction)];
 };
 
-const normalizeGenerator = ({value, ...stdioStream}, index, newGenerators, {encoding}) => {
+const normalizeGenerator = ({stdioItem, stdioItem: {value}, index, newGenerators, direction, encoding}) => {
 	const {
 		transform,
 		final,
@@ -28,10 +28,10 @@ const normalizeGenerator = ({value, ...stdioStream}, index, newGenerators, {enco
 		objectMode,
 	} = isGeneratorOptions(value) ? value : {transform: value};
 	const binary = binaryOption || isBinaryEncoding(encoding);
-	const objectModes = stdioStream.direction === 'output'
+	const objectModes = direction === 'output'
 		? getOutputObjectModes(objectMode, index, newGenerators)
 		: getInputObjectModes(objectMode, index, newGenerators);
-	return {...stdioStream, value: {transform, final, binary, preserveNewlines, ...objectModes}};
+	return {...stdioItem, value: {transform, final, binary, preserveNewlines, ...objectModes}};
 };
 
 /*
@@ -57,7 +57,7 @@ const getInputObjectModes = (objectMode, index, newGenerators) => {
 	return {writableObjectMode, readableObjectMode};
 };
 
-const sortGenerators = newGenerators => newGenerators[0]?.direction === 'input' ? newGenerators.reverse() : newGenerators;
+const sortGenerators = (newGenerators, direction) => direction === 'input' ? newGenerators.reverse() : newGenerators;
 
 /*
 Generators can be used to transform/filter standard streams.
@@ -90,24 +90,24 @@ export const generatorToDuplexStream = ({
 	].filter(Boolean);
 	const transformAsync = isAsyncGenerator(transform);
 	const finalAsync = isAsyncGenerator(final);
-	const duplexStream = generatorsToTransform(generators, {transformAsync, finalAsync, writableObjectMode, readableObjectMode});
-	return {value: duplexStream};
+	const stream = generatorsToTransform(generators, {transformAsync, finalAsync, writableObjectMode, readableObjectMode});
+	return {stream};
 };
 
 // `subprocess.stdin|stdout|stderr|stdio` is directly mutated.
-export const pipeGenerator = (subprocess, {value, direction, fdNumber}) => {
+export const pipeGenerator = (subprocess, stream, direction, fdNumber) => {
 	if (direction === 'output') {
-		pipeStreams(subprocess.stdio[fdNumber], value);
+		pipeStreams(subprocess.stdio[fdNumber], stream);
 	} else {
-		pipeStreams(value, subprocess.stdio[fdNumber]);
+		pipeStreams(stream, subprocess.stdio[fdNumber]);
 	}
 
 	const streamProperty = SUBPROCESS_STREAM_PROPERTIES[fdNumber];
 	if (streamProperty !== undefined) {
-		subprocess[streamProperty] = value;
+		subprocess[streamProperty] = stream;
 	}
 
-	subprocess.stdio[fdNumber] = value;
+	subprocess.stdio[fdNumber] = stream;
 };
 
 const SUBPROCESS_STREAM_PROPERTIES = ['stdin', 'stdout', 'stderr'];

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -1,58 +1,64 @@
 import {handleStreamsVerbose} from '../verbose/output.js';
-import {getStdioOptionType, isRegularUrl, isUnknownStdioString} from './type.js';
-import {addStreamDirection} from './direction.js';
+import {getStdioItemType, isRegularUrl, isUnknownStdioString} from './type.js';
+import {getStreamDirection} from './direction.js';
 import {normalizeStdio} from './option.js';
 import {handleNativeStream} from './native.js';
 import {handleInputOptions} from './input.js';
 import {handleStreamsLines} from './lines.js';
 import {handleStreamsEncoding} from './encoding-final.js';
 import {normalizeGenerators} from './generator.js';
-import {forwardStdio} from './forward.js';
+import {forwardStdio, willPipeFileDescriptor} from './forward.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async/sync mode
 export const handleInput = (addProperties, options, verboseInfo, isSync) => {
 	const stdioState = {};
 	const stdio = normalizeStdio(options);
-	const [stdinStreams, ...otherStreamsGroups] = stdio.map((stdioOption, fdNumber) => getStdioStreams(stdioOption, fdNumber));
-	const stdioStreamsGroups = [[...stdinStreams, ...handleInputOptions(options)], ...otherStreamsGroups]
-		.map(stdioStreams => validateStreams(stdioStreams))
-		.map(stdioStreams => addStreamDirection(stdioStreams))
-		.map(stdioStreams => handleStreamsVerbose({stdioStreams, options, isSync, stdioState, verboseInfo}))
-		.map(stdioStreams => handleStreamsLines(stdioStreams, options, isSync))
-		.map(stdioStreams => handleStreamsEncoding(stdioStreams, options, isSync))
-		.map(stdioStreams => normalizeGenerators(stdioStreams, options))
-		.map(stdioStreams => addStreamsProperties(stdioStreams, addProperties));
-	options.stdio = forwardStdio(stdioStreamsGroups);
-	return {stdioStreamsGroups, stdioState};
+	const fileDescriptors = stdio.map((stdioOption, fdNumber) =>
+		getFileDescriptor({stdioOption, fdNumber, addProperties, options, isSync, stdioState, verboseInfo}));
+	options.stdio = fileDescriptors.map(({stdioItems}) => forwardStdio(stdioItems));
+	return {fileDescriptors, stdioState};
 };
 
 // We make sure passing an array with a single item behaves the same as passing that item without an array.
 // This is what users would expect.
 // For example, `stdout: ['ignore']` behaves the same as `stdout: 'ignore'`.
-const getStdioStreams = (stdioOption, fdNumber) => {
+const getFileDescriptor = ({stdioOption, fdNumber, addProperties, options, isSync, stdioState, verboseInfo}) => {
 	const optionName = getOptionName(fdNumber);
-	const stdioOptions = Array.isArray(stdioOption) ? stdioOption : [stdioOption];
-	const rawStdioStreams = stdioOptions.map(stdioOption => getStdioStream(stdioOption, optionName, fdNumber));
-	const stdioStreams = filterDuplicates(rawStdioStreams);
-	const isStdioArray = stdioStreams.length > 1;
-	validateStdioArray(stdioStreams, isStdioArray, optionName);
-	return stdioStreams.map(stdioStream => handleNativeStream(stdioStream, isStdioArray));
+	const stdioItems = initializeStdioItems(stdioOption, fdNumber, options, optionName);
+	const direction = getStreamDirection(stdioItems, fdNumber, optionName);
+	const normalizedStdioItems = normalizeStdioItems({stdioItems, fdNumber, optionName, addProperties, options, isSync, direction, stdioState, verboseInfo});
+	return {fdNumber, direction, stdioItems: normalizedStdioItems};
 };
 
 const getOptionName = fdNumber => KNOWN_OPTION_NAMES[fdNumber] ?? `stdio[${fdNumber}]`;
 const KNOWN_OPTION_NAMES = ['stdin', 'stdout', 'stderr'];
 
-const getStdioStream = (stdioOption, optionName, fdNumber) => {
-	const type = getStdioOptionType(stdioOption, optionName);
-	return {type, value: stdioOption, optionName, fdNumber};
+const initializeStdioItems = (stdioOption, fdNumber, options, optionName) => {
+	const values = Array.isArray(stdioOption) ? stdioOption : [stdioOption];
+	const initialStdioItems = [
+		...values.map(value => initializeStdioItem(value, optionName)),
+		...handleInputOptions(options, fdNumber),
+	];
+
+	const stdioItems = filterDuplicates(initialStdioItems);
+	const isStdioArray = stdioItems.length > 1;
+	validateStdioArray(stdioItems, isStdioArray, optionName);
+	validateStreams(stdioItems);
+	return stdioItems.map(stdioItem => handleNativeStream(stdioItem, isStdioArray, fdNumber));
 };
 
-const filterDuplicates = stdioStreams => stdioStreams.filter((stdioStreamOne, indexOne) =>
-	stdioStreams.every((stdioStreamTwo, indexTwo) =>
-		stdioStreamOne.value !== stdioStreamTwo.value || indexOne >= indexTwo || stdioStreamOne.type === 'generator'));
+const initializeStdioItem = (value, optionName) => ({
+	type: getStdioItemType(value, optionName),
+	value,
+	optionName,
+});
 
-const validateStdioArray = (stdioStreams, isStdioArray, optionName) => {
-	if (stdioStreams.length === 0) {
+const filterDuplicates = stdioItems => stdioItems.filter((stdioItemOne, indexOne) =>
+	stdioItems.every((stdioItemTwo, indexTwo) =>
+		stdioItemOne.value !== stdioItemTwo.value || indexOne >= indexTwo || stdioItemOne.type === 'generator'));
+
+const validateStdioArray = (stdioItems, isStdioArray, optionName) => {
+	if (stdioItems.length === 0) {
 		throw new TypeError(`The \`${optionName}\` option must not be an empty array.`);
 	}
 
@@ -60,7 +66,7 @@ const validateStdioArray = (stdioStreams, isStdioArray, optionName) => {
 		return;
 	}
 
-	for (const {value, optionName} of stdioStreams) {
+	for (const {value, optionName} of stdioItems) {
 		if (INVALID_STDIO_ARRAY_OPTIONS.has(value)) {
 			throw new Error(`The \`${optionName}\` option must not include \`${value}\`.`);
 		}
@@ -71,12 +77,10 @@ const validateStdioArray = (stdioStreams, isStdioArray, optionName) => {
 // However, we do allow it if the array has a single item.
 const INVALID_STDIO_ARRAY_OPTIONS = new Set(['ignore', 'ipc']);
 
-const validateStreams = stdioStreams => {
-	for (const stdioStream of stdioStreams) {
-		validateFileStdio(stdioStream);
+const validateStreams = stdioItems => {
+	for (const stdioItem of stdioItems) {
+		validateFileStdio(stdioItem);
 	}
-
-	return stdioStreams;
 };
 
 const validateFileStdio = ({type, value, optionName}) => {
@@ -90,10 +94,32 @@ For example, you can use the \`pathToFileURL()\` method of the \`url\` core modu
 	}
 };
 
+const normalizeStdioItems = ({stdioItems, fdNumber, optionName, addProperties, options, isSync, direction, stdioState, verboseInfo}) => {
+	const allStdioItems = addInternalStdioItems({stdioItems, fdNumber, optionName, options, isSync, direction, stdioState, verboseInfo});
+	const normalizedStdioItems = normalizeGenerators(allStdioItems, direction, options);
+	return normalizedStdioItems.map(stdioItem => addStreamProperties(stdioItem, addProperties, direction));
+};
+
+const addInternalStdioItems = ({stdioItems, fdNumber, optionName, options, isSync, direction, stdioState, verboseInfo}) => {
+	if (!willPipeFileDescriptor(stdioItems)) {
+		return stdioItems;
+	}
+
+	const newStdioItems = [
+		...stdioItems,
+		...handleStreamsVerbose({stdioItems, options, isSync, stdioState, verboseInfo, fdNumber, optionName}),
+		...handleStreamsLines({options, isSync, direction, optionName}),
+	];
+	return [
+		...newStdioItems,
+		...handleStreamsEncoding({stdioItems: newStdioItems, options, isSync, direction, optionName}),
+	];
+};
+
 // Some `stdio` values require Execa to create streams.
 // For example, file paths create file read/write streams.
 // Those transformations are specified in `addProperties`, which is both direction-specific and type-specific.
-const addStreamsProperties = (stdioStreams, addProperties) => stdioStreams.map(stdioStream => ({
-	...stdioStream,
-	...addProperties[stdioStream.direction][stdioStream.type]?.(stdioStream),
-}));
+const addStreamProperties = (stdioItem, addProperties, direction) => ({
+	...stdioItem,
+	...addProperties[direction][stdioItem.type](stdioItem),
+});

--- a/lib/stdio/input.js
+++ b/lib/stdio/input.js
@@ -3,17 +3,18 @@ import {isUint8Array} from '../encoding.js';
 import {isUrl, isFilePathString} from './type.js';
 
 // Append the `stdin` option with the `input` and `inputFile` options
-export const handleInputOptions = ({input, inputFile}) => [
-	handleInputOption(input),
-	handleInputFileOption(inputFile),
-].filter(Boolean);
+export const handleInputOptions = ({input, inputFile}, fdNumber) => fdNumber === 0
+	? [
+		...handleInputOption(input),
+		...handleInputFileOption(inputFile),
+	]
+	: [];
 
-const handleInputOption = input => input === undefined ? undefined : {
+const handleInputOption = input => input === undefined ? [] : [{
 	type: getInputType(input),
 	value: input,
 	optionName: 'input',
-	fdNumber: 0,
-};
+}];
 
 const getInputType = input => {
 	if (isReadableStream(input, {checkOpen: false})) {
@@ -31,11 +32,10 @@ const getInputType = input => {
 	throw new Error('The `input` option must be a string, a Uint8Array or a Node.js Readable stream.');
 };
 
-const handleInputFileOption = inputFile => inputFile === undefined ? undefined : {
+const handleInputFileOption = inputFile => inputFile === undefined ? [] : [{
 	...getInputFileType(inputFile),
 	optionName: 'inputFile',
-	fdNumber: 0,
-};
+}];
 
 const getInputFileType = inputFile => {
 	if (isUrl(inputFile)) {

--- a/lib/stdio/lines.js
+++ b/lib/stdio/lines.js
@@ -1,24 +1,19 @@
 import {isBinaryEncoding} from '../encoding.js';
-import {willPipeStreams} from './forward.js';
 
 // Split chunks line-wise for streams exposed to users like `subprocess.stdout`.
 // Appending a noop transform in object mode is enough to do this, since every non-binary transform iterates line-wise.
-export const handleStreamsLines = (stdioStreams, {lines, encoding, stripFinalNewline}, isSync) => shouldSplitLines({stdioStreams, lines, encoding, isSync})
-	? [
-		...stdioStreams,
-		{
-			...stdioStreams[0],
-			type: 'generator',
-			value: {transform: linesEndGenerator, objectMode: true, preserveNewlines: !stripFinalNewline},
-		},
-	]
-	: stdioStreams;
+export const handleStreamsLines = ({options: {lines, encoding, stripFinalNewline}, isSync, direction, optionName}) => shouldSplitLines({lines, encoding, isSync, direction})
+	? [{
+		type: 'generator',
+		value: {transform: linesEndGenerator, objectMode: true, preserveNewlines: !stripFinalNewline},
+		optionName,
+	}]
+	: [];
 
-const shouldSplitLines = ({stdioStreams, lines, encoding, isSync}) => stdioStreams[0].direction === 'output'
+const shouldSplitLines = ({lines, encoding, isSync, direction}) => direction === 'output'
 	&& lines
 	&& !isBinaryEncoding(encoding)
-	&& !isSync
-	&& willPipeStreams(stdioStreams);
+	&& !isSync;
 
 const linesEndGenerator = function * (chunk) {
 	yield chunk;

--- a/lib/stdio/native.js
+++ b/lib/stdio/native.js
@@ -8,26 +8,26 @@ import {STANDARD_STREAMS} from '../utils.js';
 //  - 'inherit' becomes `process.stdin|stdout|stderr`
 //  - any file descriptor integer becomes `process.stdio[fdNumber]`
 // All of the above transformations tell Execa to perform manual piping.
-export const handleNativeStream = (stdioStream, isStdioArray) => {
-	const {type, value, fdNumber, optionName} = stdioStream;
+export const handleNativeStream = (stdioItem, isStdioArray, fdNumber) => {
+	const {type, value, optionName} = stdioItem;
 
 	if (!isStdioArray || type !== 'native') {
-		return stdioStream;
+		return stdioItem;
 	}
 
 	if (value === 'inherit') {
-		return {...stdioStream, type: 'nodeStream', value: getStandardStream(fdNumber, value, optionName)};
+		return {type: 'nodeStream', value: getStandardStream(fdNumber, value, optionName), optionName};
 	}
 
 	if (typeof value === 'number') {
-		return {...stdioStream, type: 'nodeStream', value: getStandardStream(value, value, optionName)};
+		return {type: 'nodeStream', value: getStandardStream(value, value, optionName), optionName};
 	}
 
 	if (isNodeStream(value, {checkOpen: false})) {
-		return {...stdioStream, type: 'nodeStream'};
+		return {type: 'nodeStream', value, optionName};
 	}
 
-	return stdioStream;
+	return stdioItem;
 };
 
 // Node.js does not allow to easily retrieve file descriptors beyond stdin/stdout/stderr as streams.

--- a/lib/stdio/sync.js
+++ b/lib/stdio/sync.js
@@ -5,9 +5,9 @@ import {TYPE_TO_MESSAGE} from './type.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in sync mode
 export const handleInputSync = (options, verboseInfo) => {
-	const {stdioStreamsGroups} = handleInput(addPropertiesSync, options, verboseInfo, true);
-	addInputOptionSync(stdioStreamsGroups, options);
-	return stdioStreamsGroups;
+	const {fileDescriptors} = handleInput(addPropertiesSync, options, verboseInfo, true);
+	addInputOptionSync(fileDescriptors, options);
+	return fileDescriptors;
 };
 
 const forbiddenIfSync = ({type, optionName}) => {
@@ -17,54 +17,64 @@ const forbiddenIfSync = ({type, optionName}) => {
 const addPropertiesSync = {
 	input: {
 		generator: forbiddenIfSync,
-		fileUrl: ({value}) => ({value: bufferToUint8Array(readFileSync(value)), type: 'uint8Array'}),
-		filePath: ({value}) => ({value: bufferToUint8Array(readFileSync(value.file)), type: 'uint8Array'}),
+		fileUrl: ({value}) => ({contents: bufferToUint8Array(readFileSync(value))}),
+		filePath: ({value: {file}}) => ({contents: bufferToUint8Array(readFileSync(file))}),
 		webStream: forbiddenIfSync,
 		nodeStream: forbiddenIfSync,
 		iterable: forbiddenIfSync,
+		string: ({value}) => ({contents: value}),
+		uint8Array: ({value}) => ({contents: value}),
+		native() {},
 	},
 	output: {
 		generator: forbiddenIfSync,
-		filePath: ({value}) => ({value: value.file}),
+		fileUrl: ({value}) => ({path: value}),
+		filePath: ({value: {file}}) => ({path: file}),
 		webStream: forbiddenIfSync,
 		nodeStream: forbiddenIfSync,
 		iterable: forbiddenIfSync,
+		string: forbiddenIfSync,
 		uint8Array: forbiddenIfSync,
+		native() {},
 	},
 };
 
-const addInputOptionSync = (stdioStreamsGroups, options) => {
-	const inputs = stdioStreamsGroups.flat().filter(({direction, type}) => direction === 'input' && (type === 'string' || type === 'uint8Array'));
-	if (inputs.length === 0) {
+const addInputOptionSync = (fileDescriptors, options) => {
+	const allContents = fileDescriptors
+		.filter(({direction}) => direction === 'input')
+		.flatMap(({stdioItems}) => stdioItems)
+		.map(({contents}) => contents)
+		.filter(contents => contents !== undefined);
+	if (allContents.length === 0) {
 		return;
 	}
 
-	options.input = inputs.length === 1
-		? inputs[0].value
-		: inputs.map(stdioStream => serializeInput(stdioStream)).join('');
+	options.input = allContents.length === 1
+		? allContents[0]
+		: allContents.map(contents => serializeContents(contents)).join('');
 };
 
-const serializeInput = ({type, value}) => type === 'string' ? value : uint8ArrayToString(value);
+const serializeContents = contents => typeof contents === 'string' ? contents : uint8ArrayToString(contents);
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, after spawning, in sync mode
-export const pipeOutputSync = (stdioStreamsGroups, {output}) => {
+export const pipeOutputSync = (fileDescriptors, {output}) => {
 	if (output === null) {
 		return;
 	}
 
-	for (const stdioStreams of stdioStreamsGroups) {
-		for (const stdioStream of stdioStreams) {
-			pipeStdioOptionSync(output[stdioStream.fdNumber], stdioStream);
+	for (const {stdioItems, fdNumber, direction} of fileDescriptors) {
+		for (const {type, path} of stdioItems) {
+			pipeStdioItemSync(output[fdNumber], type, path, direction);
 		}
 	}
 };
 
-const pipeStdioOptionSync = (result, {type, value, direction}) => {
+const pipeStdioItemSync = (result, type, path, direction) => {
 	if (result === null || direction === 'input') {
 		return;
 	}
 
 	if (type === 'fileUrl' || type === 'filePath') {
-		writeFileSync(value, result);
+		writeFileSync(path, result);
 	}
 };

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -2,37 +2,37 @@ import {isStream as isNodeStream} from 'is-stream';
 import {isUint8Array} from '../encoding.js';
 
 // The `stdin`/`stdout`/`stderr` option can be of many types. This detects it.
-export const getStdioOptionType = (stdioOption, optionName) => {
-	if (isGenerator(stdioOption)) {
+export const getStdioItemType = (value, optionName) => {
+	if (isGenerator(value)) {
 		return 'generator';
 	}
 
-	if (isUrl(stdioOption)) {
+	if (isUrl(value)) {
 		return 'fileUrl';
 	}
 
-	if (isFilePathObject(stdioOption)) {
+	if (isFilePathObject(value)) {
 		return 'filePath';
 	}
 
-	if (isWebStream(stdioOption)) {
+	if (isWebStream(value)) {
 		return 'webStream';
 	}
 
-	if (isNodeStream(stdioOption, {checkOpen: false})) {
+	if (isNodeStream(value, {checkOpen: false})) {
 		return 'native';
 	}
 
-	if (isUint8Array(stdioOption)) {
+	if (isUint8Array(value)) {
 		return 'uint8Array';
 	}
 
-	if (isIterableObject(stdioOption)) {
+	if (isIterableObject(value)) {
 		return 'iterable';
 	}
 
-	if (isGeneratorOptions(stdioOption)) {
-		return getGeneratorObjectType(stdioOption, optionName);
+	if (isGeneratorOptions(value)) {
+		return getGeneratorObjectType(value, optionName);
 	}
 
 	return 'native';
@@ -59,32 +59,34 @@ const checkBooleanOption = (value, optionName) => {
 	}
 };
 
-const isGenerator = stdioOption => isAsyncGenerator(stdioOption) || isSyncGenerator(stdioOption);
-export const isAsyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object AsyncGeneratorFunction]';
-const isSyncGenerator = stdioOption => Object.prototype.toString.call(stdioOption) === '[object GeneratorFunction]';
-export const isGeneratorOptions = stdioOption => typeof stdioOption === 'object'
-	&& stdioOption !== null
-	&& (stdioOption.transform !== undefined || stdioOption.final !== undefined);
+const isGenerator = value => isAsyncGenerator(value) || isSyncGenerator(value);
+export const isAsyncGenerator = value => Object.prototype.toString.call(value) === '[object AsyncGeneratorFunction]';
+const isSyncGenerator = value => Object.prototype.toString.call(value) === '[object GeneratorFunction]';
+export const isGeneratorOptions = value => typeof value === 'object'
+	&& value !== null
+	&& (value.transform !== undefined || value.final !== undefined);
 
-export const isUrl = stdioOption => Object.prototype.toString.call(stdioOption) === '[object URL]';
-export const isRegularUrl = stdioOption => isUrl(stdioOption) && stdioOption.protocol !== 'file:';
+export const isUrl = value => Object.prototype.toString.call(value) === '[object URL]';
+export const isRegularUrl = value => isUrl(value) && value.protocol !== 'file:';
 
-const isFilePathObject = stdioOption => typeof stdioOption === 'object'
-	&& stdioOption !== null
-	&& Object.keys(stdioOption).length === 1
-	&& isFilePathString(stdioOption.file);
+const isFilePathObject = value => typeof value === 'object'
+	&& value !== null
+	&& Object.keys(value).length === 1
+	&& isFilePathString(value.file);
 export const isFilePathString = file => typeof file === 'string';
 
-export const isUnknownStdioString = (type, stdioOption) => type === 'native' && typeof stdioOption === 'string' && !KNOWN_STDIO_STRINGS.has(stdioOption);
+export const isUnknownStdioString = (type, value) => type === 'native'
+	&& typeof value === 'string'
+	&& !KNOWN_STDIO_STRINGS.has(value);
 const KNOWN_STDIO_STRINGS = new Set(['ipc', 'ignore', 'inherit', 'overlapped', 'pipe']);
 
-const isReadableStream = stdioOption => Object.prototype.toString.call(stdioOption) === '[object ReadableStream]';
-export const isWritableStream = stdioOption => Object.prototype.toString.call(stdioOption) === '[object WritableStream]';
-const isWebStream = stdioOption => isReadableStream(stdioOption) || isWritableStream(stdioOption);
+const isReadableStream = value => Object.prototype.toString.call(value) === '[object ReadableStream]';
+export const isWritableStream = value => Object.prototype.toString.call(value) === '[object WritableStream]';
+const isWebStream = value => isReadableStream(value) || isWritableStream(value);
 
-const isIterableObject = stdioOption => typeof stdioOption === 'object'
-	&& stdioOption !== null
-	&& (typeof stdioOption[Symbol.asyncIterator] === 'function' || typeof stdioOption[Symbol.iterator] === 'function');
+const isIterableObject = value => typeof value === 'object'
+	&& value !== null
+	&& (typeof value[Symbol.asyncIterator] === 'function' || typeof value[Symbol.iterator] === 'function');
 
 // Convert types to human-friendly strings for error messages
 export const TYPE_TO_MESSAGE = {

--- a/lib/stream/all.js
+++ b/lib/stream/all.js
@@ -24,7 +24,7 @@ export const waitForAllStream = ({subprocess, encoding, buffer, maxBuffer, strea
 //  - `getStreamAsArrayBuffer()` or `getStream()` for the chunks not in objectMode, to convert them from Buffers to string or Uint8Array
 // We do this by emulating the Buffer -> string|Uint8Array conversion performed by `get-stream` with our own, which is identical.
 const getAllStream = ({all, stdout, stderr}, encoding) => all && stdout && stderr && stdout.readableObjectMode !== stderr.readableObjectMode
-	? all.pipe(generatorToDuplexStream(getAllStreamTransform(encoding)).value)
+	? all.pipe(generatorToDuplexStream(getAllStreamTransform(encoding)).stream)
 	: all;
 
 const getAllStreamTransform = encoding => ({
@@ -36,4 +36,5 @@ const getAllStreamTransform = encoding => ({
 		preserveNewlines: true,
 	},
 	forceEncoding: true,
+	optionName: 'all',
 });

--- a/lib/stream/resolve.js
+++ b/lib/stream/resolve.js
@@ -1,5 +1,5 @@
 import {once} from 'node:events';
-import {isStream} from 'is-stream';
+import {isStream as isNodeStream} from 'is-stream';
 import {waitForSuccessfulExit} from '../exit/code.js';
 import {errorSignal} from '../exit/kill.js';
 import {throwOnTimeout} from '../exit/timeout.js';
@@ -14,17 +14,17 @@ export const getSubprocessResult = async ({
 	subprocess,
 	options: {encoding, buffer, maxBuffer, timeoutDuration: timeout},
 	context,
-	stdioStreamsGroups,
+	fileDescriptors,
 	originalStreams,
 	controller,
 }) => {
 	const exitPromise = waitForExit(subprocess);
-	const streamInfo = {originalStreams, stdioStreamsGroups, subprocess, exitPromise, propagating: false};
+	const streamInfo = {originalStreams, fileDescriptors, subprocess, exitPromise, propagating: false};
 
 	const stdioPromises = waitForSubprocessStreams({subprocess, encoding, buffer, maxBuffer, streamInfo});
 	const allPromise = waitForAllStream({subprocess, encoding, buffer, maxBuffer, streamInfo});
 	const originalPromises = waitForOriginalStreams(originalStreams, subprocess, streamInfo);
-	const customStreamsEndPromises = waitForCustomStreamsEnd(stdioStreamsGroups, streamInfo);
+	const customStreamsEndPromises = waitForCustomStreamsEnd(fileDescriptors, streamInfo);
 
 	try {
 		return await Promise.race([
@@ -66,12 +66,12 @@ const waitForOriginalStreams = (originalStreams, subprocess, streamInfo) =>
 // Some `stdin`/`stdout`/`stderr` options create a stream, e.g. when passing a file path.
 // The `.pipe()` method automatically ends that stream when `subprocess` ends.
 // This makes sure we wait for the completion of those streams, in order to catch any error.
-const waitForCustomStreamsEnd = (stdioStreamsGroups, streamInfo) => stdioStreamsGroups.flat()
-	.filter(({value}) => isStream(value, {checkOpen: false}) && !isStandardStream(value))
-	.map(({type, value, fdNumber}) => waitForStream(value, fdNumber, streamInfo, {
+const waitForCustomStreamsEnd = (fileDescriptors, streamInfo) => fileDescriptors.flatMap(({stdioItems, fdNumber}) => stdioItems
+	.filter(({value, stream = value}) => isNodeStream(stream, {checkOpen: false}) && !isStandardStream(stream))
+	.map(({type, value, stream = value}) => waitForStream(stream, fdNumber, streamInfo, {
 		isSameDirection: type === 'generator',
 		stopOnExit: type === 'native',
-	}));
+	})));
 
 const throwOnSubprocessError = async (subprocess, {signal}) => {
 	const [error] = await once(subprocess, 'error', {signal});

--- a/lib/stream/subprocess.js
+++ b/lib/stream/subprocess.js
@@ -8,7 +8,7 @@ export const waitForSubprocessStream = async ({stream, subprocess, fdNumber, enc
 		return;
 	}
 
-	if (isInputFileDescriptor(fdNumber, streamInfo.stdioStreamsGroups)) {
+	if (isInputFileDescriptor(fdNumber, streamInfo.fileDescriptors)) {
 		await waitForStream(stream, fdNumber, streamInfo);
 		return;
 	}

--- a/lib/stream/wait.js
+++ b/lib/stream/wait.js
@@ -71,7 +71,7 @@ const shouldIgnoreStreamError = (error, fdNumber, streamInfo, isSameDirection = 
 	}
 
 	streamInfo.propagating = true;
-	return isInputFileDescriptor(fdNumber, streamInfo.stdioStreamsGroups) === isSameDirection
+	return isInputFileDescriptor(fdNumber, streamInfo.fileDescriptors) === isSameDirection
 		? isStreamEpipe(error)
 		: isStreamAbort(error);
 };
@@ -81,10 +81,9 @@ const shouldIgnoreStreamError = (error, fdNumber, streamInfo, isSameDirection = 
 // Therefore, we need to use the file descriptor's direction (`stdin` is input, `stdout` is output, etc.).
 // However, while `subprocess.std*` and transforms follow that direction, any stream passed the `std*` option has the opposite direction.
 // For example, `subprocess.stdin` is a writable, but the `stdin` option is a readable.
-export const isInputFileDescriptor = (fdNumber, stdioStreamsGroups) => {
-	const [{direction}] = stdioStreamsGroups.find(stdioStreams => stdioStreams[0].fdNumber === fdNumber);
-	return direction === 'input';
-};
+export const isInputFileDescriptor = (fdNumber, fileDescriptors) => fileDescriptors
+	.find(fileDescriptor => fileDescriptor.fdNumber === fdNumber)
+	.direction === 'input';
 
 // When `stream.destroy()` is called without an `error` argument, stream is aborted.
 // This is the only way to abort a readable stream, which can be useful in some instances.

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -7,8 +7,8 @@ import {logEarlyResult} from './verbose/complete.js';
 import {getSyncExitResult} from './exit/code.js';
 
 export const execaSync = (rawFile, rawArgs, rawOptions) => {
-	const {file, args, command, escapedCommand, startTime, verboseInfo, options, stdioStreamsGroups} = handleSyncArguments(rawFile, rawArgs, rawOptions);
-	const result = spawnSubprocessSync({file, args, options, command, escapedCommand, stdioStreamsGroups, startTime});
+	const {file, args, command, escapedCommand, startTime, verboseInfo, options, fileDescriptors} = handleSyncArguments(rawFile, rawArgs, rawOptions);
+	const result = spawnSubprocessSync({file, args, options, command, escapedCommand, fileDescriptors, startTime});
 	return handleResult(result, verboseInfo, options);
 };
 
@@ -20,8 +20,8 @@ const handleSyncArguments = (rawFile, rawArgs, rawOptions) => {
 		const syncOptions = normalizeSyncOptions(rawOptions);
 		const {file, args, options} = handleArguments(rawFile, rawArgs, syncOptions);
 		validateSyncOptions(options);
-		const stdioStreamsGroups = handleInputSync(options, verboseInfo);
-		return {file, args, command, escapedCommand, startTime, verboseInfo, options, stdioStreamsGroups};
+		const fileDescriptors = handleInputSync(options, verboseInfo);
+		return {file, args, command, escapedCommand, startTime, verboseInfo, options, fileDescriptors};
 	} catch (error) {
 		logEarlyResult(error, startTime, verboseInfo);
 		throw error;
@@ -36,16 +36,16 @@ const validateSyncOptions = ({ipc}) => {
 	}
 };
 
-const spawnSubprocessSync = ({file, args, options, command, escapedCommand, stdioStreamsGroups, startTime}) => {
+const spawnSubprocessSync = ({file, args, options, command, escapedCommand, fileDescriptors, startTime}) => {
 	let syncResult;
 	try {
 		syncResult = spawnSync(file, args, options);
 	} catch (error) {
-		return makeEarlyError({error, command, escapedCommand, stdioStreamsGroups, options, startTime, isSync: true});
+		return makeEarlyError({error, command, escapedCommand, fileDescriptors, options, startTime, isSync: true});
 	}
 
 	const {error, exitCode, signal} = getSyncExitResult(syncResult);
-	pipeOutputSync(stdioStreamsGroups, syncResult);
+	pipeOutputSync(fileDescriptors, syncResult);
 
 	const output = syncResult.output || Array.from({length: 3});
 	const stdio = output.map(stdioOutput => handleOutput(options, stdioOutput));

--- a/lib/verbose/output.js
+++ b/lib/verbose/output.js
@@ -4,36 +4,31 @@ import {isBinaryEncoding} from '../encoding.js';
 import {PIPED_STDIO_VALUES} from '../stdio/forward.js';
 import {verboseLog} from './log.js';
 
-export const handleStreamsVerbose = ({stdioStreams, options, isSync, stdioState, verboseInfo}) => {
-	if (!shouldLogOutput(stdioStreams, options, isSync, verboseInfo)) {
-		return stdioStreams;
-	}
-
-	const [{fdNumber}] = stdioStreams;
-	return [...stdioStreams, {
-		...stdioStreams[0],
+export const handleStreamsVerbose = ({stdioItems, options, isSync, stdioState, verboseInfo, fdNumber, optionName}) => shouldLogOutput({stdioItems, options, isSync, verboseInfo, fdNumber})
+	? [{
 		type: 'generator',
 		value: verboseGenerator.bind(undefined, {stdioState, fdNumber, verboseInfo}),
-	}];
-};
+		optionName,
+	}]
+	: [];
 
 // `ignore` opts-out of `verbose` for a specific stream.
 // `ipc` cannot use piping.
 // `inherit` would result in double printing.
 // They can also lead to double printing when passing file descriptor integers or `process.std*`.
 // This only leaves with `pipe` and `overlapped`.
-const shouldLogOutput = (stdioStreams, {encoding}, isSync, {verbose}) => verbose === 'full'
+const shouldLogOutput = ({stdioItems, options: {encoding}, isSync, verboseInfo: {verbose}, fdNumber}) => verbose === 'full'
 	&& !isSync
 	&& !isBinaryEncoding(encoding)
-	&& fdUsesVerbose(stdioStreams)
-	&& (stdioStreams.some(({type, value}) => type === 'native' && PIPED_STDIO_VALUES.has(value))
-	|| stdioStreams.every(({type}) => type === 'generator'));
+	&& fdUsesVerbose(fdNumber)
+	&& (stdioItems.some(({type, value}) => type === 'native' && PIPED_STDIO_VALUES.has(value))
+	|| stdioItems.every(({type}) => type === 'generator'));
 
 // Printing input streams would be confusing.
 // Files and streams can produce big outputs, which we don't want to print.
 // We could print `stdio[3+]` but it often is redirected to files and streams, with the same issue.
 // So we only print stdout and stderr.
-const fdUsesVerbose = ([{fdNumber}]) => fdNumber === 1 || fdNumber === 2;
+const fdUsesVerbose = fdNumber => fdNumber === 1 || fdNumber === 2;
 
 const verboseGenerator = function * ({stdioState: {subprocess: {stdio}}, fdNumber, verboseInfo}, line) {
 	if (!isPiping(stdio[fdNumber])) {


### PR DESCRIPTION
This PR refactors the implementation of the `stdin`/`stdout`/`stderr`/`stdio` option.

This mostly renames variables and moves lines of code around.
This does not change the logic's behavior. No tests needed to be updated.