### PR TITLE
Refactor `all` option

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -82,8 +82,8 @@ const handlePromise = async ({subprocess, options, startTime, verboseInfo, fileD
 	] = await getSubprocessResult({subprocess, options, context, verboseInfo, fileDescriptors, originalStreams, controller});
 	controller.abort();
 
-	const stdio = stdioResults.map((stdioResult, fdNumber) => stripNewline(stdioResult, options, false, fdNumber));
-	const all = stripNewline(allResult, options, true);
+	const stdio = stdioResults.map((stdioResult, fdNumber) => stripNewline(stdioResult, options, fdNumber));
+	const all = stripNewline(allResult, options, 'all');
 	const result = getAsyncResult({errorInfo, exitCode, signal, stdio, all, context, options, command, escapedCommand, startTime});
 	return handleResult(result, verboseInfo, options);
 };

--- a/lib/return/output.js
+++ b/lib/return/output.js
@@ -1,11 +1,11 @@
 import stripFinalNewlineFunction from 'strip-final-newline';
 import {logFinalResult} from '../verbose/complete.js';
 
-export const stripNewline = (value, {stripFinalNewline}, isAll, fdNumber) => getStripFinalNewline(stripFinalNewline, isAll, fdNumber) && value !== undefined && !Array.isArray(value)
+export const stripNewline = (value, {stripFinalNewline}, fdNumber) => getStripFinalNewline(stripFinalNewline, fdNumber) && value !== undefined && !Array.isArray(value)
 	? stripFinalNewlineFunction(value)
 	: value;
 
-export const getStripFinalNewline = (stripFinalNewline, isAll, fdNumber) => isAll
+export const getStripFinalNewline = (stripFinalNewline, fdNumber) => fdNumber === 'all'
 	? stripFinalNewline[1] || stripFinalNewline[2]
 	: stripFinalNewline[fdNumber];
 

--- a/lib/stdio/output-sync.js
+++ b/lib/stdio/output-sync.js
@@ -107,11 +107,11 @@ export const getAllSync = ([, stdout, stderr], options) => {
 	if (Array.isArray(stdout)) {
 		return Array.isArray(stderr)
 			? [...stdout, ...stderr]
-			: [...stdout, stripNewline(stderr, options, true, 2)];
+			: [...stdout, stripNewline(stderr, options, 'all')];
 	}
 
 	if (Array.isArray(stderr)) {
-		return [stripNewline(stdout, options, true, 1), ...stderr];
+		return [stripNewline(stdout, options, 'all'), ...stderr];
 	}
 
 	if (isUint8Array(stdout) && isUint8Array(stderr)) {

--- a/lib/stream/all.js
+++ b/lib/stream/all.js
@@ -9,11 +9,10 @@ export const makeAllStream = ({stdout, stderr}, {all}) => all && (stdout || stde
 // Read the contents of `subprocess.all` and|or wait for its completion
 export const waitForAllStream = ({subprocess, encoding, buffer, maxBuffer, lines, stripFinalNewline, verboseInfo, streamInfo}) => waitForSubprocessStream({
 	...getAllStream(subprocess, buffer),
-	fdNumber: 1,
+	fdNumber: 'all',
 	encoding,
 	maxBuffer: maxBuffer[1] + maxBuffer[2],
 	lines: lines[1] || lines[2],
-	isAll: true,
 	allMixed: getAllMixed(subprocess),
 	stripFinalNewline,
 	verboseInfo,

--- a/lib/stream/max-buffer.js
+++ b/lib/stream/max-buffer.js
@@ -1,12 +1,12 @@
 import {MaxBufferError} from 'get-stream';
 import {getStreamName} from '../utils.js';
 
-export const handleMaxBuffer = ({error, stream, readableObjectMode, lines, encoding, fdNumber, isAll}) => {
+export const handleMaxBuffer = ({error, stream, readableObjectMode, lines, encoding, fdNumber}) => {
 	if (!(error instanceof MaxBufferError)) {
 		throw error;
 	}
 
-	if (isAll) {
+	if (fdNumber === 'all') {
 		return error;
 	}
 

--- a/lib/stream/resolve.js
+++ b/lib/stream/resolve.js
@@ -56,7 +56,7 @@ export const getSubprocessResult = async ({
 
 // Read the contents of `subprocess.std*` and|or wait for its completion
 const waitForSubprocessStreams = ({subprocess, encoding, buffer, maxBuffer, lines, stripFinalNewline, verboseInfo, streamInfo}) =>
-	subprocess.stdio.map((stream, fdNumber) => waitForSubprocessStream({stream, fdNumber, encoding, buffer: buffer[fdNumber], maxBuffer: maxBuffer[fdNumber], lines: lines[fdNumber], isAll: false, allMixed: false, stripFinalNewline, verboseInfo, streamInfo}));
+	subprocess.stdio.map((stream, fdNumber) => waitForSubprocessStream({stream, fdNumber, encoding, buffer: buffer[fdNumber], maxBuffer: maxBuffer[fdNumber], lines: lines[fdNumber], allMixed: false, stripFinalNewline, verboseInfo, streamInfo}));
 
 // Transforms replace `subprocess.std*`, which means they are not exposed to users.
 // However, we still want to wait for their completion.

--- a/lib/stream/subprocess.js
+++ b/lib/stream/subprocess.js
@@ -7,25 +7,25 @@ import {getStripFinalNewline} from '../return/output.js';
 import {handleMaxBuffer} from './max-buffer.js';
 import {waitForStream, isInputFileDescriptor} from './wait.js';
 
-export const waitForSubprocessStream = async ({stream, fdNumber, encoding, buffer, maxBuffer, lines, isAll, allMixed, stripFinalNewline, verboseInfo, streamInfo}) => {
+export const waitForSubprocessStream = async ({stream, fdNumber, encoding, buffer, maxBuffer, lines, allMixed, stripFinalNewline, verboseInfo, streamInfo}) => {
 	if (!stream) {
 		return;
 	}
 
 	const onStreamEnd = waitForStream(stream, fdNumber, streamInfo);
 	const [output] = await Promise.all([
-		waitForDefinedStream({stream, onStreamEnd, fdNumber, encoding, buffer, maxBuffer, lines, isAll, allMixed, stripFinalNewline, verboseInfo, streamInfo}),
+		waitForDefinedStream({stream, onStreamEnd, fdNumber, encoding, buffer, maxBuffer, lines, allMixed, stripFinalNewline, verboseInfo, streamInfo}),
 		onStreamEnd,
 	]);
 	return output;
 };
 
-const waitForDefinedStream = async ({stream, onStreamEnd, fdNumber, encoding, buffer, maxBuffer, lines, isAll, allMixed, stripFinalNewline, verboseInfo, streamInfo, streamInfo: {fileDescriptors}}) => {
+const waitForDefinedStream = async ({stream, onStreamEnd, fdNumber, encoding, buffer, maxBuffer, lines, allMixed, stripFinalNewline, verboseInfo, streamInfo, streamInfo: {fileDescriptors}}) => {
 	if (isInputFileDescriptor(streamInfo, fdNumber)) {
 		return;
 	}
 
-	if (!isAll && shouldLogOutput({stdioItems: fileDescriptors[fdNumber].stdioItems, encoding, verboseInfo, fdNumber})) {
+	if (shouldLogOutput({stdioItems: fileDescriptors[fdNumber]?.stdioItems, encoding, verboseInfo, fdNumber})) {
 		const linesIterable = iterateForResult({stream, onStreamEnd, lines: true, encoding, stripFinalNewline: true, allMixed});
 		logLines(linesIterable, stream, verboseInfo);
 	}
@@ -35,9 +35,9 @@ const waitForDefinedStream = async ({stream, onStreamEnd, fdNumber, encoding, bu
 		return;
 	}
 
-	const stripFinalNewlineValue = getStripFinalNewline(stripFinalNewline, isAll, fdNumber);
+	const stripFinalNewlineValue = getStripFinalNewline(stripFinalNewline, fdNumber);
 	const iterable = iterateForResult({stream, onStreamEnd, lines, encoding, stripFinalNewline: stripFinalNewlineValue, allMixed});
-	return getStreamContents({stream, iterable, fdNumber, encoding, maxBuffer, lines, isAll});
+	return getStreamContents({stream, iterable, fdNumber, encoding, maxBuffer, lines});
 };
 
 // When using `buffer: false`, users need to read `subprocess.stdout|stderr|all` right away
@@ -49,7 +49,7 @@ const resumeStream = async stream => {
 	}
 };
 
-const getStreamContents = async ({stream, stream: {readableObjectMode}, iterable, fdNumber, encoding, maxBuffer, lines, isAll}) => {
+const getStreamContents = async ({stream, stream: {readableObjectMode}, iterable, fdNumber, encoding, maxBuffer, lines}) => {
 	try {
 		if (readableObjectMode || lines) {
 			return await getStreamAsArray(iterable, {maxBuffer});
@@ -61,7 +61,7 @@ const getStreamContents = async ({stream, stream: {readableObjectMode}, iterable
 
 		return await getStream(iterable, {maxBuffer});
 	} catch (error) {
-		return handleBufferedData(handleMaxBuffer({error, stream, readableObjectMode, lines, encoding, fdNumber, isAll}));
+		return handleBufferedData(handleMaxBuffer({error, stream, readableObjectMode, lines, encoding, fdNumber}));
 	}
 };
 

--- a/lib/stream/wait.js
+++ b/lib/stream/wait.js
@@ -81,7 +81,7 @@ const shouldIgnoreStreamError = (error, fdNumber, streamInfo, isSameDirection = 
 // Therefore, we need to use the file descriptor's direction (`stdin` is input, `stdout` is output, etc.).
 // However, while `subprocess.std*` and transforms follow that direction, any stream passed the `std*` option has the opposite direction.
 // For example, `subprocess.stdin` is a writable, but the `stdin` option is a readable.
-export const isInputFileDescriptor = ({fileDescriptors}, fdNumber) => fileDescriptors[fdNumber].direction === 'input';
+export const isInputFileDescriptor = ({fileDescriptors}, fdNumber) => fdNumber !== 'all' && fileDescriptors[fdNumber].direction === 'input';
 
 // When `stream.destroy()` is called without an `error` argument, stream is aborted.
 // This is the only way to abort a readable stream, which can be useful in some instances.

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -58,8 +58,8 @@ const spawnSubprocessSync = ({file, args, options, command, escapedCommand, verb
 
 	const {resultError, exitCode, signal, timedOut, isMaxBuffer} = getSyncExitResult(syncResult, options);
 	const {output, error = resultError} = transformOutputSync({fileDescriptors, syncResult, options, isMaxBuffer, verboseInfo});
-	const stdio = output.map((stdioOutput, fdNumber) => stripNewline(stdioOutput, options, false, fdNumber));
-	const all = stripNewline(getAllSync(output, options), options, true);
+	const stdio = output.map((stdioOutput, fdNumber) => stripNewline(stdioOutput, options, fdNumber));
+	const all = stripNewline(getAllSync(output, options), options, 'all');
 	return getSyncResult({error, exitCode, signal, timedOut, isMaxBuffer, stdio, all, options, command, escapedCommand, startTime});
 };
 

--- a/lib/verbose/output.js
+++ b/lib/verbose/output.js
@@ -9,7 +9,8 @@ import {verboseLog} from './log.js';
 // `inherit` would result in double printing.
 // They can also lead to double printing when passing file descriptor integers or `process.std*`.
 // This only leaves with `pipe` and `overlapped`.
-export const shouldLogOutput = ({stdioItems, encoding, verboseInfo: {verbose}, fdNumber}) => verbose[fdNumber] === 'full'
+export const shouldLogOutput = ({stdioItems, encoding, verboseInfo: {verbose}, fdNumber}) => fdNumber !== 'all'
+	&& verbose[fdNumber] === 'full'
 	&& !BINARY_ENCODINGS.has(encoding)
 	&& fdUsesVerbose(fdNumber)
 	&& (stdioItems.some(({type, value}) => type === 'native' && PIPED_STDIO_VALUES.has(value))


### PR DESCRIPTION
This PR is a small refactoring of the `all` option. It does not change its behavior.