### PR TITLE
Allow setting different `buffer` values for `stdout`/`stderr`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -247,13 +247,13 @@ type IgnoresStdioResult<
 type IgnoresStreamOutput<
 	FdNumber extends string,
 	OptionsType extends CommonOptions = CommonOptions,
-> = LacksBuffer<OptionsType['buffer']> extends true
+> = LacksBuffer<FdSpecificOption<OptionsType['buffer'], FdNumber>> extends true
 	? true
 	: IsInputStdioDescriptor<FdNumber, OptionsType> extends true
 		? true
 		: IgnoresStreamResult<FdNumber, OptionsType>;
 
-type LacksBuffer<BufferOption extends CommonOptions['buffer']> = BufferOption extends false ? true : false;
+type LacksBuffer<BufferOption extends boolean | undefined> = BufferOption extends false ? true : false;
 
 // Whether `result.stdio[FdNumber]` is an input stream
 type IsInputStdioDescriptor<
@@ -774,9 +774,11 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 
 	When `buffer` is `false`, the output can still be read using the `subprocess.stdout`, `subprocess.stderr`, `subprocess.stdio` and `subprocess.all` streams. If the output is read, this should be done right away to avoid missing any data.
 
+	By default, this applies to both `stdout` and `stderr`, but different values can also be passed.
+
 	@default true
 	*/
-	readonly buffer?: boolean;
+	readonly buffer?: FdGenericOption<boolean>;
 
 	/**
 	Add a `subprocess.all` stream and a `result.all` property. They contain the combined/[interleaved](#ensuring-all-output-is-interleaved) output of the subprocess' `stdout` and `stderr`.
@@ -840,7 +842,7 @@ type CommonOptions<IsSync extends boolean = boolean> = {
 /**
 Subprocess options.
 
-Some options are related to the subprocess output: `verbose`, `lines`, `stripFinalNewline`, `maxBuffer`. By default, those options apply to all file descriptors (`stdout`, `stderr`, etc.). A plain object can be passed instead to apply them to only `stdout`, `stderr`, `fd3`, etc.
+Some options are related to the subprocess output: `verbose`, `lines`, `stripFinalNewline`, `buffer`, `maxBuffer`. By default, those options apply to all file descriptors (`stdout`, `stderr`, etc.). A plain object can be passed instead to apply them to only `stdout`, `stderr`, `fd3`, etc.
 
 @example
 
@@ -854,7 +856,7 @@ export type Options = CommonOptions<false>;
 /**
 Subprocess options, with synchronous methods.
 
-Some options are related to the subprocess output: `verbose`, `lines`, `stripFinalNewline`, `maxBuffer`. By default, those options apply to all file descriptors (`stdout`, `stderr`, etc.). A plain object can be passed instead to apply them to only `stdout`, `stderr`, `fd3`, etc.
+Some options are related to the subprocess output: `verbose`, `lines`, `stripFinalNewline`, `buffer`, `maxBuffer`. By default, those options apply to all file descriptors (`stdout`, `stderr`, etc.). A plain object can be passed instead to apply them to only `stdout`, `stderr`, `fd3`, etc.
 
 @example
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1614,6 +1614,26 @@ execaSync('unicorns', {lines: {fd1: true}});
 execaSync('unicorns', {lines: {fd2: true}});
 execaSync('unicorns', {lines: {fd3: true}});
 expectError(execaSync('unicorns', {lines: {stdout: 'true'}}));
+execa('unicorns', {buffer: {}});
+expectError(execa('unicorns', {buffer: []}));
+execa('unicorns', {buffer: {stdout: true}});
+execa('unicorns', {buffer: {stderr: true}});
+execa('unicorns', {buffer: {stdout: true, stderr: true} as const});
+execa('unicorns', {buffer: {all: true}});
+execa('unicorns', {buffer: {fd1: true}});
+execa('unicorns', {buffer: {fd2: true}});
+execa('unicorns', {buffer: {fd3: true}});
+expectError(execa('unicorns', {buffer: {stdout: 'true'}}));
+execaSync('unicorns', {buffer: {}});
+expectError(execaSync('unicorns', {buffer: []}));
+execaSync('unicorns', {buffer: {stdout: true}});
+execaSync('unicorns', {buffer: {stderr: true}});
+execaSync('unicorns', {buffer: {stdout: true, stderr: true} as const});
+execaSync('unicorns', {buffer: {all: true}});
+execaSync('unicorns', {buffer: {fd1: true}});
+execaSync('unicorns', {buffer: {fd2: true}});
+execaSync('unicorns', {buffer: {fd3: true}});
+expectError(execaSync('unicorns', {buffer: {stdout: 'true'}}));
 
 const linesStdoutResult = await execa('unicorns', {all: true, lines: {stdout: true}});
 expectType<string[]>(linesStdoutResult.stdout);
@@ -1702,6 +1722,94 @@ expectType<string>(linesFd3ResultSync.stdio[2]);
 expectType<string>(linesFd3ResultSync.all);
 expectType<string[]>(linesFd3ResultSync.stdio[3]);
 expectType<string>(linesFd3ResultSync.stdio[4]);
+
+const noBufferStdoutResult = await execa('unicorns', {all: true, buffer: {stdout: false}});
+expectType<undefined>(noBufferStdoutResult.stdout);
+expectType<undefined>(noBufferStdoutResult.stdio[1]);
+expectType<string>(noBufferStdoutResult.stderr);
+expectType<string>(noBufferStdoutResult.stdio[2]);
+expectType<string>(noBufferStdoutResult.all);
+
+const noBufferStderrResult = await execa('unicorns', {all: true, buffer: {stderr: false}});
+expectType<string>(noBufferStderrResult.stdout);
+expectType<string>(noBufferStderrResult.stdio[1]);
+expectType<undefined>(noBufferStderrResult.stderr);
+expectType<undefined>(noBufferStderrResult.stdio[2]);
+expectType<string>(noBufferStderrResult.all);
+
+const noBufferFd1Result = await execa('unicorns', {all: true, buffer: {fd1: false}});
+expectType<undefined>(noBufferFd1Result.stdout);
+expectType<undefined>(noBufferFd1Result.stdio[1]);
+expectType<string>(noBufferFd1Result.stderr);
+expectType<string>(noBufferFd1Result.stdio[2]);
+expectType<string>(noBufferFd1Result.all);
+
+const noBufferFd2Result = await execa('unicorns', {all: true, buffer: {fd2: false}});
+expectType<string>(noBufferFd2Result.stdout);
+expectType<string>(noBufferFd2Result.stdio[1]);
+expectType<undefined>(noBufferFd2Result.stderr);
+expectType<undefined>(noBufferFd2Result.stdio[2]);
+expectType<string>(noBufferFd2Result.all);
+
+const noBufferAllResult = await execa('unicorns', {all: true, buffer: {all: false}});
+expectType<undefined>(noBufferAllResult.stdout);
+expectType<undefined>(noBufferAllResult.stdio[1]);
+expectType<undefined>(noBufferAllResult.stderr);
+expectType<undefined>(noBufferAllResult.stdio[2]);
+expectType<undefined>(noBufferAllResult.all);
+
+const noBufferFd3Result = await execa('unicorns', {all: true, buffer: {fd3: false}, stdio: ['pipe', 'pipe', 'pipe', 'pipe', 'pipe']});
+expectType<string>(noBufferFd3Result.stdout);
+expectType<string>(noBufferFd3Result.stdio[1]);
+expectType<string>(noBufferFd3Result.stderr);
+expectType<string>(noBufferFd3Result.stdio[2]);
+expectType<string>(noBufferFd3Result.all);
+expectType<undefined>(noBufferFd3Result.stdio[3]);
+expectType<string>(noBufferFd3Result.stdio[4]);
+
+const noBufferStdoutResultSync = execaSync('unicorns', {all: true, buffer: {stdout: false}});
+expectType<undefined>(noBufferStdoutResultSync.stdout);
+expectType<undefined>(noBufferStdoutResultSync.stdio[1]);
+expectType<string>(noBufferStdoutResultSync.stderr);
+expectType<string>(noBufferStdoutResultSync.stdio[2]);
+expectType<string>(noBufferStdoutResultSync.all);
+
+const noBufferStderrResultSync = execaSync('unicorns', {all: true, buffer: {stderr: false}});
+expectType<string>(noBufferStderrResultSync.stdout);
+expectType<string>(noBufferStderrResultSync.stdio[1]);
+expectType<undefined>(noBufferStderrResultSync.stderr);
+expectType<undefined>(noBufferStderrResultSync.stdio[2]);
+expectType<string>(noBufferStderrResultSync.all);
+
+const noBufferFd1ResultSync = execaSync('unicorns', {all: true, buffer: {fd1: false}});
+expectType<undefined>(noBufferFd1ResultSync.stdout);
+expectType<undefined>(noBufferFd1ResultSync.stdio[1]);
+expectType<string>(noBufferFd1ResultSync.stderr);
+expectType<string>(noBufferFd1ResultSync.stdio[2]);
+expectType<string>(noBufferFd1ResultSync.all);
+
+const noBufferFd2ResultSync = execaSync('unicorns', {all: true, buffer: {fd2: false}});
+expectType<string>(noBufferFd2ResultSync.stdout);
+expectType<string>(noBufferFd2ResultSync.stdio[1]);
+expectType<undefined>(noBufferFd2ResultSync.stderr);
+expectType<undefined>(noBufferFd2ResultSync.stdio[2]);
+expectType<string>(noBufferFd2ResultSync.all);
+
+const noBufferAllResultSync = execaSync('unicorns', {all: true, buffer: {all: false}});
+expectType<undefined>(noBufferAllResultSync.stdout);
+expectType<undefined>(noBufferAllResultSync.stdio[1]);
+expectType<undefined>(noBufferAllResultSync.stderr);
+expectType<undefined>(noBufferAllResultSync.stdio[2]);
+expectType<undefined>(noBufferAllResultSync.all);
+
+const noBufferFd3ResultSync = execaSync('unicorns', {all: true, buffer: {fd3: false}, stdio: ['pipe', 'pipe', 'pipe', 'pipe', 'pipe']});
+expectType<string>(noBufferFd3ResultSync.stdout);
+expectType<string>(noBufferFd3ResultSync.stdio[1]);
+expectType<string>(noBufferFd3ResultSync.stderr);
+expectType<string>(noBufferFd3ResultSync.stdio[2]);
+expectType<string>(noBufferFd3ResultSync.all);
+expectType<undefined>(noBufferFd3ResultSync.stdio[3]);
+expectType<string>(noBufferFd3ResultSync.stdio[4]);
 
 expectError(execa('unicorns', {stdio: []}));
 expectError(execaSync('unicorns', {stdio: []}));

--- a/lib/arguments/options.js
+++ b/lib/arguments/options.js
@@ -34,10 +34,7 @@ export const handleOptions = (filePath, rawArgs, rawOptions) => {
 	options.shell = normalizeFileUrl(options.shell);
 	options.env = getEnv(options);
 	options.forceKillAfterDelay = normalizeForceKillAfterDelay(options.forceKillAfterDelay);
-
-	if (BINARY_ENCODINGS.has(options.encoding) || !options.buffer) {
-		options.lines.fill(false);
-	}
+	options.lines = options.lines.map((lines, fdNumber) => lines && !BINARY_ENCODINGS.has(options.encoding) && options.buffer[fdNumber]);
 
 	if (process.platform === 'win32' && basename(file, '.exe') === 'cmd') {
 		// #116
@@ -48,7 +45,6 @@ export const handleOptions = (filePath, rawArgs, rawOptions) => {
 };
 
 const addDefaultOptions = ({
-	buffer = true,
 	extendEnv = true,
 	preferLocal = false,
 	cwd,
@@ -65,7 +61,6 @@ const addDefaultOptions = ({
 	...options
 }) => ({
 	...options,
-	buffer,
 	extendEnv,
 	preferLocal,
 	cwd,

--- a/lib/arguments/specific.js
+++ b/lib/arguments/specific.js
@@ -74,9 +74,10 @@ const addDefaultValue = (optionArray, optionName) => optionArray.map(optionValue
 
 const DEFAULT_OPTIONS = {
 	lines: false,
+	buffer: true,
 	maxBuffer: 1000 * 1000 * 100,
 	verbose: verboseDefault,
 	stripFinalNewline: true,
 };
 
-export const FD_SPECIFIC_OPTIONS = ['lines', 'maxBuffer', 'verbose', 'stripFinalNewline'];
+export const FD_SPECIFIC_OPTIONS = ['lines', 'buffer', 'maxBuffer', 'verbose', 'stripFinalNewline'];

--- a/lib/stdio/option.js
+++ b/lib/stdio/option.js
@@ -41,9 +41,13 @@ const addDefaultValue = (stdioOption, fdNumber) => {
 	return stdioOption;
 };
 
-const normalizeStdioSync = (stdioArray, buffer, verbose) => buffer
-	? stdioArray
-	: stdioArray.map((stdioOption, fdNumber) => fdNumber !== 0 && verbose[fdNumber] !== 'full' && isOutputPipeOnly(stdioOption) ? 'ignore' : stdioOption);
+const normalizeStdioSync = (stdioArray, buffer, verbose) => stdioArray.map((stdioOption, fdNumber) =>
+	!buffer[fdNumber]
+	&& fdNumber !== 0
+	&& verbose[fdNumber] !== 'full'
+	&& isOutputPipeOnly(stdioOption)
+		? 'ignore'
+		: stdioOption);
 
 const isOutputPipeOnly = stdioOption => stdioOption === 'pipe'
 	|| (Array.isArray(stdioOption) && stdioOption.every(item => item === 'pipe'));

--- a/lib/stdio/output-sync.js
+++ b/lib/stdio/output-sync.js
@@ -39,7 +39,7 @@ const transformOutputResultSync = ({result, fileDescriptors, fdNumber, state, is
 		logLinesSync(linesArray, verboseInfo);
 	}
 
-	const returnedResult = buffer ? finalResult : undefined;
+	const returnedResult = buffer[fdNumber] ? finalResult : undefined;
 
 	try {
 		if (state.error === undefined) {

--- a/lib/stream/all.js
+++ b/lib/stream/all.js
@@ -8,10 +8,9 @@ export const makeAllStream = ({stdout, stderr}, {all}) => all && (stdout || stde
 
 // Read the contents of `subprocess.all` and|or wait for its completion
 export const waitForAllStream = ({subprocess, encoding, buffer, maxBuffer, lines, stripFinalNewline, verboseInfo, streamInfo}) => waitForSubprocessStream({
-	stream: subprocess.all,
+	...getAllStream(subprocess, buffer),
 	fdNumber: 1,
 	encoding,
-	buffer,
 	maxBuffer: maxBuffer[1] + maxBuffer[2],
 	lines: lines[1] || lines[2],
 	isAll: true,
@@ -20,6 +19,23 @@ export const waitForAllStream = ({subprocess, encoding, buffer, maxBuffer, lines
 	verboseInfo,
 	streamInfo,
 });
+
+const getAllStream = ({stdout, stderr, all}, [, bufferStdout, bufferStderr]) => {
+	const buffer = bufferStdout || bufferStderr;
+	if (!buffer) {
+		return {stream: all, buffer};
+	}
+
+	if (!bufferStdout) {
+		return {stream: stderr, buffer};
+	}
+
+	if (!bufferStderr) {
+		return {stream: stdout, buffer};
+	}
+
+	return {stream: all, buffer};
+};
 
 // When `subprocess.stdout` is in objectMode but not `subprocess.stderr` (or the opposite), we need to use both:
 //  - `getStreamAsArray()` for the chunks in objectMode, to return as an array without changing each chunk

--- a/lib/stream/resolve.js
+++ b/lib/stream/resolve.js
@@ -56,7 +56,7 @@ export const getSubprocessResult = async ({
 
 // Read the contents of `subprocess.std*` and|or wait for its completion
 const waitForSubprocessStreams = ({subprocess, encoding, buffer, maxBuffer, lines, stripFinalNewline, verboseInfo, streamInfo}) =>
-	subprocess.stdio.map((stream, fdNumber) => waitForSubprocessStream({stream, fdNumber, encoding, buffer, maxBuffer: maxBuffer[fdNumber], lines: lines[fdNumber], isAll: false, allMixed: false, stripFinalNewline, verboseInfo, streamInfo}));
+	subprocess.stdio.map((stream, fdNumber) => waitForSubprocessStream({stream, fdNumber, encoding, buffer: buffer[fdNumber], maxBuffer: maxBuffer[fdNumber], lines: lines[fdNumber], isAll: false, allMixed: false, stripFinalNewline, verboseInfo, streamInfo}));
 
 // Transforms replace `subprocess.std*`, which means they are not exposed to users.
 // However, we still want to wait for their completion.

--- a/readme.md
+++ b/readme.md
@@ -831,7 +831,7 @@ Type: `object`
 
 This lists all options for [`execa()`](#execafile-arguments-options) and the [other methods](#methods).
 
-Some options are related to the subprocess output: [`verbose`](#optionsverbose), [`lines`](#optionslines), [`stripFinalNewline`](#optionsstripfinalnewline), [`maxBuffer`](#optionsmaxbuffer). By default, those options apply to all file descriptors (`stdout`, `stderr`, etc.). A plain object can be passed instead to apply them to only `stdout`, `stderr`, `fd3`, etc.
+Some options are related to the subprocess output: [`verbose`](#optionsverbose), [`lines`](#optionslines), [`stripFinalNewline`](#optionsstripfinalnewline), [`buffer`](#optionsbuffer), [`maxBuffer`](#optionsmaxbuffer). By default, those options apply to all file descriptors (`stdout`, `stderr`, etc.). A plain object can be passed instead to apply them to only `stdout`, `stderr`, `fd3`, etc.
 
 ```js
 await execa('./run.js', {verbose: 'full'}) // Same value for stdout and stderr
@@ -951,6 +951,8 @@ Whether to return the subprocess' output using the [`result.stdout`](#resultstdo
 On failure, the [`error.stdout`](#resultstdout), [`error.stderr`](#resultstderr), [`error.all`](#resultall) and [`error.stdio`](#resultstdio) properties are used instead.
 
 When `buffer` is `false`, the output can still be read using the [`subprocess.stdout`](#subprocessstdout), [`subprocess.stderr`](#subprocessstderr), [`subprocess.stdio`](#subprocessstdio) and [`subprocess.all`](#subprocessall) streams. If the output is read, this should be done right away to avoid missing any data.
+
+By default, this applies to both `stdout` and `stderr`, but [different values can also be passed](#options).
 
 #### options.input
 

--- a/test/stdio/file-path.js
+++ b/test/stdio/file-path.js
@@ -322,19 +322,21 @@ test('stderr can use "lines: true" together with output file URLs, sync', testOu
 test('stdio[*] can use "lines: true" together with output file paths, sync', testOutputFileLines, 3, getAbsolutePath, execaSync);
 test('stdio[*] can use "lines: true" together with output file URLs, sync', testOutputFileLines, 3, pathToFileURL, execaSync);
 
-const testOutputFileNoBuffer = async (t, execaMethod) => {
+const testOutputFileNoBuffer = async (t, buffer, execaMethod) => {
 	const filePath = tempfile();
 	const {stdout} = await execaMethod('noop-fd.js', ['1', foobarString], {
 		stdout: getAbsolutePath(filePath),
-		buffer: false,
+		buffer,
 	});
 	t.is(stdout, undefined);
 	t.is(await readFile(filePath, 'utf8'), foobarString);
 	await rm(filePath);
 };
 
-test('stdout can use "buffer: false" together with output file paths', testOutputFileNoBuffer, execa);
-test('stdout can use "buffer: false" together with output file paths, sync', testOutputFileNoBuffer, execaSync);
+test('stdout can use "buffer: false" together with output file paths', testOutputFileNoBuffer, false, execa);
+test('stdout can use "buffer: false" together with output file paths, fd-specific', testOutputFileNoBuffer, {stdout: false}, execa);
+test('stdout can use "buffer: false" together with output file paths, sync', testOutputFileNoBuffer, false, execaSync);
+test('stdout can use "buffer: false" together with output file paths, fd-specific, sync', testOutputFileNoBuffer, {stdout: false}, execaSync);
 
 const testOutputFileObject = async (t, fdNumber, mapFile, execaMethod) => {
 	const filePath = tempfile();

--- a/test/stdio/lines.js
+++ b/test/stdio/lines.js
@@ -147,15 +147,17 @@ test('"lines: true" is a noop with "encoding: hex", fd-specific, sync', testEnco
 test('"lines: true" is a noop with "encoding: hex", stripFinalNewline, sync', testEncoding, simpleFull, simpleFullHex, 'hex', true, true, execaSync);
 test('"lines: true" is a noop with "encoding: hex", stripFinalNewline, fd-specific, sync', testEncoding, simpleFull, simpleFullHex, 'hex', true, {stdout: true}, execaSync);
 
-const testLinesNoBuffer = async (t, lines, execaMethod) => {
-	const {stdout} = await getSimpleChunkSubprocess(execaMethod, {lines, buffer: false});
+const testLinesNoBuffer = async (t, lines, buffer, execaMethod) => {
+	const {stdout} = await getSimpleChunkSubprocess(execaMethod, {lines, buffer});
 	t.is(stdout, undefined);
 };
 
-test('"lines: true" is a noop with "buffer: false"', testLinesNoBuffer, true, execa);
-test('"lines: true" is a noop with "buffer: false", fd-specific', testLinesNoBuffer, {stdout: true}, execa);
-test('"lines: true" is a noop with "buffer: false", sync', testLinesNoBuffer, true, execaSync);
-test('"lines: true" is a noop with "buffer: false", fd-specific, sync', testLinesNoBuffer, {stdout: true}, execaSync);
+test('"lines: true" is a noop with "buffer: false"', testLinesNoBuffer, true, false, execa);
+test('"lines: true" is a noop with "buffer: false", fd-specific buffer', testLinesNoBuffer, true, {stdout: false}, execa);
+test('"lines: true" is a noop with "buffer: false", fd-specific lines', testLinesNoBuffer, {stdout: true}, false, execa);
+test('"lines: true" is a noop with "buffer: false", sync', testLinesNoBuffer, true, false, execaSync);
+test('"lines: true" is a noop with "buffer: false", fd-specific buffer, sync', testLinesNoBuffer, true, {stdout: false}, execaSync);
+test('"lines: true" is a noop with "buffer: false", fd-specific lines, sync', testLinesNoBuffer, {stdout: true}, false, execaSync);
 
 const maxBuffer = simpleLines.length - 1;
 

--- a/test/stream/max-buffer.js
+++ b/test/stream/max-buffer.js
@@ -210,8 +210,8 @@ test('maxBuffer ignores other encodings and stdout, sync', testMaxBufferHexSync,
 test('maxBuffer ignores other encodings and stderr, sync', testMaxBufferHexSync, 2);
 test('maxBuffer ignores other encodings and stdio[*], sync', testMaxBufferHexSync, 3);
 
-const testNoMaxBuffer = async (t, fdNumber) => {
-	const subprocess = getMaxBufferSubprocess(execa, fdNumber, {buffer: false});
+const testNoMaxBuffer = async (t, fdNumber, buffer) => {
+	const subprocess = getMaxBufferSubprocess(execa, fdNumber, {buffer});
 	const [{isMaxBuffer, stdio}, output] = await Promise.all([
 		subprocess,
 		getStream(subprocess.stdio[fdNumber]),
@@ -221,20 +221,25 @@ const testNoMaxBuffer = async (t, fdNumber) => {
 	t.is(output, getExpectedOutput(maxBuffer + 1));
 };
 
-test('do not buffer stdout when `buffer` set to `false`', testNoMaxBuffer, 1);
-test('do not buffer stderr when `buffer` set to `false`', testNoMaxBuffer, 2);
-test('do not buffer stdio[*] when `buffer` set to `false`', testNoMaxBuffer, 3);
+test('do not buffer stdout when `buffer` set to `false`', testNoMaxBuffer, 1, false);
+test('do not buffer stdout when `buffer` set to `false`, fd-specific', testNoMaxBuffer, 1, {stdout: false});
+test('do not buffer stderr when `buffer` set to `false`', testNoMaxBuffer, 2, false);
+test('do not buffer stderr when `buffer` set to `false`, fd-specific', testNoMaxBuffer, 2, {stderr: false});
+test('do not buffer stdio[*] when `buffer` set to `false`', testNoMaxBuffer, 3, false);
+test('do not buffer stdio[*] when `buffer` set to `false`, fd-specific', testNoMaxBuffer, 3, {fd3: false});
 
-const testNoMaxBufferSync = (t, fdNumber) => {
-	const {isMaxBuffer, stdio} = getMaxBufferSubprocess(execaSync, fdNumber, {buffer: false});
+const testNoMaxBufferSync = (t, fdNumber, buffer) => {
+	const {isMaxBuffer, stdio} = getMaxBufferSubprocess(execaSync, fdNumber, {buffer});
 	t.false(isMaxBuffer);
 	t.is(stdio[fdNumber], undefined);
 };
 
-// @todo: add a test for fd3 once the following Node.js bug is fixed.
-// https://github.com/nodejs/node/issues/52338
-test('do not buffer stdout when `buffer` set to `false`, sync', testNoMaxBufferSync, 1);
-test('do not buffer stderr when `buffer` set to `false`, sync', testNoMaxBufferSync, 2);
+// @todo: add tests for fd3 once the following Node.js bug is fixed.
+// https://github.com/nodejs/node/issues/52422
+test('do not buffer stdout when `buffer` set to `false`, sync', testNoMaxBufferSync, 1, false);
+test('do not buffer stdout when `buffer` set to `false`, fd-specific, sync', testNoMaxBufferSync, 1, {stdout: false});
+test('do not buffer stderr when `buffer` set to `false`, sync', testNoMaxBufferSync, 2, false);
+test('do not buffer stderr when `buffer` set to `false`, fd-specific, sync', testNoMaxBufferSync, 2, {stderr: false});
 
 const testMaxBufferAbort = async (t, fdNumber) => {
 	const subprocess = getMaxBufferSubprocess(execa, fdNumber);

--- a/test/stream/no-buffer.js
+++ b/test/stream/no-buffer.js
@@ -86,25 +86,37 @@ test('Listen to stderr errors even when `buffer` is `false`', testNoBufferStream
 test('Listen to stdio[*] errors even when `buffer` is `false`', testNoBufferStreamError, 3, false);
 test('Listen to all errors even when `buffer` is `false`', testNoBufferStreamError, 1, true);
 
-const testNoOutput = async (t, stdioOption, execaMethod) => {
-	const {stdout} = await execaMethod('noop.js', {stdout: stdioOption, buffer: false});
+const testOutput = async (t, buffer, execaMethod) => {
+	const {stdout} = await execaMethod('noop-fd.js', ['1', foobarString], {buffer});
+	t.is(stdout, foobarString);
+};
+
+test('buffer: true returns output', testOutput, true, execa);
+test('buffer: true returns output, fd-specific', testOutput, {stderr: false}, execa);
+test('buffer: default returns output', testOutput, undefined, execa);
+test('buffer: default returns output, fd-specific', testOutput, {}, execa);
+
+const testNoOutput = async (t, stdioOption, buffer, execaMethod) => {
+	const {stdout} = await execaMethod('noop.js', {stdout: stdioOption, buffer});
 	t.is(stdout, undefined);
 };
 
-test('buffer: false does not return output', testNoOutput, 'pipe', execa);
-test('buffer: false does not return output, stdout undefined', testNoOutput, undefined, execa);
-test('buffer: false does not return output, stdout null', testNoOutput, null, execa);
-test('buffer: false does not return output, stdout ["pipe"]', testNoOutput, ['pipe'], execa);
-test('buffer: false does not return output, stdout [undefined]', testNoOutput, [undefined], execa);
-test('buffer: false does not return output, stdout [null]', testNoOutput, [null], execa);
-test('buffer: false does not return output, stdout ["pipe", undefined]', testNoOutput, ['pipe', undefined], execa);
-test('buffer: false does not return output, sync', testNoOutput, 'pipe', execaSync);
-test('buffer: false does not return output, stdout undefined, sync', testNoOutput, undefined, execaSync);
-test('buffer: false does not return output, stdout null, sync', testNoOutput, null, execaSync);
-test('buffer: false does not return output, stdout ["pipe"], sync', testNoOutput, ['pipe'], execaSync);
-test('buffer: false does not return output, stdout [undefined], sync', testNoOutput, [undefined], execaSync);
-test('buffer: false does not return output, stdout [null], sync', testNoOutput, [null], execaSync);
-test('buffer: false does not return output, stdout ["pipe", undefined], sync', testNoOutput, ['pipe', undefined], execaSync);
+test('buffer: false does not return output', testNoOutput, 'pipe', false, execa);
+test('buffer: false does not return output, fd-specific', testNoOutput, 'pipe', {stdout: false}, execa);
+test('buffer: false does not return output, stdout undefined', testNoOutput, undefined, false, execa);
+test('buffer: false does not return output, stdout null', testNoOutput, null, false, execa);
+test('buffer: false does not return output, stdout ["pipe"]', testNoOutput, ['pipe'], false, execa);
+test('buffer: false does not return output, stdout [undefined]', testNoOutput, [undefined], false, execa);
+test('buffer: false does not return output, stdout [null]', testNoOutput, [null], false, execa);
+test('buffer: false does not return output, stdout ["pipe", undefined]', testNoOutput, ['pipe', undefined], false, execa);
+test('buffer: false does not return output, sync', testNoOutput, 'pipe', false, execaSync);
+test('buffer: false does not return output, fd-specific, sync', testNoOutput, 'pipe', {stdout: false}, execaSync);
+test('buffer: false does not return output, stdout undefined, sync', testNoOutput, undefined, false, execaSync);
+test('buffer: false does not return output, stdout null, sync', testNoOutput, null, false, execaSync);
+test('buffer: false does not return output, stdout ["pipe"], sync', testNoOutput, ['pipe'], false, execaSync);
+test('buffer: false does not return output, stdout [undefined], sync', testNoOutput, [undefined], false, execaSync);
+test('buffer: false does not return output, stdout [null], sync', testNoOutput, [null], false, execaSync);
+test('buffer: false does not return output, stdout ["pipe", undefined], sync', testNoOutput, ['pipe', undefined], false, execaSync);
 
 const testNoOutputFail = async (t, execaMethod) => {
 	const {exitCode, stdout} = await execaMethod('fail.js', {buffer: false, reject: false});
@@ -114,6 +126,24 @@ const testNoOutputFail = async (t, execaMethod) => {
 
 test('buffer: false does not return output, failure', testNoOutputFail, execa);
 test('buffer: false does not return output, failure, sync', testNoOutputFail, execaSync);
+
+// eslint-disable-next-line max-params
+const testNoOutputAll = async (t, buffer, bufferStdout, bufferStderr, execaMethod) => {
+	const {stdout, stderr, all} = await execaMethod('noop-both.js', {all: true, buffer, stripFinalNewline: false});
+	t.is(stdout, bufferStdout ? `${foobarString}\n` : undefined);
+	t.is(stderr, bufferStderr ? `${foobarString}\n` : undefined);
+	const stdoutStderr = [stdout, stderr].filter(Boolean);
+	t.is(all, stdoutStderr.length === 0 ? undefined : stdoutStderr.join(''));
+};
+
+test('buffer: {}, all: true', testNoOutputAll, {}, true, true, execa);
+test('buffer: {stdout: false}, all: true', testNoOutputAll, {stdout: false}, false, true, execa);
+test('buffer: {stderr: false}, all: true', testNoOutputAll, {stderr: false}, true, false, execa);
+test('buffer: {all: false}, all: true', testNoOutputAll, {all: false}, false, false, execa);
+test('buffer: {}, all: true, sync', testNoOutputAll, {}, true, true, execaSync);
+test('buffer: {stdout: false}, all: true, sync', testNoOutputAll, {stdout: false}, false, true, execaSync);
+test('buffer: {stderr: false}, all: true, sync', testNoOutputAll, {stderr: false}, true, false, execaSync);
+test('buffer: {all: false}, all: true, sync', testNoOutputAll, {all: false}, false, false, execaSync);
 
 const testTransform = async (t, objectMode, execaMethod) => {
 	const lines = [];

--- a/test/verbose/output.js
+++ b/test/verbose/output.js
@@ -314,31 +314,37 @@ test('Prints stdout, stdout "pipe", sync', testPrintOutputOptions, {stdout: 'pip
 test('Prints stdout, stdout null, sync', testPrintOutputOptions, {stdout: null}, parentExecaSync);
 test('Prints stdout, stdout ["pipe"], sync', testPrintOutputOptions, {stdout: ['pipe']}, parentExecaSync);
 
-const testPrintOutputNoBuffer = async (t, verbose, execaMethod) => {
-	const {stderr} = await execaMethod('noop.js', [foobarString], {verbose, buffer: false});
+const testPrintOutputNoBuffer = async (t, verbose, buffer, execaMethod) => {
+	const {stderr} = await execaMethod('noop.js', [foobarString], {verbose, buffer});
 	t.is(getOutputLine(stderr), `${testTimestamp} [0]   ${foobarString}`);
 };
 
-test('Prints stdout, buffer: false', testPrintOutputNoBuffer, 'full', parentExecaAsync);
-test('Prints stdout, buffer: false, fd-specific', testPrintOutputNoBuffer, fdFullOption, parentExecaAsync);
-test('Prints stdout, buffer: false, sync', testPrintOutputNoBuffer, 'full', parentExecaSync);
-test('Prints stdout, buffer: false, fd-specific, sync', testPrintOutputNoBuffer, fdFullOption, parentExecaSync);
+test('Prints stdout, buffer: false', testPrintOutputNoBuffer, 'full', false, parentExecaAsync);
+test('Prints stdout, buffer: false, fd-specific buffer', testPrintOutputNoBuffer, 'full', {stdout: false}, parentExecaAsync);
+test('Prints stdout, buffer: false, fd-specific verbose', testPrintOutputNoBuffer, fdFullOption, false, parentExecaAsync);
+test('Prints stdout, buffer: false, sync', testPrintOutputNoBuffer, 'full', false, parentExecaSync);
+test('Prints stdout, buffer: false, fd-specific buffer, sync', testPrintOutputNoBuffer, 'full', {stdout: false}, parentExecaSync);
+test('Prints stdout, buffer: false, fd-specific verbose, sync', testPrintOutputNoBuffer, fdFullOption, false, parentExecaSync);
 
-const testPrintOutputNoBufferFalse = async (t, execaMethod) => {
-	const {stderr} = await execaMethod('noop.js', [foobarString], {verbose: fdStderrFullOption, buffer: false});
+const testPrintOutputNoBufferFalse = async (t, buffer, execaMethod) => {
+	const {stderr} = await execaMethod('noop.js', [foobarString], {verbose: fdStderrFullOption, buffer});
 	t.is(getOutputLine(stderr), undefined);
 };
 
-test('Does not print stdout, buffer: false, different fd', testPrintOutputNoBufferFalse, parentExecaAsync);
-test('Does not print stdout, buffer: false, different fd, sync', testPrintOutputNoBufferFalse, parentExecaSync);
+test('Does not print stdout, buffer: false, different fd', testPrintOutputNoBufferFalse, false, parentExecaAsync);
+test('Does not print stdout, buffer: false, different fd, fd-specific buffer', testPrintOutputNoBufferFalse, {stdout: false}, parentExecaAsync);
+test('Does not print stdout, buffer: false, different fd, sync', testPrintOutputNoBufferFalse, false, parentExecaSync);
+test('Does not print stdout, buffer: false, different fd, fd-specific buffer, sync', testPrintOutputNoBufferFalse, {stdout: false}, parentExecaSync);
 
-const testPrintOutputNoBufferTransform = async (t, isSync) => {
-	const {stderr} = await parentExeca('nested-transform.js', 'noop.js', [foobarString], {verbose: 'full', buffer: false, type: 'generator', isSync});
+const testPrintOutputNoBufferTransform = async (t, buffer, isSync) => {
+	const {stderr} = await parentExeca('nested-transform.js', 'noop.js', [foobarString], {verbose: 'full', buffer, type: 'generator', isSync});
 	t.is(getOutputLine(stderr), `${testTimestamp} [0]   ${foobarUppercase}`);
 };
 
-test('Prints stdout, buffer: false, transform', testPrintOutputNoBufferTransform, false);
-test('Prints stdout, buffer: false, transform, sync', testPrintOutputNoBufferTransform, true);
+test('Prints stdout, buffer: false, transform', testPrintOutputNoBufferTransform, false, false);
+test('Prints stdout, buffer: false, transform, fd-specific buffer', testPrintOutputNoBufferTransform, {stdout: false}, false);
+test('Prints stdout, buffer: false, transform, sync', testPrintOutputNoBufferTransform, false, true);
+test('Prints stdout, buffer: false, transform, fd-specific buffer, sync', testPrintOutputNoBufferTransform, {stdout: false}, true);
 
 const testPrintOutputFixture = async (t, fixtureName, ...args) => {
 	const {stderr} = await parentExeca(fixtureName, 'noop.js', [foobarString, ...args], {verbose: 'full'});


### PR DESCRIPTION
This continues #930.

This allows setting different `buffer` values for `stdout` and `stderr`.