### PR TITLE
Fix `error.originalMessage`

### DIFF
--- a/lib/return/message.js
+++ b/lib/return/message.js
@@ -35,8 +35,8 @@ export const createMessages = ({
 		isCanceled,
 	});
 	const originalMessage = getOriginalMessage(originalError, cwd);
-	const newline = originalMessage === '' ? '' : '\n';
-	const shortMessage = `${prefix}: ${escapedCommand}${newline}${originalMessage}`;
+	const suffix = originalMessage === undefined ? '' : `\n${originalMessage}`;
+	const shortMessage = `${prefix}: ${escapedCommand}${suffix}`;
 	const messageStdio = all === undefined ? [stdio[2], stdio[1]] : [all];
 	const message = [shortMessage, ...messageStdio, ...stdio.slice(3)]
 		.map(messagePart => escapeLines(stripFinalNewline(serializeMessagePart(messagePart))))
@@ -75,13 +75,14 @@ const getErrorPrefix = ({originalError, timedOut, timeout, isMaxBuffer, maxBuffe
 
 const getOriginalMessage = (originalError, cwd) => {
 	if (originalError instanceof DiscardedError) {
-		return '';
+		return;
 	}
 
 	const originalMessage = isExecaError(originalError)
 		? originalError.originalMessage
 		: String(originalError?.message ?? originalError);
-	return escapeLines(fixCwdError(originalMessage, cwd));
+	const escapedOriginalMessage = escapeLines(fixCwdError(originalMessage, cwd));
+	return escapedOriginalMessage === '' ? undefined : escapedOriginalMessage;
 };
 
 const serializeMessagePart = messagePart => Array.isArray(messagePart)

--- a/test/resolve/exit.js
+++ b/test/resolve/exit.js
@@ -17,7 +17,7 @@ const testExitCode = async (t, expectedExitCode) => {
 		execa('exit.js', [`${expectedExitCode}`]),
 	);
 	t.is(exitCode, expectedExitCode);
-	t.is(originalMessage, '');
+	t.is(originalMessage, undefined);
 	t.is(shortMessage, `Command failed with exit code ${expectedExitCode}: exit.js ${expectedExitCode}`);
 	t.is(message, shortMessage);
 };

--- a/test/return/final-error.js
+++ b/test/return/final-error.js
@@ -15,7 +15,7 @@ const testUnusualError = async (t, error, expectedOriginalMessage = String(error
 	const subprocess = execa('empty.js');
 	subprocess.emit('error', error);
 	const {originalMessage, shortMessage, message} = await t.throwsAsync(subprocess);
-	t.is(originalMessage, expectedOriginalMessage);
+	t.is(originalMessage, expectedOriginalMessage === '' ? undefined : expectedOriginalMessage);
 	t.true(shortMessage.includes(expectedOriginalMessage));
 	t.is(message, shortMessage);
 };

--- a/test/return/result.js
+++ b/test/return/result.js
@@ -82,7 +82,7 @@ test('error.isTerminated is true if subprocess was killed directly', async t => 
 	const {isTerminated, signal, originalMessage, message, shortMessage} = await t.throwsAsync(subprocess, {message: /was killed with SIGINT/});
 	t.true(isTerminated);
 	t.is(signal, 'SIGINT');
-	t.is(originalMessage, '');
+	t.is(originalMessage, undefined);
 	t.is(shortMessage, 'Command was killed with SIGINT (User interruption with CTRL-C): forever.js');
 	t.is(message, shortMessage);
 });

--- a/test/terminate/timeout.js
+++ b/test/terminate/timeout.js
@@ -9,7 +9,7 @@ test('timeout kills the subprocess if it times out', async t => {
 	t.true(isTerminated);
 	t.is(signal, 'SIGTERM');
 	t.true(timedOut);
-	t.is(originalMessage, '');
+	t.is(originalMessage, undefined);
 	t.is(shortMessage, 'Command timed out after 1 milliseconds: forever.js');
 	t.is(message, shortMessage);
 });


### PR DESCRIPTION
When `error.originalMessage` is empty, it should be `undefined`, not an empty string.