### PR TITLE
Improve documentation of `error.*` fields

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -193,7 +193,7 @@ Unpipe the subprocess when the signal aborts.
 `error`: `Error`\
 _Returns_: `boolean`
 
-Sends a [signal](https://nodejs.org/api/os.html#signal-constants) to the subprocess. The default signal is the [`killSignal`](#optionskillsignal) option. `killSignal` defaults to `SIGTERM`, which [terminates](#resultisterminated) the subprocess.
+Sends a [signal](https://nodejs.org/api/os.html#signal-constants) to the subprocess. The default signal is the [`killSignal`](#optionskillsignal) option. `killSignal` defaults to `SIGTERM`, which [terminates](#erroristerminated) the subprocess.
 
 This returns `false` when the signal could not be sent, for example when the subprocess has already exited.
 
@@ -369,7 +369,7 @@ Converts the subprocess to a duplex stream.
 
 Type: `object`
 
-[Result](execution.md#result) of a subprocess execution.
+[Result](execution.md#result) of a subprocess successful execution.
 
 When the subprocess [fails](errors.md#subprocess-failure), it is rejected with an [`ExecaError`](#execaerror) instead.
 
@@ -471,80 +471,18 @@ Type: `boolean`
 
 Whether the subprocess failed to run.
 
+When this is `true`, the result is an [`ExecaError`](#execaerror) instance with additional error-related properties.
+
 [More info.](errors.md#subprocess-failure)
-
-### result.timedOut
-
-Type: `boolean`
-
-Whether the subprocess timed out due to the [`timeout`](#optionstimeout) option.
-
-[More info.](termination.md#timeout)
-
-### result.isCanceled
-
-Type: `boolean`
-
-Whether the subprocess was canceled using the [`cancelSignal`](#optionscancelsignal) option.
-
-[More info.](termination.md#canceling)
-
-### result.isMaxBuffer
-
-Type: `boolean`
-
-Whether the subprocess failed because its output was larger than the [`maxBuffer`](#optionsmaxbuffer) option.
-
-[More info.](output.md#big-output)
-
-### result.isTerminated
-
-Type: `boolean`
-
-Whether the subprocess was terminated by a [signal](termination.md#signal-termination) (like [`SIGTERM`](termination.md#sigterm)) sent by either:
-- The current process.
-- [Another process](termination.md#inter-process-termination). This case is [not supported on Windows](https://nodejs.org/api/process.html#signal-events).
-
-[More info.](termination.md#signal-name-and-description)
-
-### result.exitCode
-
-Type: `number | undefined`
-
-The numeric [exit code](https://en.wikipedia.org/wiki/Exit_status) of the subprocess that was run.
-
-This is `undefined` when the subprocess could not be spawned or was terminated by a [signal](#resultsignal).
-
-[More info.](errors.md#exit-code)
-
-### result.signal
-
-Type: `string | undefined`
-
-The name of the [signal](termination.md#signal-termination) (like [`SIGTERM`](termination.md#sigterm)) that terminated the subprocess, sent by either:
-- The current process.
-- [Another process](termination.md#inter-process-termination). This case is [not supported on Windows](https://nodejs.org/api/process.html#signal-events).
-
-If a signal terminated the subprocess, this property is defined and included in the [error message](#errormessage). Otherwise it is `undefined`.
-
-[More info.](termination.md#signal-name-and-description)
-
-### result.signalDescription
-
-Type: `string | undefined`
-
-A human-friendly description of the [signal](termination.md#signal-termination) that was used to terminate the subprocess.
-
-If a signal terminated the subprocess, this property is defined and included in the error message. Otherwise it is `undefined`. It is also `undefined` when the signal is very uncommon which should seldomly happen.
-
-[More info.](termination.md#signal-name-and-description)
 
 ## ExecaError
 ## ExecaSyncError
 
 Type: `Error`
 
-Exception thrown when the subprocess [fails](errors.md#subprocess-failure).
+Result of a subprocess [failed execution](errors.md#subprocess-failure).
+
+This error is thrown as an exception. If the [`reject`](#optionsreject) option is false, it is returned instead.
 
 This has the same shape as [successful results](#result), with the following additional properties.
 
@@ -589,6 +527,72 @@ This is usually an `Error` instance.
 Type: `string | undefined`
 
 Node.js-specific [error code](https://nodejs.org/api/errors.html#errorcode), when available.
+
+### error.timedOut
+
+Type: `boolean`
+
+Whether the subprocess timed out due to the [`timeout`](#optionstimeout) option.
+
+[More info.](termination.md#timeout)
+
+### error.isCanceled
+
+Type: `boolean`
+
+Whether the subprocess was canceled using the [`cancelSignal`](#optionscancelsignal) option.
+
+[More info.](termination.md#canceling)
+
+### error.isMaxBuffer
+
+Type: `boolean`
+
+Whether the subprocess failed because its output was larger than the [`maxBuffer`](#optionsmaxbuffer) option.
+
+[More info.](output.md#big-output)
+
+### error.isTerminated
+
+Type: `boolean`
+
+Whether the subprocess was terminated by a [signal](termination.md#signal-termination) (like [`SIGTERM`](termination.md#sigterm)) sent by either:
+- The current process.
+- [Another process](termination.md#inter-process-termination). This case is [not supported on Windows](https://nodejs.org/api/process.html#signal-events).
+
+[More info.](termination.md#signal-name-and-description)
+
+### error.exitCode
+
+Type: `number | undefined`
+
+The numeric [exit code](https://en.wikipedia.org/wiki/Exit_status) of the subprocess that was run.
+
+This is `undefined` when the subprocess could not be spawned or was terminated by a [signal](#errorsignal).
+
+[More info.](errors.md#exit-code)
+
+### error.signal
+
+Type: `string | undefined`
+
+The name of the [signal](termination.md#signal-termination) (like [`SIGTERM`](termination.md#sigterm)) that terminated the subprocess, sent by either:
+- The current process.
+- [Another process](termination.md#inter-process-termination). This case is [not supported on Windows](https://nodejs.org/api/process.html#signal-events).
+
+If a signal terminated the subprocess, this property is defined and included in the [error message](#errormessage). Otherwise it is `undefined`.
+
+[More info.](termination.md#signal-name-and-description)
+
+### error.signalDescription
+
+Type: `string | undefined`
+
+A human-friendly description of the [signal](termination.md#signal-termination) that was used to terminate the subprocess.
+
+If a signal terminated the subprocess, this property is defined and included in the error message. Otherwise it is `undefined`. It is also `undefined` when the signal is very uncommon which should seldomly happen.
+
+[More info.](termination.md#signal-name-and-description)
 
 ## Options
 
@@ -877,7 +881,7 @@ Default: `0`
 
 If `timeout` is greater than `0`, the subprocess will be [terminated](#optionskillsignal) if it runs for longer than that amount of milliseconds.
 
-On timeout, [`result.timedOut`](#resulttimedout) becomes `true`.
+On timeout, [`result.timedOut`](#errortimedout) becomes `true`.
 
 [More info.](termination.md#timeout)
 
@@ -887,7 +891,7 @@ Type: [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSign
 
 You can abort the subprocess using [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
 
-When `AbortController.abort()` is called, [`result.isCanceled`](#resultiscanceled) becomes `true`.
+When `AbortController.abort()` is called, [`result.isCanceled`](#erroriscanceled) becomes `true`.
 
 [More info.](termination.md#canceling)
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -36,7 +36,7 @@ if (resultOrError.failed) {
 
 ## Exit code
 
-The subprocess fails when its [exit code](https://en.wikipedia.org/wiki/Exit_status) is not `0`. The exit code is available as [`error.exitCode`](api.md#resultexitcode). It is `undefined` when the subprocess fails to spawn or when it was [terminated by a signal](termination.md#signal-termination).
+The subprocess fails when its [exit code](https://en.wikipedia.org/wiki/Exit_status) is not `0`. The exit code is available as [`error.exitCode`](api.md#errorexitcode). It is `undefined` when the subprocess fails to spawn or when it was [terminated by a signal](termination.md#signal-termination).
 
 ```js
 try {
@@ -50,10 +50,10 @@ try {
 ## Failure reason
 
 The subprocess can fail for other reasons. Some of them can be detected using a specific boolean property:
-- [`error.timedOut`](api.md#resulttimedout): [`timeout`](termination.md#timeout) option.
-- [`error.isCanceled`](api.md#resultiscanceled): [`cancelSignal`](termination.md#canceling) option.
-- [`error.isMaxBuffer`](api.md#resultismaxbuffer): [`maxBuffer`](output.md#big-output) option.
-- [`error.isTerminated`](api.md#resultisterminated): [signal termination](termination.md#signal-termination). This includes the [`timeout`](termination.md#timeout) and [`cancelSignal`](termination.md#canceling) options since those terminate the subprocess with a [signal](termination.md#default-signal). However, this does not include the [`maxBuffer`](output.md#big-output) option.
+- [`error.timedOut`](api.md#errortimedout): [`timeout`](termination.md#timeout) option.
+- [`error.isCanceled`](api.md#erroriscanceled): [`cancelSignal`](termination.md#canceling) option.
+- [`error.isMaxBuffer`](api.md#errorismaxbuffer): [`maxBuffer`](output.md#big-output) option.
+- [`error.isTerminated`](api.md#erroristerminated): [signal termination](termination.md#signal-termination). This includes the [`timeout`](termination.md#timeout) and [`cancelSignal`](termination.md#canceling) options since those terminate the subprocess with a [signal](termination.md#default-signal). However, this does not include the [`maxBuffer`](output.md#big-output) option.
 
 Otherwise, the subprocess failed because either:
 - An exception was thrown in a [stream](streams.md) or [transform](transform.md).

--- a/docs/output.md
+++ b/docs/output.md
@@ -140,7 +140,7 @@ await execa({stdin: 'ignore', stdout: 'ignore', stderr: 'ignore'})`npm run build
 
 To prevent high memory consumption, a maximum output size can be set using the [`maxBuffer`](api.md#optionsmaxbuffer) option. It defaults to 100MB.
 
-When this threshold is hit, the subprocess fails and [`error.isMaxBuffer`](api.md#resultismaxbuffer) becomes `true`. The truncated output is still available using [`error.stdout`](api.md#resultstdout) and [`error.stderr`](api.md#resultstderr).
+When this threshold is hit, the subprocess fails and [`error.isMaxBuffer`](api.md#errorismaxbuffer) becomes `true`. The truncated output is still available using [`error.stdout`](api.md#resultstdout) and [`error.stderr`](api.md#resultstderr).
 
 This is measured:
 - By default: in [characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length).

--- a/docs/termination.md
+++ b/docs/termination.md
@@ -102,9 +102,9 @@ subprocess.kill(); // Forceful termination
 
 ### Signal name and description
 
-When a subprocess was terminated by a signal, [`error.isTerminated`](api.md#resultisterminated) is `true`.
+When a subprocess was terminated by a signal, [`error.isTerminated`](api.md#erroristerminated) is `true`.
 
-Also, [`error.signal`](api.md#resultsignal) and [`error.signalDescription`](api.md#resultsignaldescription) indicate the signal's name and [human-friendly description](https://github.com/ehmicky/human-signals). On Windows, those are only set if the current process terminated the subprocess, as opposed to [another process](#inter-process-termination).
+Also, [`error.signal`](api.md#errorsignal) and [`error.signalDescription`](api.md#errorsignaldescription) indicate the signal's name and [human-friendly description](https://github.com/ehmicky/human-signals). On Windows, those are only set if the current process terminated the subprocess, as opposed to [another process](#inter-process-termination).
 
 ```js
 try {

--- a/types/return/final-error.d.ts
+++ b/types/return/final-error.d.ts
@@ -24,7 +24,9 @@ export type ErrorProperties =
   | 'code';
 
 /**
-Exception thrown when the subprocess fails.
+Result of a subprocess failed execution.
+
+This error is thrown as an exception. If the `reject` option is false, it is returned instead.
 
 This has the same shape as successful results, with a few additional properties.
 */
@@ -33,7 +35,9 @@ export class ExecaError<OptionsType extends Options = Options> extends CommonErr
 }
 
 /**
-Exception thrown when the subprocess fails.
+Result of a subprocess failed execution.
+
+This error is thrown as an exception. If the `reject` option is false, it is returned instead.
 
 This has the same shape as successful results, with a few additional properties.
 */

--- a/types/return/result.d.ts
+++ b/types/return/result.d.ts
@@ -76,6 +76,8 @@ export declare abstract class CommonResult<
 
 	/**
 	Whether the subprocess failed to run.
+
+	When this is `true`, the result is an `ExecaError` instance with additional error-related properties.
 	*/
 	failed: boolean;
 
@@ -173,14 +175,14 @@ type OmitErrorIfReject<RejectOption extends CommonOptions['reject']> = RejectOpt
 	: {[ErrorProperty in ErrorProperties]: never};
 
 /**
-Result of a subprocess execution.
+Result of a subprocess successful execution.
 
 When the subprocess fails, it is rejected with an `ExecaError` instead.
 */
 export type ExecaResult<OptionsType extends Options = Options> = SuccessResult<false, OptionsType>;
 
 /**
-Result of a subprocess execution.
+Result of a subprocess successful execution.
 
 When the subprocess fails, it is rejected with an `ExecaError` instead.
 */


### PR DESCRIPTION
This PR documents the error-related fields as `error.*` instead of `result.*`.

Technically, on success, `result.timedOut`, `result.isCanceled`, `result.isMaxBuffer` and `result.isTerminated` are `false`, and `result.exitCode` is `0`. However, those are defined on success mostly for orthogonality reasons. 

Users should instead check whether the subprocess failed first. If not, they do not need to check those properties. They can check whether the subprocess failed by using `reject: true` (the default value), `error.failed`, or `error instanceof ExecaError`.

Documenting those fields as `error.*` makes it clearer that those are intended for subprocess failures. 