### PR TITLE
Fix using both `encoding: 'utf16le'` and `lines`/`verbose` options

### DIFF
--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -109,9 +109,9 @@ const addInternalStdioItems = ({stdioItems, fdNumber, optionName, options, isSyn
 	const objectMode = getObjectMode(stdioItems, direction, options);
 	return [
 		...stdioItems,
+		...handleStreamsEncoding({options, isSync, direction, optionName, objectMode}),
 		...handleStreamsVerbose({stdioItems, options, isSync, stdioState, verboseInfo, fdNumber, optionName}),
 		...handleStreamsLines({options, isSync, direction, optionName, objectMode, outputLines}),
-		...handleStreamsEncoding({options, isSync, direction, optionName, objectMode}),
 	];
 };
 

--- a/test/convert/readable.js
+++ b/test/convert/readable.js
@@ -45,9 +45,8 @@ test('.readable() success', async t => {
 
 // eslint-disable-next-line max-params
 const testReadableDefault = async (t, fdNumber, from, options, hasResult) => {
-	const subprocess = execa('noop-stdin-fd.js', [`${fdNumber}`], options);
+	const subprocess = execa('noop-fd.js', [`${fdNumber}`, foobarString], options);
 	const stream = subprocess.readable({from});
-	subprocess.stdin.end(foobarString);
 
 	await assertStreamOutput(t, stream, hasResult ? foobarString : '');
 	await assertSubprocessOutput(t, subprocess, foobarString, fdNumber);
@@ -444,8 +443,7 @@ if (majorVersion >= 20) {
 
 const testBigOutput = async (t, methodName) => {
 	const bigChunk = '.'.repeat(1e6);
-	const subprocess = execa('stdin.js');
-	subprocess.stdin.end(bigChunk);
+	const subprocess = execa('stdin.js', {input: bigChunk});
 	const stream = subprocess[methodName]();
 
 	await assertStreamOutput(t, stream, bigChunk);

--- a/test/fixtures/nested-input.js
+++ b/test/fixtures/nested-input.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {execa} from '../../index.js';
+import {foobarUtf16Uint8Array} from '../helpers/input.js';
+
+const [options, file, ...args] = process.argv.slice(2);
+await execa(file, args, {...JSON.parse(options), input: foobarUtf16Uint8Array});

--- a/test/helpers/input.js
+++ b/test/helpers/input.js
@@ -2,11 +2,15 @@ import {Buffer} from 'node:buffer';
 
 const textEncoder = new TextEncoder();
 
+export const bufferToUint8Array = buffer => new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+
 export const foobarString = 'foobar';
 export const foobarUint8Array = textEncoder.encode('foobar');
 export const foobarArrayBuffer = foobarUint8Array.buffer;
 export const foobarUint16Array = new Uint16Array(foobarArrayBuffer);
 export const foobarBuffer = Buffer.from(foobarString);
+const foobarUtf16Buffer = Buffer.from(foobarString, 'utf16le');
+export const foobarUtf16Uint8Array = bufferToUint8Array(foobarUtf16Buffer);
 export const foobarDataView = new DataView(foobarArrayBuffer);
 export const foobarObject = {foo: 'bar'};
 export const foobarObjectString = JSON.stringify(foobarObject);

--- a/test/helpers/lines.js
+++ b/test/helpers/lines.js
@@ -1,4 +1,5 @@
 import {Buffer} from 'node:buffer';
+import {bufferToUint8Array} from './input.js';
 
 const textEncoder = new TextEncoder();
 
@@ -14,6 +15,8 @@ export const simpleFullUint8Array = textEncoder.encode(simpleFull);
 export const simpleChunksUint8Array = [simpleFullUint8Array];
 export const simpleFullHex = Buffer.from(simpleFull).toString('hex');
 export const simpleChunksBuffer = [Buffer.from(simpleFull)];
+const simpleFullUtf16Buffer = Buffer.from(simpleFull, 'utf16le');
+export const simpleFullUtf16Uint8Array = bufferToUint8Array(simpleFullUtf16Buffer);
 export const simpleLines = ['aaa\n', 'bbb\n', 'ccc'];
 export const simpleFullEndLines = ['aaa\n', 'bbb\n', 'ccc\n'];
 export const noNewlinesFull = 'aaabbbccc';

--- a/test/stdio/lines.js
+++ b/test/stdio/lines.js
@@ -14,6 +14,7 @@ import {
 	simpleChunks,
 	simpleFullUint8Array,
 	simpleFullHex,
+	simpleFullUtf16Uint8Array,
 	simpleLines,
 	simpleFullEndLines,
 	noNewlinesChunks,
@@ -81,15 +82,28 @@ test('"lines: true" is a noop with objects generators, objectMode', async t => {
 	t.deepEqual(stdout, [foobarObject]);
 });
 
-const testOtherEncoding = async (t, expectedOutput, encoding, stripFinalNewline) => {
+const testBinaryEncoding = async (t, expectedOutput, encoding, stripFinalNewline) => {
 	const {stdout} = await getSimpleChunkSubprocess({encoding, stripFinalNewline});
 	t.deepEqual(stdout, expectedOutput);
 };
 
-test('"lines: true" is a noop with "encoding: buffer"', testOtherEncoding, simpleFullUint8Array, 'buffer', false);
-test('"lines: true" is a noop with "encoding: buffer", stripFinalNewline', testOtherEncoding, simpleFullUint8Array, 'buffer', false);
-test('"lines: true" is a noop with "encoding: hex"', testOtherEncoding, simpleFullHex, 'hex', false);
-test('"lines: true" is a noop with "encoding: hex", stripFinalNewline', testOtherEncoding, simpleFullHex, 'hex', true);
+test('"lines: true" is a noop with "encoding: buffer"', testBinaryEncoding, simpleFullUint8Array, 'buffer', false);
+test('"lines: true" is a noop with "encoding: buffer", stripFinalNewline', testBinaryEncoding, simpleFullUint8Array, 'buffer', false);
+test('"lines: true" is a noop with "encoding: hex"', testBinaryEncoding, simpleFullHex, 'hex', false);
+test('"lines: true" is a noop with "encoding: hex", stripFinalNewline', testBinaryEncoding, simpleFullHex, 'hex', true);
+
+const testTextEncoding = async (t, expectedLines, stripFinalNewline) => {
+	const {stdout} = await execa('stdin.js', {
+		lines: true,
+		stripFinalNewline,
+		encoding: 'utf16le',
+		input: simpleFullUtf16Uint8Array,
+	});
+	t.deepEqual(stdout, expectedLines);
+};
+
+test('"lines: true" is a noop with "encoding: utf16"', testTextEncoding, simpleLines, false);
+test('"lines: true" is a noop with "encoding: utf16", stripFinalNewline', testTextEncoding, noNewlinesChunks, true);
 
 test('"lines: true" is a noop with "buffer: false"', async t => {
 	const {stdout} = await getSimpleChunkSubprocess({buffer: false});

--- a/test/stdio/node-stream.js
+++ b/test/stdio/node-stream.js
@@ -151,8 +151,7 @@ test('stdio[*] can be a Node.js Writable with a file descriptor - sync', testFil
 const testFileWritableError = async (t, fdNumber) => {
 	const {stream, filePath} = await createFileWriteStream();
 
-	const subprocess = execa('noop-stdin-fd.js', [`${fdNumber}`], getStdio(fdNumber, stream));
-	subprocess.stdin.end(foobarString);
+	const subprocess = execa('noop-fd.js', [`${fdNumber}`, foobarString], getStdio(fdNumber, stream));
 
 	await assertFileStreamError(t, subprocess, stream, filePath);
 };

--- a/test/verbose/output.js
+++ b/test/verbose/output.js
@@ -186,6 +186,11 @@ test('Prints stdout, single newline', async t => {
 	t.deepEqual(getOutputLines(stderr), [`${testTimestamp} [0]   `]);
 });
 
+test('Can use encoding UTF16, verbose "full"', async t => {
+	const {stderr} = await nestedExeca('nested-input.js', 'stdin.js', {verbose: 'full', encoding: 'utf16le'});
+	t.is(getOutputLine(stderr), `${testTimestamp} [0]   ${foobarString}`);
+});
+
 const testNoOutputOptions = async (t, options, fixtureName = 'nested.js') => {
 	const {stderr} = await nestedExeca(fixtureName, 'noop.js', [foobarString], {verbose: 'full', ...options});
 	t.is(getOutputLine(stderr), undefined);


### PR DESCRIPTION
Using both `encoding: 'utf16le'` and either `lines: true` or `verbose: true` does not currently work.
This PR fixes that.