### PR TITLE
Improve examples used in types

### DIFF
--- a/types/arguments/options.d.ts
+++ b/types/arguments/options.d.ts
@@ -244,17 +244,19 @@ export type CommonOptions<IsSync extends boolean = boolean> = {
 	import {execa} from 'execa';
 
 	const abortController = new AbortController();
-	const subprocess = execa('node', [], {cancelSignal: abortController.signal});
 
 	setTimeout(() => {
 		abortController.abort();
-	}, 1000);
+	}, 5000);
 
 	try {
-		await subprocess;
+		await execa({cancelSignal: abortController.signal})`npm run build`;
 	} catch (error) {
-		console.log(error.isTerminated); // true
-		console.log(error.isCanceled); // true
+		if (error.isCanceled) {
+			console.error('Aborted by cancelSignal.');
+		}
+
+		throw error;
 	}
 	```
 	*/
@@ -334,8 +336,11 @@ Some options are related to the subprocess output: `verbose`, `lines`, `stripFin
 @example
 
 ```
-await execa('./run.js', {verbose: 'full'}) // Same value for stdout and stderr
-await execa('./run.js', {verbose: {stdout: 'none', stderr: 'full'}}) // Different values
+// Same value for stdout and stderr
+await execa({verbose: 'full'})`npm run build`;
+
+// Different values for stdout and stderr
+await execa({verbose: {stdout: 'none', stderr: 'full'}})`npm run build`;
 ```
 */
 export type Options = CommonOptions<false>;
@@ -348,8 +353,11 @@ Some options are related to the subprocess output: `verbose`, `lines`, `stripFin
 @example
 
 ```
-execaSync('./run.js', {verbose: 'full'}) // Same value for stdout and stderr
-execaSync('./run.js', {verbose: {stdout: 'none', stderr: 'full'}}) // Different values
+// Same value for stdout and stderr
+execaSync({verbose: 'full'})`npm run build`;
+
+// Different values for stdout and stderr
+execaSync({verbose: {stdout: 'none', stderr: 'full'}})`npm run build`;
 ```
 */
 export type SyncOptions = CommonOptions<true>;

--- a/types/methods/command.d.ts
+++ b/types/methods/command.d.ts
@@ -31,9 +31,9 @@ Just like `execa()`, this can bind options. It can also be run synchronously usi
 ```
 import {execaCommand} from 'execa';
 
-const {stdout} = await execaCommand('echo unicorns');
-console.log(stdout);
-//=> 'unicorns'
+for await (const commandAndArguments of getReplLine()) {
+	await execaCommand(commandAndArguments);
+}
 ```
 */
 export declare const execaCommand: ExecaCommand<{}>;
@@ -62,9 +62,9 @@ Returns or throws a subprocess `result`. The `subprocess` is not returned: its m
 ```
 import {execaCommandSync} from 'execa';
 
-const {stdout} = execaCommandSync('echo unicorns');
-console.log(stdout);
-//=> 'unicorns'
+for (const commandAndArguments of getReplLine()) {
+	execaCommandSync(commandAndArguments);
+}
 ```
 */
 export declare const execaCommandSync: ExecaCommandSync<{}>;

--- a/types/methods/main-sync.d.ts
+++ b/types/methods/main-sync.d.ts
@@ -29,57 +29,14 @@ Returns or throws a subprocess `result`. The `subprocess` is not returned: its m
 @returns A subprocess `result` object
 @throws A subprocess `result` error
 
-@example <caption>Promise interface</caption>
-```
-import {execa} from 'execa';
+@example
 
-const {stdout} = execaSync('echo', ['unicorns']);
+```
+import {execaSync} from 'execa';
+
+const {stdout} = execaSync`npm run build`;
+// Print command's output
 console.log(stdout);
-//=> 'unicorns'
-```
-
-@example <caption>Redirect input from a file</caption>
-```
-import {execa} from 'execa';
-
-// Similar to `cat < stdin.txt` in Bash
-const {stdout} = execaSync('cat', {inputFile: 'stdin.txt'});
-console.log(stdout);
-//=> 'unicorns'
-```
-
-@example <caption>Handling errors</caption>
-```
-import {execa} from 'execa';
-
-// Catching an error
-try {
-	execaSync('unknown', ['command']);
-} catch (error) {
-	console.log(error);
-	/*
-	{
-		message: 'Command failed with ENOENT: unknown command\nspawnSync unknown ENOENT',
-		errno: -2,
-		code: 'ENOENT',
-		syscall: 'spawnSync unknown',
-		path: 'unknown',
-		spawnargs: ['command'],
-		shortMessage: 'Command failed with ENOENT: unknown command\nspawnSync unknown ENOENT',
-		originalMessage: 'spawnSync unknown ENOENT',
-		command: 'unknown command',
-		escapedCommand: 'unknown command',
-		cwd: '/path/to/cwd',
-		failed: true,
-		timedOut: false,
-		isCanceled: false,
-		isTerminated: false,
-		isMaxBuffer: false,
-		stdio: [],
-		pipedFrom: []
-	}
-	\*\/
-}
 ```
 */
 export declare const execaSync: ExecaSync<{}>;

--- a/types/methods/node.d.ts
+++ b/types/methods/node.d.ts
@@ -36,9 +36,13 @@ This is the preferred method when executing Node.js files.
 
 @example
 ```
-import {execaNode} from 'execa';
+import {execaNode, execa} from 'execa';
 
-await execaNode('scriptPath', ['argument']);
+await execaNode`file.js argument`;
+// Is the same as:
+await execa({node: true})`file.js argument`;
+// Or:
+await execa`node file.js argument`;
 ```
 */
 export declare const execaNode: ExecaNode<{}>;

--- a/types/methods/script.d.ts
+++ b/types/methods/script.d.ts
@@ -69,17 +69,22 @@ await $`dep deploy --branch=${branch}`;
 
 @example <caption>Verbose mode</caption>
 ```
-> node file.js
-unicorns
-rainbows
+$ node build.js
+Building application...
+Done building.
+Running tests...
+Error: the entrypoint is invalid.
 
-> NODE_DEBUG=execa node file.js
-[19:49:00.360] [0] $ echo unicorns
-unicorns
-[19:49:00.383] [0] √ (done in 23ms)
-[19:49:00.383] [1] $ echo rainbows
-rainbows
-[19:49:00.404] [1] √ (done in 21ms)
+$ NODE_DEBUG=execa node build.js
+[00:57:44.581] [0] $ npm run build
+[00:57:44.653] [0]   Building application...
+[00:57:44.653] [0]   Done building.
+[00:57:44.658] [0] ✔ (done in 78ms)
+[00:57:44.658] [1] $ npm run test
+[00:57:44.740] [1]   Running tests...
+[00:57:44.740] [1]   Error: the entrypoint is invalid.
+[00:57:44.747] [1] ✘ Command failed with exit code 1: npm run test
+[00:57:44.747] [1] ✘ (done in 89ms)
 ```
 */
 export const $: ExecaScript<{}>;


### PR DESCRIPTION
This fixes the examples used in the TypeScript types, so they match the ones used in the documentation.

This is just copy and pasting the examples as is.

Happy 1000th PR/issue! :tada: 