### PR TITLE
Simplify `lines` option

### DIFF
--- a/docs/transform.md
+++ b/docs/transform.md
@@ -53,8 +53,6 @@ This is more efficient and recommended if the data is either:
 - Binary: Which does not have lines.
 - Text: But the transform works even if a line or word is split across multiple chunks.
 
-Please note the [`lines`](../readme.md#lines) option is unrelated: it has no impact on transforms.
-
 ## Newlines
 
 Unless [`{transform, binary: true}`](#binary-data) is used, the transform iterates over lines.

--- a/index.d.ts
+++ b/index.d.ts
@@ -219,7 +219,9 @@ type StreamEncoding<
 	: Encoding extends BufferEncodingOption
 		? Uint8Array
 		: LinesOption extends true
-			? string[]
+			? Encoding extends BinaryEncodingOption
+				? string
+				: string[]
 			: string;
 
 // Type of `result.all`
@@ -401,10 +403,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 	readonly stdio?: StdioOptions<IsSync>;
 
 	/**
-	Split `stdout` and `stderr` into lines.
-	- `result.stdout`, `result.stderr`, `result.all` and `result.stdio` are arrays of lines.
-	- `subprocess.stdout`, `subprocess.stderr`, `subprocess.all`, `subprocess.stdio`, `subprocess.readable()` and `subprocess.duplex()` iterate over lines instead of arbitrary chunks.
-	- Any stream passed to the `stdout`, `stderr` or `stdio` option receives lines instead of arbitrary chunks.
+	Set `result.stdout`, `result.stderr`, `result.all` and `result.stdio` as arrays of strings, splitting the subprocess' output into lines.
 
 	This cannot be used if the `encoding` option is binary.
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -453,6 +453,13 @@ try {
 	expectType<Uint8Array>(linesBufferResult.stdio[2]);
 	expectType<Uint8Array>(linesBufferResult.all);
 
+	const linesHexResult = await execa('unicorns', {lines: true, encoding: 'hex', all: true});
+	expectType<string>(linesHexResult.stdout);
+	expectType<string>(linesHexResult.stdio[1]);
+	expectType<string>(linesHexResult.stderr);
+	expectType<string>(linesHexResult.stdio[2]);
+	expectType<string>(linesHexResult.all);
+
 	const noBufferPromise = execa('unicorns', {buffer: false, all: true});
 	expectType<Writable>(noBufferPromise.stdin);
 	expectType<Readable>(noBufferPromise.stdout);
@@ -655,6 +662,10 @@ try {
 
 	const ignoreFd3Result = await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', 'ignore']});
 	expectType<undefined>(ignoreFd3Result.stdio[3]);
+
+	const objectTransformLinesStdoutResult = await execa('unicorns', {lines: true, stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}});
+	expectType<unknown[]>(objectTransformLinesStdoutResult.stdout);
+	expectType<[undefined, unknown[], string[]]>(objectTransformLinesStdoutResult.stdio);
 
 	const objectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}});
 	expectType<unknown[]>(objectTransformStdoutResult.stdout);

--- a/lib/arguments/options.js
+++ b/lib/arguments/options.js
@@ -8,7 +8,7 @@ import {validateTimeout} from '../exit/timeout.js';
 import {logCommand} from '../verbose/start.js';
 import {getVerboseInfo} from '../verbose/info.js';
 import {getStartTime} from '../return/duration.js';
-import {validateEncoding} from './encoding.js';
+import {validateEncoding, BINARY_ENCODINGS} from './encoding.js';
 import {handleNodeOption} from './node.js';
 import {joinCommand} from './escape.js';
 import {normalizeCwd, safeNormalizeFileUrl, normalizeFileUrl} from './cwd.js';
@@ -60,6 +60,7 @@ export const handleArguments = (filePath, rawArgs, rawOptions) => {
 	options.shell = normalizeFileUrl(options.shell);
 	options.env = getEnv(options);
 	options.forceKillAfterDelay = normalizeForceKillAfterDelay(options.forceKillAfterDelay);
+	options.lines &&= !BINARY_ENCODINGS.has(options.encoding) && options.buffer;
 
 	if (process.platform === 'win32' && basename(file, '.exe') === 'cmd') {
 		// #116

--- a/lib/stdio/encoding-final.js
+++ b/lib/stdio/encoding-final.js
@@ -2,8 +2,8 @@ import {StringDecoder} from 'node:string_decoder';
 
 // Apply the `encoding` option using an implicit generator.
 // This encodes the final output of `stdout`/`stderr`.
-export const handleStreamsEncoding = ({stdioItems, options: {encoding}, isSync, direction, optionName}) => {
-	if (!shouldEncodeOutput({stdioItems, encoding, isSync, direction})) {
+export const handleStreamsEncoding = ({options: {encoding}, isSync, direction, optionName, objectMode}) => {
+	if (!shouldEncodeOutput({encoding, isSync, direction, objectMode})) {
 		return [];
 	}
 
@@ -19,16 +19,11 @@ export const handleStreamsEncoding = ({stdioItems, options: {encoding}, isSync, 
 	}];
 };
 
-const shouldEncodeOutput = ({stdioItems, encoding, isSync, direction}) => direction === 'output'
+const shouldEncodeOutput = ({encoding, isSync, direction, objectMode}) => direction === 'output'
 	&& encoding !== 'utf8'
 	&& encoding !== 'buffer'
 	&& !isSync
-	&& !isWritableObjectMode(stdioItems);
-
-const isWritableObjectMode = stdioItems => {
-	const lastObjectStdioItem = stdioItems.findLast(({type, value}) => type === 'generator' && value.objectMode !== undefined);
-	return lastObjectStdioItem !== undefined && lastObjectStdioItem.value.objectMode;
-};
+	&& !objectMode;
 
 const encodingStringGenerator = function * (stringDecoder, chunk) {
 	yield stringDecoder.write(chunk);

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -6,17 +6,30 @@ import {pipeStreams} from './pipeline.js';
 import {isGeneratorOptions, isAsyncGenerator} from './type.js';
 import {getValidateTransformReturn} from './validate.js';
 
-export const normalizeGenerators = (stdioItems, direction, {encoding}) => {
-	const nonGenerators = stdioItems.filter(({type}) => type !== 'generator');
-	const generators = stdioItems.filter(({type}) => type === 'generator');
+export const getObjectMode = (stdioItems, direction, options) => {
+	const generators = getGenerators(stdioItems, direction, options);
+	if (generators.length === 0) {
+		return false;
+	}
 
+	const {value: {readableObjectMode, writableObjectMode}} = generators.at(-1);
+	return direction === 'input' ? writableObjectMode : readableObjectMode;
+};
+
+export const normalizeGenerators = (stdioItems, direction, options) => [
+	...stdioItems.filter(({type}) => type !== 'generator'),
+	...getGenerators(stdioItems, direction, options),
+];
+
+const getGenerators = (stdioItems, direction, {encoding}) => {
+	const generators = stdioItems.filter(({type}) => type === 'generator');
 	const newGenerators = Array.from({length: generators.length});
 
 	for (const [index, stdioItem] of Object.entries(generators)) {
 		newGenerators[index] = normalizeGenerator({stdioItem, index: Number(index), newGenerators, direction, encoding});
 	}
 
-	return [...nonGenerators, ...sortGenerators(newGenerators, direction)];
+	return sortGenerators(newGenerators, direction);
 };
 
 const normalizeGenerator = ({stdioItem, stdioItem: {value}, index, newGenerators, direction, encoding}) => {

--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -6,7 +6,7 @@ import {handleNativeStream} from './native.js';
 import {handleInputOptions} from './input.js';
 import {handleStreamsLines} from './lines.js';
 import {handleStreamsEncoding} from './encoding-final.js';
-import {normalizeGenerators} from './generator.js';
+import {normalizeGenerators, getObjectMode} from './generator.js';
 import {forwardStdio, willPipeFileDescriptor} from './forward.js';
 
 // Handle `input`, `inputFile`, `stdin`, `stdout` and `stderr` options, before spawning, in async/sync mode
@@ -23,11 +23,12 @@ export const handleInput = (addProperties, options, verboseInfo, isSync) => {
 // This is what users would expect.
 // For example, `stdout: ['ignore']` behaves the same as `stdout: 'ignore'`.
 const getFileDescriptor = ({stdioOption, fdNumber, addProperties, options, isSync, stdioState, verboseInfo}) => {
+	const outputLines = [];
 	const optionName = getOptionName(fdNumber);
 	const stdioItems = initializeStdioItems(stdioOption, fdNumber, options, optionName);
 	const direction = getStreamDirection(stdioItems, fdNumber, optionName);
-	const normalizedStdioItems = normalizeStdioItems({stdioItems, fdNumber, optionName, addProperties, options, isSync, direction, stdioState, verboseInfo});
-	return {fdNumber, direction, stdioItems: normalizedStdioItems};
+	const normalizedStdioItems = normalizeStdioItems({stdioItems, fdNumber, optionName, addProperties, options, isSync, direction, stdioState, verboseInfo, outputLines});
+	return {fdNumber, direction, outputLines, stdioItems: normalizedStdioItems};
 };
 
 const getOptionName = fdNumber => KNOWN_OPTION_NAMES[fdNumber] ?? `stdio[${fdNumber}]`;
@@ -94,25 +95,23 @@ For example, you can use the \`pathToFileURL()\` method of the \`url\` core modu
 	}
 };
 
-const normalizeStdioItems = ({stdioItems, fdNumber, optionName, addProperties, options, isSync, direction, stdioState, verboseInfo}) => {
-	const allStdioItems = addInternalStdioItems({stdioItems, fdNumber, optionName, options, isSync, direction, stdioState, verboseInfo});
+const normalizeStdioItems = ({stdioItems, fdNumber, optionName, addProperties, options, isSync, direction, stdioState, verboseInfo, outputLines}) => {
+	const allStdioItems = addInternalStdioItems({stdioItems, fdNumber, optionName, options, isSync, direction, stdioState, verboseInfo, outputLines});
 	const normalizedStdioItems = normalizeGenerators(allStdioItems, direction, options);
 	return normalizedStdioItems.map(stdioItem => addStreamProperties(stdioItem, addProperties, direction));
 };
 
-const addInternalStdioItems = ({stdioItems, fdNumber, optionName, options, isSync, direction, stdioState, verboseInfo}) => {
+const addInternalStdioItems = ({stdioItems, fdNumber, optionName, options, isSync, direction, stdioState, verboseInfo, outputLines}) => {
 	if (!willPipeFileDescriptor(stdioItems)) {
 		return stdioItems;
 	}
 
-	const newStdioItems = [
+	const objectMode = getObjectMode(stdioItems, direction, options);
+	return [
 		...stdioItems,
 		...handleStreamsVerbose({stdioItems, options, isSync, stdioState, verboseInfo, fdNumber, optionName}),
-		...handleStreamsLines({options, isSync, direction, optionName}),
-	];
-	return [
-		...newStdioItems,
-		...handleStreamsEncoding({stdioItems: newStdioItems, options, isSync, direction, optionName}),
+		...handleStreamsLines({options, isSync, direction, optionName, objectMode, outputLines}),
+		...handleStreamsEncoding({options, isSync, direction, optionName, objectMode}),
 	];
 };
 

--- a/lib/stdio/lines.js
+++ b/lib/stdio/lines.js
@@ -1,20 +1,30 @@
-import {BINARY_ENCODINGS} from '../arguments/encoding.js';
+import {MaxBufferError} from 'get-stream';
+import stripFinalNewlineFunction from 'strip-final-newline';
 
 // Split chunks line-wise for streams exposed to users like `subprocess.stdout`.
 // Appending a noop transform in object mode is enough to do this, since every non-binary transform iterates line-wise.
-export const handleStreamsLines = ({options: {lines, encoding, stripFinalNewline}, isSync, direction, optionName}) => shouldSplitLines({lines, encoding, isSync, direction})
+export const handleStreamsLines = ({options: {lines, stripFinalNewline, maxBuffer}, isSync, direction, optionName, objectMode, outputLines}) => shouldSplitLines({lines, isSync, direction, objectMode})
 	? [{
 		type: 'generator',
-		value: {transform: linesEndGenerator, objectMode: true, preserveNewlines: !stripFinalNewline},
+		value: {transform: linesEndGenerator.bind(undefined, {outputLines, stripFinalNewline, maxBuffer}), preserveNewlines: true},
 		optionName,
 	}]
 	: [];
 
-const shouldSplitLines = ({lines, encoding, isSync, direction}) => direction === 'output'
+const shouldSplitLines = ({lines, isSync, direction, objectMode}) => direction === 'output'
 	&& lines
-	&& !BINARY_ENCODINGS.has(encoding)
+	&& !objectMode
 	&& !isSync;
 
-const linesEndGenerator = function * (chunk) {
-	yield chunk;
+const linesEndGenerator = function * ({outputLines, stripFinalNewline, maxBuffer}, line) {
+	if (outputLines.length >= maxBuffer) {
+		const error = new MaxBufferError();
+		error.bufferedData = outputLines;
+		throw error;
+	}
+
+	const strippedLine = stripFinalNewline ? stripFinalNewlineFunction(line) : line;
+	outputLines.push(strippedLine);
+
+	yield line;
 };

--- a/lib/stream/resolve.js
+++ b/lib/stream/resolve.js
@@ -12,7 +12,7 @@ import {waitForStream} from './wait.js';
 // Retrieve result of subprocess: exit code, signal, error, streams (stdout/stderr/all)
 export const getSubprocessResult = async ({
 	subprocess,
-	options: {encoding, buffer, maxBuffer, timeoutDuration: timeout},
+	options: {encoding, buffer, maxBuffer, lines, timeoutDuration: timeout},
 	context,
 	fileDescriptors,
 	originalStreams,
@@ -21,7 +21,7 @@ export const getSubprocessResult = async ({
 	const exitPromise = waitForExit(subprocess);
 	const streamInfo = {originalStreams, fileDescriptors, subprocess, exitPromise, propagating: false};
 
-	const stdioPromises = waitForSubprocessStreams({subprocess, encoding, buffer, maxBuffer, streamInfo});
+	const stdioPromises = waitForSubprocessStreams({subprocess, encoding, buffer, maxBuffer, lines, streamInfo});
 	const allPromise = waitForAllStream({subprocess, encoding, buffer, maxBuffer, streamInfo});
 	const originalPromises = waitForOriginalStreams(originalStreams, subprocess, streamInfo);
 	const customStreamsEndPromises = waitForCustomStreamsEnd(fileDescriptors, streamInfo);
@@ -53,8 +53,8 @@ export const getSubprocessResult = async ({
 };
 
 // Read the contents of `subprocess.std*` and|or wait for its completion
-const waitForSubprocessStreams = ({subprocess, encoding, buffer, maxBuffer, streamInfo}) =>
-	subprocess.stdio.map((stream, fdNumber) => waitForSubprocessStream({stream, subprocess, fdNumber, encoding, buffer, maxBuffer, streamInfo}));
+const waitForSubprocessStreams = ({subprocess, encoding, buffer, maxBuffer, lines, streamInfo}) =>
+	subprocess.stdio.map((stream, fdNumber) => waitForSubprocessStream({stream, subprocess, fdNumber, encoding, buffer, maxBuffer, lines, streamInfo}));
 
 // Transforms replace `subprocess.std*`, which means they are not exposed to users.
 // However, we still want to wait for their completion.

--- a/lib/stream/subprocess.js
+++ b/lib/stream/subprocess.js
@@ -1,13 +1,13 @@
 import {setImmediate} from 'node:timers/promises';
 import getStream, {getStreamAsArrayBuffer, getStreamAsArray, MaxBufferError} from 'get-stream';
-import {waitForStream, handleStreamError, isInputFileDescriptor} from './wait.js';
+import {waitForStream, handleStreamError, isInputFileDescriptor, getFileDescriptor} from './wait.js';
 
-export const waitForSubprocessStream = async ({stream, subprocess, fdNumber, encoding, buffer, maxBuffer, streamInfo}) => {
+export const waitForSubprocessStream = async ({stream, subprocess, fdNumber, encoding, buffer, maxBuffer, lines, streamInfo}) => {
 	if (!stream) {
 		return;
 	}
 
-	if (isInputFileDescriptor(fdNumber, streamInfo.fileDescriptors)) {
+	if (isInputFileDescriptor(streamInfo, fdNumber)) {
 		await waitForStream(stream, fdNumber, streamInfo);
 		return;
 	}
@@ -21,7 +21,7 @@ export const waitForSubprocessStream = async ({stream, subprocess, fdNumber, enc
 	}
 
 	try {
-		return await getAnyStream(stream, encoding, maxBuffer);
+		return await getAnyStream({stream, fdNumber, encoding, maxBuffer, lines, streamInfo});
 	} catch (error) {
 		if (error instanceof MaxBufferError) {
 			subprocess.kill();
@@ -41,15 +41,24 @@ const resumeStream = async stream => {
 	}
 };
 
-const getAnyStream = async (stream, encoding, maxBuffer) => {
+const getAnyStream = async ({stream, fdNumber, encoding, maxBuffer, lines, streamInfo}) => {
 	if (stream.readableObjectMode) {
 		return getStreamAsArray(stream, {maxBuffer});
+	}
+
+	if (lines) {
+		return getOutputLines(stream, fdNumber, streamInfo);
 	}
 
 	const contents = encoding === 'buffer'
 		? await getStreamAsArrayBuffer(stream, {maxBuffer})
 		: await getStream(stream, {maxBuffer});
 	return applyEncoding(contents, encoding);
+};
+
+const getOutputLines = async (stream, fdNumber, streamInfo) => {
+	await waitForStream(stream, fdNumber, streamInfo);
+	return getFileDescriptor(streamInfo, fdNumber).outputLines;
 };
 
 // On failure, `result.stdout|stderr|all` should contain the currently buffered stream
@@ -63,8 +72,8 @@ export const getBufferedData = async (streamPromise, encoding) => {
 	}
 };
 
-const handleBufferedData = (error, encoding) => error.bufferedData === undefined || Array.isArray(error.bufferedData)
-	? error.bufferedData
-	: applyEncoding(error.bufferedData, encoding);
+const handleBufferedData = ({bufferedData}, encoding) => bufferedData === undefined || Array.isArray(bufferedData)
+	? bufferedData
+	: applyEncoding(bufferedData, encoding);
 
 const applyEncoding = (contents, encoding) => encoding === 'buffer' ? new Uint8Array(contents) : contents;

--- a/lib/stream/wait.js
+++ b/lib/stream/wait.js
@@ -71,7 +71,7 @@ const shouldIgnoreStreamError = (error, fdNumber, streamInfo, isSameDirection = 
 	}
 
 	streamInfo.propagating = true;
-	return isInputFileDescriptor(fdNumber, streamInfo.fileDescriptors) === isSameDirection
+	return isInputFileDescriptor(streamInfo, fdNumber) === isSameDirection
 		? isStreamEpipe(error)
 		: isStreamAbort(error);
 };
@@ -81,9 +81,9 @@ const shouldIgnoreStreamError = (error, fdNumber, streamInfo, isSameDirection = 
 // Therefore, we need to use the file descriptor's direction (`stdin` is input, `stdout` is output, etc.).
 // However, while `subprocess.std*` and transforms follow that direction, any stream passed the `std*` option has the opposite direction.
 // For example, `subprocess.stdin` is a writable, but the `stdin` option is a readable.
-export const isInputFileDescriptor = (fdNumber, fileDescriptors) => fileDescriptors
-	.find(fileDescriptor => fileDescriptor.fdNumber === fdNumber)
-	.direction === 'input';
+export const isInputFileDescriptor = (streamInfo, fdNumber) => getFileDescriptor(streamInfo, fdNumber).direction === 'input';
+
+export const getFileDescriptor = ({fileDescriptors}, fdNumber) => fileDescriptors.find(fileDescriptor => fileDescriptor.fdNumber === fdNumber);
 
 // When `stream.destroy()` is called without an `error` argument, stream is aborted.
 // This is the only way to abort a readable stream, which can be useful in some instances.

--- a/readme.md
+++ b/readme.md
@@ -944,10 +944,7 @@ Add an `.all` property on the [promise](#all) and the [resolved value](#all-1). 
 Type: `boolean`\
 Default: `false`
 
-Split `stdout` and `stderr` into lines.
-- [`result.stdout`](#stdout), [`result.stderr`](#stderr), [`result.all`](#all-1) and [`result.stdio`](#stdio) are arrays of lines.
-- [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), [`subprocess.all`](#all), [`subprocess.stdio`](https://nodejs.org/api/child_process.html#subprocessstdio), [`subprocess.readable()`](#readablereadableoptions) and [`subprocess.duplex`](#duplexduplexoptions) iterate over lines instead of arbitrary chunks.
-- Any stream passed to the [`stdout`](#stdout-1), [`stderr`](#stderr-1) or [`stdio`](#stdio-1) option receives lines instead of arbitrary chunks.
+Set [`result.stdout`](#stdout), [`result.stderr`](#stderr), [`result.all`](#all-1) and [`result.stdio`](#stdio) as arrays of strings, splitting the subprocess' output into lines.
 
 This cannot be used if the [`encoding` option](#encoding) is binary.
 

--- a/test/convert/readable.js
+++ b/test/convert/readable.js
@@ -23,6 +23,7 @@ import {
 	getReadWriteSubprocess,
 } from '../helpers/convert.js';
 import {foobarString, foobarBuffer, foobarObject} from '../helpers/input.js';
+import {simpleFull} from '../helpers/lines.js';
 import {prematureClose, fullStdio} from '../helpers/stdio.js';
 import {outputObjectGenerator, getChunksGenerator} from '../helpers/generator.js';
 import {defaultHighWaterMark, defaultObjectHighWaterMark} from '../helpers/stream.js';
@@ -313,15 +314,15 @@ test('.readable() has the right highWaterMark', async t => {
 });
 
 test('.readable() can iterate over lines', async t => {
-	const subprocess = execa('noop-fd.js', ['1', 'aaa\nbbb\nccc'], {lines: true});
+	const subprocess = execa('noop-fd.js', ['1', simpleFull]);
 	const lines = [];
-	for await (const line of subprocess.readable()) {
+	for await (const line of subprocess.readable({binary: false, preserveNewlines: false})) {
 		lines.push(line);
 	}
 
 	const expectedLines = ['aaa', 'bbb', 'ccc'];
 	t.deepEqual(lines, expectedLines);
-	await assertSubprocessOutput(t, subprocess, expectedLines);
+	await assertSubprocessOutput(t, subprocess, simpleFull);
 });
 
 test('.readable() can wait for data', async t => {

--- a/test/stdio/lines.js
+++ b/test/stdio/lines.js
@@ -1,11 +1,14 @@
+import {Buffer} from 'node:buffer';
 import {once} from 'node:events';
 import {Writable} from 'node:stream';
 import test from 'ava';
+import {MaxBufferError} from 'get-stream';
 import {execa, execaSync} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {fullStdio} from '../helpers/stdio.js';
 import {getChunksGenerator} from '../helpers/generator.js';
-import {foobarObject} from '../helpers/input.js';
+import {foobarString, foobarObject} from '../helpers/input.js';
+import {assertStreamOutput, assertIterableChunks} from '../helpers/convert.js';
 import {
 	simpleFull,
 	simpleChunks,
@@ -17,6 +20,8 @@ import {
 } from '../helpers/lines.js';
 
 setFixtureDir();
+
+const getSimpleChunkSubprocess = options => execa('noop-fd.js', ['1', simpleFull], {lines: true, ...options});
 
 // eslint-disable-next-line max-params
 const testStreamLines = async (t, fdNumber, input, expectedOutput, stripFinalNewline) => {
@@ -60,13 +65,13 @@ const testStreamLinesGenerator = async (t, input, expectedLines, objectMode, bin
 };
 
 test('"lines: true" works with strings generators', testStreamLinesGenerator, simpleChunks, simpleFullEndLines, false, false);
-test('"lines: true" works with strings generators, objectMode', testStreamLinesGenerator, simpleChunks, simpleChunks, true, false);
 test('"lines: true" works with strings generators, binary', testStreamLinesGenerator, simpleChunks, simpleLines, false, true);
-test('"lines: true" works with strings generators, binary, objectMode', testStreamLinesGenerator, simpleChunks, simpleChunks, true, true);
 test('"lines: true" works with big strings generators', testStreamLinesGenerator, [bigString], bigArray, false, false);
-test('"lines: true" works with big strings generators, objectMode', testStreamLinesGenerator, [bigString], [bigString], true, false);
 test('"lines: true" works with big strings generators without newlines', testStreamLinesGenerator, [bigStringNoNewlines], [bigStringNoNewlinesEnd], false, false);
-test('"lines: true" works with big strings generators without newlines, objectMode', testStreamLinesGenerator, [bigStringNoNewlines], [bigStringNoNewlines], true, false);
+test('"lines: true" is a noop with strings generators, objectMode', testStreamLinesGenerator, simpleChunks, simpleChunks, true, false);
+test('"lines: true" is a noop with strings generators, binary, objectMode', testStreamLinesGenerator, simpleChunks, simpleChunks, true, true);
+test('"lines: true" is a noop big strings generators, objectMode', testStreamLinesGenerator, [bigString], [bigString], true, false);
+test('"lines: true" is a noop big strings generators without newlines, objectMode', testStreamLinesGenerator, [bigStringNoNewlines], [bigStringNoNewlines], true, false);
 
 test('"lines: true" is a noop with objects generators, objectMode', async t => {
 	const {stdout} = await execa('noop.js', {
@@ -77,7 +82,7 @@ test('"lines: true" is a noop with objects generators, objectMode', async t => {
 });
 
 const testOtherEncoding = async (t, expectedOutput, encoding, stripFinalNewline) => {
-	const {stdout} = await execa('noop-fd.js', ['1', simpleFull], {lines: true, encoding, stripFinalNewline});
+	const {stdout} = await getSimpleChunkSubprocess({encoding, stripFinalNewline});
 	t.deepEqual(stdout, expectedOutput);
 };
 
@@ -86,42 +91,84 @@ test('"lines: true" is a noop with "encoding: buffer", stripFinalNewline', testO
 test('"lines: true" is a noop with "encoding: hex"', testOtherEncoding, simpleFullHex, 'hex', false);
 test('"lines: true" is a noop with "encoding: hex", stripFinalNewline', testOtherEncoding, simpleFullHex, 'hex', true);
 
-const getSimpleChunkSubprocess = (stripFinalNewline, options) => execa('noop-fd.js', ['1', ...simpleChunks], {
-	lines: true,
-	stripFinalNewline,
-	...options,
+test('"lines: true" is a noop with "buffer: false"', async t => {
+	const {stdout} = await getSimpleChunkSubprocess({buffer: false});
+	t.is(stdout, undefined);
 });
 
-const testAsyncIteration = async (t, expectedOutput, stripFinalNewline) => {
-	const subprocess = getSimpleChunkSubprocess(stripFinalNewline);
-	const [stdout] = await Promise.all([subprocess.stdout.toArray(), subprocess]);
-	t.deepEqual(stdout, expectedOutput);
+test('"lines: true" can be below "maxBuffer"', async t => {
+	const maxBuffer = simpleLines.length;
+	const {stdout} = await getSimpleChunkSubprocess({maxBuffer});
+	t.deepEqual(stdout, noNewlinesChunks);
+});
+
+test('"lines: true" can be above "maxBuffer"', async t => {
+	const maxBuffer = simpleLines.length - 1;
+	const {cause, stdout} = await t.throwsAsync(getSimpleChunkSubprocess({maxBuffer}));
+	t.true(cause instanceof MaxBufferError);
+	t.deepEqual(stdout, noNewlinesChunks.slice(0, maxBuffer));
+});
+
+test('"lines: true" stops on stream error', async t => {
+	const cause = new Error(foobarString);
+	const error = await t.throwsAsync(getSimpleChunkSubprocess({
+		* stdout(line) {
+			if (line === noNewlinesChunks[2]) {
+				throw cause;
+			}
+
+			yield line;
+		},
+	}));
+	t.is(error.cause, cause);
+	t.deepEqual(error.stdout, noNewlinesChunks.slice(0, 2));
+});
+
+const testAsyncIteration = async (t, expectedLines, stripFinalNewline) => {
+	const subprocess = getSimpleChunkSubprocess({stripFinalNewline});
+	t.false(subprocess.stdout.readableObjectMode);
+	await assertStreamOutput(t, subprocess.stdout, simpleFull);
+	const {stdout} = await subprocess;
+	t.deepEqual(stdout, expectedLines);
 };
 
-test('"lines: true" works with stream async iteration, string', testAsyncIteration, simpleLines, false);
-test('"lines: true" works with stream async iteration, string, stripFinalNewline', testAsyncIteration, noNewlinesChunks, true);
+test('"lines: true" works with stream async iteration', testAsyncIteration, simpleLines, false);
+test('"lines: true" works with stream async iteration, stripFinalNewline', testAsyncIteration, noNewlinesChunks, true);
 
-const testDataEvents = async (t, [expectedFirstLine], stripFinalNewline) => {
-	const subprocess = getSimpleChunkSubprocess(stripFinalNewline);
-	const [[firstLine]] = await Promise.all([once(subprocess.stdout, 'data'), subprocess]);
-	t.deepEqual(firstLine, expectedFirstLine);
+const testDataEvents = async (t, expectedLines, stripFinalNewline) => {
+	const subprocess = getSimpleChunkSubprocess({stripFinalNewline});
+	const [firstLine] = await once(subprocess.stdout, 'data');
+	t.deepEqual(firstLine, Buffer.from(simpleLines[0]));
+	const {stdout} = await subprocess;
+	t.deepEqual(stdout, expectedLines);
 };
 
-test('"lines: true" works with stream "data" events, string', testDataEvents, simpleLines, false);
-test('"lines: true" works with stream "data" events, string, stripFinalNewline', testDataEvents, noNewlinesChunks, true);
+test('"lines: true" works with stream "data" events', testDataEvents, simpleLines, false);
+test('"lines: true" works with stream "data" events, stripFinalNewline', testDataEvents, noNewlinesChunks, true);
 
-const testWritableStream = async (t, expectedOutput, stripFinalNewline) => {
+const testWritableStream = async (t, expectedLines, stripFinalNewline) => {
 	const lines = [];
 	const writable = new Writable({
 		write(line, encoding, done) {
-			lines.push(line);
+			lines.push(line.toString());
 			done();
 		},
 		decodeStrings: false,
 	});
-	await getSimpleChunkSubprocess(stripFinalNewline, {stdout: ['pipe', writable]});
-	t.deepEqual(lines, expectedOutput);
+	const {stdout} = await getSimpleChunkSubprocess({stripFinalNewline, stdout: ['pipe', writable]});
+	t.deepEqual(lines, simpleLines);
+	t.deepEqual(stdout, expectedLines);
 };
 
-test('"lines: true" works with writable streams targets, string', testWritableStream, simpleLines, false);
-test('"lines: true" works with writable streams targets, string, stripFinalNewline', testWritableStream, noNewlinesChunks, true);
+test('"lines: true" works with writable streams targets', testWritableStream, simpleLines, false);
+test('"lines: true" works with writable streams targets, stripFinalNewline', testWritableStream, noNewlinesChunks, true);
+
+const testIterable = async (t, expectedLines, stripFinalNewline) => {
+	const subprocess = getSimpleChunkSubprocess({stripFinalNewline});
+	await assertIterableChunks(t, subprocess, noNewlinesChunks);
+	const {stdout} = await subprocess;
+	t.deepEqual(stdout, expectedLines);
+};
+
+test('"lines: true" works with subprocess.iterable()', testIterable, simpleLines, false);
+test('"lines: true" works with subprocess.iterable(), stripFinalNewline', testIterable, noNewlinesChunks, true);


### PR DESCRIPTION
The `lines` option currently does two different things:
1. Split `result.stdout`/`result.stderr` into arrays of lines
2. Make `subprocess.stdout`/`subprocess.stderr` streams iterate over chunks of lines instead of arbitrary chunks of data

If users only want to do `1.`, then getting `2.` as a side effect might be unwanted, since it sets `subprocess.stdout`/`subprocess.stderr` in object mode, and makes it iterate over smaller chunks of data.

Also, `2.` can now be achieved using either `subprocess.iterable()`, transforms or `subprocess.readable({binary: false})`. So it is now redundant with those methods. In fact, those methods are better because they create a new stream/iterable instead of directly modifying `subprocess.stdout`/`subprocess.stderr`.

Therefore, this PR makes the `lines` option do only `1.`. This also makes this option much simpler to understand, as the shortening of the `readme.md` description shows. Line-wise iteration over `subprocess.stdout`/`subprocess.stderr` can still be achieved, but using `subprocess.iterable()`, transforms or `subprocess.readable({binary: false})` instead.