### PR TITLE
Make `maxBuffer` option terminate subprocess gracefully

### DIFF
--- a/lib/convert/loop.js
+++ b/lib/convert/loop.js
@@ -1,6 +1,7 @@
 import {on} from 'node:events';
 import {getEncodingTransformGenerator} from '../stdio/encoding-transform.js';
 import {getSplitLinesGenerator} from '../stdio/split.js';
+import {transformChunkSync, finalChunksSync} from '../stdio/transform.js';
 
 // Iterate over lines of `subprocess.stdout`, used by `subprocess.readable|duplex|iterable()`
 export const iterateOnSubprocessStream = ({subprocessStdout, subprocess, binary, shouldEncode, encoding, preserveNewlines}) => {
@@ -10,7 +11,7 @@ export const iterateOnSubprocessStream = ({subprocessStdout, subprocess, binary,
 		stream: subprocessStdout,
 		controller,
 		binary,
-		shouldEncode: shouldEncode && !subprocessStdout.readableObjectMode,
+		shouldEncode: !subprocessStdout.readableObjectMode && shouldEncode,
 		encoding,
 		shouldSplit: !subprocessStdout.readableObjectMode,
 		preserveNewlines,
@@ -26,24 +27,27 @@ const stopReadingOnExit = async (subprocess, controller) => {
 };
 
 // Iterate over lines of `subprocess.stdout`, used by `result.stdout` + `lines: true` option
-export const iterateForResult = ({stream, onStreamEnd, lines, encoding, stripFinalNewline}) => {
+export const iterateForResult = ({stream, onStreamEnd, lines, encoding, stripFinalNewline, allMixed}) => {
 	const controller = new AbortController();
-	stopReadingOnStreamEnd(controller, onStreamEnd);
+	stopReadingOnStreamEnd(onStreamEnd, controller, stream);
+	const objectMode = stream.readableObjectMode && !allMixed;
 	return iterateOnStream({
 		stream,
 		controller,
 		binary: encoding === 'buffer',
-		shouldEncode: true,
+		shouldEncode: !objectMode,
 		encoding,
-		shouldSplit: lines,
+		shouldSplit: !objectMode && lines,
 		preserveNewlines: !stripFinalNewline,
 	});
 };
 
-const stopReadingOnStreamEnd = async (controller, onStreamEnd) => {
+const stopReadingOnStreamEnd = async (onStreamEnd, controller, stream) => {
 	try {
 		await onStreamEnd;
-	} catch {} finally {
+	} catch {
+		stream.destroy();
+	} finally {
 		controller.abort();
 	}
 };
@@ -70,49 +74,22 @@ export const DEFAULT_OBJECT_HIGH_WATER_MARK = 16;
 const HIGH_WATER_MARK = DEFAULT_OBJECT_HIGH_WATER_MARK;
 
 const iterateOnData = async function * ({onStdoutChunk, controller, binary, shouldEncode, encoding, shouldSplit, preserveNewlines}) {
-	const {encodeChunk, encodeChunkFinal, splitLines, splitLinesFinal} = getTransforms({binary, shouldEncode, encoding, shouldSplit, preserveNewlines});
+	const generators = getGenerators({binary, shouldEncode, encoding, shouldSplit, preserveNewlines});
 
 	try {
 		for await (const [chunk] of onStdoutChunk) {
-			yield * handleChunk(encodeChunk, splitLines, chunk);
+			yield * transformChunkSync(chunk, generators, 0);
 		}
 	} catch (error) {
 		if (!controller.signal.aborted) {
 			throw error;
 		}
 	} finally {
-		yield * handleFinalChunks(encodeChunkFinal, splitLines, splitLinesFinal);
+		yield * finalChunksSync(generators);
 	}
 };
 
-const getTransforms = ({binary, shouldEncode, encoding, shouldSplit, preserveNewlines}) => {
-	const {
-		transform: encodeChunk = identityGenerator,
-		final: encodeChunkFinal = noopGenerator,
-	} = getEncodingTransformGenerator(binary, encoding, !shouldEncode) ?? {};
-	const {
-		transform: splitLines = identityGenerator,
-		final: splitLinesFinal = noopGenerator,
-	} = getSplitLinesGenerator(binary, preserveNewlines, !shouldSplit, {}) ?? {};
-	return {encodeChunk, encodeChunkFinal, splitLines, splitLinesFinal};
-};
-
-const identityGenerator = function * (chunk) {
-	yield chunk;
-};
-
-const noopGenerator = function * () {};
-
-const handleChunk = function * (encodeChunk, splitLines, chunk) {
-	for (const encodedChunk of encodeChunk(chunk)) {
-		yield * splitLines(encodedChunk);
-	}
-};
-
-const handleFinalChunks = function * (encodeChunkFinal, splitLines, splitLinesFinal) {
-	for (const encodedChunk of encodeChunkFinal()) {
-		yield * splitLines(encodedChunk);
-	}
-
-	yield * splitLinesFinal();
-};
+const getGenerators = ({binary, shouldEncode, encoding, shouldSplit, preserveNewlines}) => [
+	getEncodingTransformGenerator(binary, encoding, !shouldEncode),
+	getSplitLinesGenerator(binary, preserveNewlines, !shouldSplit, {}),
+].filter(Boolean);

--- a/lib/stdio/transform.js
+++ b/lib/stdio/transform.js
@@ -104,7 +104,7 @@ export const runTransformSync = (generators, chunks) => [
 	...finalChunksSync(generators),
 ];
 
-const transformChunkSync = function * (chunk, generators, index) {
+export const transformChunkSync = function * (chunk, generators, index) {
 	if (index === generators.length) {
 		yield chunk;
 		return;
@@ -116,7 +116,7 @@ const transformChunkSync = function * (chunk, generators, index) {
 	}
 };
 
-const finalChunksSync = function * (generators) {
+export const finalChunksSync = function * (generators) {
 	for (const [index, {final}] of Object.entries(generators)) {
 		yield * generatorFinalChunksSync(final, Number(index), generators);
 	}

--- a/lib/stream/all.js
+++ b/lib/stream/all.js
@@ -9,7 +9,6 @@ export const makeAllStream = ({stdout, stderr}, {all}) => all && (stdout || stde
 // Read the contents of `subprocess.all` and|or wait for its completion
 export const waitForAllStream = ({subprocess, encoding, buffer, maxBuffer, lines, stripFinalNewline, streamInfo}) => waitForSubprocessStream({
 	stream: subprocess.all,
-	subprocess,
 	fdNumber: 1,
 	encoding,
 	buffer,

--- a/lib/stream/resolve.js
+++ b/lib/stream/resolve.js
@@ -55,7 +55,7 @@ export const getSubprocessResult = async ({
 
 // Read the contents of `subprocess.std*` and|or wait for its completion
 const waitForSubprocessStreams = ({subprocess, encoding, buffer, maxBuffer, lines, stripFinalNewline, streamInfo}) =>
-	subprocess.stdio.map((stream, fdNumber) => waitForSubprocessStream({stream, subprocess, fdNumber, encoding, buffer, maxBuffer, lines, allMixed: false, stripFinalNewline, streamInfo}));
+	subprocess.stdio.map((stream, fdNumber) => waitForSubprocessStream({stream, fdNumber, encoding, buffer, maxBuffer, lines, allMixed: false, stripFinalNewline, streamInfo}));
 
 // Transforms replace `subprocess.std*`, which means they are not exposed to users.
 // However, we still want to wait for their completion.

--- a/lib/stream/subprocess.js
+++ b/lib/stream/subprocess.js
@@ -2,36 +2,33 @@ import {setImmediate} from 'node:timers/promises';
 import getStream, {getStreamAsArrayBuffer, getStreamAsArray, MaxBufferError} from 'get-stream';
 import {iterateForResult} from '../convert/loop.js';
 import {isArrayBuffer} from '../stdio/uint-array.js';
-import {waitForStream, handleStreamError, isInputFileDescriptor} from './wait.js';
+import {waitForStream, isInputFileDescriptor} from './wait.js';
 
-export const waitForSubprocessStream = async ({stream, subprocess, fdNumber, encoding, buffer, maxBuffer, lines, allMixed, stripFinalNewline, streamInfo}) => {
+export const waitForSubprocessStream = async ({stream, fdNumber, encoding, buffer, maxBuffer, lines, allMixed, stripFinalNewline, streamInfo}) => {
 	if (!stream) {
 		return;
 	}
 
+	const onStreamEnd = waitForStream(stream, fdNumber, streamInfo);
+	const [output] = await Promise.all([
+		waitForDefinedStream({stream, onStreamEnd, fdNumber, encoding, buffer, maxBuffer, lines, allMixed, stripFinalNewline, streamInfo}),
+		onStreamEnd,
+	]);
+	return output;
+};
+
+const waitForDefinedStream = async ({stream, onStreamEnd, fdNumber, encoding, buffer, maxBuffer, lines, allMixed, stripFinalNewline, streamInfo}) => {
 	if (isInputFileDescriptor(streamInfo, fdNumber)) {
-		await waitForStream(stream, fdNumber, streamInfo);
 		return;
 	}
 
 	if (!buffer) {
-		await Promise.all([
-			waitForStream(stream, fdNumber, streamInfo),
-			resumeStream(stream),
-		]);
+		await resumeStream(stream);
 		return;
 	}
 
-	try {
-		return await getAnyStream({stream, fdNumber, encoding, maxBuffer, lines, allMixed, stripFinalNewline, streamInfo});
-	} catch (error) {
-		if (error instanceof MaxBufferError) {
-			subprocess.kill();
-		}
-
-		handleStreamError(error, fdNumber, streamInfo);
-		return handleBufferedData(error);
-	}
+	const iterable = iterateForResult({stream, onStreamEnd, lines, encoding, stripFinalNewline, allMixed});
+	return getStreamContents({stream, iterable, encoding, maxBuffer, lines});
 };
 
 // When using `buffer: false`, users need to read `subprocess.stdout|stderr|all` right away
@@ -43,36 +40,24 @@ const resumeStream = async stream => {
 	}
 };
 
-const getAnyStream = async ({stream, fdNumber, encoding, maxBuffer, lines, allMixed, stripFinalNewline, streamInfo}) => {
-	if (allMixed) {
-		const iterable = getIterable({stream, fdNumber, encoding, lines, stripFinalNewline, streamInfo});
-		return getStreamAsArray(iterable, {maxBuffer});
+const getStreamContents = async ({stream, iterable, encoding, maxBuffer, lines}) => {
+	try {
+		if (stream.readableObjectMode || lines) {
+			return await getStreamAsArray(iterable, {maxBuffer});
+		}
+
+		if (encoding === 'buffer') {
+			return new Uint8Array(await getStreamAsArrayBuffer(iterable, {maxBuffer}));
+		}
+
+		return await getStream(iterable, {maxBuffer});
+	} catch (error) {
+		if (error instanceof MaxBufferError) {
+			stream.destroy();
+		}
+
+		throw error;
 	}
-
-	if (stream.readableObjectMode) {
-		return getStreamAsArray(stream, {maxBuffer});
-	}
-
-	if (encoding === 'buffer') {
-		return new Uint8Array(await getStreamAsArrayBuffer(stream, {maxBuffer}));
-	}
-
-	if (lines) {
-		const iterable = getIterable({stream, fdNumber, encoding, lines, stripFinalNewline, streamInfo});
-		return getStreamAsArray(iterable, {maxBuffer});
-	}
-
-	if (encoding !== 'utf8') {
-		const iterable = getIterable({stream, fdNumber, encoding, lines, stripFinalNewline, streamInfo});
-		return getStream(iterable, {maxBuffer});
-	}
-
-	return getStream(stream, {maxBuffer});
-};
-
-const getIterable = ({stream, fdNumber, encoding, lines, stripFinalNewline, streamInfo}) => {
-	const onStreamEnd = waitForStream(stream, fdNumber, streamInfo);
-	return iterateForResult({stream, onStreamEnd, lines, encoding, stripFinalNewline});
 };
 
 // On failure, `result.stdout|stderr|all` should contain the currently buffered stream

--- a/lib/stream/wait.js
+++ b/lib/stream/wait.js
@@ -59,7 +59,7 @@ const setStdinCleanedUp = ({exitCode, signalCode}, state) => {
 // Those other streams might have a different direction due to the above.
 // When this happens, the direction of both the initial stream and the others should then be taken into account.
 // Therefore, we keep track of whether a stream error is currently propagating.
-export const handleStreamError = (error, fdNumber, streamInfo, isSameDirection) => {
+const handleStreamError = (error, fdNumber, streamInfo, isSameDirection) => {
 	if (!shouldIgnoreStreamError(error, fdNumber, streamInfo, isSameDirection)) {
 		throw error;
 	}

--- a/test/exit/kill.js
+++ b/test/exit/kill.js
@@ -25,8 +25,6 @@ const spawnNoKillable = async (forceKillAfterDelay, options) => {
 
 const spawnNoKillableSimple = options => execa('forever.js', {killSignal: 'SIGWINCH', forceKillAfterDelay: 1, ...options});
 
-const spawnNoKillableOutput = options => execa('noop-forever.js', ['.'], {killSignal: 'SIGWINCH', forceKillAfterDelay: 1, ...options});
-
 test('kill("SIGKILL") should terminate cleanly', async t => {
 	const {subprocess} = await spawnNoKillable();
 
@@ -113,13 +111,6 @@ if (isWindows) {
 		t.true(isTerminated);
 		t.is(signal, 'SIGKILL');
 		t.true(timedOut);
-	});
-
-	test('`forceKillAfterDelay` works with the "maxBuffer" option', async t => {
-		const subprocess = spawnNoKillableOutput({maxBuffer: 1});
-		const {isTerminated, signal} = await t.throwsAsync(subprocess);
-		t.true(isTerminated);
-		t.is(signal, 'SIGKILL');
 	});
 
 	test.serial('Can call `.kill()` with `forceKillAfterDelay` many times without triggering the maxListeners warning', async t => {

--- a/test/stream/subprocess.js
+++ b/test/stream/subprocess.js
@@ -101,9 +101,9 @@ const testStreamOutputError = async (t, fdNumber) => {
 	assertStreamOutputError(t, fdNumber, error);
 };
 
-test('Errors on stdout should not make the subprocess exit', testStreamOutputError, 1);
-test('Errors on stderr should not make the subprocess exit', testStreamOutputError, 2);
-test('Errors on output stdio[*] should not make the subprocess exit', testStreamOutputError, 3);
+test('Errors on stdout should make the subprocess exit', testStreamOutputError, 1);
+test('Errors on stderr should make the subprocess exit', testStreamOutputError, 2);
+test('Errors on output stdio[*] should make the subprocess exit', testStreamOutputError, 3);
 
 const testWaitOnStreamEnd = async (t, fdNumber) => {
 	const subprocess = execa('stdin-fd.js', [`${fdNumber}`], fullStdio);


### PR DESCRIPTION
This PR improves the `maxBuffer` option so that it allows the subprocess to terminate gracefully.

This PR also simplifies the logic related to retrieving the subprocess' output.