### PR TITLE
Fix fd-specific options

### DIFF
--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1635,6 +1635,19 @@ execaSync('unicorns', {buffer: {fd2: true}});
 execaSync('unicorns', {buffer: {fd3: true}});
 expectError(execaSync('unicorns', {buffer: {stdout: 'true'}}));
 
+expectType<string[]>(execaSync('unicorns', {lines: {stdout: true, fd1: false}}).stdout);
+expectType<string[]>(execaSync('unicorns', {lines: {stdout: true, all: false}}).stdout);
+expectType<string[]>(execaSync('unicorns', {lines: {fd1: true, all: false}}).stdout);
+expectType<string[]>(execaSync('unicorns', {lines: {stderr: true, fd2: false}}).stderr);
+expectType<string[]>(execaSync('unicorns', {lines: {stderr: true, all: false}}).stderr);
+expectType<string[]>(execaSync('unicorns', {lines: {fd2: true, all: false}}).stderr);
+expectType<string[]>(execaSync('unicorns', {lines: {fd1: false, stdout: true}}).stdout);
+expectType<string[]>(execaSync('unicorns', {lines: {all: false, stdout: true}}).stdout);
+expectType<string[]>(execaSync('unicorns', {lines: {all: false, fd1: true}}).stdout);
+expectType<string[]>(execaSync('unicorns', {lines: {fd2: false, stderr: true}}).stderr);
+expectType<string[]>(execaSync('unicorns', {lines: {all: false, stderr: true}}).stderr);
+expectType<string[]>(execaSync('unicorns', {lines: {all: false, fd2: true}}).stderr);
+
 const linesStdoutResult = await execa('unicorns', {all: true, lines: {stdout: true}});
 expectType<string[]>(linesStdoutResult.stdout);
 expectType<string[]>(linesStdoutResult.stdio[1]);

--- a/lib/arguments/specific.js
+++ b/lib/arguments/specific.js
@@ -27,13 +27,24 @@ const normalizeFdSpecificValue = (optionValue, optionArray, optionName) => isPla
 	: optionArray.fill(optionValue);
 
 const normalizeOptionObject = (optionValue, optionArray, optionName) => {
-	for (const [fdName, fdValue] of Object.entries(optionValue)) {
+	for (const fdName of Object.keys(optionValue).sort(compareFdName)) {
 		for (const fdNumber of parseFdName(fdName, optionName, optionArray)) {
-			optionArray[fdNumber] = fdValue;
+			optionArray[fdNumber] = optionValue[fdName];
 		}
 	}
 
 	return optionArray;
+};
+
+// Ensure priority order when setting both `stdout`/`stderr`, `fd1`/`fd2`, and `all`
+const compareFdName = (fdNameA, fdNameB) => getFdNameOrder(fdNameA) < getFdNameOrder(fdNameB) ? 1 : -1;
+
+const getFdNameOrder = fdName => {
+	if (fdName === 'stdout' || fdName === 'stderr') {
+		return 0;
+	}
+
+	return fdName === 'all' ? 2 : 1;
 };
 
 const parseFdName = (fdName, optionName, optionArray) => {

--- a/test/stream/no-buffer.js
+++ b/test/stream/no-buffer.js
@@ -145,6 +145,38 @@ test('buffer: {stdout: false}, all: true, sync', testNoOutputAll, {stdout: false
 test('buffer: {stderr: false}, all: true, sync', testNoOutputAll, {stderr: false}, true, false, execaSync);
 test('buffer: {all: false}, all: true, sync', testNoOutputAll, {all: false}, false, false, execaSync);
 
+// eslint-disable-next-line max-params
+const testPriorityOrder = async (t, buffer, bufferStdout, bufferStderr, execaMethod) => {
+	const {stdout, stderr} = await execaMethod('noop-both.js', {buffer});
+	t.is(stdout, bufferStdout ? foobarString : undefined);
+	t.is(stderr, bufferStderr ? foobarString : undefined);
+};
+
+test('buffer: {stdout, fd1}', testPriorityOrder, {stdout: true, fd1: false}, true, true, execa);
+test('buffer: {stdout, all}', testPriorityOrder, {stdout: true, all: false}, true, false, execa);
+test('buffer: {fd1, all}', testPriorityOrder, {fd1: true, all: false}, true, false, execa);
+test('buffer: {stderr, fd2}', testPriorityOrder, {stderr: true, fd2: false}, true, true, execa);
+test('buffer: {stderr, all}', testPriorityOrder, {stderr: true, all: false}, false, true, execa);
+test('buffer: {fd2, all}', testPriorityOrder, {fd2: true, all: false}, false, true, execa);
+test('buffer: {fd1, stdout}', testPriorityOrder, {fd1: false, stdout: true}, true, true, execa);
+test('buffer: {all, stdout}', testPriorityOrder, {all: false, stdout: true}, true, false, execa);
+test('buffer: {all, fd1}', testPriorityOrder, {all: false, fd1: true}, true, false, execa);
+test('buffer: {fd2, stderr}', testPriorityOrder, {fd2: false, stderr: true}, true, true, execa);
+test('buffer: {all, stderr}', testPriorityOrder, {all: false, stderr: true}, false, true, execa);
+test('buffer: {all, fd2}', testPriorityOrder, {all: false, fd2: true}, false, true, execa);
+test('buffer: {stdout, fd1}, sync', testPriorityOrder, {stdout: true, fd1: false}, true, true, execaSync);
+test('buffer: {stdout, all}, sync', testPriorityOrder, {stdout: true, all: false}, true, false, execaSync);
+test('buffer: {fd1, all}, sync', testPriorityOrder, {fd1: true, all: false}, true, false, execaSync);
+test('buffer: {stderr, fd2}, sync', testPriorityOrder, {stderr: true, fd2: false}, true, true, execaSync);
+test('buffer: {stderr, all}, sync', testPriorityOrder, {stderr: true, all: false}, false, true, execaSync);
+test('buffer: {fd2, all}, sync', testPriorityOrder, {fd2: true, all: false}, false, true, execaSync);
+test('buffer: {fd1, stdout}, sync', testPriorityOrder, {fd1: false, stdout: true}, true, true, execaSync);
+test('buffer: {all, stdout}, sync', testPriorityOrder, {all: false, stdout: true}, true, false, execaSync);
+test('buffer: {all, fd1}, sync', testPriorityOrder, {all: false, fd1: true}, true, false, execaSync);
+test('buffer: {fd2, stderr}, sync', testPriorityOrder, {fd2: false, stderr: true}, true, true, execaSync);
+test('buffer: {all, stderr}, sync', testPriorityOrder, {all: false, stderr: true}, false, true, execaSync);
+test('buffer: {all, fd2}, sync', testPriorityOrder, {all: false, fd2: true}, false, true, execaSync);
+
 const testTransform = async (t, objectMode, execaMethod) => {
 	const lines = [];
 	const {stdout} = await execaMethod('noop.js', {


### PR DESCRIPTION
Fixes #930.

Users can now set different values for `stdout` and `stderr` for a few options like `verbose`.

```js
await execa(..., {verbose: {stdout: 'full', stderr: 'none'}})
```

When users pass things like `stdout` + `all`, the priority order is currently undefined.

```js
await execa(..., {verbose: {stdout: 'full', all: 'none'}})
```

This PR defines a clearer priority order: `stdout`/`stderr` > `fd*` > `all`.