### PR TITLE
Fix types for `stdio: [..., undefined]`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,15 +9,18 @@ type Unless<Condition extends boolean, ThenValue, ElseValue = never> = Condition
 
 type AndUnless<Condition extends boolean, ThenValue, ElseValue = unknown> = Condition extends true ? ElseValue : ThenValue;
 
+type IsMainFd<FdNumber extends string> = FdNumber extends keyof StreamOptionsNames ? true : false;
+
 // When the `stdin`/`stdout`/`stderr`/`stdio` option is set to one of those values, no stream is created
-type NoStreamStdioOption =
+type NoStreamStdioOption<FdNumber extends string> =
 	| 'ignore'
 	| 'inherit'
 	| 'ipc'
 	| number
 	| Readable
 	| Writable
-	| [NoStreamStdioOption];
+	| Unless<IsMainFd<FdNumber>, undefined>
+	| readonly [NoStreamStdioOption<FdNumber>];
 
 type BaseStdioOption<
 	IsSync extends boolean = boolean,
@@ -198,10 +201,13 @@ type DuplexObjectMode<OutputOption extends DuplexTransform> = OutputOption['obje
 type IgnoresStreamResult<
 	FdNumber extends string,
 	OptionsType extends CommonOptions = CommonOptions,
-> = IgnoresStdioResult<StreamOption<FdNumber, OptionsType>>;
+> = IgnoresStdioResult<FdNumber, StreamOption<FdNumber, OptionsType>>;
 
 // Whether `result.stdio[*]` is `undefined`
-type IgnoresStdioResult<StdioOptionType extends StdioOptionCommon> = StdioOptionType extends NoStreamStdioOption ? true : false;
+type IgnoresStdioResult<
+	FdNumber extends string,
+	StdioOptionType extends StdioOptionCommon,
+> = StdioOptionType extends NoStreamStdioOption<FdNumber> ? true : false;
 
 // Whether `result.stdout|stderr|all` is `undefined`
 type IgnoresStreamOutput<

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -713,6 +713,26 @@ try {
 	expectType<undefined>(streamArrayStderrResult.stderr);
 	expectType<string>(streamArrayStderrResult.all);
 
+	const undefinedStdoutResult = await execa('unicorns', {stdout: undefined, all: true});
+	expectType<string>(undefinedStdoutResult.stdout);
+	expectType<string>(undefinedStdoutResult.stderr);
+	expectType<string>(undefinedStdoutResult.all);
+
+	const undefinedArrayStdoutResult = await execa('unicorns', {stdout: [undefined] as const, all: true});
+	expectType<string>(undefinedArrayStdoutResult.stdout);
+	expectType<string>(undefinedArrayStdoutResult.stderr);
+	expectType<string>(undefinedArrayStdoutResult.all);
+
+	const undefinedStderrResult = await execa('unicorns', {stderr: undefined, all: true});
+	expectType<string>(undefinedStderrResult.stdout);
+	expectType<string>(undefinedStderrResult.stderr);
+	expectType<string>(undefinedStderrResult.all);
+
+	const undefinedArrayStderrResult = await execa('unicorns', {stderr: [undefined] as const, all: true});
+	expectType<string>(undefinedArrayStderrResult.stdout);
+	expectType<string>(undefinedArrayStderrResult.stderr);
+	expectType<string>(undefinedArrayStderrResult.all);
+
 	const fd3Result = await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', 'pipe']});
 	expectType<string>(fd3Result.stdio[3]);
 
@@ -736,6 +756,12 @@ try {
 
 	const ignoreFd3Result = await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', 'ignore']});
 	expectType<undefined>(ignoreFd3Result.stdio[3]);
+
+	const undefinedFd3Result = await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', undefined]});
+	expectType<undefined>(undefinedFd3Result.stdio[3]);
+
+	const undefinedArrayFd3Result = await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [undefined] as const]});
+	expectType<undefined>(undefinedArrayFd3Result.stdio[3]);
 
 	const objectTransformLinesStdoutResult = await execa('unicorns', {lines: true, stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}});
 	expectType<unknown[]>(objectTransformLinesStdoutResult.stdout);

--- a/lib/stdio/option.js
+++ b/lib/stdio/option.js
@@ -32,6 +32,10 @@ const getStdioArray = (stdio, options) => {
 const hasAlias = options => STANDARD_STREAMS_ALIASES.some(alias => options[alias] !== undefined);
 
 const addDefaultValue = (stdioOption, fdNumber) => {
+	if (Array.isArray(stdioOption)) {
+		return stdioOption.map(item => addDefaultValue(item, fdNumber));
+	}
+
 	if (stdioOption === null || stdioOption === undefined) {
 		return fdNumber >= STANDARD_STREAMS_ALIASES.length ? 'ignore' : 'pipe';
 	}

--- a/test/stdio/forward.js
+++ b/test/stdio/forward.js
@@ -35,7 +35,13 @@ const testFd3Undefined = async (t, stdioOption, options) => {
 
 test('stdio[*] undefined means "ignore"', testFd3Undefined, undefined, {});
 test('stdio[*] null means "ignore"', testFd3Undefined, null, {});
+test('stdio[*] [undefined] means "ignore"', testFd3Undefined, [undefined], {});
+test('stdio[*] [null] means "ignore"', testFd3Undefined, [null], {});
 test('stdio[*] undefined means "ignore", "lines: true"', testFd3Undefined, undefined, {lines: true});
 test('stdio[*] null means "ignore", "lines: true"', testFd3Undefined, null, {lines: true});
+test('stdio[*] [undefined] means "ignore", "lines: true"', testFd3Undefined, [undefined], {lines: true});
+test('stdio[*] [null] means "ignore", "lines: true"', testFd3Undefined, [null], {lines: true});
 test('stdio[*] undefined means "ignore", "encoding: hex"', testFd3Undefined, undefined, {encoding: 'hex'});
 test('stdio[*] null means "ignore", "encoding: hex"', testFd3Undefined, null, {encoding: 'hex'});
+test('stdio[*] [undefined] means "ignore", "encoding: hex"', testFd3Undefined, [undefined], {encoding: 'hex'});
+test('stdio[*] [null] means "ignore", "encoding: hex"', testFd3Undefined, [null], {encoding: 'hex'});


### PR DESCRIPTION
This is a follow-up on #948.

When `stdio: [..., undefined]` is passed to the `stdio[3]` option, it should be handled as if `"ignore"` was passed. 
This PR fixes the types, and adds more tests.