### PR TITLE
Improve options binding

### DIFF
--- a/lib/arguments/create.js
+++ b/lib/arguments/create.js
@@ -17,7 +17,7 @@ export const createExeca = (mapArguments, boundOptions, deepOptions, setBoundExe
 
 const callBoundExeca = ({mapArguments, deepOptions = {}, boundOptions = {}, setBoundExeca, createNested}, firstArgument, ...nextArguments) => {
 	if (isPlainObject(firstArgument)) {
-		return createNested(mapArguments, {...boundOptions, ...firstArgument}, setBoundExeca);
+		return createNested(mapArguments, mergeOptions(boundOptions, firstArgument), setBoundExeca);
 	}
 
 	const {file, args, options, isSync} = parseArguments({mapArguments, firstArgument, nextArguments, deepOptions, boundOptions});
@@ -31,7 +31,7 @@ const parseArguments = ({mapArguments, firstArgument, nextArguments, deepOptions
 		? parseTemplates(firstArgument, nextArguments)
 		: [firstArgument, ...nextArguments];
 	const [rawFile, rawArgs, rawOptions] = normalizeArguments(...callArguments);
-	const mergedOptions = {...deepOptions, ...boundOptions, ...rawOptions};
+	const mergedOptions = mergeOptions(mergeOptions(deepOptions, boundOptions), rawOptions);
 	const {
 		file = rawFile,
 		args = rawArgs,
@@ -40,3 +40,24 @@ const parseArguments = ({mapArguments, firstArgument, nextArguments, deepOptions
 	} = mapArguments({file: rawFile, args: rawArgs, options: mergedOptions});
 	return {file, args, options, isSync};
 };
+
+// Deep merge specific options like `env`. Shallow merge the other ones.
+const mergeOptions = (boundOptions, options) => {
+	const newOptions = Object.fromEntries(
+		Object.entries(options).map(([optionName, optionValue]) => [
+			optionName,
+			mergeOption(optionName, boundOptions[optionName], optionValue),
+		]),
+	);
+	return {...boundOptions, ...newOptions};
+};
+
+const mergeOption = (optionName, boundOptionValue, optionValue) => {
+	if (DEEP_OPTIONS.has(optionName) && isPlainObject(boundOptionValue) && isPlainObject(optionValue)) {
+		return {...boundOptionValue, ...optionValue};
+	}
+
+	return optionValue;
+};
+
+const DEEP_OPTIONS = new Set(['env']);

--- a/test/arguments/create.js
+++ b/test/arguments/create.js
@@ -1,11 +1,13 @@
 import {join} from 'node:path';
 import test from 'ava';
 import {execa, execaSync, execaNode, $} from '../../index.js';
-import {foobarString, foobarArray} from '../helpers/input.js';
+import {foobarString, foobarArray, foobarUppercase} from '../helpers/input.js';
+import {uppercaseGenerator} from '../helpers/generator.js';
 import {setFixtureDir, FIXTURES_DIR} from '../helpers/fixtures-dir.js';
 
 setFixtureDir();
 const NOOP_PATH = join(FIXTURES_DIR, 'noop.js');
+const PRINT_ENV_PATH = join(FIXTURES_DIR, 'environment.js');
 
 const testTemplate = async (t, execaMethod) => {
 	const {stdout} = await execaMethod`${NOOP_PATH} ${foobarString}`;
@@ -68,6 +70,61 @@ test('execaSync() bound options have lower priority', testBindPriority, execaSyn
 test('execaNode() bound options have lower priority', testBindPriority, execaNode);
 test('$ bound options have lower priority', testBindPriority, $);
 test('$.sync bound options have lower priority', testBindPriority, $.sync);
+
+const testBindUndefined = async (t, execaMethod) => {
+	const {stdout} = await execaMethod({stripFinalNewline: false})(NOOP_PATH, [foobarString], {stripFinalNewline: undefined});
+	t.is(stdout, foobarString);
+};
+
+test('execa() undefined options use default value', testBindUndefined, execa);
+test('execaSync() undefined options use default value', testBindUndefined, execaSync);
+test('execaNode() undefined options use default value', testBindUndefined, execaNode);
+test('$ undefined options use default value', testBindUndefined, $);
+test('$.sync undefined options use default value', testBindUndefined, $.sync);
+
+const testMergeEnv = async (t, execaMethod) => {
+	const {stdout} = await execaMethod({env: {FOO: 'foo'}})(PRINT_ENV_PATH, {env: {BAR: 'bar'}});
+	t.is(stdout, 'foo\nbar');
+};
+
+test('execa() bound options are merged', testMergeEnv, execa);
+test('execaSync() bound options are merged', testMergeEnv, execaSync);
+test('execaNode() bound options are merged', testMergeEnv, execaNode);
+test('$ bound options are merged', testMergeEnv, $);
+test('$.sync bound options are merged', testMergeEnv, $.sync);
+
+const testMergeMultiple = async (t, execaMethod) => {
+	const {stdout} = await execaMethod({env: {FOO: 'baz'}})({env: {BAR: 'bar'}})(PRINT_ENV_PATH, {env: {FOO: 'foo'}});
+	t.is(stdout, 'foo\nbar');
+};
+
+test('execa() bound options are merged multiple times', testMergeMultiple, execa);
+test('execaSync() bound options are merged multiple times', testMergeMultiple, execaSync);
+test('execaNode() bound options are merged multiple times', testMergeMultiple, execaNode);
+test('$ bound options are merged multiple times', testMergeMultiple, $);
+test('$.sync bound options are merged multiple times', testMergeMultiple, $.sync);
+
+const testMergeEnvUndefined = async (t, execaMethod) => {
+	const {stdout} = await execaMethod({env: {FOO: 'foo'}})(PRINT_ENV_PATH, {env: {BAR: undefined}});
+	t.is(stdout, 'foo\nundefined');
+};
+
+test('execa() bound options are merged even if undefined', testMergeEnvUndefined, execa);
+test('execaSync() bound options are merged even if undefined', testMergeEnvUndefined, execaSync);
+test('execaNode() bound options are merged even if undefined', testMergeEnvUndefined, execaNode);
+test('$ bound options are merged even if undefined', testMergeEnvUndefined, $);
+test('$.sync bound options are merged even if undefined', testMergeEnvUndefined, $.sync);
+
+const testMergeSpecific = async (t, execaMethod) => {
+	const {stdout} = await execaMethod({stdout: {transform: uppercaseGenerator().transform, objectMode: true}})(NOOP_PATH, {stdout: {transform: uppercaseGenerator().transform}});
+	t.is(stdout, foobarUppercase);
+};
+
+test('execa() bound options only merge specific ones', testMergeSpecific, execa);
+test('execaSync() bound options only merge specific ones', testMergeSpecific, execaSync);
+test('execaNode() bound options only merge specific ones', testMergeSpecific, execaNode);
+test('$ bound options only merge specific ones', testMergeSpecific, $);
+test('$.sync bound options only merge specific ones', testMergeSpecific, $.sync);
 
 const testSpacedCommand = async (t, args, execaMethod) => {
 	const {stdout} = await execaMethod('command with space.js', args);


### PR DESCRIPTION
Options can now be bound:

```js
const boundExeca = execa(options);
```

This PR improves the behavior by merging the `env` option.
It also adds more tests.