### PR TITLE
Add support for `std*: TransformStream` option

### DIFF
--- a/docs/transform.md
+++ b/docs/transform.md
@@ -173,15 +173,26 @@ const {stdout} = await execa('./command.js', {stdout: {transform, final}});
 console.log(stdout); // Ends with: 'Number of lines: 54'
 ```
 
-## Node.js Duplex/Transform streams
+## Duplex/Transform streams
 
-A Node.js [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) or [`Transform`](https://nodejs.org/api/stream.html#class-streamtransform) stream can be used instead of a generator function. A `{transform}` plain object must be passed. The [`objectMode`](#object-mode) transform option can be used, but not the [`binary`](#encoding) nor [`preserveNewlines`](#newlines) options.
+A [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) stream, Node.js [`Transform`](https://nodejs.org/api/stream.html#class-streamtransform) stream or web [`TransformStream`](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream) can be used instead of a generator function.
+
+Like generator functions, web `TransformStream` can be passed either directly or as a `{transform}` plain object. But `Duplex` and `Transform` must always be passed as a `{transform}` plain object.
+
+The [`objectMode`](#object-mode) transform option can be used, but not the [`binary`](#encoding) nor [`preserveNewlines`](#newlines) options.
 
 ```js
 import {createGzip} from 'node:zlib';
 import {execa} from 'execa';
 
 const {stdout} = await execa('./run.js', {stdout: {transform: createGzip()}});
+console.log(stdout); // `stdout` is compressed with gzip
+```
+
+```js
+import {execa} from 'execa';
+
+const {stdout} = await execa('./run.js', {stdout: new CompressionStream('gzip')});
 console.log(stdout); // `stdout` is compressed with gzip
 ```
 
@@ -197,6 +208,12 @@ This also allows using multiple transforms.
 
 ```js
 await execa('echo', ['hello'], {stdout: [transform, otherTransform]});
+```
+
+Or saving to files.
+
+```js
+await execa('./run.js', {stdout: [new CompressionStream('gzip'), {file: './output.gz'}]});
 ```
 
 ## Async iteration

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,11 @@ type DuplexTransform = {
 	objectMode?: boolean;
 };
 
+type WebTransform = {
+	transform: TransformStream;
+	objectMode?: boolean;
+};
+
 type CommonStdioOption<IsSync extends boolean = boolean> =
 	| BaseStdioOption
 	| 'ipc'
@@ -47,7 +52,9 @@ type CommonStdioOption<IsSync extends boolean = boolean> =
 	| IfAsync<IsSync,
 	| GeneratorTransform
 	| GeneratorTransformFull
-	| DuplexTransform>;
+	| DuplexTransform
+	| WebTransform
+	| TransformStream>;
 
 type InputStdioOption<IsSync extends boolean = boolean> =
 	| Uint8Array
@@ -126,13 +133,13 @@ type IsObjectOutputOptions<OutputOptions extends StdioOption> = IsObjectOutputOp
 	: OutputOptions
 >;
 
-type IsObjectOutputOption<OutputOption extends StdioSingleOption> = OutputOption extends GeneratorTransformFull
+type IsObjectOutputOption<OutputOption extends StdioSingleOption> = OutputOption extends GeneratorTransformFull | WebTransform
 	? BooleanObjectMode<OutputOption['objectMode']>
 	: OutputOption extends DuplexTransform
 		? DuplexObjectMode<OutputOption>
 		: false;
 
-type BooleanObjectMode<ObjectModeOption extends GeneratorTransformFull['objectMode']> = ObjectModeOption extends true ? true : false;
+type BooleanObjectMode<ObjectModeOption extends boolean | undefined> = ObjectModeOption extends true ? true : false;
 
 type DuplexObjectMode<OutputOption extends DuplexTransform> = OutputOption['objectMode'] extends boolean
 	? OutputOption['objectMode']
@@ -357,7 +364,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-	This can also be a generator function or a [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) to transform the input. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
+	This can also be a generator function or a [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) or a [web `TransformStream`](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream) to transform the input. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
 
 	@default `inherit` with `$`, `pipe` otherwise
 	*/
@@ -377,7 +384,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-	This can also be a generator function or a [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) to transform the output. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
+	This can also be a generator function or a [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) or a [web `TransformStream`](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream) to transform the output. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
 
 	@default 'pipe'
 	*/
@@ -397,7 +404,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	This can be an [array of values](https://github.com/sindresorhus/execa#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-	This can also be a generator function or a [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) to transform the output. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
+	This can also be a generator function or a [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) or a [web `TransformStream`](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream) to transform the output. [Learn more.](https://github.com/sindresorhus/execa/tree/main/docs/transform.md)
 
 	@default 'pipe'
 	*/

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -29,6 +29,10 @@ const duplexNotObject = {transform: duplexStream as Duplex & {readableObjectMode
 const duplexObjectProperty = {transform: duplexStream, objectMode: true as const};
 const duplexNotObjectProperty = {transform: duplexStream, objectMode: false as const};
 const duplexTransform = {transform: new Transform()};
+const webTransformInstance = new TransformStream();
+const webTransform = {transform: webTransformInstance};
+const webTransformObject = {transform: webTransformInstance, objectMode: true as const};
+const webTransformNotObject = {transform: webTransformInstance, objectMode: false as const};
 
 type AnySyncChunk = string | Uint8Array | undefined;
 type AnyChunk = AnySyncChunk | string[] | unknown[];
@@ -674,6 +678,10 @@ try {
 	expectType<unknown[]>(objectTransformLinesStdoutResult.stdout);
 	expectType<[undefined, unknown[], string[]]>(objectTransformLinesStdoutResult.stdio);
 
+	const objectWebTransformStdoutResult = await execa('unicorns', {stdout: webTransformObject});
+	expectType<unknown[]>(objectWebTransformStdoutResult.stdout);
+	expectType<[undefined, unknown[], string]>(objectWebTransformStdoutResult.stdio);
+
 	const objectDuplexStdoutResult = await execa('unicorns', {stdout: duplexObject});
 	expectType<unknown[]>(objectDuplexStdoutResult.stdout);
 	expectType<[undefined, unknown[], string]>(objectDuplexStdoutResult.stdio);
@@ -685,6 +693,10 @@ try {
 	const objectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}});
 	expectType<unknown[]>(objectTransformStdoutResult.stdout);
 	expectType<[undefined, unknown[], string]>(objectTransformStdoutResult.stdio);
+
+	const objectWebTransformStderrResult = await execa('unicorns', {stderr: webTransformObject});
+	expectType<unknown[]>(objectWebTransformStderrResult.stderr);
+	expectType<[undefined, string, unknown[]]>(objectWebTransformStderrResult.stdio);
 
 	const objectDuplexStderrResult = await execa('unicorns', {stderr: duplexObject});
 	expectType<unknown[]>(objectDuplexStderrResult.stderr);
@@ -698,6 +710,10 @@ try {
 	expectType<unknown[]>(objectTransformStderrResult.stderr);
 	expectType<[undefined, string, unknown[]]>(objectTransformStderrResult.stdio);
 
+	const objectWebTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', webTransformObject]});
+	expectType<unknown[]>(objectWebTransformStdioResult.stderr);
+	expectType<[undefined, string, unknown[]]>(objectWebTransformStdioResult.stdio);
+
 	const objectDuplexStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', duplexObject]});
 	expectType<unknown[]>(objectDuplexStdioResult.stderr);
 	expectType<[undefined, string, unknown[]]>(objectDuplexStdioResult.stdio);
@@ -709,6 +725,10 @@ try {
 	const objectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, final: objectFinal, objectMode: true}]});
 	expectType<unknown[]>(objectTransformStdioResult.stderr);
 	expectType<[undefined, string, unknown[]]>(objectTransformStdioResult.stdio);
+
+	const singleObjectWebTransformStdoutResult = await execa('unicorns', {stdout: [webTransformObject]});
+	expectType<unknown[]>(singleObjectWebTransformStdoutResult.stdout);
+	expectType<[undefined, unknown[], string]>(singleObjectWebTransformStdoutResult.stdio);
 
 	const singleObjectDuplexStdoutResult = await execa('unicorns', {stdout: [duplexObject]});
 	expectType<unknown[]>(singleObjectDuplexStdoutResult.stdout);
@@ -722,6 +742,10 @@ try {
 	expectType<unknown[]>(singleObjectTransformStdoutResult.stdout);
 	expectType<[undefined, unknown[], string]>(singleObjectTransformStdoutResult.stdio);
 
+	const manyObjectWebTransformStdoutResult = await execa('unicorns', {stdout: [webTransformObject, webTransformObject]});
+	expectType<unknown[]>(manyObjectWebTransformStdoutResult.stdout);
+	expectType<[undefined, unknown[], string]>(manyObjectWebTransformStdoutResult.stdio);
+
 	const manyObjectDuplexStdoutResult = await execa('unicorns', {stdout: [duplexObject, duplexObject]});
 	expectType<unknown[]>(manyObjectDuplexStdoutResult.stdout);
 	expectType<[undefined, unknown[], string]>(manyObjectDuplexStdoutResult.stdio);
@@ -733,6 +757,10 @@ try {
 	const manyObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, final: objectFinal, objectMode: true}, {transform: objectGenerator, final: objectFinal, objectMode: true}]});
 	expectType<unknown[]>(manyObjectTransformStdoutResult.stdout);
 	expectType<[undefined, unknown[], string]>(manyObjectTransformStdoutResult.stdio);
+
+	const falseObjectWebTransformStdoutResult = await execa('unicorns', {stdout: webTransformNotObject});
+	expectType<string>(falseObjectWebTransformStdoutResult.stdout);
+	expectType<[undefined, string, string]>(falseObjectWebTransformStdoutResult.stdio);
 
 	const falseObjectDuplexStdoutResult = await execa('unicorns', {stdout: duplexNotObject});
 	expectType<string>(falseObjectDuplexStdoutResult.stdout);
@@ -746,6 +774,10 @@ try {
 	expectType<string>(falseObjectTransformStdoutResult.stdout);
 	expectType<[undefined, string, string]>(falseObjectTransformStdoutResult.stdio);
 
+	const falseObjectWebTransformStderrResult = await execa('unicorns', {stderr: webTransformNotObject});
+	expectType<string>(falseObjectWebTransformStderrResult.stderr);
+	expectType<[undefined, string, string]>(falseObjectWebTransformStderrResult.stdio);
+
 	const falseObjectDuplexStderrResult = await execa('unicorns', {stderr: duplexNotObject});
 	expectType<string>(falseObjectDuplexStderrResult.stderr);
 	expectType<[undefined, string, string]>(falseObjectDuplexStderrResult.stdio);
@@ -758,6 +790,10 @@ try {
 	expectType<string>(falseObjectTransformStderrResult.stderr);
 	expectType<[undefined, string, string]>(falseObjectTransformStderrResult.stdio);
 
+	const falseObjectWebTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', webTransformNotObject]});
+	expectType<string>(falseObjectWebTransformStdioResult.stderr);
+	expectType<[undefined, string, string]>(falseObjectWebTransformStdioResult.stdio);
+
 	const falseObjectDuplexStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', duplexNotObject]});
 	expectType<string>(falseObjectDuplexStdioResult.stderr);
 	expectType<[undefined, string, string]>(falseObjectDuplexStdioResult.stdio);
@@ -769,6 +805,14 @@ try {
 	const falseObjectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, final: objectFinal, objectMode: false}]});
 	expectType<string>(falseObjectTransformStdioResult.stderr);
 	expectType<[undefined, string, string]>(falseObjectTransformStdioResult.stdio);
+
+	const topObjectWebTransformStdoutResult = await execa('unicorns', {stdout: webTransformInstance});
+	expectType<string>(topObjectWebTransformStdoutResult.stdout);
+	expectType<[undefined, string, string]>(topObjectWebTransformStdoutResult.stdio);
+
+	const undefinedObjectWebTransformStdoutResult = await execa('unicorns', {stdout: webTransform});
+	expectType<string>(undefinedObjectWebTransformStdoutResult.stdout);
+	expectType<[undefined, string, string]>(undefinedObjectWebTransformStdoutResult.stdio);
 
 	const undefinedObjectDuplexStdoutResult = await execa('unicorns', {stdout: duplex});
 	expectType<string | unknown[]>(undefinedObjectDuplexStdoutResult.stdout);
@@ -1279,6 +1323,16 @@ execa('unicorns', {stdin: [duplexTransform]});
 expectError(execaSync('unicorns', {stdin: [duplexTransform]}));
 expectError(execa('unicorns', {stdin: {...duplex, objectMode: 'true'}}));
 expectError(execaSync('unicorns', {stdin: {...duplex, objectMode: 'true'}}));
+execa('unicorns', {stdin: webTransformInstance});
+expectError(execaSync('unicorns', {stdin: webTransformInstance}));
+execa('unicorns', {stdin: [webTransformInstance]});
+expectError(execaSync('unicorns', {stdin: [webTransformInstance]}));
+execa('unicorns', {stdin: webTransform});
+expectError(execaSync('unicorns', {stdin: webTransform}));
+execa('unicorns', {stdin: [webTransform]});
+expectError(execaSync('unicorns', {stdin: [webTransform]}));
+expectError(execa('unicorns', {stdin: {...webTransform, objectMode: 'true'}}));
+expectError(execaSync('unicorns', {stdin: {...webTransform, objectMode: 'true'}}));
 execa('unicorns', {stdin: unknownGenerator});
 expectError(execaSync('unicorns', {stdin: unknownGenerator}));
 execa('unicorns', {stdin: [unknownGenerator]});
@@ -1392,6 +1446,16 @@ execa('unicorns', {stdout: [duplexTransform]});
 expectError(execaSync('unicorns', {stdout: [duplexTransform]}));
 expectError(execa('unicorns', {stdout: {...duplex, objectMode: 'true'}}));
 expectError(execaSync('unicorns', {stdout: {...duplex, objectMode: 'true'}}));
+execa('unicorns', {stdout: webTransformInstance});
+expectError(execaSync('unicorns', {stdout: webTransformInstance}));
+execa('unicorns', {stdout: [webTransformInstance]});
+expectError(execaSync('unicorns', {stdout: [webTransformInstance]}));
+execa('unicorns', {stdout: webTransform});
+expectError(execaSync('unicorns', {stdout: webTransform}));
+execa('unicorns', {stdout: [webTransform]});
+expectError(execaSync('unicorns', {stdout: [webTransform]}));
+expectError(execa('unicorns', {stdout: {...webTransform, objectMode: 'true'}}));
+expectError(execaSync('unicorns', {stdout: {...webTransform, objectMode: 'true'}}));
 execa('unicorns', {stdout: unknownGenerator});
 expectError(execaSync('unicorns', {stdout: unknownGenerator}));
 execa('unicorns', {stdout: [unknownGenerator]});
@@ -1505,6 +1569,16 @@ execa('unicorns', {stderr: [duplexTransform]});
 expectError(execaSync('unicorns', {stderr: [duplexTransform]}));
 expectError(execa('unicorns', {stderr: {...duplex, objectMode: 'true'}}));
 expectError(execaSync('unicorns', {stderr: {...duplex, objectMode: 'true'}}));
+execa('unicorns', {stderr: webTransformInstance});
+expectError(execaSync('unicorns', {stderr: webTransformInstance}));
+execa('unicorns', {stderr: [webTransformInstance]});
+expectError(execaSync('unicorns', {stderr: [webTransformInstance]}));
+execa('unicorns', {stderr: webTransform});
+expectError(execaSync('unicorns', {stderr: webTransform}));
+execa('unicorns', {stderr: [webTransform]});
+expectError(execaSync('unicorns', {stderr: [webTransform]}));
+expectError(execa('unicorns', {stderr: {...webTransform, objectMode: 'true'}}));
+expectError(execaSync('unicorns', {stderr: {...webTransform, objectMode: 'true'}}));
 execa('unicorns', {stderr: unknownGenerator});
 expectError(execaSync('unicorns', {stderr: unknownGenerator}));
 execa('unicorns', {stderr: [unknownGenerator]});
@@ -1596,6 +1670,10 @@ expectError(execa('unicorns', {stdio: duplex}));
 expectError(execaSync('unicorns', {stdio: duplex}));
 expectError(execa('unicorns', {stdio: duplexTransform}));
 expectError(execaSync('unicorns', {stdio: duplexTransform}));
+expectError(execa('unicorns', {stdio: webTransformInstance}));
+expectError(execaSync('unicorns', {stdio: webTransformInstance}));
+expectError(execa('unicorns', {stdio: webTransform}));
+expectError(execaSync('unicorns', {stdio: webTransform}));
 expectError(execa('unicorns', {stdio: new Writable()}));
 expectError(execaSync('unicorns', {stdio: new Writable()}));
 expectError(execa('unicorns', {stdio: new Readable()}));
@@ -1653,6 +1731,8 @@ execa('unicorns', {
 		{file: './test'},
 		duplex,
 		duplexTransform,
+		webTransformInstance,
+		webTransform,
 		new Writable(),
 		new Readable(),
 		new WritableStream(),
@@ -1683,6 +1763,8 @@ expectError(execaSync('unicorns', {stdio: [unknownGenerator]}));
 expectError(execaSync('unicorns', {stdio: [{transform: unknownGenerator}]}));
 expectError(execaSync('unicorns', {stdio: [duplex]}));
 expectError(execaSync('unicorns', {stdio: [duplexTransform]}));
+expectError(execaSync('unicorns', {stdio: [webTransformInstance]}));
+expectError(execaSync('unicorns', {stdio: [webTransform]}));
 expectError(execaSync('unicorns', {stdio: [new WritableStream()]}));
 expectError(execaSync('unicorns', {stdio: [new ReadableStream()]}));
 expectError(execaSync('unicorns', {stdio: [emptyStringGenerator()]}));
@@ -1708,6 +1790,8 @@ execa('unicorns', {
 		[{file: './test'}],
 		[duplex],
 		[duplexTransform],
+		[webTransformInstance],
+		[webTransform],
 		[new Writable()],
 		[new Readable()],
 		[new WritableStream()],
@@ -1742,6 +1826,8 @@ expectError(execaSync('unicorns', {stdio: [[unknownGenerator]]}));
 expectError(execaSync('unicorns', {stdio: [[{transform: unknownGenerator}]]}));
 expectError(execaSync('unicorns', {stdio: [[duplex]]}));
 expectError(execaSync('unicorns', {stdio: [[duplexTransform]]}));
+expectError(execaSync('unicorns', {stdio: [[webTransformInstance]]}));
+expectError(execaSync('unicorns', {stdio: [[webTransform]]}));
 expectError(execaSync('unicorns', {stdio: [[new WritableStream()]]}));
 expectError(execaSync('unicorns', {stdio: [[new ReadableStream()]]}));
 expectError(execaSync('unicorns', {stdio: [[['foo', 'bar']]]}));

--- a/lib/stdio/async.js
+++ b/lib/stdio/async.js
@@ -1,6 +1,6 @@
 import {createReadStream, createWriteStream} from 'node:fs';
 import {Buffer} from 'node:buffer';
-import {Readable, Writable} from 'node:stream';
+import {Readable, Writable, Duplex} from 'node:stream';
 import mergeStreams from '@sindresorhus/merge-streams';
 import {isStandardStream, incrementMaxListeners} from '../utils.js';
 import {handleInput} from './handle.js';
@@ -18,6 +18,11 @@ const forbiddenIfAsync = ({type, optionName}) => {
 const addProperties = {
 	generator: generatorToDuplexStream,
 	nodeStream: ({value}) => ({stream: value}),
+	webTransform({value: {transform, writableObjectMode, readableObjectMode}}) {
+		const objectMode = writableObjectMode || readableObjectMode;
+		const stream = Duplex.fromWeb(transform, {objectMode});
+		return {stream};
+	},
 	duplex: ({value: {transform}}) => ({stream: transform}),
 	native() {},
 };

--- a/lib/stdio/direction.js
+++ b/lib/stdio/direction.js
@@ -48,6 +48,7 @@ const guessStreamDirection = {
 
 		return isNodeWritableStream(value, {checkOpen: false}) ? undefined : 'input';
 	},
+	webTransform: anyDirection,
 	duplex: anyDirection,
 	native(value) {
 		const standardStreamDirection = getStandardStreamDirection(value);

--- a/lib/stdio/generator.js
+++ b/lib/stdio/generator.js
@@ -33,11 +33,19 @@ const getTransforms = (stdioItems, optionName, direction, {encoding}) => {
 	return sortTransforms(newTransforms, direction);
 };
 
-export const TRANSFORM_TYPES = new Set(['generator', 'duplex']);
+export const TRANSFORM_TYPES = new Set(['generator', 'duplex', 'webTransform']);
 
-const normalizeTransform = ({stdioItem, stdioItem: {type}, index, newTransforms, optionName, direction, encoding}) => type === 'duplex'
-	? normalizeDuplex({stdioItem, optionName})
-	: normalizeGenerator({stdioItem, index, newTransforms, direction, encoding});
+const normalizeTransform = ({stdioItem, stdioItem: {type}, index, newTransforms, optionName, direction, encoding}) => {
+	if (type === 'duplex') {
+		return normalizeDuplex({stdioItem, optionName});
+	}
+
+	if (type === 'webTransform') {
+		return normalizeTransformStream({stdioItem, index, newTransforms, direction});
+	}
+
+	return normalizeGenerator({stdioItem, index, newTransforms, direction, encoding});
+};
 
 const normalizeDuplex = ({
 	stdioItem,
@@ -62,6 +70,15 @@ const normalizeDuplex = ({
 		...stdioItem,
 		value: {transform, writableObjectMode, readableObjectMode},
 	};
+};
+
+const normalizeTransformStream = ({stdioItem, stdioItem: {value}, index, newTransforms, direction}) => {
+	const {transform, objectMode} = isPlainObj(value) ? value : {transform: value};
+	const {writableObjectMode, readableObjectMode} = getObjectModes(objectMode, index, newTransforms, direction);
+	return ({
+		...stdioItem,
+		value: {transform, writableObjectMode, readableObjectMode},
+	});
 };
 
 const normalizeGenerator = ({stdioItem, stdioItem: {value}, index, newTransforms, direction, encoding}) => {

--- a/lib/stdio/sync.js
+++ b/lib/stdio/sync.js
@@ -18,6 +18,7 @@ const addProperties = {
 	generator: forbiddenIfSync,
 	webStream: forbiddenIfSync,
 	nodeStream: forbiddenIfSync,
+	webTransform: forbiddenIfSync,
 	duplex: forbiddenIfSync,
 	iterable: forbiddenIfSync,
 	native() {},

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -32,6 +32,10 @@ export const getStdioItemType = (value, optionName) => {
 		return 'iterable';
 	}
 
+	if (isTransformStream(value)) {
+		return getTransformStreamType({transform: value}, optionName);
+	}
+
 	if (isTransformOptions(value)) {
 		return getTransformObjectType(value, optionName);
 	}
@@ -39,31 +43,51 @@ export const getStdioItemType = (value, optionName) => {
 	return 'native';
 };
 
-const getTransformObjectType = (value, optionName) => isDuplexStream(value.transform, {checkOpen: false})
-	? getDuplexType(value, optionName)
-	: getGeneratorObjectType(value, optionName);
+const getTransformObjectType = (value, optionName) => {
+	if (isDuplexStream(value.transform, {checkOpen: false})) {
+		return getDuplexType(value, optionName);
+	}
 
-const getDuplexType = ({final, binary, objectMode}, optionName) => {
-	checkUndefinedOption(final, `${optionName}.final`);
-	checkUndefinedOption(binary, `${optionName}.binary`);
-	checkBooleanOption(objectMode, `${optionName}.objectMode`);
+	if (isTransformStream(value.transform)) {
+		return getTransformStreamType(value, optionName);
+	}
 
+	return getGeneratorObjectType(value, optionName);
+};
+
+const getDuplexType = (value, optionName) => {
+	validateNonGeneratorType(value, optionName, 'Duplex stream');
 	return 'duplex';
 };
 
-const checkUndefinedOption = (value, optionName) => {
+const getTransformStreamType = (value, optionName) => {
+	validateNonGeneratorType(value, optionName, 'web TransformStream');
+	return 'webTransform';
+};
+
+const validateNonGeneratorType = ({final, binary, objectMode}, optionName, typeName) => {
+	checkUndefinedOption(final, `${optionName}.final`, typeName);
+	checkUndefinedOption(binary, `${optionName}.binary`, typeName);
+	checkBooleanOption(objectMode, `${optionName}.objectMode`);
+};
+
+const checkUndefinedOption = (value, optionName, typeName) => {
 	if (value !== undefined) {
-		throw new TypeError(`The \`${optionName}\` option can only be defined when using a generator, not a Duplex stream.`);
+		throw new TypeError(`The \`${optionName}\` option can only be defined when using a generator, not a ${typeName}.`);
 	}
 };
 
 const getGeneratorObjectType = ({transform, final, binary, objectMode}, optionName) => {
 	if (transform !== undefined && !isGenerator(transform)) {
-		throw new TypeError(`The \`${optionName}.transform\` option must be a generator or a Duplex stream.`);
+		throw new TypeError(`The \`${optionName}.transform\` option must be a generator, a Duplex stream or a web TransformStream.`);
 	}
 
 	if (isDuplexStream(final, {checkOpen: false})) {
 		throw new TypeError(`The \`${optionName}.final\` option must not be a Duplex stream.`);
+	}
+
+	if (isTransformStream(final)) {
+		throw new TypeError(`The \`${optionName}.final\` option must not be a web TransformStream.`);
 	}
 
 	if (final !== undefined && !isGenerator(final)) {
@@ -104,6 +128,7 @@ const KNOWN_STDIO_STRINGS = new Set(['ipc', 'ignore', 'inherit', 'overlapped', '
 const isReadableStream = value => Object.prototype.toString.call(value) === '[object ReadableStream]';
 export const isWritableStream = value => Object.prototype.toString.call(value) === '[object WritableStream]';
 const isWebStream = value => isReadableStream(value) || isWritableStream(value);
+const isTransformStream = value => isReadableStream(value?.readable) && isWritableStream(value?.writable);
 
 const isIterableObject = value => typeof value === 'object'
 	&& value !== null
@@ -116,6 +141,7 @@ export const TYPE_TO_MESSAGE = {
 	filePath: 'a file path string',
 	webStream: 'a web stream',
 	nodeStream: 'a Node.js stream',
+	webTransform: 'a web TransformStream',
 	duplex: 'a Duplex stream',
 	native: 'any value',
 	iterable: 'an iterable',

--- a/readme.md
+++ b/readme.md
@@ -319,7 +319,7 @@ Same as [`execa()`](#execafile-arguments-options) but synchronous.
 
 Returns or throws a [`subprocessResult`](#subprocessResult). The [`subprocess`](#subprocess) is not returned: its methods and properties are not available. This includes [`.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`.pid`](https://nodejs.org/api/child_process.html#subprocesspid), [`.pipe()`](#pipefile-arguments-options), [`.iterable()`](#iterablereadableoptions), [`.readable()`](#readablereadableoptions), [`.writable()`](#writablewritableoptions), [`.duplex()`](#duplexduplexoptions) and the [`.stdin`/`.stdout`/`.stderr`](https://nodejs.org/api/child_process.html#subprocessstdout) streams.
 
-Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`ipc`](#ipc), [`serialization`](#serialization), [`cancelSignal`](#cancelsignal), [`forceKillAfterDelay`](#forcekillafterdelay), [`lines`](#lines) and [`verbose: 'full'`](#verbose). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio-1) and [`input`](#input) options cannot be an array, [`overlapped`](https://nodejs.org/api/child_process.html#optionsstdio), an iterable, a [transform](docs/transform.md), a [`Duplex`](docs/transform.md#nodejs-duplextransform-streams), or a web stream. Node.js streams [must have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr) unless the `input` option is used.
+Cannot use the following options: [`all`](#all-2), [`cleanup`](#cleanup), [`buffer`](#buffer), [`detached`](#detached), [`ipc`](#ipc), [`serialization`](#serialization), [`cancelSignal`](#cancelsignal), [`forceKillAfterDelay`](#forcekillafterdelay), [`lines`](#lines) and [`verbose: 'full'`](#verbose). Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1), [`stdio`](#stdio-1) and [`input`](#input) options cannot be an array, [`overlapped`](https://nodejs.org/api/child_process.html#optionsstdio), an iterable, a [transform](docs/transform.md), a [`Duplex`](docs/transform.md#duplextransform-streams), or a web stream. Node.js streams [must have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr) unless the `input` option is used.
 
 #### $(file, arguments?, options?)
 
@@ -870,7 +870,7 @@ See also the [`input`](#input) and [`stdin`](#stdin) options.
 
 #### stdin
 
-Type: `string | number | stream.Readable | ReadableStream | URL | {file: string} | Uint8Array | Iterable<string | Uint8Array | unknown> | AsyncIterable<string | Uint8Array | unknown> | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown> | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex}` (or a tuple of those types)\
+Type: `string | number | stream.Readable | ReadableStream | TransformStream | URL | {file: string} | Uint8Array | Iterable<string | Uint8Array | unknown> | AsyncIterable<string | Uint8Array | unknown> | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown> | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex | TransformStream}` (or a tuple of those types)\
 Default: `inherit` with [`$`](#file-arguments-options), `pipe` otherwise
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the subprocess' standard input. This can be:
@@ -888,11 +888,11 @@ Default: `inherit` with [`$`](#file-arguments-options), `pipe` otherwise
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-This can also be a generator function or a [`Duplex`](docs/transform.md#nodejs-duplextransform-streams) to transform the input. [Learn more.](docs/transform.md)
+This can also be a generator function, a [`Duplex`](docs/transform.md#duplextransform-streams) or a web [`TransformStream`](docs/transform.md#duplextransform-streams) to transform the input. [Learn more.](docs/transform.md)
 
 #### stdout
 
-Type: `string | number | stream.Writable | WritableStream | URL | {file: string} | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown>  | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex}` (or a tuple of those types)\
+Type: `string | number | stream.Writable | WritableStream | TransformStream | URL | {file: string} | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown>  | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex | TransformStream}` (or a tuple of those types)\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the subprocess' standard output. This can be:
@@ -908,11 +908,11 @@ Default: `pipe`
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-This can also be a generator function or a [`Duplex`](docs/transform.md#nodejs-duplextransform-streams) to transform the output. [Learn more.](docs/transform.md)
+This can also be a generator function, a [`Duplex`](docs/transform.md#duplextransform-streams) or a web [`TransformStream`](docs/transform.md#duplextransform-streams) to transform the output. [Learn more.](docs/transform.md)
 
 #### stderr
 
-Type: `string | number | stream.Writable | WritableStream | URL | {file: string} | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown> | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex}` (or a tuple of those types)\
+Type: `string | number | stream.Writable | WritableStream | TransformStream | URL | {file: string} | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown> | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex | TransformStream}` (or a tuple of those types)\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the subprocess' standard error. This can be:
@@ -928,11 +928,11 @@ Default: `pipe`
 
 This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destinations) such as `['inherit', 'pipe']` or `[filePath, 'pipe']`.
 
-This can also be a generator function or a [`Duplex`](docs/transform.md#nodejs-duplextransform-streams) to transform the output. [Learn more.](docs/transform.md)
+This can also be a generator function, a [`Duplex`](docs/transform.md#duplextransform-streams) or a web [`TransformStream`](docs/transform.md#duplextransform-streams) to transform the output. [Learn more.](docs/transform.md)
 
 #### stdio
 
-Type: `string | Array<string | number | stream.Readable | stream.Writable | ReadableStream | WritableStream | URL | {file: string} | Uint8Array | Iterable<string> | Iterable<Uint8Array> | Iterable<unknown> | AsyncIterable<string | Uint8Array | unknown> | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown> | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex}>` (or a tuple of those types)\
+Type: `string | Array<string | number | stream.Readable | stream.Writable | ReadableStream | WritableStream | TransformStream | URL | {file: string} | Uint8Array | Iterable<string> | Iterable<Uint8Array> | Iterable<unknown> | AsyncIterable<string | Uint8Array | unknown> | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown> | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex | TransformStream}>` (or a tuple of those types)\
 Default: `pipe`
 
 Like the [`stdin`](#stdin), [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options but for all file descriptors at once. For example, `{stdio: ['ignore', 'pipe', 'pipe']}` is the same as `{stdin: 'ignore', stdout: 'pipe', stderr: 'pipe'}`.

--- a/test/helpers/map.js
+++ b/test/helpers/map.js
@@ -27,6 +27,20 @@ import {
 	appendDuplex,
 	timeoutDuplex,
 } from './duplex.js';
+import {
+	addNoopWebTransform,
+	noopWebTransform,
+	serializeWebTransform,
+	uppercaseBufferWebTransform,
+	getOutputWebTransform,
+	outputObjectWebTransform,
+	getOutputsWebTransform,
+	noYieldWebTransform,
+	multipleYieldWebTransform,
+	throwingWebTransform,
+	appendWebTransform,
+	timeoutWebTransform,
+} from './web-transform.js';
 
 export const generatorsMap = {
 	generator: {
@@ -58,5 +72,20 @@ export const generatorsMap = {
 		throwing: throwingDuplex,
 		append: appendDuplex,
 		timeout: timeoutDuplex,
+	},
+	webTransform: {
+		addNoop: addNoopWebTransform,
+		noop: noopWebTransform,
+		serialize: serializeWebTransform,
+		uppercaseBuffer: uppercaseBufferWebTransform,
+		uppercase: uppercaseBufferWebTransform,
+		getOutput: getOutputWebTransform,
+		outputObject: outputObjectWebTransform,
+		getOutputs: getOutputsWebTransform,
+		noYield: noYieldWebTransform,
+		multipleYield: multipleYieldWebTransform,
+		throwing: throwingWebTransform,
+		append: appendWebTransform,
+		timeout: timeoutWebTransform,
 	},
 };

--- a/test/helpers/web-transform.js
+++ b/test/helpers/web-transform.js
@@ -1,0 +1,59 @@
+import {setTimeout, scheduler} from 'node:timers/promises';
+import {foobarObject, foobarString} from './input.js';
+import {casedSuffix, prefix, suffix} from './generator.js';
+
+const getWebTransform = transform => objectMode => ({
+	transform: new TransformStream({transform}),
+	objectMode,
+});
+
+export const addNoopWebTransform = (webTransform, addNoopTransform, objectMode) => addNoopTransform
+	? [webTransform, noopWebTransform(objectMode)]
+	: [webTransform];
+
+export const noopWebTransform = getWebTransform((value, controller) => {
+	controller.enqueue(value);
+});
+
+export const serializeWebTransform = getWebTransform((object, controller) => {
+	controller.enqueue(JSON.stringify(object));
+});
+
+export const getOutputWebTransform = (input, outerObjectMode) => getWebTransform((_, controller) => {
+	controller.enqueue(input);
+}, undefined, outerObjectMode);
+
+export const outputObjectWebTransform = () => getOutputWebTransform(foobarObject)(true);
+
+export const getOutputsWebTransform = inputs => getWebTransform((_, controller) => {
+	for (const input of inputs) {
+		controller.enqueue(input);
+	}
+});
+
+export const noYieldWebTransform = getWebTransform(() => {});
+
+export const multipleYieldWebTransform = getWebTransform(async (line, controller) => {
+	controller.enqueue(prefix);
+	await scheduler.yield();
+	controller.enqueue(line);
+	await scheduler.yield();
+	controller.enqueue(suffix);
+});
+
+export const uppercaseBufferWebTransform = getWebTransform((string, controller) => {
+	controller.enqueue(string.toString().toUpperCase());
+});
+
+export const throwingWebTransform = getWebTransform(() => {
+	throw new Error('Generator error');
+});
+
+export const appendWebTransform = getWebTransform((string, controller) => {
+	controller.enqueue(`${string}${casedSuffix}`);
+});
+
+export const timeoutWebTransform = timeout => getWebTransform(async (_, controller) => {
+	await setTimeout(timeout);
+	controller.enqueue(foobarString);
+});

--- a/test/stdio/generator.js
+++ b/test/stdio/generator.js
@@ -24,6 +24,7 @@ import {
 	casedSuffix,
 } from '../helpers/generator.js';
 import {appendDuplex, uppercaseBufferDuplex} from '../helpers/duplex.js';
+import {appendWebTransform, uppercaseBufferWebTransform} from '../helpers/web-transform.js';
 import {generatorsMap} from '../helpers/map.js';
 
 setFixtureDir();
@@ -77,6 +78,14 @@ test('Can use duplexes with result.stdin, noop transform', testGeneratorInput, 0
 test('Can use duplexes with result.stdio[*] as input, noop transform', testGeneratorInput, 3, false, true, 'duplex');
 test('Can use duplexes with result.stdin, objectMode, noop transform', testGeneratorInput, 0, true, true, 'duplex');
 test('Can use duplexes with result.stdio[*] as input, objectMode, noop transform', testGeneratorInput, 3, true, true, 'duplex');
+test('Can use webTransforms with result.stdin', testGeneratorInput, 0, false, false, 'webTransform');
+test('Can use webTransforms with result.stdio[*] as input', testGeneratorInput, 3, false, false, 'webTransform');
+test('Can use webTransforms with result.stdin, objectMode', testGeneratorInput, 0, true, false, 'webTransform');
+test('Can use webTransforms with result.stdio[*] as input, objectMode', testGeneratorInput, 3, true, false, 'webTransform');
+test('Can use webTransforms with result.stdin, noop transform', testGeneratorInput, 0, false, true, 'webTransform');
+test('Can use webTransforms with result.stdio[*] as input, noop transform', testGeneratorInput, 3, false, true, 'webTransform');
+test('Can use webTransforms with result.stdin, objectMode, noop transform', testGeneratorInput, 0, true, true, 'webTransform');
+test('Can use webTransforms with result.stdio[*] as input, objectMode, noop transform', testGeneratorInput, 3, true, true, 'webTransform');
 
 // eslint-disable-next-line max-params
 const testGeneratorInputPipe = async (t, useShortcutProperty, objectMode, addNoopTransform, type, input) => {
@@ -120,6 +129,22 @@ test('Can use duplexes with subprocess.stdio[0] and encoding "hex", noop transfo
 test('Can use duplexes with subprocess.stdin and encoding "hex", noop transform', testGeneratorInputPipe, true, false, true, 'duplex', [foobarHex, 'hex']);
 test('Can use duplexes with subprocess.stdio[0], objectMode, noop transform', testGeneratorInputPipe, false, true, true, 'duplex', [foobarObject]);
 test('Can use duplexes with subprocess.stdin, objectMode, noop transform', testGeneratorInputPipe, true, true, true, 'duplex', [foobarObject]);
+test('Can use webTransforms with subprocess.stdio[0] and default encoding', testGeneratorInputPipe, false, false, false, 'webTransform', [foobarString, 'utf8']);
+test('Can use webTransforms with subprocess.stdin and default encoding', testGeneratorInputPipe, true, false, false, 'webTransform', [foobarString, 'utf8']);
+test('Can use webTransforms with subprocess.stdio[0] and encoding "buffer"', testGeneratorInputPipe, false, false, false, 'webTransform', [foobarBuffer, 'buffer']);
+test('Can use webTransforms with subprocess.stdin and encoding "buffer"', testGeneratorInputPipe, true, false, false, 'webTransform', [foobarBuffer, 'buffer']);
+test('Can use webTransforms with subprocess.stdio[0] and encoding "hex"', testGeneratorInputPipe, false, false, false, 'webTransform', [foobarHex, 'hex']);
+test('Can use webTransforms with subprocess.stdin and encoding "hex"', testGeneratorInputPipe, true, false, false, 'webTransform', [foobarHex, 'hex']);
+test('Can use webTransforms with subprocess.stdio[0], objectMode', testGeneratorInputPipe, false, true, false, 'webTransform', [foobarObject]);
+test('Can use webTransforms with subprocess.stdin, objectMode', testGeneratorInputPipe, true, true, false, 'webTransform', [foobarObject]);
+test('Can use webTransforms with subprocess.stdio[0] and default encoding, noop transform', testGeneratorInputPipe, false, false, true, 'webTransform', [foobarString, 'utf8']);
+test('Can use webTransforms with subprocess.stdin and default encoding, noop transform', testGeneratorInputPipe, true, false, true, 'webTransform', [foobarString, 'utf8']);
+test('Can use webTransforms with subprocess.stdio[0] and encoding "buffer", noop transform', testGeneratorInputPipe, false, false, true, 'webTransform', [foobarBuffer, 'buffer']);
+test('Can use webTransforms with subprocess.stdin and encoding "buffer", noop transform', testGeneratorInputPipe, true, false, true, 'webTransform', [foobarBuffer, 'buffer']);
+test('Can use webTransforms with subprocess.stdio[0] and encoding "hex", noop transform', testGeneratorInputPipe, false, false, true, 'webTransform', [foobarHex, 'hex']);
+test('Can use webTransforms with subprocess.stdin and encoding "hex", noop transform', testGeneratorInputPipe, true, false, true, 'webTransform', [foobarHex, 'hex']);
+test('Can use webTransforms with subprocess.stdio[0], objectMode, noop transform', testGeneratorInputPipe, false, true, true, 'webTransform', [foobarObject]);
+test('Can use webTransforms with subprocess.stdin, objectMode, noop transform', testGeneratorInputPipe, true, true, true, 'webTransform', [foobarObject]);
 
 const testGeneratorStdioInputPipe = async (t, objectMode, addNoopTransform, type) => {
 	const {input, generators, output} = getInputObjectMode(objectMode, addNoopTransform, type);
@@ -137,6 +162,10 @@ test('Can use duplexes with subprocess.stdio[*] as input', testGeneratorStdioInp
 test('Can use duplexes with subprocess.stdio[*] as input, objectMode', testGeneratorStdioInputPipe, true, false, 'duplex');
 test('Can use duplexes with subprocess.stdio[*] as input, noop transform', testGeneratorStdioInputPipe, false, true, 'duplex');
 test('Can use duplexes with subprocess.stdio[*] as input, objectMode, noop transform', testGeneratorStdioInputPipe, true, true, 'duplex');
+test('Can use webTransforms with subprocess.stdio[*] as input', testGeneratorStdioInputPipe, false, false, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[*] as input, objectMode', testGeneratorStdioInputPipe, true, false, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[*] as input, noop transform', testGeneratorStdioInputPipe, false, true, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[*] as input, objectMode, noop transform', testGeneratorStdioInputPipe, true, true, 'webTransform');
 
 // eslint-disable-next-line max-params
 const testGeneratorOutput = async (t, fdNumber, reject, useShortcutProperty, objectMode, addNoopTransform, type) => {
@@ -227,6 +256,46 @@ test('Can use duplexes with error.stdout, objectMode, noop transform', testGener
 test('Can use duplexes with error.stdio[2], objectMode, noop transform', testGeneratorOutput, 2, false, false, true, true, 'duplex');
 test('Can use duplexes with error.stderr, objectMode, noop transform', testGeneratorOutput, 2, false, true, true, true, 'duplex');
 test('Can use duplexes with error.stdio[*] as output, objectMode, noop transform', testGeneratorOutput, 3, false, false, true, true, 'duplex');
+test('Can use webTransforms with result.stdio[1]', testGeneratorOutput, 1, true, false, false, false, 'webTransform');
+test('Can use webTransforms with result.stdout', testGeneratorOutput, 1, true, true, false, false, 'webTransform');
+test('Can use webTransforms with result.stdio[2]', testGeneratorOutput, 2, true, false, false, false, 'webTransform');
+test('Can use webTransforms with result.stderr', testGeneratorOutput, 2, true, true, false, false, 'webTransform');
+test('Can use webTransforms with result.stdio[*] as output', testGeneratorOutput, 3, true, false, false, false, 'webTransform');
+test('Can use webTransforms with error.stdio[1]', testGeneratorOutput, 1, false, false, false, false, 'webTransform');
+test('Can use webTransforms with error.stdout', testGeneratorOutput, 1, false, true, false, false, 'webTransform');
+test('Can use webTransforms with error.stdio[2]', testGeneratorOutput, 2, false, false, false, false, 'webTransform');
+test('Can use webTransforms with error.stderr', testGeneratorOutput, 2, false, true, false, false, 'webTransform');
+test('Can use webTransforms with error.stdio[*] as output', testGeneratorOutput, 3, false, false, false, false, 'webTransform');
+test('Can use webTransforms with result.stdio[1], objectMode', testGeneratorOutput, 1, true, false, true, false, 'webTransform');
+test('Can use webTransforms with result.stdout, objectMode', testGeneratorOutput, 1, true, true, true, false, 'webTransform');
+test('Can use webTransforms with result.stdio[2], objectMode', testGeneratorOutput, 2, true, false, true, false, 'webTransform');
+test('Can use webTransforms with result.stderr, objectMode', testGeneratorOutput, 2, true, true, true, false, 'webTransform');
+test('Can use webTransforms with result.stdio[*] as output, objectMode', testGeneratorOutput, 3, true, false, true, false, 'webTransform');
+test('Can use webTransforms with error.stdio[1], objectMode', testGeneratorOutput, 1, false, false, true, false, 'webTransform');
+test('Can use webTransforms with error.stdout, objectMode', testGeneratorOutput, 1, false, true, true, false, 'webTransform');
+test('Can use webTransforms with error.stdio[2], objectMode', testGeneratorOutput, 2, false, false, true, false, 'webTransform');
+test('Can use webTransforms with error.stderr, objectMode', testGeneratorOutput, 2, false, true, true, false, 'webTransform');
+test('Can use webTransforms with error.stdio[*] as output, objectMode', testGeneratorOutput, 3, false, false, true, false, 'webTransform');
+test('Can use webTransforms with result.stdio[1], noop transform', testGeneratorOutput, 1, true, false, false, true, 'webTransform');
+test('Can use webTransforms with result.stdout, noop transform', testGeneratorOutput, 1, true, true, false, true, 'webTransform');
+test('Can use webTransforms with result.stdio[2], noop transform', testGeneratorOutput, 2, true, false, false, true, 'webTransform');
+test('Can use webTransforms with result.stderr, noop transform', testGeneratorOutput, 2, true, true, false, true, 'webTransform');
+test('Can use webTransforms with result.stdio[*] as output, noop transform', testGeneratorOutput, 3, true, false, false, true, 'webTransform');
+test('Can use webTransforms with error.stdio[1], noop transform', testGeneratorOutput, 1, false, false, false, true, 'webTransform');
+test('Can use webTransforms with error.stdout, noop transform', testGeneratorOutput, 1, false, true, false, true, 'webTransform');
+test('Can use webTransforms with error.stdio[2], noop transform', testGeneratorOutput, 2, false, false, false, true, 'webTransform');
+test('Can use webTransforms with error.stderr, noop transform', testGeneratorOutput, 2, false, true, false, true, 'webTransform');
+test('Can use webTransforms with error.stdio[*] as output, noop transform', testGeneratorOutput, 3, false, false, false, true, 'webTransform');
+test('Can use webTransforms with result.stdio[1], objectMode, noop transform', testGeneratorOutput, 1, true, false, true, true, 'webTransform');
+test('Can use webTransforms with result.stdout, objectMode, noop transform', testGeneratorOutput, 1, true, true, true, true, 'webTransform');
+test('Can use webTransforms with result.stdio[2], objectMode, noop transform', testGeneratorOutput, 2, true, false, true, true, 'webTransform');
+test('Can use webTransforms with result.stderr, objectMode, noop transform', testGeneratorOutput, 2, true, true, true, true, 'webTransform');
+test('Can use webTransforms with result.stdio[*] as output, objectMode, noop transform', testGeneratorOutput, 3, true, false, true, true, 'webTransform');
+test('Can use webTransforms with error.stdio[1], objectMode, noop transform', testGeneratorOutput, 1, false, false, true, true, 'webTransform');
+test('Can use webTransforms with error.stdout, objectMode, noop transform', testGeneratorOutput, 1, false, true, true, true, 'webTransform');
+test('Can use webTransforms with error.stdio[2], objectMode, noop transform', testGeneratorOutput, 2, false, false, true, true, 'webTransform');
+test('Can use webTransforms with error.stderr, objectMode, noop transform', testGeneratorOutput, 2, false, true, true, true, 'webTransform');
+test('Can use webTransforms with error.stdio[*] as output, objectMode, noop transform', testGeneratorOutput, 3, false, false, true, true, 'webTransform');
 
 // eslint-disable-next-line max-params
 const testGeneratorOutputPipe = async (t, fdNumber, useShortcutProperty, objectMode, addNoopTransform, type) => {
@@ -277,6 +346,26 @@ test('Can use duplexes with subprocess.stdout, objectMode, noop transform', test
 test('Can use duplexes with subprocess.stdio[2], objectMode, noop transform', testGeneratorOutputPipe, 2, false, true, true, 'duplex');
 test('Can use duplexes with subprocess.stderr, objectMode, noop transform', testGeneratorOutputPipe, 2, true, true, true, 'duplex');
 test('Can use duplexes with subprocess.stdio[*] as output, objectMode, noop transform', testGeneratorOutputPipe, 3, false, true, true, 'duplex');
+test('Can use webTransforms with subprocess.stdio[1]', testGeneratorOutputPipe, 1, false, false, false, 'webTransform');
+test('Can use webTransforms with subprocess.stdout', testGeneratorOutputPipe, 1, true, false, false, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[2]', testGeneratorOutputPipe, 2, false, false, false, 'webTransform');
+test('Can use webTransforms with subprocess.stderr', testGeneratorOutputPipe, 2, true, false, false, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[*] as output', testGeneratorOutputPipe, 3, false, false, false, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[1], objectMode', testGeneratorOutputPipe, 1, false, true, false, 'webTransform');
+test('Can use webTransforms with subprocess.stdout, objectMode', testGeneratorOutputPipe, 1, true, true, false, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[2], objectMode', testGeneratorOutputPipe, 2, false, true, false, 'webTransform');
+test('Can use webTransforms with subprocess.stderr, objectMode', testGeneratorOutputPipe, 2, true, true, false, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[*] as output, objectMode', testGeneratorOutputPipe, 3, false, true, false, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[1], noop transform', testGeneratorOutputPipe, 1, false, false, true, 'webTransform');
+test('Can use webTransforms with subprocess.stdout, noop transform', testGeneratorOutputPipe, 1, true, false, true, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[2], noop transform', testGeneratorOutputPipe, 2, false, false, true, 'webTransform');
+test('Can use webTransforms with subprocess.stderr, noop transform', testGeneratorOutputPipe, 2, true, false, true, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[*] as output, noop transform', testGeneratorOutputPipe, 3, false, false, true, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[1], objectMode, noop transform', testGeneratorOutputPipe, 1, false, true, true, 'webTransform');
+test('Can use webTransforms with subprocess.stdout, objectMode, noop transform', testGeneratorOutputPipe, 1, true, true, true, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[2], objectMode, noop transform', testGeneratorOutputPipe, 2, false, true, true, 'webTransform');
+test('Can use webTransforms with subprocess.stderr, objectMode, noop transform', testGeneratorOutputPipe, 2, true, true, true, 'webTransform');
+test('Can use webTransforms with subprocess.stdio[*] as output, objectMode, noop transform', testGeneratorOutputPipe, 3, false, true, true, 'webTransform');
 
 const getAllStdioOption = (stdioOption, encoding, objectMode) => {
 	if (stdioOption) {
@@ -378,6 +467,7 @@ const testInputOption = async (t, type) => {
 
 test('Can use generators with input option', testInputOption, 'generator');
 test('Can use duplexes with input option', testInputOption, 'duplex');
+test('Can use webTransforms with input option', testInputOption, 'webTransform');
 
 const testInputFile = async (t, getOptions, reversed) => {
 	const filePath = tempfile();
@@ -395,6 +485,9 @@ test('Can use generators with inputFile option', testInputFile, filePath => ({in
 test('Can use duplexes with a file as input', testInputFile, filePath => ({stdin: [{file: filePath}, uppercaseBufferDuplex()]}), false);
 test('Can use duplexes with a file as input, reversed', testInputFile, filePath => ({stdin: [{file: filePath}, uppercaseBufferDuplex()]}), true);
 test('Can use duplexes with inputFile option', testInputFile, filePath => ({inputFile: filePath, stdin: uppercaseBufferDuplex()}), false);
+test('Can use webTransforms with a file as input', testInputFile, filePath => ({stdin: [{file: filePath}, uppercaseBufferWebTransform()]}), false);
+test('Can use webTransforms with a file as input, reversed', testInputFile, filePath => ({stdin: [{file: filePath}, uppercaseBufferWebTransform()]}), true);
+test('Can use webTransforms with inputFile option', testInputFile, filePath => ({inputFile: filePath, stdin: uppercaseBufferWebTransform()}), false);
 
 const testOutputFile = async (t, reversed, type) => {
 	const filePath = tempfile();
@@ -410,6 +503,8 @@ test('Can use generators with a file as output', testOutputFile, false, 'generat
 test('Can use generators with a file as output, reversed', testOutputFile, true, 'generator');
 test('Can use duplexes with a file as output', testOutputFile, false, 'duplex');
 test('Can use duplexes with a file as output, reversed', testOutputFile, true, 'duplex');
+test('Can use webTransforms with a file as output', testOutputFile, false, 'webTransform');
+test('Can use webTransforms with a file as output, reversed', testOutputFile, true, 'webTransform');
 
 const testWritableDestination = async (t, type) => {
 	const passThrough = new PassThrough();
@@ -423,6 +518,7 @@ const testWritableDestination = async (t, type) => {
 
 test('Can use generators to a Writable stream', testWritableDestination, 'generator');
 test('Can use duplexes to a Writable stream', testWritableDestination, 'duplex');
+test('Can use webTransforms to a Writable stream', testWritableDestination, 'webTransform');
 
 const testReadableSource = async (t, type) => {
 	const passThrough = new PassThrough();
@@ -434,6 +530,7 @@ const testReadableSource = async (t, type) => {
 
 test('Can use generators from a Readable stream', testReadableSource, 'generator');
 test('Can use duplexes from a Readable stream', testReadableSource, 'duplex');
+test('Can use webTransforms from a Readable stream', testReadableSource, 'webTransform');
 
 const testInherit = async (t, type) => {
 	const {stdout} = await execa('nested-inherit.js', [type]);
@@ -442,6 +539,7 @@ const testInherit = async (t, type) => {
 
 test('Can use generators with "inherit"', testInherit, 'generator');
 test('Can use duplexes with "inherit"', testInherit, 'duplex');
+test('Can use webTransforms with "inherit"', testInherit, 'webTransform');
 
 const testAppendInput = async (t, reversed, type) => {
 	const stdin = [foobarUint8Array, generatorsMap[type].uppercase(), generatorsMap[type].append()];
@@ -455,6 +553,8 @@ test('Can use multiple generators as input', testAppendInput, false, 'generator'
 test('Can use multiple generators as input, reversed', testAppendInput, true, 'generator');
 test('Can use multiple duplexes as input', testAppendInput, false, 'duplex');
 test('Can use multiple duplexes as input, reversed', testAppendInput, true, 'duplex');
+test('Can use multiple webTransforms as input', testAppendInput, false, 'webTransform');
+test('Can use multiple webTransforms as input, reversed', testAppendInput, true, 'webTransform');
 
 const testAppendOutput = async (t, reversed, type) => {
 	const stdoutOption = [generatorsMap[type].uppercase(), generatorsMap[type].append()];
@@ -468,6 +568,8 @@ test('Can use multiple generators as output', testAppendOutput, false, 'generato
 test('Can use multiple generators as output, reversed', testAppendOutput, true, 'generator');
 test('Can use multiple duplexes as output', testAppendOutput, false, 'duplex');
 test('Can use multiple duplexes as output, reversed', testAppendOutput, true, 'duplex');
+test('Can use multiple webTransforms as output', testAppendOutput, false, 'webTransform');
+test('Can use multiple webTransforms as output, reversed', testAppendOutput, true, 'webTransform');
 
 const testTwoGenerators = async (t, producesTwo, firstGenerator, secondGenerator = firstGenerator) => {
 	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {stdout: [firstGenerator, secondGenerator]});
@@ -478,12 +580,18 @@ const testTwoGenerators = async (t, producesTwo, firstGenerator, secondGenerator
 test('Can use multiple identical generators', testTwoGenerators, true, appendGenerator().transform);
 test('Can use multiple identical generators, options object', testTwoGenerators, true, appendGenerator());
 test('Ignore duplicate identical duplexes', testTwoGenerators, false, appendDuplex());
+test('Ignore duplicate identical webTransforms', testTwoGenerators, false, appendWebTransform());
 test('Can use multiple generators with duplexes', testTwoGenerators, true, appendGenerator(false, false, true), appendDuplex());
+test('Can use multiple generators with webTransforms', testTwoGenerators, true, appendGenerator(false, false, true), appendWebTransform());
+test('Can use multiple duplexes with webTransforms', testTwoGenerators, true, appendDuplex(), appendWebTransform());
 
-const testGeneratorSyntax = async (t, generator) => {
-	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {stdout: generator});
+const testGeneratorSyntax = async (t, type, usePlainObject) => {
+	const transform = generatorsMap[type].uppercase();
+	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {stdout: usePlainObject ? transform : transform.transform});
 	t.is(stdout, foobarUppercase);
 };
 
-test('Can pass generators with an options plain object', testGeneratorSyntax, uppercaseGenerator());
-test('Can pass generators without an options plain object', testGeneratorSyntax, uppercaseGenerator().transform);
+test('Can pass generators with an options plain object', testGeneratorSyntax, 'generator', false);
+test('Can pass generators without an options plain object', testGeneratorSyntax, 'generator', true);
+test('Can pass webTransforms with an options plain object', testGeneratorSyntax, 'webTransform', true);
+test('Can pass webTransforms without an options plain object', testGeneratorSyntax, 'webTransform', false);

--- a/test/stdio/transform.js
+++ b/test/stdio/transform.js
@@ -89,6 +89,8 @@ test('Generator can filter "final" by not calling yield', testNoYield, 'generato
 test('Generator can filter "final" by not calling yield, objectMode', testNoYield, 'generator', true, true, []);
 test('Duplex can filter by not calling push', testNoYield, 'duplex', false, false, '');
 test('Duplex can filter by not calling push, objectMode', testNoYield, 'duplex', true, false, []);
+test('WebTransform can filter by not calling push', testNoYield, 'webTransform', false, false, '');
+test('WebTransform can filter by not calling push, objectMode', testNoYield, 'webTransform', true, false, []);
 
 const testMultipleYields = async (t, type, final, binary) => {
 	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {stdout: convertTransformToFinal(generatorsMap[type].multipleYield(), final)});
@@ -99,6 +101,7 @@ const testMultipleYields = async (t, type, final, binary) => {
 test('Generator can yield "transform" multiple times at different moments', testMultipleYields, 'generator', false, false);
 test('Generator can yield "final" multiple times at different moments', testMultipleYields, 'generator', true, false);
 test('Duplex can push multiple times at different moments', testMultipleYields, 'duplex', false, true);
+test('WebTransform can push multiple times at different moments', testMultipleYields, 'webTransform', false, true);
 
 const partsPerChunk = 4;
 const chunksPerCall = 10;
@@ -143,6 +146,7 @@ const testMaxBuffer = async (t, type) => {
 
 test('Generators take "maxBuffer" into account', testMaxBuffer, 'generator');
 test('Duplexes take "maxBuffer" into account', testMaxBuffer, 'duplex');
+test('WebTransforms take "maxBuffer" into account', testMaxBuffer, 'webTransform');
 
 const testMaxBufferObject = async (t, type) => {
 	const bigArray = Array.from({length: maxBuffer}).fill('.');
@@ -157,6 +161,7 @@ const testMaxBufferObject = async (t, type) => {
 
 test('Generators take "maxBuffer" into account, objectMode', testMaxBufferObject, 'generator');
 test('Duplexes take "maxBuffer" into account, objectMode', testMaxBufferObject, 'duplex');
+test('WebTransforms take "maxBuffer" into account, objectMode', testMaxBufferObject, 'webTransform');
 
 const testAsyncGenerators = async (t, type, final) => {
 	const {stdout} = await execa('noop.js', {
@@ -168,6 +173,7 @@ const testAsyncGenerators = async (t, type, final) => {
 test('Generators "transform" is awaited on success', testAsyncGenerators, 'generator', false);
 test('Generators "final" is awaited on success', testAsyncGenerators, 'generator', true);
 test('Duplex is awaited on success', testAsyncGenerators, 'duplex', false);
+test('WebTransform is awaited on success', testAsyncGenerators, 'webTransform', false);
 
 const testThrowingGenerator = async (t, type, final) => {
 	await t.throwsAsync(
@@ -179,6 +185,7 @@ const testThrowingGenerator = async (t, type, final) => {
 test('Generators "transform" errors make subprocess fail', testThrowingGenerator, 'generator', false);
 test('Generators "final" errors make subprocess fail', testThrowingGenerator, 'generator', true);
 test('Duplexes "transform" errors make subprocess fail', testThrowingGenerator, 'duplex', false);
+test('WebTransform "transform" errors make subprocess fail', testThrowingGenerator, 'webTransform', false);
 
 const testSingleErrorOutput = async (t, type) => {
 	await t.throwsAsync(
@@ -189,6 +196,7 @@ const testSingleErrorOutput = async (t, type) => {
 
 test('Generators errors make subprocess fail even when other output generators do not throw', testSingleErrorOutput, 'generator');
 test('Duplexes errors make subprocess fail even when other output generators do not throw', testSingleErrorOutput, 'duplex');
+test('WebTransform errors make subprocess fail even when other output generators do not throw', testSingleErrorOutput, 'webTransform');
 
 const testSingleErrorInput = async (t, type) => {
 	const subprocess = execa('stdin-fd.js', ['0'], {stdin: [generatorsMap[type].noop(false), generatorsMap[type].throwing(), generatorsMap[type].noop(false)]});
@@ -198,6 +206,7 @@ const testSingleErrorInput = async (t, type) => {
 
 test('Generators errors make subprocess fail even when other input generators do not throw', testSingleErrorInput, 'generator');
 test('Duplexes errors make subprocess fail even when other input generators do not throw', testSingleErrorInput, 'duplex');
+test('WebTransform errors make subprocess fail even when other input generators do not throw', testSingleErrorInput, 'webTransform');
 
 const testGeneratorCancel = async (t, error) => {
 	const subprocess = execa('noop.js', {stdout: infiniteGenerator()});

--- a/test/stdio/web-transform.js
+++ b/test/stdio/web-transform.js
@@ -1,0 +1,23 @@
+import {promisify} from 'node:util';
+import {gunzip} from 'node:zlib';
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+import {foobarString, foobarUtf16Uint8Array, foobarUint8Array} from '../helpers/input.js';
+
+setFixtureDir();
+
+test('Can use CompressionStream()', async t => {
+	const {stdout} = await execa('noop-fd.js', ['1', foobarString], {stdout: new CompressionStream('gzip'), encoding: 'buffer'});
+	const decompressedStdout = await promisify(gunzip)(stdout);
+	t.is(decompressedStdout.toString(), foobarString);
+});
+
+test('Can use TextDecoderStream()', async t => {
+	const {stdout} = await execa('stdin.js', {
+		input: foobarUtf16Uint8Array,
+		stdout: new TextDecoderStream('utf-16le'),
+		encoding: 'buffer',
+	});
+	t.deepEqual(stdout, foobarUint8Array);
+});


### PR DESCRIPTION
This PR enables passing a web `TransformStream` to the `stdin`/`stdout`/`stderr` option. This is like #937 but using a web stream instead of a Node.js stream.

```js
await execa(..., {stdout: [new CompressionStream('gzip'), {file: './output.gz'}]});
```

Unlike Node.js `Duplex`, there is no ambiguity so users can pass the stream directly to the option. They can also pass it to a `{transform}` plain object, which is useful to provide with transform options, such as `objectMode`.