### PR TITLE
Improve `maxBuffer` option with `execaSync()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1417,9 +1417,18 @@ type ExecaSync<OptionsType extends SyncOptions> = {
 /**
 Same as `execa()` but synchronous.
 
-Returns or throws a `subprocessResult`. The `subprocess` is not returned: its methods and properties are not available. This includes [`.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`.pid`](https://nodejs.org/api/child_process.html#subprocesspid), `.pipe()`, `.iterable()`, `.readable()`, `.writable()`, `.duplex()` and the [`.stdin`/`.stdout`/`.stderr`](https://nodejs.org/api/child_process.html#subprocessstdout) streams.
+Returns or throws a `subprocessResult`. The `subprocess` is not returned: its methods and properties are not available.
 
-Cannot use the following options: `cleanup`, `detached`, `ipc`, `serialization`, `cancelSignal` and `forceKillAfterDelay`. `result.all` is not interleaved. Also, the `stdin`, `stdout`, `stderr` and `stdio` options cannot be [`'overlapped'`](https://nodejs.org/api/child_process.html#optionsstdio), an async iterable, an async transform, a `Duplex`, or a web stream. Node.js streams must have a file descriptor unless the `input` option is used.
+The following features cannot be used:
+- Streams: [`subprocess.stdin`](https://nodejs.org/api/child_process.html#subprocessstdin), [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), `subprocess.readable()`, `subprocess.writable()`, `subprocess.duplex()`.
+- The `stdin`, `stdout`, `stderr` and `stdio` options cannot be [`'overlapped'`](https://nodejs.org/api/child_process.html#optionsstdio), an async iterable, an async transform, a `Duplex`, nor a web stream. Node.js streams can be passed but only if either they [have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr), or the `input` option is used.
+- Signal termination: [`subprocess.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`subprocess.pid`](https://nodejs.org/api/child_process.html#subprocesspid), `cleanup` option, `cancelSignal` option, `forceKillAfterDelay` option.
+- Piping multiple processes: `subprocess.pipe()`.
+- `subprocess.iterable()`.
+- `ipc` and `serialization` options.
+- `result.all` is not interleaved.
+- `detached` option.
+- The `maxBuffer` option is always measured in bytes, not in characters, lines nor objects. Also, it ignores transforms and the `encoding` option.
 
 @param file - The program/script to execute, as a string or file URL
 @param arguments - Arguments to pass to `file` on execution.
@@ -1531,9 +1540,18 @@ type ExecaCommandSync<OptionsType extends SyncOptions> = {
 /**
 Same as `execaCommand()` but synchronous.
 
-Returns or throws a `subprocessResult`. The `subprocess` is not returned: its methods and properties are not available. This includes [`.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`.pid`](https://nodejs.org/api/child_process.html#subprocesspid), `.pipe()`, `.iterable()`, `.readable()`, `.writable()`, `.duplex()` and the [`.stdin`/`.stdout`/`.stderr`](https://nodejs.org/api/child_process.html#subprocessstdout) streams.
+Returns or throws a `subprocessResult`. The `subprocess` is not returned: its methods and properties are not available.
 
-Cannot use the following options: `cleanup`, `detached`, `ipc`, `serialization`, `cancelSignal` and `forceKillAfterDelay`. `result.all` is not interleaved. Also, the `stdin`, `stdout`, `stderr` and `stdio` options cannot be [`'overlapped'`](https://nodejs.org/api/child_process.html#optionsstdio), an async iterable, an async transform, a `Duplex`, or a web stream. Node.js streams must have a file descriptor unless the `input` option is used.
+The following features cannot be used:
+- Streams: [`subprocess.stdin`](https://nodejs.org/api/child_process.html#subprocessstdin), [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), `subprocess.readable()`, `subprocess.writable()`, `subprocess.duplex()`.
+- The `stdin`, `stdout`, `stderr` and `stdio` options cannot be [`'overlapped'`](https://nodejs.org/api/child_process.html#optionsstdio), an async iterable, an async transform, a `Duplex`, nor a web stream. Node.js streams can be passed but only if either they [have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr), or the `input` option is used.
+- Signal termination: [`subprocess.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`subprocess.pid`](https://nodejs.org/api/child_process.html#subprocesspid), `cleanup` option, `cancelSignal` option, `forceKillAfterDelay` option.
+- Piping multiple processes: `subprocess.pipe()`.
+- `subprocess.iterable()`.
+- `ipc` and `serialization` options.
+- `result.all` is not interleaved.
+- `detached` option.
+- The `maxBuffer` option is always measured in bytes, not in characters, lines nor objects. Also, it ignores transforms and the `encoding` option.
 
 @param command - The program/script to execute and its arguments.
 @returns A `subprocessResult` object

--- a/lib/exit/code.js
+++ b/lib/exit/code.js
@@ -10,13 +10,16 @@ export const waitForSuccessfulExit = async exitPromise => {
 	return [exitCode, signal];
 };
 
-export const getSyncExitResult = ({error, status: exitCode, signal}) => ({
-	resultError: getSyncError(error, exitCode, signal),
-	exitCode,
-	signal,
-});
+export const getSyncExitResult = ({error, status: exitCode, signal, output}, {maxBuffer}) => {
+	const resultError = getResultError(error, exitCode, signal);
+	const timedOut = resultError?.code === 'ETIMEDOUT';
+	const isMaxBuffer = resultError?.code === 'ENOBUFS'
+		&& output !== null
+		&& output.some(result => result !== null && result.length > maxBuffer);
+	return {resultError, exitCode, signal, timedOut, isMaxBuffer};
+};
 
-const getSyncError = (error, exitCode, signal) => {
+const getResultError = (error, exitCode, signal) => {
 	if (error !== undefined) {
 		return error;
 	}

--- a/lib/stdio/output-sync.js
+++ b/lib/stdio/output-sync.js
@@ -5,24 +5,25 @@ import {splitLinesSync} from './split.js';
 import {FILE_TYPES} from './type.js';
 
 // Apply `stdout`/`stderr` options, after spawning, in sync mode
-export const transformOutputSync = (fileDescriptors, {output}, options) => {
+export const transformOutputSync = ({fileDescriptors, syncResult: {output}, options, isMaxBuffer}) => {
 	if (output === null) {
 		return {output: Array.from({length: 3})};
 	}
 
 	const state = {};
 	const transformedOutput = output.map((result, fdNumber) =>
-		transformOutputResultSync({result, fileDescriptors, fdNumber, state}, options));
+		transformOutputResultSync({result, fileDescriptors, fdNumber, state, isMaxBuffer}, options));
 	return {output: transformedOutput, ...state};
 };
 
-const transformOutputResultSync = ({result, fileDescriptors, fdNumber, state}, {buffer, encoding, lines, stripFinalNewline}) => {
+const transformOutputResultSync = ({result, fileDescriptors, fdNumber, state, isMaxBuffer}, {buffer, encoding, lines, stripFinalNewline, maxBuffer}) => {
 	if (result === null) {
 		return;
 	}
 
+	const truncatedResult = truncateResult(result, isMaxBuffer, maxBuffer);
+	const uint8ArrayResult = bufferToUint8Array(truncatedResult);
 	const {stdioItems, objectMode} = fileDescriptors[fdNumber];
-	const uint8ArrayResult = bufferToUint8Array(result);
 	const generators = getGenerators(stdioItems);
 	const chunks = runOutputGeneratorsSync([uint8ArrayResult], generators, encoding, state);
 	const {serializedResult, finalResult} = serializeChunks({chunks, objectMode, encoding, lines, stripFinalNewline});
@@ -39,6 +40,10 @@ const transformOutputResultSync = ({result, fileDescriptors, fdNumber, state}, {
 		return returnedResult;
 	}
 };
+
+const truncateResult = (result, isMaxBuffer, maxBuffer) => isMaxBuffer && result.length > maxBuffer
+	? result.slice(0, maxBuffer)
+	: result;
 
 const runOutputGeneratorsSync = (chunks, generators, encoding, state) => {
 	try {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -55,11 +55,11 @@ const spawnSubprocessSync = ({file, args, options, command, escapedCommand, file
 		return syncResult;
 	}
 
-	const {resultError, exitCode, signal} = getSyncExitResult(syncResult);
-	const {output, error = resultError} = transformOutputSync(fileDescriptors, syncResult, options);
+	const {resultError, exitCode, signal, timedOut, isMaxBuffer} = getSyncExitResult(syncResult, options);
+	const {output, error = resultError} = transformOutputSync({fileDescriptors, syncResult, options, isMaxBuffer});
 	const stdio = output.map(stdioOutput => stripNewline(stdioOutput, options));
 	const all = stripNewline(getAllSync(output, options), options);
-	return getSyncResult({error, exitCode, signal, stdio, all, options, command, escapedCommand, startTime});
+	return getSyncResult({error, exitCode, signal, timedOut, stdio, all, options, command, escapedCommand, startTime});
 };
 
 const runSubprocessSync = ({file, args, options, command, escapedCommand, fileDescriptors, startTime}) => {
@@ -74,13 +74,13 @@ const runSubprocessSync = ({file, args, options, command, escapedCommand, fileDe
 
 const normalizeSpawnSyncOptions = ({encoding, ...options}) => ({...options, encoding: 'buffer'});
 
-const getSyncResult = ({error, exitCode, signal, stdio, all, options, command, escapedCommand, startTime}) => error === undefined
+const getSyncResult = ({error, exitCode, signal, timedOut, stdio, all, options, command, escapedCommand, startTime}) => error === undefined
 	? makeSuccessResult({command, escapedCommand, stdio, all, options, startTime})
 	: makeError({
 		error,
 		command,
 		escapedCommand,
-		timedOut: error.code === 'ETIMEDOUT',
+		timedOut,
 		isCanceled: false,
 		exitCode,
 		signal,

--- a/readme.md
+++ b/readme.md
@@ -317,9 +317,18 @@ This allows setting global options or [sharing options](#globalshared-options) b
 
 Same as [`execa()`](#execafile-arguments-options) but synchronous.
 
-Returns or throws a [`subprocessResult`](#subprocessResult). The [`subprocess`](#subprocess) is not returned: its methods and properties are not available. This includes [`.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`.pid`](https://nodejs.org/api/child_process.html#subprocesspid), [`.pipe()`](#pipefile-arguments-options), [`.iterable()`](#iterablereadableoptions), [`.readable()`](#readablereadableoptions), [`.writable()`](#writablewritableoptions), [`.duplex()`](#duplexduplexoptions) and the [`.stdin`/`.stdout`/`.stderr`](https://nodejs.org/api/child_process.html#subprocessstdout) streams.
+Returns or throws a [`subprocessResult`](#subprocessResult). The [`subprocess`](#subprocess) is not returned: its methods and properties are not available.
 
-Cannot use the following options: [`cleanup`](#cleanup), [`detached`](#detached), [`ipc`](#ipc), [`serialization`](#serialization), [`cancelSignal`](#cancelsignal) and [`forceKillAfterDelay`](#forcekillafterdelay). [`result.all`](#all-1) is not interleaved. Also, the [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1) and [`stdio`](#stdio-1) options cannot be [`'overlapped'`](https://nodejs.org/api/child_process.html#optionsstdio), an async iterable, an async [transform](docs/transform.md), a [`Duplex`](docs/transform.md#duplextransform-streams), or a web stream. Node.js streams [must have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr) unless the `input` option is used.
+The following features cannot be used:
+- Streams: [`subprocess.stdin`](https://nodejs.org/api/child_process.html#subprocessstdin), [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), [`subprocess.readable()`](#readablereadableoptions), [`subprocess.writable()`](#writablewritableoptions), [`subprocess.duplex()`](#duplexduplexoptions).
+- The [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1) and [`stdio`](#stdio-1) options cannot be [`'overlapped'`](https://nodejs.org/api/child_process.html#optionsstdio), an async iterable, an async [transform](docs/transform.md), a [`Duplex`](docs/transform.md#duplextransform-streams), nor a web stream. Node.js streams can be passed but only if either they [have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr), or the `input` option is used.
+- Signal termination: [`subprocess.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`subprocess.pid`](https://nodejs.org/api/child_process.html#subprocesspid), [`cleanup`](#cleanup) option, [`cancelSignal`](#cancelsignal) option, [`forceKillAfterDelay`](#forcekillafterdelay) option.
+- Piping multiple processes: [`subprocess.pipe()`](#pipefile-arguments-options).
+- [`subprocess.iterable()`](#iterablereadableoptions).
+- [`ipc`](#ipc) and [`serialization`](#serialization) options.
+- [`result.all`](#all-1) is not interleaved.
+- [`detached`](#detached) option.
+- The [`maxBuffer`](#maxbuffer) option is always measured in bytes, not in characters, [lines](#lines) nor [objects](docs/transform.md#object-mode). Also, it ignores transforms and the [`encoding`](#encoding) option.
 
 #### $(file, arguments?, options?)
 

--- a/test/stdio/lines.js
+++ b/test/stdio/lines.js
@@ -137,6 +137,18 @@ test('"lines: true" can be above "maxBuffer"', async t => {
 	t.deepEqual(stdout, noNewlinesChunks.slice(0, maxBuffer));
 });
 
+test('"maxBuffer" is measured in lines with "lines: true"', async t => {
+	const {stdout} = await t.throwsAsync(execa('noop-repeat.js', ['1', '...\n'], {lines: true, maxBuffer: 2}));
+	t.deepEqual(stdout, ['...', '...']);
+});
+
+test('"maxBuffer" is measured in bytes with "lines: true", sync', t => {
+	const {stdout} = t.throws(() => {
+		execaSync('noop-repeat.js', ['1', '...\n'], {lines: true, maxBuffer: 2});
+	}, {code: 'ENOBUFS'});
+	t.deepEqual(stdout, ['..']);
+});
+
 test('"lines: true" stops on stream error', async t => {
 	const cause = new Error(foobarString);
 	const error = await t.throwsAsync(getSimpleChunkSubprocessAsync({


### PR DESCRIPTION
When the `maxBuffer` option is used and the subprocess output is too big, the subprocess fails. 
Then, the subprocess output is truncated to fit the `maxBuffer` value. However, this currently only happens with `execa()`, not `execaSync()`. This PR fixes this, for feature parity.

This PR also adds tests for the `maxBuffer` option with `execaSync()`.

Finally, this improves the documentation listing which features are not available with `execaSync()`.