### PR TITLE
Improve headers in `readme.md`

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -5,7 +5,7 @@ With Execa, you can write scripts with Node.js instead of a shell language. [Com
   - [cross-platform](#shell): [no shell](../readme.md#shell-syntax) is used, only JavaScript.
   - [secure](#escaping): no shell injection.
   - [simple](#simplicity): minimalistic API, no [globals](#global-variables), no [binary](#main-binary), no [builtin CLI utilities](#builtin-utilities).
-  - [featureful](#simplicity): all Execa features are available ([subprocess piping](#piping-stdout-to-another-command), [IPC](#ipc), [transforms](#transforms), [background subprocesses](#background-subprocesses), [cancellation](#cancellation), [local binaries](#local-binaries), [cleanup on exit](../readme.md#cleanup), [interleaved output](#interleaved-output), [forceful termination](../readme.md#forcekillafterdelay), etc.).
+  - [featureful](#simplicity): all Execa features are available ([subprocess piping](#piping-stdout-to-another-command), [IPC](#ipc), [transforms](#transforms), [background subprocesses](#background-subprocesses), [cancellation](#cancellation), [local binaries](#local-binaries), [cleanup on exit](../readme.md#optionscleanup), [interleaved output](#interleaved-output), [forceful termination](../readme.md#optionsforcekillafterdelay), etc.).
   - [easy to debug](#debugging): [verbose mode](#verbose-mode), [detailed errors](#errors), [messages and stack traces](#cancellation), stateless API.
 
 ```js
@@ -817,7 +817,7 @@ This is more cross-platform. For example, your code works the same on Windows ma
 
 Also, there is no shell syntax to remember: everything is just plain JavaScript.
 
-If you really need a shell though, the [`shell` option](../readme.md#shell) can be used.
+If you really need a shell though, the [`shell`](../readme.md#optionsshell) option can be used.
 
 ### Simplicity
 
@@ -841,8 +841,8 @@ Also, [local binaries](#local-binaries) can be directly executed without using `
 
 ### Debugging
 
-Subprocesses can be hard to debug, which is why Execa includes a [`verbose` option](#verbose-mode).
+Subprocesses can be hard to debug, which is why Execa includes a [`verbose`](#verbose-mode) option.
 
-Also, Execa's error messages and [properties](#errors) are very detailed to make it clear to determine why a subprocess failed. Error messages and stack traces can be set with [`subprocess.kill(error)`](../readme.md#killerror).
+Also, Execa's error messages and [properties](#errors) are very detailed to make it clear to determine why a subprocess failed. Error messages and stack traces can be set with [`subprocess.kill(error)`](../readme.md#subprocesskillerror).
 
 Finally, unlike Bash and zx, which are stateful (options, current directory, etc.), Execa is [purely functional](#current-directory), which also helps with debugging.

--- a/docs/transform.md
+++ b/docs/transform.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Transforms map or filter the input or output of a subprocess. They are defined by passing a [generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) to the [`stdin`](../readme.md#stdin), [`stdout`](../readme.md#stdout-1), [`stderr`](../readme.md#stderr-1) or [`stdio`](../readme.md#stdio-1) option. It can be [`async`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*).
+Transforms map or filter the input or output of a subprocess. They are defined by passing a [generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) to the [`stdin`](../readme.md#optionsstdin), [`stdout`](../readme.md#optionsstdout), [`stderr`](../readme.md#optionsstderr) or [`stdio`](../readme.md#optionsstdio) option. It can be [`async`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*).
 
 ```js
 import {execa} from 'execa';
@@ -19,7 +19,7 @@ console.log(stdout); // HELLO
 ## Encoding
 
 The `line` argument passed to the transform is a string by default.\
-However, if either a `{transform, binary: true}` plain object is passed, or if the [`encoding` option](../readme.md#encoding) is binary, it is an `Uint8Array` instead.
+However, if either a `{transform, binary: true}` plain object is passed, or if the [`encoding`](../readme.md#optionsencoding) option is binary, it is an `Uint8Array` instead.
 
 The transform can `yield` either a `string` or an `Uint8Array`, regardless of the `line` argument's type.
 
@@ -43,7 +43,7 @@ console.log(stdout); // ''
 ## Binary data
 
 The transform iterates over lines by default.\
-However, if either a `{transform, binary: true}` plain object is passed, or if the [`encoding` option](../readme.md#encoding) is binary, it iterates over arbitrary chunks of data instead.
+However, if either a `{transform, binary: true}` plain object is passed, or if the [`encoding`](../readme.md#optionsencoding) option is binary, it iterates over arbitrary chunks of data instead.
 
 ```js
 await execa('./binary.js', {stdout: {transform, binary: true}});
@@ -116,7 +116,7 @@ await execa('./run.js', {stdout: {transform, preserveNewlines: true}});
 ## Object mode
 
 By default, `stdout` and `stderr`'s transforms must return a string or an `Uint8Array`.\
-However, if a `{transform, objectMode: true}` plain object is passed, any type can be returned instead, except `null` or `undefined`. The subprocess' [`stdout`](../readme.md#stdout)/[`stderr`](../readme.md#stderr) will be an array of values.
+However, if a `{transform, objectMode: true}` plain object is passed, any type can be returned instead, except `null` or `undefined`. The subprocess' [`stdout`](../readme.md#resultstdout)/[`stderr`](../readme.md#resultstderr) will be an array of values.
 
 ```js
 const transform = function * (line) {
@@ -198,7 +198,7 @@ console.log(stdout); // `stdout` is compressed with gzip
 
 ## Combining
 
-The [`stdin`](../readme.md#stdin), [`stdout`](../readme.md#stdout-1), [`stderr`](../readme.md#stderr-1) and [`stdio`](../readme.md#stdio-1) options can accept an array of values. While this is not specific to transforms, this can be useful with them too. For example, the following transform impacts the value printed by `inherit`.
+The [`stdin`](../readme.md#optionsstdin), [`stdout`](../readme.md#optionsstdout), [`stderr`](../readme.md#optionsstderr) and [`stdio`](../readme.md#optionsstdio) options can accept an array of values. While this is not specific to transforms, this can be useful with them too. For example, the following transform impacts the value printed by `inherit`.
 
 ```js
 await execa('echo', ['hello'], {stdout: [transform, 'inherit']});
@@ -218,7 +218,7 @@ await execa('./run.js', {stdout: [new CompressionStream('gzip'), {file: './outpu
 
 ## Async iteration
 
-In some cases, [iterating](../readme.md#iterablereadableoptions) over the subprocess can be an alternative to transforms.
+In some cases, [iterating](../readme.md#subprocessiterablereadableoptions) over the subprocess can be an alternative to transforms.
 
 ```js
 import {execa} from 'execa';

--- a/readme.md
+++ b/readme.md
@@ -50,15 +50,15 @@ This package improves [`child_process`](https://nodejs.org/api/child_process.htm
 - [Promise interface](#execafile-arguments-options).
 - [Script interface](docs/scripts.md) and [template strings](#template-string-syntax), like `zx`.
 - Improved [Windows support](https://github.com/IndigoUnited/node-cross-spawn#why), including [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) binaries.
-- Executes [locally installed binaries](#preferlocal) without `npx`.
-- [Cleans up](#cleanup) subprocesses when the current process ends.
-- Redirect [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1) from/to files, streams, iterables, strings, `Uint8Array` or [objects](docs/transform.md#object-mode).
+- Executes [locally installed binaries](#optionspreferlocal) without `npx`.
+- [Cleans up](#optionscleanup) subprocesses when the current process ends.
+- Redirect [`stdin`](#optionsstdin)/[`stdout`](#optionsstdout)/[`stderr`](#optionsstderr) from/to files, streams, iterables, strings, `Uint8Array` or [objects](docs/transform.md#object-mode).
 - [Transform](docs/transform.md) `stdin`/`stdout`/`stderr` with simple functions.
 - Iterate over [each text line](docs/transform.md#binary-data) output by the subprocess.
-- [Fail-safe subprocess termination](#forcekillafterdelay).
-- Get [interleaved output](#all) from `stdout` and `stderr` similar to what is printed on the terminal.
-- [Strips the final newline](#stripfinalnewline) from the output so you don't have to do `stdout.trim()`.
-- Convenience methods to pipe subprocesses' [input](#input) and [output](#redirect-output-to-a-file).
+- [Fail-safe subprocess termination](#optionsforcekillafterdelay).
+- Get [interleaved output](#optionsall) from `stdout` and `stderr` similar to what is printed on the terminal.
+- [Strips the final newline](#optionsstripfinalnewline) from the output so you don't have to do `stdout.trim()`.
+- Convenience methods to pipe subprocesses' [input](#redirect-input-from-a-file) and [output](#redirect-output-to-a-file).
 - [Verbose mode](#verbose-mode) for debugging.
 - More descriptive errors.
 - Higher max buffer: 100 MB instead of 1 MB.
@@ -298,7 +298,7 @@ _Returns_: [`Subprocess`](#subprocess)
 
 Executes a command. `command` is a [template string](#template-string-syntax) and includes both the `file` and its `arguments`.
 
-The `command` template string can inject any `${value}` with the following types: string, number, [`subprocess`](#subprocess) or an array of those types. For example: `` execa`echo one ${'two'} ${3} ${['four', 'five']}` ``. For `${subprocess}`, the subprocess's [`stdout`](#stdout) is used.
+The `command` template string can inject any `${value}` with the following types: string, number, [`subprocess`](#subprocess) or an array of those types. For example: `` execa`echo one ${'two'} ${3} ${['four', 'five']}` ``. For `${subprocess}`, the subprocess's [`stdout`](#resultstdout) is used.
 
 Arguments are [automatically escaped](#shell-syntax). They can contain any character, but spaces, tabs and newlines must use `${}` like `` execa`echo ${'has space'}` ``.
 
@@ -318,18 +318,18 @@ This allows setting global options or [sharing options](#globalshared-options) b
 
 Same as [`execa()`](#execafile-arguments-options) but synchronous.
 
-Returns or throws a [`subprocessResult`](#subprocessResult). The [`subprocess`](#subprocess) is not returned: its methods and properties are not available.
+Returns or throws a subprocess [`result`](#result). The [`subprocess`](#subprocess) is not returned: its methods and properties are not available.
 
 The following features cannot be used:
-- Streams: [`subprocess.stdin`](https://nodejs.org/api/child_process.html#subprocessstdin), [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), [`subprocess.readable()`](#readablereadableoptions), [`subprocess.writable()`](#writablewritableoptions), [`subprocess.duplex()`](#duplexduplexoptions).
-- The [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1) and [`stdio`](#stdio-1) options cannot be [`'overlapped'`](https://nodejs.org/api/child_process.html#optionsstdio), an async iterable, an async [transform](docs/transform.md), a [`Duplex`](docs/transform.md#duplextransform-streams), nor a web stream. Node.js streams can be passed but only if either they [have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr), or the `input` option is used.
-- Signal termination: [`subprocess.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`subprocess.pid`](https://nodejs.org/api/child_process.html#subprocesspid), [`cleanup`](#cleanup) option, [`cancelSignal`](#cancelsignal) option, [`forceKillAfterDelay`](#forcekillafterdelay) option.
-- Piping multiple processes: [`subprocess.pipe()`](#pipefile-arguments-options).
-- [`subprocess.iterable()`](#iterablereadableoptions).
-- [`ipc`](#ipc) and [`serialization`](#serialization) options.
-- [`result.all`](#all-1) is not interleaved.
-- [`detached`](#detached) option.
-- The [`maxBuffer`](#maxbuffer) option is always measured in bytes, not in characters, [lines](#lines) nor [objects](docs/transform.md#object-mode). Also, it ignores transforms and the [`encoding`](#encoding) option.
+- Streams: [`subprocess.stdin`](https://nodejs.org/api/child_process.html#subprocessstdin), [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), [`subprocess.readable()`](#subprocessreadablereadableoptions), [`subprocess.writable()`](#subprocesswritablewritableoptions), [`subprocess.duplex()`](#subprocessduplexduplexoptions).
+- The [`stdin`](#optionsstdin), [`stdout`](#optionsstdout), [`stderr`](#optionsstderr) and [`stdio`](#optionsstdio) options cannot be [`'overlapped'`](https://nodejs.org/api/child_process.html#optionsstdio), an async iterable, an async [transform](docs/transform.md), a [`Duplex`](docs/transform.md#duplextransform-streams), nor a web stream. Node.js streams can be passed but only if either they [have a file descriptor](#redirect-a-nodejs-stream-fromto-stdinstdoutstderr), or the `input` option is used.
+- Signal termination: [`subprocess.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal), [`subprocess.pid`](https://nodejs.org/api/child_process.html#subprocesspid), [`cleanup`](#optionscleanup) option, [`cancelSignal`](#optionscancelsignal) option, [`forceKillAfterDelay`](#optionsforcekillafterdelay) option.
+- Piping multiple processes: [`subprocess.pipe()`](#subprocesspipefile-arguments-options).
+- [`subprocess.iterable()`](#subprocessiterablereadableoptions).
+- [`ipc`](#optionsipc) and [`serialization`](#optionsserialization) options.
+- [`result.all`](#resultall) is not interleaved.
+- [`detached`](#optionsdetached) option.
+- The [`maxBuffer`](#optionsmaxbuffer) option is always measured in bytes, not in characters, [lines](#optionslines) nor [objects](docs/transform.md#object-mode). Also, it ignores transforms and the [`encoding`](#optionsencoding) option.
 
 #### $(file, arguments?, options?)
 
@@ -338,7 +338,7 @@ The following features cannot be used:
 `options`: [`Options`](#options)\
 _Returns_: [`Subprocess`](#subprocess)
 
-Same as [`execa()`](#execafile-arguments-options) but using the [`stdin: 'inherit'`](#stdin) and [`preferLocal: true`](#preferlocal) options.
+Same as [`execa()`](#execafile-arguments-options) but using the [`stdin: 'inherit'`](#optionsstdin) and [`preferLocal: true`](#optionspreferlocal) options.
 
 Just like `execa()`, this can use the [template string syntax](#execacommand) or [bind options](#execaoptions). It can also be [run synchronously](#execasyncfile-arguments-options) using `$.sync()` or `$.s()`.
 
@@ -351,7 +351,7 @@ This is the preferred method when executing multiple commands in a script file. 
 `options`: [`Options`](#options)\
 _Returns_: [`Subprocess`](#subprocess)
 
-Same as [`execa()`](#execafile-arguments-options) but using the [`node: true`](#node) option.
+Same as [`execa()`](#execafile-arguments-options) but using the [`node: true`](#optionsnode) option.
 Executes a Node.js file using `node scriptPath ...arguments`.
 
 Just like `execa()`, this can use the [template string syntax](#execacommand) or [bind options](#execaoptions).
@@ -374,32 +374,32 @@ Arguments are [automatically escaped](#shell-syntax). They can contain any chara
 
 ### Shell syntax
 
-For all the [methods above](#methods), no shell interpreter (Bash, cmd.exe, etc.) is used unless the [`shell` option](#shell) is set. This means shell-specific characters and expressions (`$variable`, `&&`, `||`, `;`, `|`, etc.) have no special meaning and do not need to be escaped.
+For all the [methods above](#methods), no shell interpreter (Bash, cmd.exe, etc.) is used unless the [`shell`](#optionsshell) option is set. This means shell-specific characters and expressions (`$variable`, `&&`, `||`, `;`, `|`, etc.) have no special meaning and do not need to be escaped.
 
 ### subprocess
 
 The return value of all [asynchronous methods](#methods) is both:
-- a `Promise` resolving or rejecting with a [`subprocessResult`](#subprocessResult).
+- a `Promise` resolving or rejecting with a subprocess [`result`](#result).
 - a [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess) with the following additional methods and properties.
 
-#### all
+#### subprocess.all
 
 Type: `ReadableStream | undefined`
 
 Stream [combining/interleaving](#ensuring-all-output-is-interleaved) [`stdout`](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout) and [`stderr`](https://nodejs.org/api/child_process.html#child_process_subprocess_stderr).
 
 This is `undefined` if either:
-- the [`all` option](#all-2) is `false` (the default value)
-- both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio)
+- the [`all`](#optionsall) option is `false` (the default value)
+- both [`stdout`](#optionsstdout) and [`stderr`](#optionsstderr) options are set to [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio)
 
-#### pipe(file, arguments?, options?)
+#### subprocess.pipe(file, arguments?, options?)
 
 `file`: `string | URL`\
 `arguments`: `string[]`\
 `options`: [`Options`](#options) and [`PipeOptions`](#pipeoptions)\
-_Returns_: [`Promise<SubprocessResult>`](#subprocessresult)
+_Returns_: [`Promise<Result>`](#result)
 
-[Pipe](https://nodejs.org/api/stream.html#readablepipedestination-options) the subprocess' `stdout` to a second Execa subprocess' `stdin`. This resolves with that second subprocess' [result](#subprocessresult). If either subprocess is rejected, this is rejected with that subprocess' [error](#execaerror) instead.
+[Pipe](https://nodejs.org/api/stream.html#readablepipedestination-options) the subprocess' `stdout` to a second Execa subprocess' `stdin`. This resolves with that second subprocess' [result](#result). If either subprocess is rejected, this is rejected with that subprocess' [error](#execaerror) instead.
 
 This follows the same syntax as [`execa(file, arguments?, options?)`](#execafile-arguments-options) except both [regular options](#options) and [pipe-specific options](#pipeoptions) can be specified.
 
@@ -407,22 +407,22 @@ This can be called multiple times to chain a series of subprocesses.
 
 Multiple subprocesses can be piped to the same subprocess. Conversely, the same subprocess can be piped to multiple other subprocesses.
 
-#### pipe\`command\`
-#### pipe(options)\`command\`
+#### subprocess.pipe\`command\`
+#### subprocess.pipe(options)\`command\`
 
 `command`: `string`\
 `options`: [`Options`](#options) and [`PipeOptions`](#pipeoptions)\
-_Returns_: [`Promise<SubprocessResult>`](#subprocessresult)
+_Returns_: [`Promise<Result>`](#result)
 
-Like [`.pipe(file, arguments?, options?)`](#pipefile-arguments-options) but using a [`command` template string](docs/scripts.md#piping-stdout-to-another-command) instead. This follows the same syntax as `execa` [template strings](#execacommand).
+Like [`subprocess.pipe(file, arguments?, options?)`](#subprocesspipefile-arguments-options) but using a [`command` template string](docs/scripts.md#piping-stdout-to-another-command) instead. This follows the same syntax as `execa` [template strings](#execacommand).
 
-#### pipe(secondSubprocess, pipeOptions?)
+#### subprocess.pipe(secondSubprocess, pipeOptions?)
 
 `secondSubprocess`: [`execa()` return value](#subprocess)\
 `pipeOptions`: [`PipeOptions`](#pipeoptions)\
-_Returns_: [`Promise<SubprocessResult>`](#subprocessresult)
+_Returns_: [`Promise<Result>`](#result)
 
-Like [`.pipe(file, arguments?, options?)`](#pipefile-arguments-options) but using the [return value](#subprocess) of another `execa()` call instead.
+Like [`subprocess.pipe(file, arguments?, options?)`](#subprocesspipefile-arguments-options) but using the [return value](#subprocess) of another `execa()` call instead.
 
 This is the most advanced method to pipe subprocesses. It is useful in specific cases, such as piping multiple subprocesses to the same subprocess.
 
@@ -437,7 +437,7 @@ Default: `"stdout"`
 
 Which stream to pipe from the source subprocess. A file descriptor like `"fd3"` can also be passed.
 
-`"all"` pipes both `stdout` and `stderr`. This requires the [`all` option](#all-2) to be `true`.
+`"all"` pipes both `stdout` and `stderr`. This requires the [`all`](#optionsall) option to be `true`.
 
 ##### pipeOptions.to
 
@@ -452,70 +452,70 @@ Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSign
 
 Unpipe the subprocess when the signal aborts.
 
-The [`.pipe()`](#pipefile-arguments-options) method will be rejected with a cancellation error.
+The [`subprocess.pipe()`](#subprocesspipefile-arguments-options) method will be rejected with a cancellation error.
 
-#### kill(signal, error?)
-#### kill(error?)
+#### subprocess.kill(signal, error?)
+#### subprocess.kill(error?)
 
 `signal`: `string | number`\
 `error`: `Error`\
 _Returns_: `boolean`
 
-Sends a [signal](https://nodejs.org/api/os.html#signal-constants) to the subprocess. The default signal is the [`killSignal`](#killsignal) option. `killSignal` defaults to `SIGTERM`, which [terminates](#isterminated) the subprocess.
+Sends a [signal](https://nodejs.org/api/os.html#signal-constants) to the subprocess. The default signal is the [`killSignal`](#optionskillsignal) option. `killSignal` defaults to `SIGTERM`, which [terminates](#resultisterminated) the subprocess.
 
 This returns `false` when the signal could not be sent, for example when the subprocess has already exited.
 
-When an error is passed as argument, it is set to the subprocess' [`error.cause`](#cause). The subprocess is then terminated with the default signal. This does not emit the [`error` event](https://nodejs.org/api/child_process.html#event-error).
+When an error is passed as argument, it is set to the subprocess' [`error.cause`](#errorcause). The subprocess is then terminated with the default signal. This does not emit the [`error` event](https://nodejs.org/api/child_process.html#event-error).
 
 [More info.](https://nodejs.org/api/child_process.html#subprocesskillsignal)
 
-#### [Symbol.asyncIterator]()
+#### subprocess[Symbol.asyncIterator]()
 
 _Returns_: `AsyncIterable`
 
 Subprocesses are [async iterables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator). They iterate over each output line.
 
-The iteration waits for the subprocess to end. It throws if the subprocess [fails](#subprocessresult). This means you do not need to `await` the subprocess' [promise](#subprocess).
+The iteration waits for the subprocess to end. It throws if the subprocess [fails](#result). This means you do not need to `await` the subprocess' [promise](#subprocess).
 
-#### iterable(readableOptions?)
+#### subprocess.iterable(readableOptions?)
 
 `readableOptions`: [`ReadableOptions`](#readableoptions)\
 _Returns_: `AsyncIterable`
 
-Same as [`subprocess[Symbol.asyncIterator]`](#symbolasynciterator) except [options](#readableoptions) can be provided.
+Same as [`subprocess[Symbol.asyncIterator]`](#subprocesssymbolasynciterator) except [options](#readableoptions) can be provided.
 
-#### readable(readableOptions?)
+#### subprocess.readable(readableOptions?)
 
 `readableOptions`: [`ReadableOptions`](#readableoptions)\
 _Returns_: [`Readable`](https://nodejs.org/api/stream.html#class-streamreadable) Node.js stream
 
 Converts the subprocess to a readable stream.
 
-Unlike [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), the stream waits for the subprocess to end and emits an [`error`](https://nodejs.org/api/stream.html#event-error) event if the subprocess [fails](#subprocessresult). This means you do not need to `await` the subprocess' [promise](#subprocess). On the other hand, you do need to handle to the stream `error` event. This can be done by using [`await finished(stream)`](https://nodejs.org/api/stream.html#streamfinishedstream-options), [`await pipeline(..., stream)`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options) or [`await text(stream)`](https://nodejs.org/api/webstreams.html#streamconsumerstextstream) which throw an exception when the stream errors.
+Unlike [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), the stream waits for the subprocess to end and emits an [`error`](https://nodejs.org/api/stream.html#event-error) event if the subprocess [fails](#result). This means you do not need to `await` the subprocess' [promise](#subprocess). On the other hand, you do need to handle to the stream `error` event. This can be done by using [`await finished(stream)`](https://nodejs.org/api/stream.html#streamfinishedstream-options), [`await pipeline(..., stream)`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options) or [`await text(stream)`](https://nodejs.org/api/webstreams.html#streamconsumerstextstream) which throw an exception when the stream errors.
 
-Before using this method, please first consider the [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1)/[`stdio`](#stdio-1) options, [`subprocess.pipe()`](#pipefile-arguments-options) or [`subprocess.iterable()`](#iterablereadableoptions).
+Before using this method, please first consider the [`stdin`](#optionsstdin)/[`stdout`](#optionsstdout)/[`stderr`](#optionsstderr)/[`stdio`](#optionsstdio) options, [`subprocess.pipe()`](#subprocesspipefile-arguments-options) or [`subprocess.iterable()`](#subprocessiterablereadableoptions).
 
-#### writable(writableOptions?)
+#### subprocess.writable(writableOptions?)
 
 `writableOptions`: [`WritableOptions`](#writableoptions)\
 _Returns_: [`Writable`](https://nodejs.org/api/stream.html#class-streamwritable) Node.js stream
 
 Converts the subprocess to a writable stream.
 
-Unlike [`subprocess.stdin`](https://nodejs.org/api/child_process.html#subprocessstdin), the stream waits for the subprocess to end and emits an [`error`](https://nodejs.org/api/stream.html#event-error) event if the subprocess [fails](#subprocessresult). This means you do not need to `await` the subprocess' [promise](#subprocess). On the other hand, you do need to handle to the stream `error` event. This can be done by using [`await finished(stream)`](https://nodejs.org/api/stream.html#streamfinishedstream-options) or [`await pipeline(stream, ...)`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options) which throw an exception when the stream errors.
+Unlike [`subprocess.stdin`](https://nodejs.org/api/child_process.html#subprocessstdin), the stream waits for the subprocess to end and emits an [`error`](https://nodejs.org/api/stream.html#event-error) event if the subprocess [fails](#result). This means you do not need to `await` the subprocess' [promise](#subprocess). On the other hand, you do need to handle to the stream `error` event. This can be done by using [`await finished(stream)`](https://nodejs.org/api/stream.html#streamfinishedstream-options) or [`await pipeline(stream, ...)`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options) which throw an exception when the stream errors.
 
-Before using this method, please first consider the [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1)/[`stdio`](#stdio-1) options or [`subprocess.pipe()`](#pipefile-arguments-options).
+Before using this method, please first consider the [`stdin`](#optionsstdin)/[`stdout`](#optionsstdout)/[`stderr`](#optionsstderr)/[`stdio`](#optionsstdio) options or [`subprocess.pipe()`](#subprocesspipefile-arguments-options).
 
-#### duplex(duplexOptions?)
+#### subprocess.duplex(duplexOptions?)
 
 `duplexOptions`: [`ReadableOptions | WritableOptions`](#readableoptions)\
 _Returns_: [`Duplex`](https://nodejs.org/api/stream.html#class-streamduplex) Node.js stream
 
 Converts the subprocess to a duplex stream.
 
-The stream waits for the subprocess to end and emits an [`error`](https://nodejs.org/api/stream.html#event-error) event if the subprocess [fails](#subprocessresult). This means you do not need to `await` the subprocess' [promise](#subprocess). On the other hand, you do need to handle to the stream `error` event. This can be done by using [`await finished(stream)`](https://nodejs.org/api/stream.html#streamfinishedstream-options), [`await pipeline(..., stream, ...)`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options) or [`await text(stream)`](https://nodejs.org/api/webstreams.html#streamconsumerstextstream) which throw an exception when the stream errors.
+The stream waits for the subprocess to end and emits an [`error`](https://nodejs.org/api/stream.html#event-error) event if the subprocess [fails](#result). This means you do not need to `await` the subprocess' [promise](#subprocess). On the other hand, you do need to handle to the stream `error` event. This can be done by using [`await finished(stream)`](https://nodejs.org/api/stream.html#streamfinishedstream-options), [`await pipeline(..., stream, ...)`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-options) or [`await text(stream)`](https://nodejs.org/api/webstreams.html#streamconsumerstextstream) which throw an exception when the stream errors.
 
-Before using this method, please first consider the [`stdin`](#stdin)/[`stdout`](#stdout-1)/[`stderr`](#stderr-1)/[`stdio`](#stdio-1) options, [`subprocess.pipe()`](#pipefile-arguments-options) or [`subprocess.iterable()`](#iterablereadableoptions).
+Before using this method, please first consider the [`stdin`](#optionsstdin)/[`stdout`](#optionsstdout)/[`stderr`](#optionsstderr)/[`stdio`](#optionsstdio) options, [`subprocess.pipe()`](#subprocesspipefile-arguments-options) or [`subprocess.iterable()`](#subprocessiterablereadableoptions).
 
 ##### readableOptions
 
@@ -528,25 +528,25 @@ Default: `"stdout"`
 
 Which stream to read from the subprocess. A file descriptor like `"fd3"` can also be passed.
 
-`"all"` reads both `stdout` and `stderr`. This requires the [`all` option](#all-2) to be `true`.
+`"all"` reads both `stdout` and `stderr`. This requires the [`all`](#optionsall) option to be `true`.
 
 ##### readableOptions.binary
 
 Type: `boolean`\
-Default: `false` with [`.iterable()`](#iterablereadableoptions), `true` with [`.readable()`](#readablereadableoptions)/[`.duplex()`](#duplexduplexoptions)
+Default: `false` with [`subprocess.iterable()`](#subprocessiterablereadableoptions), `true` with [`subprocess.readable()`](#subprocessreadablereadableoptions)/[`subprocess.duplex()`](#subprocessduplexduplexoptions)
 
 If `false`, the stream iterates over lines. Each line is a string. Also, the stream is in [object mode](https://nodejs.org/api/stream.html#object-mode).
 
-If `true`, the stream iterates over arbitrary chunks of data. Each line is an `Uint8Array` (with [`.iterable()`](#iterablereadableoptions)) or a [`Buffer`](https://nodejs.org/api/buffer.html#class-buffer) (otherwise).
+If `true`, the stream iterates over arbitrary chunks of data. Each line is an `Uint8Array` (with [`subprocess.iterable()`](#subprocessiterablereadableoptions)) or a [`Buffer`](https://nodejs.org/api/buffer.html#class-buffer) (otherwise).
 
-This is always `true` when the [`encoding` option](#encoding) is binary.
+This is always `true` when the [`encoding`](#optionsencoding) option is binary.
 
 ##### readableOptions.preserveNewlines
 
 Type: `boolean`\
-Default: `false` with [`.iterable()`](#iterablereadableoptions), `true` with [`.readable()`](#readablereadableoptions)/[`.duplex()`](#duplexduplexoptions)
+Default: `false` with [`subprocess.iterable()`](#subprocessiterablereadableoptions), `true` with [`subprocess.readable()`](#subprocessreadablereadableoptions)/[`subprocess.duplex()`](#subprocessduplexduplexoptions)
 
-If both this option and the [`binary` option](#readableoptionsbinary) is `false`, newlines are stripped from each line.
+If both this option and the [`binary`](#readableoptionsbinary) option is `false`, newlines are stripped from each line.
 
 ##### writableOptions
 
@@ -559,15 +559,15 @@ Default: `"stdin"`
 
 Which stream to write to the subprocess. A file descriptor like `"fd3"` can also be passed.
 
-### SubprocessResult
+### Result
 
 Type: `object`
 
 Result of a subprocess execution.
 
-When the subprocess [fails](#failed), it is rejected with an [`ExecaError`](#execaerror) instead.
+When the subprocess [fails](#resultfailed), it is rejected with an [`ExecaError`](#execaerror) instead.
 
-#### command
+#### result.command
 
 Type: `string`
 
@@ -575,84 +575,84 @@ The file and arguments that were run, for logging purposes.
 
 This is not escaped and should not be executed directly as a subprocess, including using [`execa()`](#execafile-arguments-options) or [`execaCommand()`](#execacommandcommand-options).
 
-#### escapedCommand
+#### result.escapedCommand
 
 Type: `string`
 
-Same as [`command`](#command) but escaped.
+Same as [`command`](#resultcommand) but escaped.
 
 Unlike `command`, control characters are escaped, which makes it safe to print in a terminal.
 
 This can also be copied and pasted into a shell, for debugging purposes.
 Since the escaping is fairly basic, this should not be executed directly as a subprocess, including using [`execa()`](#execafile-arguments-options) or [`execaCommand()`](#execacommandcommand-options).
 
-#### cwd
+#### result.cwd
 
 Type: `string`
 
-The [current directory](#cwd-1) in which the command was run.
+The [current directory](#optionscwd) in which the command was run.
 
-#### durationMs
+#### result.durationMs
 
 Type: `number`
 
 Duration of the subprocess, in milliseconds.
 
-#### stdout
+#### result.stdout
 
 Type: `string | Uint8Array | string[] | Uint8Array[] | unknown[] | undefined`
 
 The output of the subprocess on `stdout`.
 
-This is `undefined` if the [`stdout`](#stdout-1) option is set to only [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio). This is an array if the [`lines` option](#lines) is `true`, or if the `stdout` option is a [transform in object mode](docs/transform.md#object-mode).
+This is `undefined` if the [`stdout`](#optionsstdout) option is set to only [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio). This is an array if the [`lines`](#optionslines) option is `true`, or if the `stdout` option is a [transform in object mode](docs/transform.md#object-mode).
 
-#### stderr
+#### result.stderr
 
 Type: `string | Uint8Array | string[] | Uint8Array[] | unknown[] | undefined`
 
 The output of the subprocess on `stderr`.
 
-This is `undefined` if the [`stderr`](#stderr-1) option is set to only [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio). This is an array if the [`lines` option](#lines) is `true`, or if the `stderr` option is a [transform in object mode](docs/transform.md#object-mode).
+This is `undefined` if the [`stderr`](#optionsstderr) option is set to only [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio). This is an array if the [`lines`](#optionslines) option is `true`, or if the `stderr` option is a [transform in object mode](docs/transform.md#object-mode).
 
-#### all
+#### result.all
 
 Type: `string | Uint8Array | string[] | Uint8Array[] | unknown[] | undefined`
 
 The output of the subprocess with `stdout` and `stderr` [interleaved](#ensuring-all-output-is-interleaved).
 
 This is `undefined` if either:
-- the [`all` option](#all-2) is `false` (the default value)
-- both [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options are set to only [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio)
+- the [`all`](#optionsall) option is `false` (the default value)
+- both [`stdout`](#optionsstdout) and [`stderr`](#optionsstderr) options are set to only [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio)
 
-This is an array if the [`lines` option](#lines) is `true`, or if either the `stdout` or `stderr` option is a [transform in object mode](docs/transform.md#object-mode).
+This is an array if the [`lines`](#optionslines) option is `true`, or if either the `stdout` or `stderr` option is a [transform in object mode](docs/transform.md#object-mode).
 
-#### stdio
+#### result.stdio
 
 Type: `Array<string | Uint8Array | string[] | Uint8Array[] | unknown[] | undefined>`
 
-The output of the subprocess on [`stdin`](#stdin), [`stdout`](#stdout-1), [`stderr`](#stderr-1) and [other file descriptors](#stdio-1).
+The output of the subprocess on [`stdin`](#optionsstdin), [`stdout`](#optionsstdout), [`stderr`](#optionsstderr) and [other file descriptors](#optionsstdio).
 
-Items are `undefined` when their corresponding [`stdio`](#stdio-1) option is set to [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio). Items are arrays when their corresponding `stdio` option is a [transform in object mode](docs/transform.md#object-mode).
+Items are `undefined` when their corresponding [`stdio`](#optionsstdio) option is set to [`'inherit'`, `'ignore'`, `Stream` or `integer`](https://nodejs.org/api/child_process.html#child_process_options_stdio). Items are arrays when their corresponding `stdio` option is a [transform in object mode](docs/transform.md#object-mode).
 
-#### failed
+#### result.failed
 
 Type: `boolean`
 
 Whether the subprocess failed to run.
 
-#### timedOut
+#### result.timedOut
 
 Type: `boolean`
 
 Whether the subprocess timed out.
 
-#### isCanceled
+#### result.isCanceled
 
 Type: `boolean`
 
-Whether the subprocess was canceled using the [`cancelSignal`](#cancelsignal) option.
+Whether the subprocess was canceled using the [`cancelSignal`](#optionscancelsignal) option.
 
-#### isTerminated
+#### result.isTerminated
 
 Type: `boolean`
 
@@ -660,21 +660,21 @@ Whether the subprocess was terminated by a signal (like `SIGTERM`) sent by eithe
 - The current process.
 - Another process. This case is [not supported on Windows](https://nodejs.org/api/process.html#signal-events).
 
-#### isMaxBuffer
+#### result.isMaxBuffer
 
 Type: `boolean`
 
-Whether the subprocess failed because its output was larger than the [`maxBuffer`](#maxbuffer) option.
+Whether the subprocess failed because its output was larger than the [`maxBuffer`](#optionsmaxbuffer) option.
 
-#### exitCode
+#### result.exitCode
 
 Type: `number | undefined`
 
 The numeric exit code of the subprocess that was run.
 
-This is `undefined` when the subprocess could not be spawned or was terminated by a [signal](#signal).
+This is `undefined` when the subprocess could not be spawned or was terminated by a [signal](#resultsignal).
 
-#### signal
+#### result.signal
 
 Type: `string | undefined`
 
@@ -684,7 +684,7 @@ The name of the signal (like `SIGTERM`) that terminated the subprocess, sent by 
 
 If a signal terminated the subprocess, this property is defined and included in the error message. Otherwise it is `undefined`.
 
-#### signalDescription
+#### result.signalDescription
 
 Type: `string | undefined`
 
@@ -692,59 +692,59 @@ A human-friendly description of the signal that was used to terminate the subpro
 
 If a signal terminated the subprocess, this property is defined and included in the error message. Otherwise it is `undefined`. It is also `undefined` when the signal is very uncommon which should seldomly happen.
 
-#### pipedFrom
+#### result.pipedFrom
 
-Type: [`Array<SubprocessResult | ExecaError>`](#subprocessresult)
+Type: [`Array<Result | ExecaError>`](#result)
 
 Results of the other subprocesses that were [piped](#pipe-multiple-subprocesses) into this subprocess. This is useful to inspect a series of subprocesses piped with each other.
 
-This array is initially empty and is populated each time the [`.pipe()`](#pipefile-arguments-options) method resolves.
+This array is initially empty and is populated each time the [`subprocess.pipe()`](#subprocesspipefile-arguments-options) method resolves.
 
 ### ExecaError
 ### ExecaSyncError
 
 Type: `Error`
 
-Exception thrown when the subprocess [fails](#failed), either:
-- its [exit code](#exitcode) is not `0`
-- it was [terminated](#isterminated) with a [signal](#signal), including [`.kill()`](#killerror)
-- [timing out](#timedout)
-- [being canceled](#iscanceled)
+Exception thrown when the subprocess [fails](#resultfailed), either:
+- its [exit code](#resultexitcode) is not `0`
+- it was [terminated](#resultisterminated) with a [signal](#resultsignal), including [`subprocess.kill()`](#subprocesskillerror)
+- [timing out](#resulttimedout)
+- [being canceled](#resultiscanceled)
 - there's not enough memory or there are already too many subprocesses
 
-This has the same shape as [successful results](#subprocessresult), with the following additional properties.
+This has the same shape as [successful results](#result), with the following additional properties.
 
-#### message
-
-Type: `string`
-
-Error message when the subprocess failed to run. In addition to the [underlying error message](#originalMessage), it also contains some information related to why the subprocess errored.
-
-The subprocess [`stderr`](#stderr), [`stdout`](#stdout) and other [file descriptors' output](#stdio) are appended to the end, separated with newlines and not interleaved.
-
-#### shortMessage
+#### error.message
 
 Type: `string`
 
-This is the same as the [`message` property](#message) except it does not include the subprocess [`stdout`](#stdout)/[`stderr`](#stderr)/[`stdio`](#stdio).
+Error message when the subprocess failed to run. In addition to the [underlying error message](#errororiginalmessage), it also contains some information related to why the subprocess errored.
 
-#### originalMessage
+The subprocess [`stderr`](#resultstderr), [`stdout`](#resultstdout) and other [file descriptors' output](#resultstdio) are appended to the end, separated with newlines and not interleaved.
+
+#### error.shortMessage
+
+Type: `string`
+
+This is the same as the [`message` property](#errormessage) except it does not include the subprocess [`stdout`](#resultstdout)/[`stderr`](#resultstderr)/[`stdio`](#resultstdio).
+
+#### error.originalMessage
 
 Type: `string | undefined`
 
-Original error message. This is the same as the `message` property excluding the subprocess [`stdout`](#stdout)/[`stderr`](#stderr)/[`stdio`](#stdio) and some additional information added by Execa.
+Original error message. This is the same as the `message` property excluding the subprocess [`stdout`](#resultstdout)/[`stderr`](#resultstderr)/[`stdio`](#resultstdio) and some additional information added by Execa.
 
 This exists only if the subprocess exited due to an `error` event or a timeout.
 
-#### cause
+#### error.cause
 
 Type: `unknown | undefined`
 
-Underlying error, if there is one. For example, this is set by [`.kill(error)`](#killerror).
+Underlying error, if there is one. For example, this is set by [`subprocess.kill(error)`](#subprocesskillerror).
 
 This is usually an `Error` instance.
 
-#### code
+#### error.code
 
 Type: `string | undefined`
 
@@ -756,21 +756,21 @@ Type: `object`
 
 This lists all options for [`execa()`](#execafile-arguments-options) and the [other methods](#methods).
 
-Some options are related to the subprocess output: [`maxBuffer`](#maxbuffer). By default, those options apply to all file descriptors (`stdout`, `stderr`, etc.). A plain object can be passed instead to apply them to only `stdout`, `stderr`, `fd3`, etc.
+Some options are related to the subprocess output: [`maxBuffer`](#optionsmaxbuffer). By default, those options apply to all file descriptors (`stdout`, `stderr`, etc.). A plain object can be passed instead to apply them to only `stdout`, `stderr`, `fd3`, etc.
 
 ```js
 await execa('./run.js', {maxBuffer: 1e6}) // Same value for stdout and stderr
 await execa('./run.js', {maxBuffer: {stdout: 1e4, stderr: 1e6}}) // Different values
 ```
 
-#### reject
+#### options.reject
 
 Type: `boolean`\
 Default: `true`
 
 Setting this to `false` resolves the promise with the [error](#execaerror) instead of rejecting it.
 
-#### shell
+#### options.shell
 
 Type: `boolean | string | URL`\
 Default: `false`
@@ -782,33 +782,33 @@ We recommend against using this option since it is:
 - slower, because of the additional shell interpretation.
 - unsafe, potentially allowing command injection.
 
-#### cwd
+#### options.cwd
 
 Type: `string | URL`\
 Default: `process.cwd()`
 
 Current working directory of the subprocess.
 
-This is also used to resolve the [`nodePath`](#nodepath) option when it is a relative path.
+This is also used to resolve the [`nodePath`](#optionsnodepath) option when it is a relative path.
 
-#### env
+#### options.env
 
 Type: `object`\
 Default: `process.env`
 
 Environment key-value pairs.
 
-Unless the [`extendEnv` option](#extendenv) is `false`, the subprocess also uses the current process' environment variables ([`process.env`](https://nodejs.org/api/process.html#processenv)).
+Unless the [`extendEnv`](#optionsextendenv) option is `false`, the subprocess also uses the current process' environment variables ([`process.env`](https://nodejs.org/api/process.html#processenv)).
 
-#### extendEnv
+#### options.extendEnv
 
 Type: `boolean`\
 Default: `true`
 
-If `true`, the subprocess uses both the [`env` option](#env) and the current process' environment variables ([`process.env`](https://nodejs.org/api/process.html#processenv)).
+If `true`, the subprocess uses both the [`env`](#optionsenv) option and the current process' environment variables ([`process.env`](https://nodejs.org/api/process.html#processenv)).
 If `false`, only the `env` option is used, not `process.env`.
 
-#### preferLocal
+#### options.preferLocal
 
 Type: `boolean`\
 Default: `true` with [`$`](#file-arguments-options), `false` otherwise
@@ -816,30 +816,30 @@ Default: `true` with [`$`](#file-arguments-options), `false` otherwise
 Prefer locally installed binaries when looking for a binary to execute.\
 If you `$ npm install foo`, you can then `execa('foo')`.
 
-#### localDir
+#### options.localDir
 
 Type: `string | URL`\
 Default: `process.cwd()`
 
 Preferred path to find locally installed binaries in (use with `preferLocal`).
 
-#### node
+#### options.node
 
 Type: `boolean`\
 Default: `true` with [`execaNode()`](#execanodescriptpath-arguments-options), `false` otherwise
 
 If `true`, runs with Node.js. The first argument must be a Node.js file.
 
-#### nodeOptions
+#### options.nodeOptions
 
 Type: `string[]`\
 Default: [`process.execArgv`](https://nodejs.org/api/process.html#process_process_execargv) (current Node.js CLI options)
 
-List of [CLI options](https://nodejs.org/api/cli.html#cli_options) passed to the [Node.js executable](#nodepath).
+List of [CLI options](https://nodejs.org/api/cli.html#cli_options) passed to the [Node.js executable](#optionsnodepath).
 
-Requires the [`node`](#node) option to be `true`.
+Requires the [`node`](#optionsnode) option to be `true`.
 
-#### nodePath
+#### options.nodePath
 
 Type: `string | URL`\
 Default: [`process.execPath`](https://nodejs.org/api/process.html#process_process_execpath) (current Node.js executable)
@@ -848,9 +848,9 @@ Path to the Node.js executable.
 
 For example, this can be used together with [`get-node`](https://github.com/ehmicky/get-node) to run a specific Node.js version.
 
-Requires the [`node`](#node) option to be `true`.
+Requires the [`node`](#optionsnode) option to be `true`.
 
-#### verbose
+#### options.verbose
 
 Type: `'none' | 'short' | 'full'`\
 Default: `'none'`
@@ -858,40 +858,40 @@ Default: `'none'`
 If `verbose` is `'short'` or `'full'`, [prints each command](#verbose-mode) on `stderr` before executing it. When the command completes, prints its duration and (if it failed) its error.
 
 If `verbose` is `'full'`, the command's `stdout` and `stderr` are printed too, unless either:
-- the [`stdout`](#stdout-1)/[`stderr`](#stderr-1) option is `ignore` or `inherit`.
-- the `stdout`/`stderr` is redirected to [a stream](https://nodejs.org/api/stream.html#readablepipedestination-options), [a file](#stdout-1), a file descriptor, or [another subprocess](#pipefile-arguments-options).
-- the [`encoding` option](#encoding) is binary.
+- the [`stdout`](#optionsstdout)/[`stderr`](#optionsstderr) option is `ignore` or `inherit`.
+- the `stdout`/`stderr` is redirected to [a stream](https://nodejs.org/api/stream.html#readablepipedestination-options), [a file](#optionsstdout), a file descriptor, or [another subprocess](#subprocesspipefile-arguments-options).
+- the [`encoding`](#optionsencoding) option is binary.
 
 This can also be set to `'full'` by setting the `NODE_DEBUG=execa` environment variable in the current process.
 
-#### buffer
+#### options.buffer
 
 Type: `boolean`\
 Default: `true`
 
-Whether to return the subprocess' output using the [`result.stdout`](#stdout), [`result.stderr`](#stderr), [`result.all`](#all-1) and [`result.stdio`](#stdio) properties.
+Whether to return the subprocess' output using the [`result.stdout`](#resultstdout), [`result.stderr`](#resultstderr), [`result.all`](#resultall) and [`result.stdio`](#resultstdio) properties.
 
-On failure, the [`error.stdout`](#stdout), [`error.stderr`](#stderr), [`error.all`](#all-1) and [`error.stdio`](#stdio) properties are used instead.
+On failure, the [`error.stdout`](#resultstdout), [`error.stderr`](#resultstderr), [`error.all`](#resultall) and [`error.stdio`](#resultstdio) properties are used instead.
 
-When `buffer` is `false`, the output can still be read using the [`subprocess.stdout`](#stdout-1), [`subprocess.stderr`](#stderr-1), [`subprocess.stdio`](https://nodejs.org/api/child_process.html#subprocessstdio) and [`subprocess.all`](#all) streams. If the output is read, this should be done right away to avoid missing any data.
+When `buffer` is `false`, the output can still be read using the [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout), [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr), [`subprocess.stdio`](https://nodejs.org/api/child_process.html#subprocessstdio) and [`subprocess.all`](#subprocessall) streams. If the output is read, this should be done right away to avoid missing any data.
 
-#### input
+#### options.input
 
 Type: `string | Uint8Array | stream.Readable`
 
 Write some input to the subprocess' `stdin`.
 
-See also the [`inputFile`](#inputfile) and [`stdin`](#stdin) options.
+See also the [`inputFile`](#optionsinputfile) and [`stdin`](#optionsstdin) options.
 
-#### inputFile
+#### options.inputFile
 
 Type: `string | URL`
 
 Use a file as input to the subprocess' `stdin`.
 
-See also the [`input`](#input) and [`stdin`](#stdin) options.
+See also the [`input`](#optionsinput) and [`stdin`](#optionsstdin) options.
 
-#### stdin
+#### options.stdin
 
 Type: `string | number | stream.Readable | ReadableStream | TransformStream | URL | {file: string} | Uint8Array | Iterable<string | Uint8Array | unknown> | AsyncIterable<string | Uint8Array | unknown> | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown> | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex | TransformStream}` (or a tuple of those types)\
 Default: `inherit` with [`$`](#file-arguments-options), `pipe` otherwise
@@ -913,13 +913,13 @@ This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destina
 
 This can also be a generator function, a [`Duplex`](docs/transform.md#duplextransform-streams) or a web [`TransformStream`](docs/transform.md#duplextransform-streams) to transform the input. [Learn more.](docs/transform.md)
 
-#### stdout
+#### options.stdout
 
 Type: `string | number | stream.Writable | WritableStream | TransformStream | URL | {file: string} | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown>  | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex | TransformStream}` (or a tuple of those types)\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the subprocess' standard output. This can be:
-- `'pipe'`: Sets [`subprocessResult.stdout`](#stdout) (as a string or `Uint8Array`) and [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout) (as a stream).
+- `'pipe'`: Sets [`result.stdout`](#resultstdout) (as a string or `Uint8Array`) and [`subprocess.stdout`](https://nodejs.org/api/child_process.html#subprocessstdout) (as a stream).
 - `'overlapped'`: Like `'pipe'` but asynchronous on Windows.
 - `'ignore'`: Do not use `stdout`.
 - `'inherit'`: Re-use the current process' `stdout`.
@@ -933,13 +933,13 @@ This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destina
 
 This can also be a generator function, a [`Duplex`](docs/transform.md#duplextransform-streams) or a web [`TransformStream`](docs/transform.md#duplextransform-streams) to transform the output. [Learn more.](docs/transform.md)
 
-#### stderr
+#### options.stderr
 
 Type: `string | number | stream.Writable | WritableStream | TransformStream | URL | {file: string} | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown> | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex | TransformStream}` (or a tuple of those types)\
 Default: `pipe`
 
 [How to setup](https://nodejs.org/api/child_process.html#child_process_options_stdio) the subprocess' standard error. This can be:
-- `'pipe'`: Sets [`subprocessResult.stderr`](#stderr) (as a string or `Uint8Array`) and [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr) (as a stream).
+- `'pipe'`: Sets [`result.stderr`](#resultstderr) (as a string or `Uint8Array`) and [`subprocess.stderr`](https://nodejs.org/api/child_process.html#subprocessstderr) (as a stream).
 - `'overlapped'`: Like `'pipe'` but asynchronous on Windows.
 - `'ignore'`: Do not use `stderr`.
 - `'inherit'`: Re-use the current process' `stderr`.
@@ -953,34 +953,34 @@ This can be an [array of values](#redirect-stdinstdoutstderr-to-multiple-destina
 
 This can also be a generator function, a [`Duplex`](docs/transform.md#duplextransform-streams) or a web [`TransformStream`](docs/transform.md#duplextransform-streams) to transform the output. [Learn more.](docs/transform.md)
 
-#### stdio
+#### options.stdio
 
 Type: `string | Array<string | number | stream.Readable | stream.Writable | ReadableStream | WritableStream | TransformStream | URL | {file: string} | Uint8Array | Iterable<string> | Iterable<Uint8Array> | Iterable<unknown> | AsyncIterable<string | Uint8Array | unknown> | GeneratorFunction<string | Uint8Array | unknown> | AsyncGeneratorFunction<string | Uint8Array | unknown> | {transform: GeneratorFunction | AsyncGeneratorFunction | Duplex | TransformStream}>` (or a tuple of those types)\
 Default: `pipe`
 
-Like the [`stdin`](#stdin), [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options but for all file descriptors at once. For example, `{stdio: ['ignore', 'pipe', 'pipe']}` is the same as `{stdin: 'ignore', stdout: 'pipe', stderr: 'pipe'}`.
+Like the [`stdin`](#optionsstdin), [`stdout`](#optionsstdout) and [`stderr`](#optionsstderr) options but for all file descriptors at once. For example, `{stdio: ['ignore', 'pipe', 'pipe']}` is the same as `{stdin: 'ignore', stdout: 'pipe', stderr: 'pipe'}`.
 
 A single string can be used as a shortcut. For example, `{stdio: 'pipe'}` is the same as `{stdin: 'pipe', stdout: 'pipe', stderr: 'pipe'}`.
 
 The array can have more than 3 items, to create additional file descriptors beyond `stdin`/`stdout`/`stderr`. For example, `{stdio: ['pipe', 'pipe', 'pipe', 'pipe']}` sets a fourth file descriptor.
 
-#### all
+#### options.all
 
 Type: `boolean`\
 Default: `false`
 
-Add an `.all` property on the [promise](#all) and the [resolved value](#all-1). The property contains the output of the subprocess with `stdout` and `stderr` [interleaved](#ensuring-all-output-is-interleaved).
+Add a [`subprocess.all`](#subprocessall) stream and a [`result.all`](#resultall) property. They contain the combined/[interleaved](#ensuring-all-output-is-interleaved) output of the subprocess' `stdout` and `stderr`.
 
-#### lines
+#### options.lines
 
 Type: `boolean`\
 Default: `false`
 
-Set [`result.stdout`](#stdout), [`result.stderr`](#stderr), [`result.all`](#all-1) and [`result.stdio`](#stdio) as arrays of strings, splitting the subprocess' output into lines.
+Set [`result.stdout`](#resultstdout), [`result.stderr`](#resultstdout), [`result.all`](#resultall) and [`result.stdio`](#resultstdio) as arrays of strings, splitting the subprocess' output into lines.
 
-This cannot be used if the [`encoding` option](#encoding) is binary.
+This cannot be used if the [`encoding`](#optionsencoding) option is binary.
 
-#### encoding
+#### options.encoding
 
 Type: `string`\
 Default: `'utf8'`
@@ -991,60 +991,60 @@ If it outputs binary data instead, this should be either:
 - `'buffer'`: returns the binary output as an `Uint8Array`.
 - `'hex'`, `'base64'`, `'base64url'`, [`'latin1'`](https://nodejs.org/api/buffer.html#buffers-and-character-encodings) or [`'ascii'`](https://nodejs.org/api/buffer.html#buffers-and-character-encodings): encodes the binary output as a string.
 
-The output is available with [`result.stdout`](#stdout), [`result.stderr`](#stderr) and [`result.stdio`](#stdio).
+The output is available with [`result.stdout`](#resultstdout), [`result.stderr`](#resultstderr) and [`result.stdio`](#resultstdio).
 
-#### stripFinalNewline
+#### options.stripFinalNewline
 
 Type: `boolean`\
 Default: `true`
 
 Strip the final [newline character](https://en.wikipedia.org/wiki/Newline) from the output.
 
-If the [`lines` option](#lines) is true, this applies to each output line instead.
+If the [`lines`](#optionslines) option is true, this applies to each output line instead.
 
-#### maxBuffer
+#### options.maxBuffer
 
 Type: `number`\
 Default: `100_000_000`
 
-Largest amount of data allowed on [`stdout`](#stdout), [`stderr`](#stderr) and [`stdio`](#stdio).
+Largest amount of data allowed on [`stdout`](#resultstdout), [`stderr`](#resultstderr) and [`stdio`](#resultstdio).
 
-When this threshold is hit, the subprocess fails and [`error.isMaxBuffer`](#ismaxbuffer) becomes `true`.
+When this threshold is hit, the subprocess fails and [`error.isMaxBuffer`](#resultismaxbuffer) becomes `true`.
 
 This is measured:
 - By default: in [characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length).
-- If the [`encoding` option](#encoding) is `'buffer'`: in bytes.
-- If the [`lines` option](#lines) is `true`: in lines.
+- If the [`encoding`](#optionsencoding) option is `'buffer'`: in bytes.
+- If the [`lines`](#optionslines) option is `true`: in lines.
 - If a [transform in object mode](docs/transform.md#object-mode) is used: in objects.
 
 By default, this applies to both `stdout` and `stderr`, but [different values can also be passed](#options).
 
-#### ipc
+#### options.ipc
 
 Type: `boolean`\
-Default: `true` if the [`node`](#node) option is enabled, `false` otherwise
+Default: `true` if the [`node`](#optionsnode) option is enabled, `false` otherwise
 
 Enables exchanging messages with the subprocess using [`subprocess.send(value)`](https://nodejs.org/api/child_process.html#subprocesssendmessage-sendhandle-options-callback) and [`subprocess.on('message', (value) => {})`](https://nodejs.org/api/child_process.html#event-message).
 
-#### serialization
+#### options.serialization
 
 Type: `string`\
 Default: `'advanced'`
 
-Specify the kind of serialization used for sending messages between subprocesses when using the [`ipc`](#ipc) option:
+Specify the kind of serialization used for sending messages between subprocesses when using the [`ipc`](#optionsipc) option:
 	- `json`: Uses `JSON.stringify()` and `JSON.parse()`.
 	- `advanced`: Uses [`v8.serialize()`](https://nodejs.org/api/v8.html#v8_v8_serialize_value)
 
 [More info.](https://nodejs.org/api/child_process.html#child_process_advanced_serialization)
 
-#### detached
+#### options.detached
 
 Type: `boolean`\
 Default: `false`
 
 Prepare subprocess to run independently of the current process. Specific behavior [depends on the platform](https://nodejs.org/api/child_process.html#child_process_options_detached).
 
-#### cleanup
+#### options.cleanup
 
 Type: `boolean`\
 Default: `true`
@@ -1053,22 +1053,22 @@ Kill the subprocess when the current process exits unless either:
 	- the subprocess is [`detached`](https://nodejs.org/api/child_process.html#child_process_options_detached)
 	- the current process is terminated abruptly, for example, with `SIGKILL` as opposed to `SIGTERM` or a normal exit
 
-#### timeout
+#### options.timeout
 
 Type: `number`\
 Default: `0`
 
-If `timeout` is greater than `0`, the subprocess will be [terminated](#killsignal) if it runs for longer than that amount of milliseconds.
+If `timeout` is greater than `0`, the subprocess will be [terminated](#optionskillsignal) if it runs for longer than that amount of milliseconds.
 
-#### cancelSignal
+#### options.cancelSignal
 
 Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
 
 You can abort the subprocess using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
 
-When `AbortController.abort()` is called, [`.isCanceled`](#iscanceled) becomes `true`.
+When `AbortController.abort()` is called, [`result.isCanceled`](#resultiscanceled) becomes `true`.
 
-#### forceKillAfterDelay
+#### options.forceKillAfterDelay
 
 Type: `number | false`\
 Default: `5000`
@@ -1078,7 +1078,7 @@ If the subprocess is terminated but does not exit, forcefully exit it by sending
 The grace period is 5 seconds by default. This feature can be disabled with `false`.
 
 This works when the subprocess is terminated by either:
-- the [`cancelSignal`](#cancelsignal), [`timeout`](#timeout), [`maxBuffer`](#maxbuffer) or [`cleanup`](#cleanup) option
+- the [`cancelSignal`](#optionscancelsignal), [`timeout`](#optionstimeout), [`maxBuffer`](#optionsmaxbuffer) or [`cleanup`](#optionscleanup) option
 - calling [`subprocess.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal) with no arguments
 
 This does not work when the subprocess is terminated by either:
@@ -1088,43 +1088,43 @@ This does not work when the subprocess is terminated by either:
 
 Also, this does not work on Windows, because Windows [doesn't support signals](https://nodejs.org/api/process.html#process_signal_events): `SIGKILL` and `SIGTERM` both terminate the subprocess immediately. Other packages (such as [`taskkill`](https://github.com/sindresorhus/taskkill)) can be used to achieve fail-safe termination on Windows.
 
-#### killSignal
+#### options.killSignal
 
 Type: `string | number`\
 Default: `SIGTERM`
 
 Signal used to terminate the subprocess when:
-- using the [`cancelSignal`](#cancelsignal), [`timeout`](#timeout), [`maxBuffer`](#maxbuffer) or [`cleanup`](#cleanup) option
+- using the [`cancelSignal`](#optionscancelsignal), [`timeout`](#optionstimeout), [`maxBuffer`](#optionsmaxbuffer) or [`cleanup`](#optionscleanup) option
 - calling [`subprocess.kill()`](https://nodejs.org/api/child_process.html#subprocesskillsignal) with no arguments
 
 This can be either a name (like `"SIGTERM"`) or a number (like `9`).
 
-#### argv0
+#### options.argv0
 
 Type: `string`
 
 Explicitly set the value of `argv[0]` sent to the subprocess. This will be set to `file` if not specified.
 
-#### uid
+#### options.uid
 
 Type: `number`
 
 Sets the user identity of the subprocess.
 
-#### gid
+#### options.gid
 
 Type: `number`
 
 Sets the group identity of the subprocess.
 
-#### windowsVerbatimArguments
+#### options.windowsVerbatimArguments
 
 Type: `boolean`\
 Default: `false`
 
 If `true`, no quoting or escaping of arguments is done on Windows. Ignored on other platforms. This is set to `true` automatically when the `shell` option is `true`.
 
-#### windowsHide
+#### options.windowsHide
 
 Type: `boolean`\
 Default: `true`
@@ -1135,7 +1135,7 @@ On Windows, do not create a new console window. Please note this also prevents `
 
 ### Redirect stdin/stdout/stderr to multiple destinations
 
-The [`stdin`](#stdin), [`stdout`](#stdout-1) and [`stderr`](#stderr-1) options can be an array of values.
+The [`stdin`](#optionsstdin), [`stdout`](#optionsstdout) and [`stderr`](#optionsstderr) options can be an array of values.
 The following example redirects `stdout` to both the terminal and an `output.txt` file, while also retrieving its value programmatically.
 
 ```js
@@ -1147,7 +1147,7 @@ When combining `inherit` with other values, please note that the subprocess will
 
 ### Redirect a Node.js stream from/to stdin/stdout/stderr
 
-When passing a Node.js stream to the [`stdin`](#stdin), [`stdout`](#stdout-1) or [`stderr`](#stderr-1) option, Node.js requires that stream to have an underlying file or socket, such as the streams created by the `fs`, `net` or `http` core modules. Otherwise the following error is thrown.
+When passing a Node.js stream to the [`stdin`](#optionsstdin), [`stdout`](#optionsstdout) or [`stderr`](#optionsstderr) option, Node.js requires that stream to have an underlying file or socket, such as the streams created by the `fs`, `net` or `http` core modules. Otherwise the following error is thrown.
 
 ```
 TypeError [ERR_INVALID_ARG_VALUE]: The argument 'stdio' is invalid.
@@ -1210,7 +1210,7 @@ await execa(binPath);
 
 ### Ensuring `all` output is interleaved
 
-The `all` [stream](#all) and [string/`Uint8Array`](#all-1) properties are guaranteed to interleave [`stdout`](#stdout) and [`stderr`](#stderr).
+The `subprocess.all` [stream](#subprocessall) and `result.all` [string/`Uint8Array`](#resultall) property are guaranteed to interleave [`stdout`](#resultstdout) and [`stderr`](#resultstderr).
 
 However, for performance reasons, the subprocess might buffer and merge multiple simultaneous writes to `stdout` or `stderr`. This prevents proper interleaving.
 


### PR DESCRIPTION
The `readme.md` headers can be confusing. I often scroll up and down not knowing in which section I am.

I think one of the issues is that we re-use the same words for some options, subprocess properties and result properties. In general, that's a good thing, but it creates confusion in the `readme.md`. For example, we are using 3 times the "all" header: for the option, the stream, and the result property.

This PR fixes this by prefixing those headers. For example, `options.all`, `subprocess.all`, `result.all` and `error.all`. This makes it clearer which section the user is currently reading.