### PR TITLE
Add tests for `node:worker_threads`

### DIFF
--- a/lib/verbose/log.js
+++ b/lib/verbose/log.js
@@ -1,13 +1,14 @@
 import {writeFileSync} from 'node:fs';
-import process from 'node:process';
 import figures from 'figures';
 import {gray} from 'yoctocolors';
 
 // Write synchronously to ensure lines are properly ordered and not interleaved with `stdout`
 export const verboseLog = (string, verboseId, icon, color) => {
 	const prefixedLines = addPrefix(string, verboseId, icon, color);
-	writeFileSync(process.stderr.fd, `${prefixedLines}\n`);
+	writeFileSync(STDERR_FD, `${prefixedLines}\n`);
 };
+
+const STDERR_FD = 2;
 
 const addPrefix = (string, verboseId, icon, color) => string.includes('\n')
 	? string

--- a/test/fixtures/nested-send.js
+++ b/test/fixtures/nested-send.js
@@ -1,7 +1,0 @@
-#!/usr/bin/env node
-import process from 'node:process';
-import {execa} from '../../index.js';
-
-const [options, file, ...args] = process.argv.slice(2);
-const result = await execa(file, args, JSON.parse(options));
-process.send(result);

--- a/test/fixtures/nested-sync.js
+++ b/test/fixtures/nested-sync.js
@@ -3,4 +3,9 @@ import process from 'node:process';
 import {execaSync} from '../../index.js';
 
 const [options, file, ...args] = process.argv.slice(2);
-execaSync(file, args, JSON.parse(options));
+try {
+	const result = execaSync(file, args, JSON.parse(options));
+	process.send({result});
+} catch (error) {
+	process.send({error});
+}

--- a/test/fixtures/nested.js
+++ b/test/fixtures/nested.js
@@ -3,4 +3,9 @@ import process from 'node:process';
 import {execa} from '../../index.js';
 
 const [options, file, ...args] = process.argv.slice(2);
-await execa(file, args, JSON.parse(options));
+try {
+	const result = await execa(file, args, JSON.parse(options));
+	process.send({result});
+} catch (error) {
+	process.send({error});
+}

--- a/test/fixtures/worker.js
+++ b/test/fixtures/worker.js
@@ -1,0 +1,15 @@
+import {once} from 'node:events';
+import {workerData, parentPort} from 'node:worker_threads';
+import {execa} from '../../index.js';
+import {setFixtureDir} from '../helpers/fixtures-dir.js';
+
+setFixtureDir();
+
+const {nodeFile, args, options} = workerData;
+try {
+	const subprocess = execa(nodeFile, args, options);
+	const [parentResult, [{result, error}]] = await Promise.all([subprocess, once(subprocess, 'message')]);
+	parentPort.postMessage({parentResult, result, error});
+} catch (parentError) {
+	parentPort.postMessage({parentError});
+}

--- a/test/helpers/nested.js
+++ b/test/helpers/nested.js
@@ -1,0 +1,49 @@
+import {once} from 'node:events';
+import {Worker} from 'node:worker_threads';
+import {execa} from '../../index.js';
+import {FIXTURES_DIR_URL} from './fixtures-dir.js';
+
+const WORKER_URL = new URL('worker.js', FIXTURES_DIR_URL);
+
+const runWorker = (nodeFile, args, options) => {
+	[args, options] = Array.isArray(args) ? [args, options] : [[], args];
+	return new Worker(WORKER_URL, {workerData: {nodeFile, args, options}});
+};
+
+// eslint-disable-next-line max-params
+const nestedCall = (isWorker, fixtureName, execaMethod, file, args, options, parentOptions) => {
+	[args, options = {}, parentOptions = {}] = Array.isArray(args) ? [args, options, parentOptions] : [[], args, options];
+	const subprocessOrWorker = execaMethod(fixtureName, [JSON.stringify(options), file, ...args], {...parentOptions, ipc: true});
+	const onMessage = once(subprocessOrWorker, 'message');
+	const promise = getNestedResult(onMessage);
+	promise.parent = isWorker ? getParentResult(onMessage) : subprocessOrWorker;
+	return promise;
+};
+
+const getNestedResult = async onMessage => {
+	const {result} = await getMessage(onMessage);
+	return result;
+};
+
+const getParentResult = async onMessage => {
+	const {parentResult} = await getMessage(onMessage);
+	return parentResult;
+};
+
+const getMessage = async onMessage => {
+	const [{error, parentError = error, result, parentResult}] = await onMessage;
+	if (parentError) {
+		throw parentError;
+	}
+
+	return {result, parentResult};
+};
+
+export const nestedWorker = (...args) => nestedCall(true, 'nested.js', runWorker, ...args);
+const nestedExeca = (fixtureName, ...args) => nestedCall(false, fixtureName, execa, ...args);
+export const nestedExecaAsync = (...args) => nestedExeca('nested.js', ...args);
+export const nestedExecaSync = (...args) => nestedExeca('nested-sync.js', ...args);
+export const parentWorker = (...args) => nestedWorker(...args).parent;
+export const parentExeca = (...args) => nestedExeca(...args).parent;
+export const parentExecaAsync = (...args) => nestedExecaAsync(...args).parent;
+export const parentExecaSync = (...args) => nestedExecaSync(...args).parent;

--- a/test/stdio/native.js
+++ b/test/stdio/native.js
@@ -6,13 +6,12 @@ import {execa, execaSync} from '../../index.js';
 import {getStdio, fullStdio} from '../helpers/stdio.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {foobarString} from '../helpers/input.js';
+import {parentExecaAsync, parentExecaSync} from '../helpers/nested.js';
 
 setFixtureDir();
 
 const isLinux = platform === 'linux';
 const isWindows = platform === 'win32';
-
-const getFixtureName = isSync => isSync ? 'nested-sync.js' : 'nested.js';
 
 // eslint-disable-next-line max-params
 const testRedirect = async (t, stdioOption, fdNumber, isInput, isSync) => {
@@ -131,50 +130,50 @@ test('stderr can be [process.stderr, "pipe"], encoding "buffer", sync', testInhe
 test('stdio[*] output can be ["inherit", "pipe"], encoding "buffer", sync', testInheritStdioOutput, 3, 1, ['inherit', 'pipe'], true, 'buffer');
 test('stdio[*] output can be [3, "pipe"], encoding "buffer", sync', testInheritStdioOutput, 3, 1, [3, 'pipe'], true, 'buffer');
 
-const testFd3InheritOutput = async (t, stdioOption, isSync) => {
-	const {stdio} = await execa(getFixtureName(isSync), [JSON.stringify(getStdio(3, stdioOption)), 'noop-fd.js', '3', foobarString], fullStdio);
+const testFd3InheritOutput = async (t, stdioOption, execaMethod) => {
+	const {stdio} = await execaMethod('noop-fd.js', ['3', foobarString], getStdio(3, stdioOption), fullStdio);
 	t.is(stdio[3], foobarString);
 };
 
-test('stdio[*] output can use "inherit"', testFd3InheritOutput, 'inherit', false);
-test('stdio[*] output can use ["inherit"]', testFd3InheritOutput, ['inherit'], false);
-test('stdio[*] output can use "inherit", sync', testFd3InheritOutput, 'inherit', true);
-test('stdio[*] output can use ["inherit"], sync', testFd3InheritOutput, ['inherit'], true);
+test('stdio[*] output can use "inherit"', testFd3InheritOutput, 'inherit', parentExecaAsync);
+test('stdio[*] output can use ["inherit"]', testFd3InheritOutput, ['inherit'], parentExecaAsync);
+test('stdio[*] output can use "inherit", sync', testFd3InheritOutput, 'inherit', parentExecaSync);
+test('stdio[*] output can use ["inherit"], sync', testFd3InheritOutput, ['inherit'], parentExecaSync);
 
-const testInheritNoBuffer = async (t, stdioOption, isSync) => {
+const testInheritNoBuffer = async (t, stdioOption, execaMethod) => {
 	const filePath = tempfile();
-	await execa(getFixtureName(isSync), [JSON.stringify({stdin: stdioOption, buffer: false}), 'nested-write.js', filePath, foobarString], {input: foobarString});
+	await execaMethod('nested-write.js', [filePath, foobarString], {stdin: stdioOption, buffer: false}, {input: foobarString});
 	t.is(await readFile(filePath, 'utf8'), `${foobarString} ${foobarString}`);
 	await rm(filePath);
 };
 
-test('stdin can be ["inherit", "pipe"], buffer: false', testInheritNoBuffer, ['inherit', 'pipe'], false);
-test('stdin can be [0, "pipe"], buffer: false', testInheritNoBuffer, [0, 'pipe'], false);
-test.serial('stdin can be ["inherit", "pipe"], buffer: false, sync', testInheritNoBuffer, ['inherit', 'pipe'], true);
-test.serial('stdin can be [0, "pipe"], buffer: false, sync', testInheritNoBuffer, [0, 'pipe'], true);
+test('stdin can be ["inherit", "pipe"], buffer: false', testInheritNoBuffer, ['inherit', 'pipe'], parentExecaAsync);
+test('stdin can be [0, "pipe"], buffer: false', testInheritNoBuffer, [0, 'pipe'], parentExecaAsync);
+test.serial('stdin can be ["inherit", "pipe"], buffer: false, sync', testInheritNoBuffer, ['inherit', 'pipe'], parentExecaSync);
+test.serial('stdin can be [0, "pipe"], buffer: false, sync', testInheritNoBuffer, [0, 'pipe'], parentExecaSync);
 
 if (isLinux) {
-	const testOverflowStream = async (t, fdNumber, stdioOption, isSync) => {
-		const {stdout} = await execa(getFixtureName(isSync), [JSON.stringify(getStdio(fdNumber, stdioOption)), 'empty.js'], fullStdio);
+	const testOverflowStream = async (t, fdNumber, stdioOption, execaMethod) => {
+		const {stdout} = await execaMethod('empty.js', getStdio(fdNumber, stdioOption), fullStdio);
 		t.is(stdout, '');
 	};
 
-	test('stdin can use 4+', testOverflowStream, 0, 4, false);
-	test('stdin can use [4+]', testOverflowStream, 0, [4], false);
-	test('stdout can use 4+', testOverflowStream, 1, 4, false);
-	test('stdout can use [4+]', testOverflowStream, 1, [4], false);
-	test('stderr can use 4+', testOverflowStream, 2, 4, false);
-	test('stderr can use [4+]', testOverflowStream, 2, [4], false);
-	test('stdio[*] can use 4+', testOverflowStream, 3, 4, false);
-	test('stdio[*] can use [4+]', testOverflowStream, 3, [4], false);
-	test('stdin can use 4+, sync', testOverflowStream, 0, 4, true);
-	test('stdin can use [4+], sync', testOverflowStream, 0, [4], true);
-	test('stdout can use 4+, sync', testOverflowStream, 1, 4, true);
-	test('stdout can use [4+], sync', testOverflowStream, 1, [4], true);
-	test('stderr can use 4+, sync', testOverflowStream, 2, 4, true);
-	test('stderr can use [4+], sync', testOverflowStream, 2, [4], true);
-	test('stdio[*] can use 4+, sync', testOverflowStream, 3, 4, true);
-	test('stdio[*] can use [4+], sync', testOverflowStream, 3, [4], true);
+	test('stdin can use 4+', testOverflowStream, 0, 4, parentExecaAsync);
+	test('stdin can use [4+]', testOverflowStream, 0, [4], parentExecaAsync);
+	test('stdout can use 4+', testOverflowStream, 1, 4, parentExecaAsync);
+	test('stdout can use [4+]', testOverflowStream, 1, [4], parentExecaAsync);
+	test('stderr can use 4+', testOverflowStream, 2, 4, parentExecaAsync);
+	test('stderr can use [4+]', testOverflowStream, 2, [4], parentExecaAsync);
+	test('stdio[*] can use 4+', testOverflowStream, 3, 4, parentExecaAsync);
+	test('stdio[*] can use [4+]', testOverflowStream, 3, [4], parentExecaAsync);
+	test('stdin can use 4+, sync', testOverflowStream, 0, 4, parentExecaSync);
+	test('stdin can use [4+], sync', testOverflowStream, 0, [4], parentExecaSync);
+	test('stdout can use 4+, sync', testOverflowStream, 1, 4, parentExecaSync);
+	test('stdout can use [4+], sync', testOverflowStream, 1, [4], parentExecaSync);
+	test('stderr can use 4+, sync', testOverflowStream, 2, 4, parentExecaSync);
+	test('stderr can use [4+], sync', testOverflowStream, 2, [4], parentExecaSync);
+	test('stdio[*] can use 4+, sync', testOverflowStream, 3, 4, parentExecaSync);
+	test('stdio[*] can use [4+], sync', testOverflowStream, 3, [4], parentExecaSync);
 }
 
 const testOverflowStreamArray = (t, fdNumber, stdioOption) => {

--- a/test/verbose/complete.js
+++ b/test/verbose/complete.js
@@ -3,12 +3,14 @@ import test from 'ava';
 import {execa} from '../../index.js';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {foobarString} from '../helpers/input.js';
+import {parentExecaAsync, parentExecaSync} from '../helpers/nested.js';
 import {
-	nestedExecaAsync,
-	nestedExecaSync,
-	runErrorSubprocess,
-	runWarningSubprocess,
-	runEarlyErrorSubprocess,
+	runErrorSubprocessAsync,
+	runErrorSubprocessSync,
+	runWarningSubprocessAsync,
+	runWarningSubprocessSync,
+	runEarlyErrorSubprocessAsync,
+	runEarlyErrorSubprocessSync,
 	getCompletionLine,
 	getCompletionLines,
 	testTimestamp,
@@ -22,45 +24,45 @@ const testPrintCompletion = async (t, verbose, execaMethod) => {
 	t.is(getCompletionLine(stderr), `${testTimestamp} [0] √ (done in 0ms)`);
 };
 
-test('Prints completion, verbose "short"', testPrintCompletion, 'short', nestedExecaAsync);
-test('Prints completion, verbose "full"', testPrintCompletion, 'full', nestedExecaAsync);
-test('Prints completion, verbose "short", sync', testPrintCompletion, 'short', nestedExecaSync);
-test('Prints completion, verbose "full", sync', testPrintCompletion, 'full', nestedExecaSync);
+test('Prints completion, verbose "short"', testPrintCompletion, 'short', parentExecaAsync);
+test('Prints completion, verbose "full"', testPrintCompletion, 'full', parentExecaAsync);
+test('Prints completion, verbose "short", sync', testPrintCompletion, 'short', parentExecaSync);
+test('Prints completion, verbose "full", sync', testPrintCompletion, 'full', parentExecaSync);
 
 const testNoPrintCompletion = async (t, execaMethod) => {
 	const {stderr} = await execaMethod('noop.js', [foobarString], {verbose: 'none'});
 	t.is(stderr, '');
 };
 
-test('Does not print completion, verbose "none"', testNoPrintCompletion, nestedExecaAsync);
-test('Does not print completion, verbose "none", sync', testNoPrintCompletion, nestedExecaSync);
+test('Does not print completion, verbose "none"', testNoPrintCompletion, parentExecaAsync);
+test('Does not print completion, verbose "none", sync', testNoPrintCompletion, parentExecaSync);
 
 const testPrintCompletionError = async (t, execaMethod) => {
-	const stderr = await runErrorSubprocess(t, 'short', execaMethod);
+	const stderr = await execaMethod(t, 'short');
 	t.is(getCompletionLine(stderr), `${testTimestamp} [0] × (done in 0ms)`);
 };
 
-test('Prints completion after errors', testPrintCompletionError, nestedExecaAsync);
-test('Prints completion after errors, sync', testPrintCompletionError, nestedExecaSync);
+test('Prints completion after errors', testPrintCompletionError, runErrorSubprocessAsync);
+test('Prints completion after errors, sync', testPrintCompletionError, runErrorSubprocessSync);
 
 const testPrintCompletionWarning = async (t, execaMethod) => {
-	const stderr = await runWarningSubprocess(t, execaMethod);
+	const stderr = await execaMethod(t);
 	t.is(getCompletionLine(stderr), `${testTimestamp} [0] ‼ (done in 0ms)`);
 };
 
-test('Prints completion after errors, "reject" false', testPrintCompletionWarning, nestedExecaAsync);
-test('Prints completion after errors, "reject" false, sync', testPrintCompletionWarning, nestedExecaSync);
+test('Prints completion after errors, "reject" false', testPrintCompletionWarning, runWarningSubprocessAsync);
+test('Prints completion after errors, "reject" false, sync', testPrintCompletionWarning, runWarningSubprocessSync);
 
 const testPrintCompletionEarly = async (t, execaMethod) => {
-	const stderr = await runEarlyErrorSubprocess(t, execaMethod);
+	const stderr = await execaMethod(t);
 	t.is(getCompletionLine(stderr), `${testTimestamp} [0] × (done in 0ms)`);
 };
 
-test('Prints completion after early validation errors', testPrintCompletionEarly, nestedExecaAsync);
-test('Prints completion after early validation errors, sync', testPrintCompletionEarly, nestedExecaSync);
+test('Prints completion after early validation errors', testPrintCompletionEarly, runEarlyErrorSubprocessAsync);
+test('Prints completion after early validation errors, sync', testPrintCompletionEarly, runEarlyErrorSubprocessSync);
 
 test.serial('Prints duration', async t => {
-	const {stderr} = await nestedExecaAsync('delay.js', ['1000'], {verbose: 'short'});
+	const {stderr} = await parentExecaAsync('delay.js', ['1000'], {verbose: 'short'});
 	t.regex(stripVTControlCharacters(stderr).split('\n').at(-1), /\(done in [\d.]+s\)/);
 });
 

--- a/test/verbose/info.js
+++ b/test/verbose/info.js
@@ -2,10 +2,9 @@ import test from 'ava';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {execa, execaSync} from '../../index.js';
 import {foobarString} from '../helpers/input.js';
+import {parentExecaAsync, parentExecaSync} from '../helpers/nested.js';
 import {
 	QUOTE,
-	nestedExecaAsync,
-	nestedExecaSync,
 	getCommandLine,
 	getOutputLine,
 	getNormalizedLines,
@@ -30,7 +29,7 @@ test('Prints command, NODE_DEBUG=execa + "inherit"', testVerboseGeneral, execa);
 test('Prints command, NODE_DEBUG=execa + "inherit", sync', testVerboseGeneral, execaSync);
 
 test('NODE_DEBUG=execa changes verbose default value to "full"', async t => {
-	const {stderr} = await nestedExecaAsync('noop.js', [foobarString], {}, {env: {NODE_DEBUG: 'execa'}});
+	const {stderr} = await parentExecaAsync('noop.js', [foobarString], {}, {env: {NODE_DEBUG: 'execa'}});
 	t.is(getCommandLine(stderr), `${testTimestamp} [0] $ noop.js ${foobarString}`);
 	t.is(getOutputLine(stderr), `${testTimestamp} [0]   ${foobarString}`);
 });
@@ -41,5 +40,5 @@ const testDebugEnvPriority = async (t, execaMethod) => {
 	t.is(getOutputLine(stderr), undefined);
 };
 
-test('NODE_DEBUG=execa has lower priority', testDebugEnvPriority, nestedExecaAsync);
-test('NODE_DEBUG=execa has lower priority, sync', testDebugEnvPriority, nestedExecaSync);
+test('NODE_DEBUG=execa has lower priority', testDebugEnvPriority, parentExecaAsync);
+test('NODE_DEBUG=execa has lower priority, sync', testDebugEnvPriority, parentExecaSync);

--- a/test/verbose/log.js
+++ b/test/verbose/log.js
@@ -2,7 +2,7 @@ import {stripVTControlCharacters} from 'node:util';
 import test from 'ava';
 import {setFixtureDir} from '../helpers/fixtures-dir.js';
 import {foobarString} from '../helpers/input.js';
-import {nestedExecaAsync, nestedExecaSync} from '../helpers/verbose.js';
+import {parentExecaAsync, parentExecaSync} from '../helpers/nested.js';
 
 setFixtureDir();
 
@@ -11,15 +11,15 @@ const testNoStdout = async (t, verbose, execaMethod) => {
 	t.is(stdout, foobarString);
 };
 
-test('Logs on stderr not stdout, verbose "none"', testNoStdout, 'none', nestedExecaAsync);
-test('Logs on stderr not stdout, verbose "short"', testNoStdout, 'short', nestedExecaAsync);
-test('Logs on stderr not stdout, verbose "full"', testNoStdout, 'full', nestedExecaAsync);
-test('Logs on stderr not stdout, verbose "none", sync', testNoStdout, 'none', nestedExecaSync);
-test('Logs on stderr not stdout, verbose "short", sync', testNoStdout, 'short', nestedExecaSync);
-test('Logs on stderr not stdout, verbose "full", sync', testNoStdout, 'full', nestedExecaSync);
+test('Logs on stderr not stdout, verbose "none"', testNoStdout, 'none', parentExecaAsync);
+test('Logs on stderr not stdout, verbose "short"', testNoStdout, 'short', parentExecaAsync);
+test('Logs on stderr not stdout, verbose "full"', testNoStdout, 'full', parentExecaAsync);
+test('Logs on stderr not stdout, verbose "none", sync', testNoStdout, 'none', parentExecaSync);
+test('Logs on stderr not stdout, verbose "short", sync', testNoStdout, 'short', parentExecaSync);
+test('Logs on stderr not stdout, verbose "full", sync', testNoStdout, 'full', parentExecaSync);
 
 const testColor = async (t, expectedResult, forceColor) => {
-	const {stderr} = await nestedExecaAsync('noop.js', [foobarString], {verbose: 'short'}, {env: {FORCE_COLOR: forceColor}});
+	const {stderr} = await parentExecaAsync('noop.js', [foobarString], {verbose: 'short'}, {env: {FORCE_COLOR: forceColor}});
 	t.is(stderr !== stripVTControlCharacters(stderr), expectedResult);
 };
 


### PR DESCRIPTION
This adds some tests for running Execa inside a worker thread.

This also fixes the following bug: the `verbose` option was crashing when used inside a worker thread.