### PR TITLE
Remove `StdioOption` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,8 +3,6 @@ export type {
 	StdinOptionSync,
 	StdoutStderrOption,
 	StdoutStderrOptionSync,
-	StdioOption,
-	StdioOptionSync,
 } from './types/stdio/type';
 export type {Options, SyncOptions} from './types/arguments/options';
 export type {ExecaResult, ExecaSyncResult} from './types/return/result';

--- a/test-d/stdio/direction.test-d.ts
+++ b/test-d/stdio/direction.test-d.ts
@@ -3,8 +3,10 @@ import {expectError, expectAssignable, expectNotAssignable} from 'tsd';
 import {
 	execa,
 	execaSync,
-	type StdioOption,
-	type StdioOptionSync,
+	type StdinOption,
+	type StdinOptionSync,
+	type StdoutStderrOption,
+	type StdoutStderrOptionSync,
 } from '../../index.js';
 
 await execa('unicorns', {stdio: [new Readable(), 'pipe', 'pipe']});
@@ -33,7 +35,7 @@ expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', new Readable()]}));
 expectError(await execa('unicorns', {stdio: [['pipe'], ['pipe'], [new Readable()]]}));
 expectError(execaSync('unicorns', {stdio: [['pipe'], ['pipe'], [new Readable()]]}));
 
-expectAssignable<StdioOption>([new Uint8Array(), new Uint8Array()]);
-expectAssignable<StdioOptionSync>([new Uint8Array(), new Uint8Array()]);
-expectNotAssignable<StdioOption>([new Writable(), new Uint8Array()]);
-expectNotAssignable<StdioOptionSync>([new Writable(), new Uint8Array()]);
+expectAssignable<StdinOption | StdoutStderrOption>([new Uint8Array(), new Uint8Array()]);
+expectAssignable<StdinOptionSync | StdoutStderrOptionSync>([new Uint8Array(), new Uint8Array()]);
+expectNotAssignable<StdinOption | StdoutStderrOption>([new Writable(), new Uint8Array()]);
+expectNotAssignable<StdinOptionSync | StdoutStderrOptionSync>([new Writable(), new Uint8Array()]);

--- a/test-d/stdio/option/array-binary.test-d.ts
+++ b/test-d/stdio/option/array-binary.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const binaryArray = [new Uint8Array(), new Uint8Array()] as const;
@@ -31,6 +29,3 @@ expectAssignable<StdinOptionSync>([binaryArray]);
 
 expectNotAssignable<StdoutStderrOption>([binaryArray]);
 expectNotAssignable<StdoutStderrOptionSync>([binaryArray]);
-
-expectAssignable<StdioOption>([binaryArray]);
-expectAssignable<StdioOptionSync>([binaryArray]);

--- a/test-d/stdio/option/array-object.test-d.ts
+++ b/test-d/stdio/option/array-object.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const objectArray = [{}, {}] as const;
@@ -31,6 +29,3 @@ expectAssignable<StdinOptionSync>([objectArray]);
 
 expectNotAssignable<StdoutStderrOption>([objectArray]);
 expectNotAssignable<StdoutStderrOptionSync>([objectArray]);
-
-expectAssignable<StdioOption>([objectArray]);
-expectAssignable<StdioOptionSync>([objectArray]);

--- a/test-d/stdio/option/array-string.test-d.ts
+++ b/test-d/stdio/option/array-string.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const stringArray = ['foo', 'bar'] as const;
@@ -31,6 +29,3 @@ expectAssignable<StdinOptionSync>([stringArray]);
 
 expectNotAssignable<StdoutStderrOption>([stringArray]);
 expectNotAssignable<StdoutStderrOptionSync>([stringArray]);
-
-expectAssignable<StdioOption>([stringArray]);
-expectAssignable<StdioOptionSync>([stringArray]);

--- a/test-d/stdio/option/duplex-invalid.test-d.ts
+++ b/test-d/stdio/option/duplex-invalid.test-d.ts
@@ -7,8 +7,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const duplexWithInvalidObjectMode = {
@@ -48,8 +46,3 @@ expectNotAssignable<StdoutStderrOption>(duplexWithInvalidObjectMode);
 expectNotAssignable<StdoutStderrOptionSync>(duplexWithInvalidObjectMode);
 expectNotAssignable<StdoutStderrOption>([duplexWithInvalidObjectMode]);
 expectNotAssignable<StdoutStderrOptionSync>([duplexWithInvalidObjectMode]);
-
-expectNotAssignable<StdioOption>(duplexWithInvalidObjectMode);
-expectNotAssignable<StdioOptionSync>(duplexWithInvalidObjectMode);
-expectNotAssignable<StdioOption>([duplexWithInvalidObjectMode]);
-expectNotAssignable<StdioOptionSync>([duplexWithInvalidObjectMode]);

--- a/test-d/stdio/option/duplex-object.test-d.ts
+++ b/test-d/stdio/option/duplex-object.test-d.ts
@@ -7,8 +7,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const duplexObjectProperty = {
@@ -48,8 +46,3 @@ expectAssignable<StdoutStderrOption>(duplexObjectProperty);
 expectNotAssignable<StdoutStderrOptionSync>(duplexObjectProperty);
 expectAssignable<StdoutStderrOption>([duplexObjectProperty]);
 expectNotAssignable<StdoutStderrOptionSync>([duplexObjectProperty]);
-
-expectAssignable<StdioOption>(duplexObjectProperty);
-expectNotAssignable<StdioOptionSync>(duplexObjectProperty);
-expectAssignable<StdioOption>([duplexObjectProperty]);
-expectNotAssignable<StdioOptionSync>([duplexObjectProperty]);

--- a/test-d/stdio/option/duplex-transform.test-d.ts
+++ b/test-d/stdio/option/duplex-transform.test-d.ts
@@ -7,8 +7,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const duplexTransform = {transform: new Transform()} as const;
@@ -45,8 +43,3 @@ expectAssignable<StdoutStderrOption>(duplexTransform);
 expectNotAssignable<StdoutStderrOptionSync>(duplexTransform);
 expectAssignable<StdoutStderrOption>([duplexTransform]);
 expectNotAssignable<StdoutStderrOptionSync>([duplexTransform]);
-
-expectAssignable<StdioOption>(duplexTransform);
-expectNotAssignable<StdioOptionSync>(duplexTransform);
-expectAssignable<StdioOption>([duplexTransform]);
-expectNotAssignable<StdioOptionSync>([duplexTransform]);

--- a/test-d/stdio/option/duplex.test-d.ts
+++ b/test-d/stdio/option/duplex.test-d.ts
@@ -7,8 +7,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const duplex = {transform: new Duplex()} as const;
@@ -45,8 +43,3 @@ expectAssignable<StdoutStderrOption>(duplex);
 expectNotAssignable<StdoutStderrOptionSync>(duplex);
 expectAssignable<StdoutStderrOption>([duplex]);
 expectNotAssignable<StdoutStderrOptionSync>([duplex]);
-
-expectAssignable<StdioOption>(duplex);
-expectNotAssignable<StdioOptionSync>(duplex);
-expectAssignable<StdioOption>([duplex]);
-expectNotAssignable<StdioOptionSync>([duplex]);

--- a/test-d/stdio/option/fd-integer-0.test-d.ts
+++ b/test-d/stdio/option/fd-integer-0.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 0});
@@ -38,17 +36,17 @@ expectAssignable<StdinOptionSync>(0);
 expectAssignable<StdinOption>([0]);
 expectAssignable<StdinOptionSync>([0]);
 
+expectNotAssignable<StdinOption>(0.5);
+expectNotAssignable<StdinOptionSync>(-1);
+expectNotAssignable<StdinOption>(Number.POSITIVE_INFINITY);
+expectNotAssignable<StdinOptionSync>(Number.NaN);
+
 expectNotAssignable<StdoutStderrOption>(0);
 expectNotAssignable<StdoutStderrOptionSync>(0);
 expectNotAssignable<StdoutStderrOption>([0]);
 expectNotAssignable<StdoutStderrOptionSync>([0]);
 
-expectAssignable<StdioOption>(0);
-expectAssignable<StdioOptionSync>(0);
-expectAssignable<StdioOption>([0]);
-expectAssignable<StdioOptionSync>([0]);
-
-expectNotAssignable<StdioOption>(0.5);
-expectNotAssignable<StdioOption>(-1);
-expectNotAssignable<StdioOption>(Number.POSITIVE_INFINITY);
-expectNotAssignable<StdioOption>(Number.NaN);
+expectNotAssignable<StdoutStderrOption>(0.5);
+expectNotAssignable<StdoutStderrOptionSync>(-1);
+expectNotAssignable<StdoutStderrOption>(Number.POSITIVE_INFINITY);
+expectNotAssignable<StdoutStderrOptionSync>(Number.NaN);

--- a/test-d/stdio/option/fd-integer-1.test-d.ts
+++ b/test-d/stdio/option/fd-integer-1.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: 1}));
@@ -42,8 +40,3 @@ expectAssignable<StdoutStderrOption>(1);
 expectAssignable<StdoutStderrOptionSync>(1);
 expectAssignable<StdoutStderrOption>([1]);
 expectAssignable<StdoutStderrOptionSync>([1]);
-
-expectAssignable<StdioOption>(1);
-expectAssignable<StdioOptionSync>(1);
-expectAssignable<StdioOption>([1]);
-expectAssignable<StdioOptionSync>([1]);

--- a/test-d/stdio/option/fd-integer-2.test-d.ts
+++ b/test-d/stdio/option/fd-integer-2.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: 2}));
@@ -42,8 +40,3 @@ expectAssignable<StdoutStderrOption>(2);
 expectAssignable<StdoutStderrOptionSync>(2);
 expectAssignable<StdoutStderrOption>([2]);
 expectAssignable<StdoutStderrOptionSync>([2]);
-
-expectAssignable<StdioOption>(2);
-expectAssignable<StdioOptionSync>(2);
-expectAssignable<StdioOption>([2]);
-expectAssignable<StdioOptionSync>([2]);

--- a/test-d/stdio/option/fd-integer-3.test-d.ts
+++ b/test-d/stdio/option/fd-integer-3.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 3});
@@ -42,8 +40,3 @@ expectAssignable<StdoutStderrOption>(3);
 expectAssignable<StdoutStderrOptionSync>(3);
 expectNotAssignable<StdoutStderrOption>([3]);
 expectAssignable<StdoutStderrOptionSync>([3]);
-
-expectAssignable<StdioOption>(3);
-expectAssignable<StdioOptionSync>(3);
-expectNotAssignable<StdioOption>([3]);
-expectAssignable<StdioOptionSync>([3]);

--- a/test-d/stdio/option/file-object-invalid.test-d.ts
+++ b/test-d/stdio/option/file-object-invalid.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const invalidFileObject = {file: new URL('file:///test')} as const;
@@ -44,8 +42,3 @@ expectNotAssignable<StdoutStderrOption>(invalidFileObject);
 expectNotAssignable<StdoutStderrOptionSync>(invalidFileObject);
 expectNotAssignable<StdoutStderrOption>([invalidFileObject]);
 expectNotAssignable<StdoutStderrOptionSync>([invalidFileObject]);
-
-expectNotAssignable<StdioOption>(invalidFileObject);
-expectNotAssignable<StdioOptionSync>(invalidFileObject);
-expectNotAssignable<StdioOption>([invalidFileObject]);
-expectNotAssignable<StdioOptionSync>([invalidFileObject]);

--- a/test-d/stdio/option/file-object.test-d.ts
+++ b/test-d/stdio/option/file-object.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const fileObject = {file: './test'} as const;
@@ -44,8 +42,3 @@ expectAssignable<StdoutStderrOption>(fileObject);
 expectAssignable<StdoutStderrOptionSync>(fileObject);
 expectAssignable<StdoutStderrOption>([fileObject]);
 expectAssignable<StdoutStderrOptionSync>([fileObject]);
-
-expectAssignable<StdioOption>(fileObject);
-expectAssignable<StdioOptionSync>(fileObject);
-expectAssignable<StdioOption>([fileObject]);
-expectAssignable<StdioOptionSync>([fileObject]);

--- a/test-d/stdio/option/file-url.test-d.ts
+++ b/test-d/stdio/option/file-url.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const fileUrl = new URL('file:///test');
@@ -44,8 +42,3 @@ expectAssignable<StdoutStderrOption>(fileUrl);
 expectAssignable<StdoutStderrOptionSync>(fileUrl);
 expectAssignable<StdoutStderrOption>([fileUrl]);
 expectAssignable<StdoutStderrOptionSync>([fileUrl]);
-
-expectAssignable<StdioOption>(fileUrl);
-expectAssignable<StdioOptionSync>(fileUrl);
-expectAssignable<StdioOption>([fileUrl]);
-expectAssignable<StdioOptionSync>([fileUrl]);

--- a/test-d/stdio/option/final-async-full.test-d.ts
+++ b/test-d/stdio/option/final-async-full.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const asyncFinalFull = {
@@ -51,8 +49,3 @@ expectAssignable<StdoutStderrOption>(asyncFinalFull);
 expectNotAssignable<StdoutStderrOptionSync>(asyncFinalFull);
 expectAssignable<StdoutStderrOption>([asyncFinalFull]);
 expectNotAssignable<StdoutStderrOptionSync>([asyncFinalFull]);
-
-expectAssignable<StdioOption>(asyncFinalFull);
-expectNotAssignable<StdioOptionSync>(asyncFinalFull);
-expectAssignable<StdioOption>([asyncFinalFull]);
-expectNotAssignable<StdioOptionSync>([asyncFinalFull]);

--- a/test-d/stdio/option/final-invalid-full.test-d.ts
+++ b/test-d/stdio/option/final-invalid-full.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const invalidReturnFinalFull = {
@@ -52,8 +50,3 @@ expectNotAssignable<StdoutStderrOption>(invalidReturnFinalFull);
 expectNotAssignable<StdoutStderrOptionSync>(invalidReturnFinalFull);
 expectNotAssignable<StdoutStderrOption>([invalidReturnFinalFull]);
 expectNotAssignable<StdoutStderrOptionSync>([invalidReturnFinalFull]);
-
-expectNotAssignable<StdioOption>(invalidReturnFinalFull);
-expectNotAssignable<StdioOptionSync>(invalidReturnFinalFull);
-expectNotAssignable<StdioOption>([invalidReturnFinalFull]);
-expectNotAssignable<StdioOptionSync>([invalidReturnFinalFull]);

--- a/test-d/stdio/option/final-object-full.test-d.ts
+++ b/test-d/stdio/option/final-object-full.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const objectFinalFull = {
@@ -52,8 +50,3 @@ expectAssignable<StdoutStderrOption>(objectFinalFull);
 expectAssignable<StdoutStderrOptionSync>(objectFinalFull);
 expectAssignable<StdoutStderrOption>([objectFinalFull]);
 expectAssignable<StdoutStderrOptionSync>([objectFinalFull]);
-
-expectAssignable<StdioOption>(objectFinalFull);
-expectAssignable<StdioOptionSync>(objectFinalFull);
-expectAssignable<StdioOption>([objectFinalFull]);
-expectAssignable<StdioOptionSync>([objectFinalFull]);

--- a/test-d/stdio/option/final-unknown-full.test-d.ts
+++ b/test-d/stdio/option/final-unknown-full.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const unknownFinalFull = {
@@ -52,8 +50,3 @@ expectAssignable<StdoutStderrOption>(unknownFinalFull);
 expectAssignable<StdoutStderrOptionSync>(unknownFinalFull);
 expectAssignable<StdoutStderrOption>([unknownFinalFull]);
 expectAssignable<StdoutStderrOptionSync>([unknownFinalFull]);
-
-expectAssignable<StdioOption>(unknownFinalFull);
-expectAssignable<StdioOptionSync>(unknownFinalFull);
-expectAssignable<StdioOption>([unknownFinalFull]);
-expectAssignable<StdioOptionSync>([unknownFinalFull]);

--- a/test-d/stdio/option/generator-async-full.test-d.ts
+++ b/test-d/stdio/option/generator-async-full.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const asyncGeneratorFull = {
@@ -48,8 +46,3 @@ expectAssignable<StdoutStderrOption>(asyncGeneratorFull);
 expectNotAssignable<StdoutStderrOptionSync>(asyncGeneratorFull);
 expectAssignable<StdoutStderrOption>([asyncGeneratorFull]);
 expectNotAssignable<StdoutStderrOptionSync>([asyncGeneratorFull]);
-
-expectAssignable<StdioOption>(asyncGeneratorFull);
-expectNotAssignable<StdioOptionSync>(asyncGeneratorFull);
-expectAssignable<StdioOption>([asyncGeneratorFull]);
-expectNotAssignable<StdioOptionSync>([asyncGeneratorFull]);

--- a/test-d/stdio/option/generator-async.test-d.ts
+++ b/test-d/stdio/option/generator-async.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const asyncGenerator = async function * (line: unknown) {
@@ -46,8 +44,3 @@ expectAssignable<StdoutStderrOption>(asyncGenerator);
 expectNotAssignable<StdoutStderrOptionSync>(asyncGenerator);
 expectAssignable<StdoutStderrOption>([asyncGenerator]);
 expectNotAssignable<StdoutStderrOptionSync>([asyncGenerator]);
-
-expectAssignable<StdioOption>(asyncGenerator);
-expectNotAssignable<StdioOptionSync>(asyncGenerator);
-expectAssignable<StdioOption>([asyncGenerator]);
-expectNotAssignable<StdioOptionSync>([asyncGenerator]);

--- a/test-d/stdio/option/generator-binary-invalid.test-d.ts
+++ b/test-d/stdio/option/generator-binary-invalid.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const transformWithInvalidBinary = {
@@ -49,8 +47,3 @@ expectNotAssignable<StdoutStderrOption>(transformWithInvalidBinary);
 expectNotAssignable<StdoutStderrOptionSync>(transformWithInvalidBinary);
 expectNotAssignable<StdoutStderrOption>([transformWithInvalidBinary]);
 expectNotAssignable<StdoutStderrOptionSync>([transformWithInvalidBinary]);
-
-expectNotAssignable<StdioOption>(transformWithInvalidBinary);
-expectNotAssignable<StdioOptionSync>(transformWithInvalidBinary);
-expectNotAssignable<StdioOption>([transformWithInvalidBinary]);
-expectNotAssignable<StdioOptionSync>([transformWithInvalidBinary]);

--- a/test-d/stdio/option/generator-binary.test-d.ts
+++ b/test-d/stdio/option/generator-binary.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const transformWithBinary = {
@@ -49,8 +47,3 @@ expectAssignable<StdoutStderrOption>(transformWithBinary);
 expectAssignable<StdoutStderrOptionSync>(transformWithBinary);
 expectAssignable<StdoutStderrOption>([transformWithBinary]);
 expectAssignable<StdoutStderrOptionSync>([transformWithBinary]);
-
-expectAssignable<StdioOption>(transformWithBinary);
-expectAssignable<StdioOptionSync>(transformWithBinary);
-expectAssignable<StdioOption>([transformWithBinary]);
-expectAssignable<StdioOptionSync>([transformWithBinary]);

--- a/test-d/stdio/option/generator-boolean-full.test-d.ts
+++ b/test-d/stdio/option/generator-boolean-full.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const booleanGeneratorFull = {
@@ -48,8 +46,3 @@ expectNotAssignable<StdoutStderrOption>(booleanGeneratorFull);
 expectNotAssignable<StdoutStderrOptionSync>(booleanGeneratorFull);
 expectNotAssignable<StdoutStderrOption>([booleanGeneratorFull]);
 expectNotAssignable<StdoutStderrOptionSync>([booleanGeneratorFull]);
-
-expectNotAssignable<StdioOption>(booleanGeneratorFull);
-expectNotAssignable<StdioOptionSync>(booleanGeneratorFull);
-expectNotAssignable<StdioOption>([booleanGeneratorFull]);
-expectNotAssignable<StdioOptionSync>([booleanGeneratorFull]);

--- a/test-d/stdio/option/generator-boolean.test-d.ts
+++ b/test-d/stdio/option/generator-boolean.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const booleanGenerator = function * (line: boolean) {
@@ -46,8 +44,3 @@ expectNotAssignable<StdoutStderrOption>(booleanGenerator);
 expectNotAssignable<StdoutStderrOptionSync>(booleanGenerator);
 expectNotAssignable<StdoutStderrOption>([booleanGenerator]);
 expectNotAssignable<StdoutStderrOptionSync>([booleanGenerator]);
-
-expectNotAssignable<StdioOption>(booleanGenerator);
-expectNotAssignable<StdioOptionSync>(booleanGenerator);
-expectNotAssignable<StdioOption>([booleanGenerator]);
-expectNotAssignable<StdioOptionSync>([booleanGenerator]);

--- a/test-d/stdio/option/generator-empty.test-d.ts
+++ b/test-d/stdio/option/generator-empty.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: {}}));
@@ -42,8 +40,3 @@ expectNotAssignable<StdoutStderrOption>({});
 expectNotAssignable<StdoutStderrOptionSync>({});
 expectNotAssignable<StdoutStderrOption>([{}]);
 expectNotAssignable<StdoutStderrOptionSync>([{}]);
-
-expectNotAssignable<StdioOption>({});
-expectNotAssignable<StdioOptionSync>({});
-expectNotAssignable<StdioOption>([{}]);
-expectNotAssignable<StdioOptionSync>([{}]);

--- a/test-d/stdio/option/generator-invalid-full.test-d.ts
+++ b/test-d/stdio/option/generator-invalid-full.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const invalidReturnGeneratorFull = {
@@ -49,8 +47,3 @@ expectNotAssignable<StdoutStderrOption>(invalidReturnGeneratorFull);
 expectNotAssignable<StdoutStderrOptionSync>(invalidReturnGeneratorFull);
 expectNotAssignable<StdoutStderrOption>([invalidReturnGeneratorFull]);
 expectNotAssignable<StdoutStderrOptionSync>([invalidReturnGeneratorFull]);
-
-expectNotAssignable<StdioOption>(invalidReturnGeneratorFull);
-expectNotAssignable<StdioOptionSync>(invalidReturnGeneratorFull);
-expectNotAssignable<StdioOption>([invalidReturnGeneratorFull]);
-expectNotAssignable<StdioOptionSync>([invalidReturnGeneratorFull]);

--- a/test-d/stdio/option/generator-invalid.test-d.ts
+++ b/test-d/stdio/option/generator-invalid.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const invalidReturnGenerator = function * (line: unknown) {
@@ -47,8 +45,3 @@ expectNotAssignable<StdoutStderrOption>(invalidReturnGenerator);
 expectNotAssignable<StdoutStderrOptionSync>(invalidReturnGenerator);
 expectNotAssignable<StdoutStderrOption>([invalidReturnGenerator]);
 expectNotAssignable<StdoutStderrOptionSync>([invalidReturnGenerator]);
-
-expectNotAssignable<StdioOption>(invalidReturnGenerator);
-expectNotAssignable<StdioOptionSync>(invalidReturnGenerator);
-expectNotAssignable<StdioOption>([invalidReturnGenerator]);
-expectNotAssignable<StdioOptionSync>([invalidReturnGenerator]);

--- a/test-d/stdio/option/generator-object-full.test-d.ts
+++ b/test-d/stdio/option/generator-object-full.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const objectGeneratorFull = {
@@ -49,8 +47,3 @@ expectAssignable<StdoutStderrOption>(objectGeneratorFull);
 expectAssignable<StdoutStderrOptionSync>(objectGeneratorFull);
 expectAssignable<StdoutStderrOption>([objectGeneratorFull]);
 expectAssignable<StdoutStderrOptionSync>([objectGeneratorFull]);
-
-expectAssignable<StdioOption>(objectGeneratorFull);
-expectAssignable<StdioOptionSync>(objectGeneratorFull);
-expectAssignable<StdioOption>([objectGeneratorFull]);
-expectAssignable<StdioOptionSync>([objectGeneratorFull]);

--- a/test-d/stdio/option/generator-object-mode-invalid.test-d.ts
+++ b/test-d/stdio/option/generator-object-mode-invalid.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const transformWithInvalidObjectMode = {
@@ -49,8 +47,3 @@ expectNotAssignable<StdoutStderrOption>(transformWithInvalidObjectMode);
 expectNotAssignable<StdoutStderrOptionSync>(transformWithInvalidObjectMode);
 expectNotAssignable<StdoutStderrOption>([transformWithInvalidObjectMode]);
 expectNotAssignable<StdoutStderrOptionSync>([transformWithInvalidObjectMode]);
-
-expectNotAssignable<StdioOption>(transformWithInvalidObjectMode);
-expectNotAssignable<StdioOptionSync>(transformWithInvalidObjectMode);
-expectNotAssignable<StdioOption>([transformWithInvalidObjectMode]);
-expectNotAssignable<StdioOptionSync>([transformWithInvalidObjectMode]);

--- a/test-d/stdio/option/generator-object-mode.test-d.ts
+++ b/test-d/stdio/option/generator-object-mode.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const transformWithObjectMode = {
@@ -49,8 +47,3 @@ expectAssignable<StdoutStderrOption>(transformWithObjectMode);
 expectAssignable<StdoutStderrOptionSync>(transformWithObjectMode);
 expectAssignable<StdoutStderrOption>([transformWithObjectMode]);
 expectAssignable<StdoutStderrOptionSync>([transformWithObjectMode]);
-
-expectAssignable<StdioOption>(transformWithObjectMode);
-expectAssignable<StdioOptionSync>(transformWithObjectMode);
-expectAssignable<StdioOption>([transformWithObjectMode]);
-expectAssignable<StdioOptionSync>([transformWithObjectMode]);

--- a/test-d/stdio/option/generator-object.test-d.ts
+++ b/test-d/stdio/option/generator-object.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const objectGenerator = function * (line: unknown) {
@@ -46,8 +44,3 @@ expectAssignable<StdoutStderrOption>(objectGenerator);
 expectAssignable<StdoutStderrOptionSync>(objectGenerator);
 expectAssignable<StdoutStderrOption>([objectGenerator]);
 expectAssignable<StdoutStderrOptionSync>([objectGenerator]);
-
-expectAssignable<StdioOption>(objectGenerator);
-expectAssignable<StdioOptionSync>(objectGenerator);
-expectAssignable<StdioOption>([objectGenerator]);
-expectAssignable<StdioOptionSync>([objectGenerator]);

--- a/test-d/stdio/option/generator-only-binary.test-d.ts
+++ b/test-d/stdio/option/generator-only-binary.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const binaryOnly = {binary: true} as const;
@@ -44,8 +42,3 @@ expectNotAssignable<StdoutStderrOption>(binaryOnly);
 expectNotAssignable<StdoutStderrOptionSync>(binaryOnly);
 expectNotAssignable<StdoutStderrOption>([binaryOnly]);
 expectNotAssignable<StdoutStderrOptionSync>([binaryOnly]);
-
-expectNotAssignable<StdioOption>(binaryOnly);
-expectNotAssignable<StdioOptionSync>(binaryOnly);
-expectNotAssignable<StdioOption>([binaryOnly]);
-expectNotAssignable<StdioOptionSync>([binaryOnly]);

--- a/test-d/stdio/option/generator-only-final.test-d.ts
+++ b/test-d/stdio/option/generator-only-final.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const finalOnly = {
@@ -48,8 +46,3 @@ expectNotAssignable<StdoutStderrOption>(finalOnly);
 expectNotAssignable<StdoutStderrOptionSync>(finalOnly);
 expectNotAssignable<StdoutStderrOption>([finalOnly]);
 expectNotAssignable<StdoutStderrOptionSync>([finalOnly]);
-
-expectNotAssignable<StdioOption>(finalOnly);
-expectNotAssignable<StdioOptionSync>(finalOnly);
-expectNotAssignable<StdioOption>([finalOnly]);
-expectNotAssignable<StdioOptionSync>([finalOnly]);

--- a/test-d/stdio/option/generator-only-object-mode.test-d.ts
+++ b/test-d/stdio/option/generator-only-object-mode.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const objectModeOnly = {objectMode: true} as const;
@@ -44,8 +42,3 @@ expectNotAssignable<StdoutStderrOption>(objectModeOnly);
 expectNotAssignable<StdoutStderrOptionSync>(objectModeOnly);
 expectNotAssignable<StdoutStderrOption>([objectModeOnly]);
 expectNotAssignable<StdoutStderrOptionSync>([objectModeOnly]);
-
-expectNotAssignable<StdioOption>(objectModeOnly);
-expectNotAssignable<StdioOptionSync>(objectModeOnly);
-expectNotAssignable<StdioOption>([objectModeOnly]);
-expectNotAssignable<StdioOptionSync>([objectModeOnly]);

--- a/test-d/stdio/option/generator-only-preserve.test-d.ts
+++ b/test-d/stdio/option/generator-only-preserve.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const preserveNewlinesOnly = {preserveNewlines: true} as const;
@@ -44,8 +42,3 @@ expectNotAssignable<StdoutStderrOption>(preserveNewlinesOnly);
 expectNotAssignable<StdoutStderrOptionSync>(preserveNewlinesOnly);
 expectNotAssignable<StdoutStderrOption>([preserveNewlinesOnly]);
 expectNotAssignable<StdoutStderrOptionSync>([preserveNewlinesOnly]);
-
-expectNotAssignable<StdioOption>(preserveNewlinesOnly);
-expectNotAssignable<StdioOptionSync>(preserveNewlinesOnly);
-expectNotAssignable<StdioOption>([preserveNewlinesOnly]);
-expectNotAssignable<StdioOptionSync>([preserveNewlinesOnly]);

--- a/test-d/stdio/option/generator-preserve-invalid.test-d.ts
+++ b/test-d/stdio/option/generator-preserve-invalid.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const transformWithInvalidPreserveNewlines = {
@@ -49,8 +47,3 @@ expectNotAssignable<StdoutStderrOption>(transformWithInvalidPreserveNewlines);
 expectNotAssignable<StdoutStderrOptionSync>(transformWithInvalidPreserveNewlines);
 expectNotAssignable<StdoutStderrOption>([transformWithInvalidPreserveNewlines]);
 expectNotAssignable<StdoutStderrOptionSync>([transformWithInvalidPreserveNewlines]);
-
-expectNotAssignable<StdioOption>(transformWithInvalidPreserveNewlines);
-expectNotAssignable<StdioOptionSync>(transformWithInvalidPreserveNewlines);
-expectNotAssignable<StdioOption>([transformWithInvalidPreserveNewlines]);
-expectNotAssignable<StdioOptionSync>([transformWithInvalidPreserveNewlines]);

--- a/test-d/stdio/option/generator-preserve.test-d.ts
+++ b/test-d/stdio/option/generator-preserve.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const transformWithPreserveNewlines = {
@@ -49,8 +47,3 @@ expectAssignable<StdoutStderrOption>(transformWithPreserveNewlines);
 expectAssignable<StdoutStderrOptionSync>(transformWithPreserveNewlines);
 expectAssignable<StdoutStderrOption>([transformWithPreserveNewlines]);
 expectAssignable<StdoutStderrOptionSync>([transformWithPreserveNewlines]);
-
-expectAssignable<StdioOption>(transformWithPreserveNewlines);
-expectAssignable<StdioOptionSync>(transformWithPreserveNewlines);
-expectAssignable<StdioOption>([transformWithPreserveNewlines]);
-expectAssignable<StdioOptionSync>([transformWithPreserveNewlines]);

--- a/test-d/stdio/option/generator-string-full.test-d.ts
+++ b/test-d/stdio/option/generator-string-full.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const stringGeneratorFull = {
@@ -48,8 +46,3 @@ expectNotAssignable<StdoutStderrOption>(stringGeneratorFull);
 expectNotAssignable<StdoutStderrOptionSync>(stringGeneratorFull);
 expectNotAssignable<StdoutStderrOption>([stringGeneratorFull]);
 expectNotAssignable<StdoutStderrOptionSync>([stringGeneratorFull]);
-
-expectNotAssignable<StdioOption>(stringGeneratorFull);
-expectNotAssignable<StdioOptionSync>(stringGeneratorFull);
-expectNotAssignable<StdioOption>([stringGeneratorFull]);
-expectNotAssignable<StdioOptionSync>([stringGeneratorFull]);

--- a/test-d/stdio/option/generator-string.test-d.ts
+++ b/test-d/stdio/option/generator-string.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const stringGenerator = function * (line: string) {
@@ -46,8 +44,3 @@ expectNotAssignable<StdoutStderrOption>(stringGenerator);
 expectNotAssignable<StdoutStderrOptionSync>(stringGenerator);
 expectNotAssignable<StdoutStderrOption>([stringGenerator]);
 expectNotAssignable<StdoutStderrOptionSync>([stringGenerator]);
-
-expectNotAssignable<StdioOption>(stringGenerator);
-expectNotAssignable<StdioOptionSync>(stringGenerator);
-expectNotAssignable<StdioOption>([stringGenerator]);
-expectNotAssignable<StdioOptionSync>([stringGenerator]);

--- a/test-d/stdio/option/generator-unknown-full.test-d.ts
+++ b/test-d/stdio/option/generator-unknown-full.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const unknownGeneratorFull = {
@@ -49,8 +47,3 @@ expectAssignable<StdoutStderrOption>(unknownGeneratorFull);
 expectAssignable<StdoutStderrOptionSync>(unknownGeneratorFull);
 expectAssignable<StdoutStderrOption>([unknownGeneratorFull]);
 expectAssignable<StdoutStderrOptionSync>([unknownGeneratorFull]);
-
-expectAssignable<StdioOption>(unknownGeneratorFull);
-expectAssignable<StdioOptionSync>(unknownGeneratorFull);
-expectAssignable<StdioOption>([unknownGeneratorFull]);
-expectAssignable<StdioOptionSync>([unknownGeneratorFull]);

--- a/test-d/stdio/option/generator-unknown.test-d.ts
+++ b/test-d/stdio/option/generator-unknown.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const unknownGenerator = function * (line: unknown) {
@@ -46,8 +44,3 @@ expectAssignable<StdoutStderrOption>(unknownGenerator);
 expectAssignable<StdoutStderrOptionSync>(unknownGenerator);
 expectAssignable<StdoutStderrOption>([unknownGenerator]);
 expectAssignable<StdoutStderrOptionSync>([unknownGenerator]);
-
-expectAssignable<StdioOption>(unknownGenerator);
-expectAssignable<StdioOptionSync>(unknownGenerator);
-expectAssignable<StdioOption>([unknownGenerator]);
-expectAssignable<StdioOptionSync>([unknownGenerator]);

--- a/test-d/stdio/option/ignore.test-d.ts
+++ b/test-d/stdio/option/ignore.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 'ignore'});
@@ -42,8 +40,3 @@ expectAssignable<StdoutStderrOption>('ignore');
 expectAssignable<StdoutStderrOptionSync>('ignore');
 expectNotAssignable<StdoutStderrOption>(['ignore']);
 expectNotAssignable<StdoutStderrOptionSync>(['ignore']);
-
-expectAssignable<StdioOption>('ignore');
-expectAssignable<StdioOptionSync>('ignore');
-expectNotAssignable<StdioOption>(['ignore']);
-expectNotAssignable<StdioOptionSync>(['ignore']);

--- a/test-d/stdio/option/inherit.test-d.ts
+++ b/test-d/stdio/option/inherit.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 'inherit'});
@@ -42,8 +40,3 @@ expectAssignable<StdoutStderrOption>('inherit');
 expectAssignable<StdoutStderrOptionSync>('inherit');
 expectAssignable<StdoutStderrOption>(['inherit']);
 expectAssignable<StdoutStderrOptionSync>(['inherit']);
-
-expectAssignable<StdioOption>('inherit');
-expectAssignable<StdioOptionSync>('inherit');
-expectAssignable<StdioOption>(['inherit']);
-expectAssignable<StdioOptionSync>(['inherit']);

--- a/test-d/stdio/option/ipc.test-d.ts
+++ b/test-d/stdio/option/ipc.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 'ipc'});
@@ -42,8 +40,3 @@ expectAssignable<StdoutStderrOption>('ipc');
 expectNotAssignable<StdoutStderrOptionSync>('ipc');
 expectNotAssignable<StdoutStderrOption>(['ipc']);
 expectNotAssignable<StdoutStderrOptionSync>(['ipc']);
-
-expectAssignable<StdioOption>('ipc');
-expectNotAssignable<StdioOptionSync>('ipc');
-expectNotAssignable<StdioOption>(['ipc']);
-expectNotAssignable<StdioOptionSync>(['ipc']);

--- a/test-d/stdio/option/iterable-async-binary.test-d.ts
+++ b/test-d/stdio/option/iterable-async-binary.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const asyncBinaryIterableFunction = async function * () {
@@ -48,8 +46,3 @@ expectNotAssignable<StdoutStderrOption>(asyncBinaryIterable);
 expectNotAssignable<StdoutStderrOptionSync>(asyncBinaryIterable);
 expectNotAssignable<StdoutStderrOption>([asyncBinaryIterable]);
 expectNotAssignable<StdoutStderrOptionSync>([asyncBinaryIterable]);
-
-expectAssignable<StdioOption>(asyncBinaryIterable);
-expectNotAssignable<StdioOptionSync>(asyncBinaryIterable);
-expectAssignable<StdioOption>([asyncBinaryIterable]);
-expectNotAssignable<StdioOptionSync>([asyncBinaryIterable]);

--- a/test-d/stdio/option/iterable-async-object.test-d.ts
+++ b/test-d/stdio/option/iterable-async-object.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const asyncObjectIterableFunction = async function * () {
@@ -48,8 +46,3 @@ expectNotAssignable<StdoutStderrOption>(asyncObjectIterable);
 expectNotAssignable<StdoutStderrOptionSync>(asyncObjectIterable);
 expectNotAssignable<StdoutStderrOption>([asyncObjectIterable]);
 expectNotAssignable<StdoutStderrOptionSync>([asyncObjectIterable]);
-
-expectAssignable<StdioOption>(asyncObjectIterable);
-expectNotAssignable<StdioOptionSync>(asyncObjectIterable);
-expectAssignable<StdioOption>([asyncObjectIterable]);
-expectNotAssignable<StdioOptionSync>([asyncObjectIterable]);

--- a/test-d/stdio/option/iterable-async-string.test-d.ts
+++ b/test-d/stdio/option/iterable-async-string.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const asyncStringIterableFunction = async function * () {
@@ -48,8 +46,3 @@ expectNotAssignable<StdoutStderrOption>(asyncStringIterable);
 expectNotAssignable<StdoutStderrOptionSync>(asyncStringIterable);
 expectNotAssignable<StdoutStderrOption>([asyncStringIterable]);
 expectNotAssignable<StdoutStderrOptionSync>([asyncStringIterable]);
-
-expectAssignable<StdioOption>(asyncStringIterable);
-expectNotAssignable<StdioOptionSync>(asyncStringIterable);
-expectAssignable<StdioOption>([asyncStringIterable]);
-expectNotAssignable<StdioOptionSync>([asyncStringIterable]);

--- a/test-d/stdio/option/iterable-binary.test-d.ts
+++ b/test-d/stdio/option/iterable-binary.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const binaryIterableFunction = function * () {
@@ -48,8 +46,3 @@ expectNotAssignable<StdoutStderrOption>(binaryIterable);
 expectNotAssignable<StdoutStderrOptionSync>(binaryIterable);
 expectNotAssignable<StdoutStderrOption>([binaryIterable]);
 expectNotAssignable<StdoutStderrOptionSync>([binaryIterable]);
-
-expectAssignable<StdioOption>(binaryIterable);
-expectAssignable<StdioOptionSync>(binaryIterable);
-expectAssignable<StdioOption>([binaryIterable]);
-expectAssignable<StdioOptionSync>([binaryIterable]);

--- a/test-d/stdio/option/iterable-object.test-d.ts
+++ b/test-d/stdio/option/iterable-object.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const objectIterableFunction = function * () {
@@ -48,8 +46,3 @@ expectNotAssignable<StdoutStderrOption>(objectIterable);
 expectNotAssignable<StdoutStderrOptionSync>(objectIterable);
 expectNotAssignable<StdoutStderrOption>([objectIterable]);
 expectNotAssignable<StdoutStderrOptionSync>([objectIterable]);
-
-expectAssignable<StdioOption>(objectIterable);
-expectAssignable<StdioOptionSync>(objectIterable);
-expectAssignable<StdioOption>([objectIterable]);
-expectAssignable<StdioOptionSync>([objectIterable]);

--- a/test-d/stdio/option/iterable-string.test-d.ts
+++ b/test-d/stdio/option/iterable-string.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const stringIterableFunction = function * () {
@@ -48,8 +46,3 @@ expectNotAssignable<StdoutStderrOption>(stringIterable);
 expectNotAssignable<StdoutStderrOptionSync>(stringIterable);
 expectNotAssignable<StdoutStderrOption>([stringIterable]);
 expectNotAssignable<StdoutStderrOptionSync>([stringIterable]);
-
-expectAssignable<StdioOption>(stringIterable);
-expectAssignable<StdioOptionSync>(stringIterable);
-expectAssignable<StdioOption>([stringIterable]);
-expectAssignable<StdioOptionSync>([stringIterable]);

--- a/test-d/stdio/option/null.test-d.ts
+++ b/test-d/stdio/option/null.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: null}));
@@ -42,8 +40,3 @@ expectNotAssignable<StdoutStderrOption>(null);
 expectNotAssignable<StdoutStderrOptionSync>(null);
 expectNotAssignable<StdoutStderrOption>([null]);
 expectNotAssignable<StdoutStderrOptionSync>([null]);
-
-expectNotAssignable<StdioOption>(null);
-expectNotAssignable<StdioOptionSync>(null);
-expectNotAssignable<StdioOption>([null]);
-expectNotAssignable<StdioOptionSync>([null]);

--- a/test-d/stdio/option/overlapped.test-d.ts
+++ b/test-d/stdio/option/overlapped.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 'overlapped'});
@@ -42,8 +40,3 @@ expectAssignable<StdoutStderrOption>('overlapped');
 expectNotAssignable<StdoutStderrOptionSync>('overlapped');
 expectAssignable<StdoutStderrOption>(['overlapped']);
 expectNotAssignable<StdoutStderrOptionSync>(['overlapped']);
-
-expectAssignable<StdioOption>('overlapped');
-expectNotAssignable<StdioOptionSync>('overlapped');
-expectAssignable<StdioOption>(['overlapped']);
-expectNotAssignable<StdioOptionSync>(['overlapped']);

--- a/test-d/stdio/option/pipe-inherit.test-d.ts
+++ b/test-d/stdio/option/pipe-inherit.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const pipeInherit = ['pipe', 'inherit'] as const;
@@ -29,6 +27,3 @@ expectAssignable<StdinOptionSync>(pipeInherit);
 
 expectAssignable<StdoutStderrOption>(pipeInherit);
 expectAssignable<StdoutStderrOptionSync>(pipeInherit);
-
-expectAssignable<StdioOption>(pipeInherit);
-expectAssignable<StdioOptionSync>(pipeInherit);

--- a/test-d/stdio/option/pipe-undefined.test-d.ts
+++ b/test-d/stdio/option/pipe-undefined.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const pipeUndefined = ['pipe', undefined] as const;
@@ -29,6 +27,3 @@ expectAssignable<StdinOptionSync>(pipeUndefined);
 
 expectAssignable<StdoutStderrOption>(pipeUndefined);
 expectAssignable<StdoutStderrOptionSync>(pipeUndefined);
-
-expectAssignable<StdioOption>(pipeUndefined);
-expectAssignable<StdioOptionSync>(pipeUndefined);

--- a/test-d/stdio/option/pipe.test-d.ts
+++ b/test-d/stdio/option/pipe.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 'pipe'});
@@ -42,8 +40,3 @@ expectAssignable<StdoutStderrOption>('pipe');
 expectAssignable<StdoutStderrOptionSync>('pipe');
 expectAssignable<StdoutStderrOption>(['pipe']);
 expectAssignable<StdoutStderrOptionSync>(['pipe']);
-
-expectAssignable<StdioOption>('pipe');
-expectAssignable<StdioOptionSync>('pipe');
-expectAssignable<StdioOption>(['pipe']);
-expectAssignable<StdioOptionSync>(['pipe']);

--- a/test-d/stdio/option/process-stderr.test-d.ts
+++ b/test-d/stdio/option/process-stderr.test-d.ts
@@ -7,8 +7,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: process.stderr}));
@@ -43,8 +41,3 @@ expectAssignable<StdoutStderrOption>(process.stderr);
 expectAssignable<StdoutStderrOptionSync>(process.stderr);
 expectAssignable<StdoutStderrOption>([process.stderr]);
 expectNotAssignable<StdoutStderrOptionSync>([process.stderr]);
-
-expectAssignable<StdioOption>(process.stderr);
-expectAssignable<StdioOptionSync>(process.stderr);
-expectAssignable<StdioOption>([process.stderr]);
-expectNotAssignable<StdioOptionSync>([process.stderr]);

--- a/test-d/stdio/option/process-stdin.test-d.ts
+++ b/test-d/stdio/option/process-stdin.test-d.ts
@@ -7,8 +7,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: process.stdin});
@@ -43,8 +41,3 @@ expectNotAssignable<StdoutStderrOption>(process.stdin);
 expectNotAssignable<StdoutStderrOptionSync>(process.stdin);
 expectNotAssignable<StdoutStderrOption>([process.stdin]);
 expectNotAssignable<StdoutStderrOptionSync>([process.stdin]);
-
-expectAssignable<StdioOption>(process.stdin);
-expectAssignable<StdioOptionSync>(process.stdin);
-expectAssignable<StdioOption>([process.stdin]);
-expectNotAssignable<StdioOptionSync>([process.stdin]);

--- a/test-d/stdio/option/process-stdout.test-d.ts
+++ b/test-d/stdio/option/process-stdout.test-d.ts
@@ -7,8 +7,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: process.stdout}));
@@ -43,8 +41,3 @@ expectAssignable<StdoutStderrOption>(process.stdout);
 expectAssignable<StdoutStderrOptionSync>(process.stdout);
 expectAssignable<StdoutStderrOption>([process.stdout]);
 expectNotAssignable<StdoutStderrOptionSync>([process.stdout]);
-
-expectAssignable<StdioOption>(process.stdout);
-expectAssignable<StdioOptionSync>(process.stdout);
-expectAssignable<StdioOption>([process.stdout]);
-expectNotAssignable<StdioOptionSync>([process.stdout]);

--- a/test-d/stdio/option/readable-stream.test-d.ts
+++ b/test-d/stdio/option/readable-stream.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: new ReadableStream()});
@@ -42,8 +40,3 @@ expectNotAssignable<StdoutStderrOption>(new ReadableStream());
 expectNotAssignable<StdoutStderrOptionSync>(new ReadableStream());
 expectNotAssignable<StdoutStderrOption>([new ReadableStream()]);
 expectNotAssignable<StdoutStderrOptionSync>([new ReadableStream()]);
-
-expectAssignable<StdioOption>(new ReadableStream());
-expectNotAssignable<StdioOptionSync>(new ReadableStream());
-expectAssignable<StdioOption>([new ReadableStream()]);
-expectNotAssignable<StdioOptionSync>([new ReadableStream()]);

--- a/test-d/stdio/option/readable.test-d.ts
+++ b/test-d/stdio/option/readable.test-d.ts
@@ -7,8 +7,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: new Readable()});
@@ -43,8 +41,3 @@ expectNotAssignable<StdoutStderrOption>(new Readable());
 expectNotAssignable<StdoutStderrOptionSync>(new Readable());
 expectNotAssignable<StdoutStderrOption>([new Readable()]);
 expectNotAssignable<StdoutStderrOptionSync>([new Readable()]);
-
-expectAssignable<StdioOption>(new Readable());
-expectAssignable<StdioOptionSync>(new Readable());
-expectAssignable<StdioOption>([new Readable()]);
-expectNotAssignable<StdioOptionSync>([new Readable()]);

--- a/test-d/stdio/option/uint-array.test-d.ts
+++ b/test-d/stdio/option/uint-array.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: new Uint8Array()});
@@ -42,8 +40,3 @@ expectNotAssignable<StdoutStderrOption>(new Uint8Array());
 expectNotAssignable<StdoutStderrOptionSync>(new Uint8Array());
 expectNotAssignable<StdoutStderrOption>([new Uint8Array()]);
 expectNotAssignable<StdoutStderrOptionSync>([new Uint8Array()]);
-
-expectAssignable<StdioOption>(new Uint8Array());
-expectAssignable<StdioOptionSync>(new Uint8Array());
-expectAssignable<StdioOption>([new Uint8Array()]);
-expectAssignable<StdioOptionSync>([new Uint8Array()]);

--- a/test-d/stdio/option/undefined.test-d.ts
+++ b/test-d/stdio/option/undefined.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: undefined});
@@ -42,8 +40,3 @@ expectAssignable<StdoutStderrOption>(undefined);
 expectAssignable<StdoutStderrOptionSync>(undefined);
 expectAssignable<StdoutStderrOption>([undefined]);
 expectAssignable<StdoutStderrOptionSync>([undefined]);
-
-expectAssignable<StdioOption>(undefined);
-expectAssignable<StdioOptionSync>(undefined);
-expectAssignable<StdioOption>([undefined]);
-expectAssignable<StdioOptionSync>([undefined]);

--- a/test-d/stdio/option/unknown.test-d.ts
+++ b/test-d/stdio/option/unknown.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: 'unknown'}));
@@ -42,9 +40,3 @@ expectNotAssignable<StdoutStderrOption>('unknown');
 expectNotAssignable<StdoutStderrOptionSync>('unknown');
 expectNotAssignable<StdoutStderrOption>(['unknown']);
 expectNotAssignable<StdoutStderrOptionSync>(['unknown']);
-
-expectNotAssignable<StdioOption>('unknown');
-expectNotAssignable<StdioOptionSync>('unknown');
-expectNotAssignable<StdioOption>(['unknown']);
-expectNotAssignable<StdioOptionSync>(['unknown']);
-

--- a/test-d/stdio/option/web-transform-instance.test-d.ts
+++ b/test-d/stdio/option/web-transform-instance.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const webTransformInstance = new TransformStream();
@@ -44,8 +42,3 @@ expectAssignable<StdoutStderrOption>(webTransformInstance);
 expectNotAssignable<StdoutStderrOptionSync>(webTransformInstance);
 expectAssignable<StdoutStderrOption>([webTransformInstance]);
 expectNotAssignable<StdoutStderrOptionSync>([webTransformInstance]);
-
-expectAssignable<StdioOption>(webTransformInstance);
-expectNotAssignable<StdioOptionSync>(webTransformInstance);
-expectAssignable<StdioOption>([webTransformInstance]);
-expectNotAssignable<StdioOptionSync>([webTransformInstance]);

--- a/test-d/stdio/option/web-transform-invalid.test-d.ts
+++ b/test-d/stdio/option/web-transform-invalid.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const webTransformWithInvalidObjectMode = {
@@ -47,8 +45,3 @@ expectNotAssignable<StdoutStderrOption>(webTransformWithInvalidObjectMode);
 expectNotAssignable<StdoutStderrOptionSync>(webTransformWithInvalidObjectMode);
 expectNotAssignable<StdoutStderrOption>([webTransformWithInvalidObjectMode]);
 expectNotAssignable<StdoutStderrOptionSync>([webTransformWithInvalidObjectMode]);
-
-expectNotAssignable<StdioOption>(webTransformWithInvalidObjectMode);
-expectNotAssignable<StdioOptionSync>(webTransformWithInvalidObjectMode);
-expectNotAssignable<StdioOption>([webTransformWithInvalidObjectMode]);
-expectNotAssignable<StdioOptionSync>([webTransformWithInvalidObjectMode]);

--- a/test-d/stdio/option/web-transform-object.test-d.ts
+++ b/test-d/stdio/option/web-transform-object.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const webTransformObject = {
@@ -47,8 +45,3 @@ expectAssignable<StdoutStderrOption>(webTransformObject);
 expectNotAssignable<StdoutStderrOptionSync>(webTransformObject);
 expectAssignable<StdoutStderrOption>([webTransformObject]);
 expectNotAssignable<StdoutStderrOptionSync>([webTransformObject]);
-
-expectAssignable<StdioOption>(webTransformObject);
-expectNotAssignable<StdioOptionSync>(webTransformObject);
-expectAssignable<StdioOption>([webTransformObject]);
-expectNotAssignable<StdioOptionSync>([webTransformObject]);

--- a/test-d/stdio/option/web-transform.test-d.ts
+++ b/test-d/stdio/option/web-transform.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 const webTransform = {transform: new TransformStream()} as const;
@@ -44,8 +42,3 @@ expectAssignable<StdoutStderrOption>(webTransform);
 expectNotAssignable<StdoutStderrOptionSync>(webTransform);
 expectAssignable<StdoutStderrOption>([webTransform]);
 expectNotAssignable<StdoutStderrOptionSync>([webTransform]);
-
-expectAssignable<StdioOption>(webTransform);
-expectNotAssignable<StdioOptionSync>(webTransform);
-expectAssignable<StdioOption>([webTransform]);
-expectNotAssignable<StdioOptionSync>([webTransform]);

--- a/test-d/stdio/option/writable-stream.test-d.ts
+++ b/test-d/stdio/option/writable-stream.test-d.ts
@@ -6,8 +6,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: new WritableStream()}));
@@ -42,8 +40,3 @@ expectAssignable<StdoutStderrOption>(new WritableStream());
 expectNotAssignable<StdoutStderrOptionSync>(new WritableStream());
 expectAssignable<StdoutStderrOption>([new WritableStream()]);
 expectNotAssignable<StdoutStderrOptionSync>([new WritableStream()]);
-
-expectAssignable<StdioOption>(new WritableStream());
-expectNotAssignable<StdioOptionSync>(new WritableStream());
-expectAssignable<StdioOption>([new WritableStream()]);
-expectNotAssignable<StdioOptionSync>([new WritableStream()]);

--- a/test-d/stdio/option/writable.test-d.ts
+++ b/test-d/stdio/option/writable.test-d.ts
@@ -7,8 +7,6 @@ import {
 	type StdinOptionSync,
 	type StdoutStderrOption,
 	type StdoutStderrOptionSync,
-	type StdioOption,
-	type StdioOptionSync,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: new Writable()}));
@@ -43,8 +41,3 @@ expectAssignable<StdoutStderrOption>(new Writable());
 expectAssignable<StdoutStderrOptionSync>(new Writable());
 expectAssignable<StdoutStderrOption>([new Writable()]);
 expectNotAssignable<StdoutStderrOptionSync>([new Writable()]);
-
-expectAssignable<StdioOption>(new Writable());
-expectAssignable<StdioOptionSync>(new Writable());
-expectAssignable<StdioOption>([new Writable()]);
-expectNotAssignable<StdioOptionSync>([new Writable()]);

--- a/types/stdio/type.d.ts
+++ b/types/stdio/type.d.ts
@@ -150,11 +150,6 @@ export type StdioOptionCommon<IsSync extends boolean = boolean> =
 	| StdinOptionCommon<IsSync>
 	| StdoutStderrOptionCommon<IsSync>;
 
-// `options.stdin|stdout|stderr|stdio`, async
-export type StdioOption = StdioOptionCommon<false>;
-// `options.stdin|stdout|stderr|stdio`, sync
-export type StdioOptionSync = StdioOptionCommon<true>;
-
 // `options.stdio` when it is an array
 export type StdioOptionsArray<IsSync extends boolean = boolean> = readonly [
 	StdinOptionCommon<IsSync, false>,


### PR DESCRIPTION
The `StdioOption` type is not very useful: it is the same as `StdinOption | StdoutStderrOption`. On the other hand, it can be harmful. For example, the following fails:

```ts
import {execa, type StdioOption} from 'execa';

const stdioOption: readonly StdioOption[] = ['inherit', 'pipe', 'pipe'] as const;
execa({stdio: stdioOption});
```

The `tsc` error is very confusing and does not indicate clearly that the issue is related to `StdioOption`. The actual issue there is that `StdioOption` is too wide. Instead, the following works:

```ts
import {execa, type StdinOption, type StdoutStderrOption} from 'execa';

const stdioOption: readonly [StdinOption, StdoutStderrOption, StdoutStderrOption] = ['inherit', 'pipe', 'pipe'] as const;
execa({stdio: stdioOption})
```

Or the simpler, recommended, and more accurate:

```ts
import {execa, type Options} from 'execa';

const stdioOption: Options['stdio'] = ['inherit', 'pipe', 'pipe'] as const;
execa({stdio: stdioOption})
```

Also, the allowed values for the `stdin` and the `stdout`/`stderr` options are quite different, and it would be useful to make that clear in our types.

Based on this, this PR removes the `StdioOption` type, in favor of using either `Options['stdio']` or `StdinOption`/`StdoutStderrOption`.