### PR TITLE
Rename some types

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -15,7 +15,7 @@ This lists all available [methods](#methods) and their [options](#options). This
 `file`: `string | URL`\
 `arguments`: `string[]`\
 `options`: [`Options`](#options)\
-_Returns_: [`ExecaResultPromise`](#return-value)
+_Returns_: [`ResultPromise`](#return-value)
 
 Executes a command using `file ...arguments`.
 
@@ -26,7 +26,7 @@ More info on the [syntax](execution.md#array-syntax) and [escaping](escaping.md#
 
 `command`: `string`\
 `options`: [`Options`](#options)\
-_Returns_: [`ExecaResultPromise`](#return-value)
+_Returns_: [`ResultPromise`](#return-value)
 
 Executes a command. `command` is a [template string](execution.md#template-string-syntax) that includes both the `file` and its `arguments`.
 
@@ -44,7 +44,7 @@ Returns a new instance of Execa but with different default [`options`](#options)
 ### execaSync(file, arguments?, options?)
 ### execaSync\`command\`
 
-_Returns_: [`ExecaSyncResult`](#return-value)
+_Returns_: [`SyncResult`](#return-value)
 
 Same as [`execa()`](#execafile-arguments-options) but synchronous.
 
@@ -57,7 +57,7 @@ Returns or throws a subprocess [`result`](#result). The [`subprocess`](#subproce
 `file`: `string | URL`\
 `arguments`: `string[]`\
 `options`: [`Options`](#options)\
-_Returns_: [`ExecaResultPromise`](#return-value)
+_Returns_: [`ResultPromise`](#return-value)
 
 Same as [`execa()`](#execafile-arguments-options) but using [script-friendly default options](scripts.md#script-files).
 
@@ -72,7 +72,7 @@ This is the preferred method when executing multiple commands in a script file.
 `scriptPath`: `string | URL`\
 `arguments`: `string[]`\
 `options`: [`Options`](#options)\
-_Returns_: [`ExecaResultPromise`](#return-value)
+_Returns_: [`ResultPromise`](#return-value)
 
 Same as [`execa()`](#execafile-arguments-options) but using the [`node: true`](#optionsnode) option.
 Executes a Node.js file using `node scriptPath ...arguments`.
@@ -87,7 +87,7 @@ This is the preferred method when executing Node.js files.
 
 `command`: `string`\
 `options`: [`Options`](#options)\
-_Returns_: [`ExecaResultPromise`](#return-value)
+_Returns_: [`ResultPromise`](#return-value)
 
 Executes a command. `command` is a string that includes both the `file` and its `arguments`.
 
@@ -99,7 +99,7 @@ Just like `execa()`, this can [bind options](execution.md#globalshared-options).
 
 ## Return value
 
-_Type_: `ExecaResultPromise`
+_Type_: `ResultPromise`
 
 The return value of all [asynchronous methods](#methods) is both:
 - the [subprocess](#subprocess).
@@ -109,7 +109,7 @@ The return value of all [asynchronous methods](#methods) is both:
 
 ## Subprocess
 
-_Type_: `ExecaSubprocess`
+_Type_: `Subprocess`
 
 [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess) with the following methods and properties.
 
@@ -156,7 +156,7 @@ Like [`subprocess.pipe(file, arguments?, options?)`](#subprocesspipefile-argumen
 
 ### subprocess.pipe(secondSubprocess, pipeOptions?)
 
-`secondSubprocess`: [`ExecaResultPromise`](#return-value)\
+`secondSubprocess`: [`ResultPromise`](#return-value)\
 `pipeOptions`: [`PipeOptions`](#pipeoptions)\
 _Returns_: [`Promise<Result>`](#result)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,8 +5,8 @@ export type {
 	StdoutStderrOptionSync,
 } from './types/stdio/type';
 export type {Options, SyncOptions} from './types/arguments/options';
-export type {ExecaResult, ExecaSyncResult} from './types/return/result';
-export type {ExecaResultPromise, ExecaSubprocess} from './types/subprocess/subprocess';
+export type {Result, SyncResult} from './types/return/result';
+export type {ResultPromise, Subprocess} from './types/subprocess/subprocess';
 /* eslint-disable import/extensions */
 export {ExecaError, ExecaSyncError} from './types/return/final-error';
 export {execa} from './types/methods/main-async';

--- a/test-d/methods/command.test-d.ts
+++ b/test-d/methods/command.test-d.ts
@@ -2,9 +2,9 @@ import {expectType, expectError, expectAssignable} from 'tsd';
 import {
 	execaCommand,
 	execaCommandSync,
-	type ExecaResult,
-	type ExecaResultPromise,
-	type ExecaSyncResult,
+	type Result,
+	type ResultPromise,
+	type SyncResult,
 } from '../../index.js';
 
 const fileUrl = new URL('file:///test');
@@ -13,7 +13,7 @@ const stringArray = ['foo', 'bar'] as const;
 expectError(execaCommand());
 expectError(execaCommand(true));
 expectError(execaCommand(['unicorns', 'arg']));
-expectAssignable<ExecaResultPromise>(execaCommand('unicorns'));
+expectAssignable<ResultPromise>(execaCommand('unicorns'));
 expectError(execaCommand(fileUrl));
 
 expectError(execaCommand('unicorns', []));
@@ -21,18 +21,18 @@ expectError(execaCommand('unicorns', ['foo']));
 expectError(execaCommand('unicorns', 'foo'));
 expectError(execaCommand('unicorns', [true]));
 
-expectAssignable<ExecaResultPromise>(execaCommand('unicorns', {}));
+expectAssignable<ResultPromise>(execaCommand('unicorns', {}));
 expectError(execaCommand('unicorns', [], {}));
 expectError(execaCommand('unicorns', [], []));
 expectError(execaCommand('unicorns', {other: true}));
 
-expectAssignable<ExecaResultPromise>(execaCommand`unicorns`);
-expectType<ExecaResult<{}>>(await execaCommand('unicorns'));
-expectType<ExecaResult<{}>>(await execaCommand`unicorns`);
+expectAssignable<ResultPromise>(execaCommand`unicorns`);
+expectType<Result<{}>>(await execaCommand('unicorns'));
+expectType<Result<{}>>(await execaCommand`unicorns`);
 
 expectAssignable<typeof execaCommand>(execaCommand({}));
-expectAssignable<ExecaResultPromise>(execaCommand({})('unicorns'));
-expectAssignable<ExecaResultPromise>(execaCommand({})`unicorns`);
+expectAssignable<ResultPromise>(execaCommand({})('unicorns'));
+expectAssignable<ResultPromise>(execaCommand({})`unicorns`);
 
 expectAssignable<{stdout: string}>(await execaCommand('unicorns'));
 expectAssignable<{stdout: Uint8Array}>(await execaCommand('unicorns', {encoding: 'buffer'}));
@@ -45,13 +45,13 @@ expectAssignable<{stdout: Uint8Array}>(await execaCommand({encoding: 'buffer'})`
 expectAssignable<{stdout: Uint8Array}>(await execaCommand({})({encoding: 'buffer'})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(await execaCommand({encoding: 'buffer'})({})`unicorns`);
 
-expectType<ExecaResult<{}>>(await execaCommand`${'unicorns'}`);
-expectType<ExecaResult<{}>>(await execaCommand`unicorns ${'foo'}`);
+expectType<Result<{}>>(await execaCommand`${'unicorns'}`);
+expectType<Result<{}>>(await execaCommand`unicorns ${'foo'}`);
 expectError(await execaCommand`unicorns ${'foo'} ${'bar'}`);
 expectError(await execaCommand`unicorns ${1}`);
 expectError(await execaCommand`unicorns ${stringArray}`);
 expectError(await execaCommand`unicorns ${[1, 2]}`);
-expectType<ExecaResult<{}>>(await execaCommand`unicorns ${false.toString()}`);
+expectType<Result<{}>>(await execaCommand`unicorns ${false.toString()}`);
 expectError(await execaCommand`unicorns ${false}`);
 
 expectError(await execaCommand`unicorns ${await execaCommand`echo foo`}`);
@@ -62,22 +62,22 @@ expectError(await execaCommand`unicorns ${[execaCommand`echo foo`, 'bar']}`);
 expectError(execaCommandSync());
 expectError(execaCommandSync(true));
 expectError(execaCommandSync(['unicorns', 'arg']));
-expectType<ExecaSyncResult<{}>>(execaCommandSync('unicorns'));
+expectType<SyncResult<{}>>(execaCommandSync('unicorns'));
 expectError(execaCommandSync(fileUrl));
 expectError(execaCommandSync('unicorns', []));
 expectError(execaCommandSync('unicorns', ['foo']));
-expectType<ExecaSyncResult<{}>>(execaCommandSync('unicorns', {}));
+expectType<SyncResult<{}>>(execaCommandSync('unicorns', {}));
 expectError(execaCommandSync('unicorns', [], {}));
 expectError(execaCommandSync('unicorns', 'foo'));
 expectError(execaCommandSync('unicorns', [true]));
 expectError(execaCommandSync('unicorns', [], []));
 expectError(execaCommandSync('unicorns', {other: true}));
-expectType<ExecaSyncResult<{}>>(execaCommandSync`unicorns`);
+expectType<SyncResult<{}>>(execaCommandSync`unicorns`);
 expectAssignable<typeof execaCommandSync>(execaCommandSync({}));
-expectType<ExecaSyncResult<{}>>(execaCommandSync({})('unicorns'));
-expectType<ExecaSyncResult<{}>>(execaCommandSync({})`unicorns`);
-expectType<ExecaSyncResult<{}>>(execaCommandSync('unicorns'));
-expectType<ExecaSyncResult<{}>>(execaCommandSync`unicorns`);
+expectType<SyncResult<{}>>(execaCommandSync({})('unicorns'));
+expectType<SyncResult<{}>>(execaCommandSync({})`unicorns`);
+expectType<SyncResult<{}>>(execaCommandSync('unicorns'));
+expectType<SyncResult<{}>>(execaCommandSync`unicorns`);
 expectAssignable<{stdout: string}>(execaCommandSync('unicorns'));
 expectAssignable<{stdout: Uint8Array}>(execaCommandSync('unicorns', {encoding: 'buffer'}));
 expectAssignable<{stdout: string}>(execaCommandSync({})('unicorns'));
@@ -88,13 +88,13 @@ expectAssignable<{stdout: string}>(execaCommandSync({})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(execaCommandSync({encoding: 'buffer'})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(execaCommandSync({})({encoding: 'buffer'})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(execaCommandSync({encoding: 'buffer'})({})`unicorns`);
-expectType<ExecaSyncResult<{}>>(execaCommandSync`${'unicorns'}`);
-expectType<ExecaSyncResult<{}>>(execaCommandSync`unicorns ${'foo'}`);
+expectType<SyncResult<{}>>(execaCommandSync`${'unicorns'}`);
+expectType<SyncResult<{}>>(execaCommandSync`unicorns ${'foo'}`);
 expectError(execaCommandSync`unicorns ${'foo'} ${'bar'}`);
 expectError(execaCommandSync`unicorns ${1}`);
 expectError(execaCommandSync`unicorns ${stringArray}`);
 expectError(execaCommandSync`unicorns ${[1, 2]}`);
 expectError(execaCommandSync`unicorns ${execaCommandSync`echo foo`}`);
 expectError(execaCommandSync`unicorns ${[execaCommandSync`echo foo`, 'bar']}`);
-expectType<ExecaSyncResult<{}>>(execaCommandSync`unicorns ${false.toString()}`);
+expectType<SyncResult<{}>>(execaCommandSync`unicorns ${false.toString()}`);
 expectError(execaCommandSync`unicorns ${false}`);

--- a/test-d/methods/main-async.test-d.ts
+++ b/test-d/methods/main-async.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectError, expectAssignable} from 'tsd';
-import {execa, type ExecaResult, type ExecaResultPromise} from '../../index.js';
+import {execa, type Result, type ResultPromise} from '../../index.js';
 
 const fileUrl = new URL('file:///test');
 const stringArray = ['foo', 'bar'] as const;
@@ -7,26 +7,26 @@ const stringArray = ['foo', 'bar'] as const;
 expectError(execa());
 expectError(execa(true));
 expectError(execa(['unicorns', 'arg']));
-expectAssignable<ExecaResultPromise>(execa('unicorns'));
-expectAssignable<ExecaResultPromise>(execa(fileUrl));
+expectAssignable<ResultPromise>(execa('unicorns'));
+expectAssignable<ResultPromise>(execa(fileUrl));
 
-expectAssignable<ExecaResultPromise>(execa('unicorns', []));
-expectAssignable<ExecaResultPromise>(execa('unicorns', ['foo']));
+expectAssignable<ResultPromise>(execa('unicorns', []));
+expectAssignable<ResultPromise>(execa('unicorns', ['foo']));
 expectError(execa('unicorns', 'foo'));
 expectError(execa('unicorns', [true]));
 
-expectAssignable<ExecaResultPromise>(execa('unicorns', {}));
-expectAssignable<ExecaResultPromise>(execa('unicorns', [], {}));
+expectAssignable<ResultPromise>(execa('unicorns', {}));
+expectAssignable<ResultPromise>(execa('unicorns', [], {}));
 expectError(execa('unicorns', [], []));
 expectError(execa('unicorns', {other: true}));
 
-expectAssignable<ExecaResultPromise>(execa`unicorns`);
-expectType<ExecaResult<{}>>(await execa('unicorns'));
-expectType<ExecaResult<{}>>(await execa`unicorns`);
+expectAssignable<ResultPromise>(execa`unicorns`);
+expectType<Result<{}>>(await execa('unicorns'));
+expectType<Result<{}>>(await execa`unicorns`);
 
 expectAssignable<typeof execa>(execa({}));
-expectAssignable<ExecaResultPromise>(execa({})('unicorns'));
-expectAssignable<ExecaResultPromise>(execa({})`unicorns`);
+expectAssignable<ResultPromise>(execa({})('unicorns'));
+expectAssignable<ResultPromise>(execa({})`unicorns`);
 
 expectAssignable<{stdout: string}>(await execa('unicorns'));
 expectAssignable<{stdout: Uint8Array}>(await execa('unicorns', {encoding: 'buffer'}));
@@ -41,16 +41,16 @@ expectAssignable<{stdout: Uint8Array}>(await execa({encoding: 'buffer'})`unicorn
 expectAssignable<{stdout: Uint8Array}>(await execa({})({encoding: 'buffer'})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(await execa({encoding: 'buffer'})({})`unicorns`);
 
-expectType<ExecaResult<{}>>(await execa`${'unicorns'}`);
-expectType<ExecaResult<{}>>(await execa`unicorns ${'foo'}`);
-expectType<ExecaResult<{}>>(await execa`unicorns ${'foo'} ${'bar'}`);
-expectType<ExecaResult<{}>>(await execa`unicorns ${1}`);
-expectType<ExecaResult<{}>>(await execa`unicorns ${stringArray}`);
-expectType<ExecaResult<{}>>(await execa`unicorns ${[1, 2]}`);
-expectType<ExecaResult<{}>>(await execa`unicorns ${false.toString()}`);
+expectType<Result<{}>>(await execa`${'unicorns'}`);
+expectType<Result<{}>>(await execa`unicorns ${'foo'}`);
+expectType<Result<{}>>(await execa`unicorns ${'foo'} ${'bar'}`);
+expectType<Result<{}>>(await execa`unicorns ${1}`);
+expectType<Result<{}>>(await execa`unicorns ${stringArray}`);
+expectType<Result<{}>>(await execa`unicorns ${[1, 2]}`);
+expectType<Result<{}>>(await execa`unicorns ${false.toString()}`);
 expectError(await execa`unicorns ${false}`);
 
-expectType<ExecaResult<{}>>(await execa`unicorns ${await execa`echo foo`}`);
+expectType<Result<{}>>(await execa`unicorns ${await execa`echo foo`}`);
 expectError(await execa`unicorns ${execa`echo foo`}`);
-expectType<ExecaResult<{}>>(await execa`unicorns ${[await execa`echo foo`, 'bar']}`);
+expectType<Result<{}>>(await execa`unicorns ${[await execa`echo foo`, 'bar']}`);
 expectError(await execa`unicorns ${[execa`echo foo`, 'bar']}`);

--- a/test-d/methods/main-sync.test-d.ts
+++ b/test-d/methods/main-sync.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectError, expectAssignable} from 'tsd';
-import {execaSync, type ExecaSyncResult} from '../../index.js';
+import {execaSync, type SyncResult} from '../../index.js';
 
 const fileUrl = new URL('file:///test');
 const stringArray = ['foo', 'bar'] as const;
@@ -7,26 +7,26 @@ const stringArray = ['foo', 'bar'] as const;
 expectError(execaSync());
 expectError(execaSync(true));
 expectError(execaSync(['unicorns', 'arg']));
-expectType<ExecaSyncResult<{}>>(execaSync('unicorns'));
-expectType<ExecaSyncResult<{}>>(execaSync(fileUrl));
+expectType<SyncResult<{}>>(execaSync('unicorns'));
+expectType<SyncResult<{}>>(execaSync(fileUrl));
 
-expectType<ExecaSyncResult<{}>>(execaSync('unicorns', []));
-expectType<ExecaSyncResult<{}>>(execaSync('unicorns', ['foo']));
+expectType<SyncResult<{}>>(execaSync('unicorns', []));
+expectType<SyncResult<{}>>(execaSync('unicorns', ['foo']));
 expectError(execaSync('unicorns', 'foo'));
 expectError(execaSync('unicorns', [true]));
 
-expectType<ExecaSyncResult<{}>>(execaSync('unicorns', {}));
-expectType<ExecaSyncResult<{}>>(execaSync('unicorns', [], {}));
+expectType<SyncResult<{}>>(execaSync('unicorns', {}));
+expectType<SyncResult<{}>>(execaSync('unicorns', [], {}));
 expectError(execaSync('unicorns', [], []));
 expectError(execaSync('unicorns', {other: true}));
 
-expectType<ExecaSyncResult<{}>>(execaSync`unicorns`);
-expectType<ExecaSyncResult<{}>>(execaSync('unicorns'));
-expectType<ExecaSyncResult<{}>>(execaSync`unicorns`);
+expectType<SyncResult<{}>>(execaSync`unicorns`);
+expectType<SyncResult<{}>>(execaSync('unicorns'));
+expectType<SyncResult<{}>>(execaSync`unicorns`);
 
 expectAssignable<typeof execaSync>(execaSync({}));
-expectType<ExecaSyncResult<{}>>(execaSync({})('unicorns'));
-expectType<ExecaSyncResult<{}>>(execaSync({})`unicorns`);
+expectType<SyncResult<{}>>(execaSync({})('unicorns'));
+expectType<SyncResult<{}>>(execaSync({})`unicorns`);
 
 expectAssignable<{stdout: string}>(execaSync('unicorns'));
 expectAssignable<{stdout: Uint8Array}>(execaSync('unicorns', {encoding: 'buffer'}));
@@ -41,14 +41,14 @@ expectAssignable<{stdout: Uint8Array}>(execaSync({encoding: 'buffer'})`unicorns`
 expectAssignable<{stdout: Uint8Array}>(execaSync({})({encoding: 'buffer'})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(execaSync({encoding: 'buffer'})({})`unicorns`);
 
-expectType<ExecaSyncResult<{}>>(execaSync`${'unicorns'}`);
-expectType<ExecaSyncResult<{}>>(execaSync`unicorns ${'foo'}`);
-expectType<ExecaSyncResult<{}>>(execaSync`unicorns ${'foo'} ${'bar'}`);
-expectType<ExecaSyncResult<{}>>(execaSync`unicorns ${1}`);
-expectType<ExecaSyncResult<{}>>(execaSync`unicorns ${stringArray}`);
-expectType<ExecaSyncResult<{}>>(execaSync`unicorns ${[1, 2]}`);
-expectType<ExecaSyncResult<{}>>(execaSync`unicorns ${false.toString()}`);
+expectType<SyncResult<{}>>(execaSync`${'unicorns'}`);
+expectType<SyncResult<{}>>(execaSync`unicorns ${'foo'}`);
+expectType<SyncResult<{}>>(execaSync`unicorns ${'foo'} ${'bar'}`);
+expectType<SyncResult<{}>>(execaSync`unicorns ${1}`);
+expectType<SyncResult<{}>>(execaSync`unicorns ${stringArray}`);
+expectType<SyncResult<{}>>(execaSync`unicorns ${[1, 2]}`);
+expectType<SyncResult<{}>>(execaSync`unicorns ${false.toString()}`);
 expectError(execaSync`unicorns ${false}`);
 
-expectType<ExecaSyncResult<{}>>(execaSync`unicorns ${execaSync`echo foo`}`);
-expectType<ExecaSyncResult<{}>>(execaSync`unicorns ${[execaSync`echo foo`, 'bar']}`);
+expectType<SyncResult<{}>>(execaSync`unicorns ${execaSync`echo foo`}`);
+expectType<SyncResult<{}>>(execaSync`unicorns ${[execaSync`echo foo`, 'bar']}`);

--- a/test-d/methods/node.test-d.ts
+++ b/test-d/methods/node.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectError, expectAssignable} from 'tsd';
-import {execaNode, type ExecaResult, type ExecaResultPromise} from '../../index.js';
+import {execaNode, type Result, type ResultPromise} from '../../index.js';
 
 const fileUrl = new URL('file:///test');
 const stringArray = ['foo', 'bar'] as const;
@@ -7,26 +7,26 @@ const stringArray = ['foo', 'bar'] as const;
 expectError(execaNode());
 expectError(execaNode(true));
 expectError(execaNode(['unicorns', 'arg']));
-expectAssignable<ExecaResultPromise>(execaNode('unicorns'));
-expectAssignable<ExecaResultPromise>(execaNode(fileUrl));
+expectAssignable<ResultPromise>(execaNode('unicorns'));
+expectAssignable<ResultPromise>(execaNode(fileUrl));
 
-expectAssignable<ExecaResultPromise>(execaNode('unicorns', []));
-expectAssignable<ExecaResultPromise>(execaNode('unicorns', ['foo']));
+expectAssignable<ResultPromise>(execaNode('unicorns', []));
+expectAssignable<ResultPromise>(execaNode('unicorns', ['foo']));
 expectError(execaNode('unicorns', 'foo'));
 expectError(execaNode('unicorns', [true]));
 
-expectAssignable<ExecaResultPromise>(execaNode('unicorns', {}));
-expectAssignable<ExecaResultPromise>(execaNode('unicorns', [], {}));
+expectAssignable<ResultPromise>(execaNode('unicorns', {}));
+expectAssignable<ResultPromise>(execaNode('unicorns', [], {}));
 expectError(execaNode('unicorns', [], []));
 expectError(execaNode('unicorns', {other: true}));
 
-expectAssignable<ExecaResultPromise>(execaNode`unicorns`);
-expectType<ExecaResult<{}>>(await execaNode('unicorns'));
-expectType<ExecaResult<{}>>(await execaNode`unicorns`);
+expectAssignable<ResultPromise>(execaNode`unicorns`);
+expectType<Result<{}>>(await execaNode('unicorns'));
+expectType<Result<{}>>(await execaNode`unicorns`);
 
 expectAssignable<typeof execaNode>(execaNode({}));
-expectAssignable<ExecaResultPromise>(execaNode({})('unicorns'));
-expectAssignable<ExecaResultPromise>(execaNode({})`unicorns`);
+expectAssignable<ResultPromise>(execaNode({})('unicorns'));
+expectAssignable<ResultPromise>(execaNode({})`unicorns`);
 
 expectAssignable<{stdout: string}>(await execaNode('unicorns'));
 expectAssignable<{stdout: Uint8Array}>(await execaNode('unicorns', {encoding: 'buffer'}));
@@ -41,22 +41,22 @@ expectAssignable<{stdout: Uint8Array}>(await execaNode({encoding: 'buffer'})`uni
 expectAssignable<{stdout: Uint8Array}>(await execaNode({})({encoding: 'buffer'})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(await execaNode({encoding: 'buffer'})({})`unicorns`);
 
-expectType<ExecaResult<{}>>(await execaNode`${'unicorns'}`);
-expectType<ExecaResult<{}>>(await execaNode`unicorns ${'foo'}`);
-expectType<ExecaResult<{}>>(await execaNode`unicorns ${'foo'} ${'bar'}`);
-expectType<ExecaResult<{}>>(await execaNode`unicorns ${1}`);
-expectType<ExecaResult<{}>>(await execaNode`unicorns ${stringArray}`);
-expectType<ExecaResult<{}>>(await execaNode`unicorns ${[1, 2]}`);
-expectType<ExecaResult<{}>>(await execaNode`unicorns ${false.toString()}`);
+expectType<Result<{}>>(await execaNode`${'unicorns'}`);
+expectType<Result<{}>>(await execaNode`unicorns ${'foo'}`);
+expectType<Result<{}>>(await execaNode`unicorns ${'foo'} ${'bar'}`);
+expectType<Result<{}>>(await execaNode`unicorns ${1}`);
+expectType<Result<{}>>(await execaNode`unicorns ${stringArray}`);
+expectType<Result<{}>>(await execaNode`unicorns ${[1, 2]}`);
+expectType<Result<{}>>(await execaNode`unicorns ${false.toString()}`);
 expectError(await execaNode`unicorns ${false}`);
 
-expectType<ExecaResult<{}>>(await execaNode`unicorns ${await execaNode`echo foo`}`);
+expectType<Result<{}>>(await execaNode`unicorns ${await execaNode`echo foo`}`);
 expectError(await execaNode`unicorns ${execaNode`echo foo`}`);
-expectType<ExecaResult<{}>>(await execaNode`unicorns ${[await execaNode`echo foo`, 'bar']}`);
+expectType<Result<{}>>(await execaNode`unicorns ${[await execaNode`echo foo`, 'bar']}`);
 expectError(await execaNode`unicorns ${[execaNode`echo foo`, 'bar']}`);
 
-expectAssignable<ExecaResultPromise>(execaNode('unicorns', {nodePath: './node'}));
-expectAssignable<ExecaResultPromise>(execaNode('unicorns', {nodePath: fileUrl}));
+expectAssignable<ResultPromise>(execaNode('unicorns', {nodePath: './node'}));
+expectAssignable<ResultPromise>(execaNode('unicorns', {nodePath: fileUrl}));
 expectAssignable<{stdout: string}>(await execaNode('unicorns', {nodeOptions: ['--async-stack-traces']}));
 expectAssignable<{stdout: Uint8Array}>(await execaNode('unicorns', {nodeOptions: ['--async-stack-traces'], encoding: 'buffer'}));
 expectAssignable<{stdout: string}>(await execaNode('unicorns', ['foo'], {nodeOptions: ['--async-stack-traces']}));

--- a/test-d/methods/script-s.test-d.ts
+++ b/test-d/methods/script-s.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectError, expectAssignable} from 'tsd';
-import {$, type ExecaSyncResult} from '../../index.js';
+import {$, type SyncResult} from '../../index.js';
 
 const fileUrl = new URL('file:///test');
 const stringArray = ['foo', 'bar'] as const;
@@ -7,28 +7,28 @@ const stringArray = ['foo', 'bar'] as const;
 expectError($.s());
 expectError($.s(true));
 expectError($.s(['unicorns', 'arg']));
-expectType<ExecaSyncResult<{}>>($.s('unicorns'));
-expectType<ExecaSyncResult<{}>>($.s(fileUrl));
+expectType<SyncResult<{}>>($.s('unicorns'));
+expectType<SyncResult<{}>>($.s(fileUrl));
 
-expectType<ExecaSyncResult<{}>>($.s('unicorns', []));
-expectType<ExecaSyncResult<{}>>($.s('unicorns', ['foo']));
+expectType<SyncResult<{}>>($.s('unicorns', []));
+expectType<SyncResult<{}>>($.s('unicorns', ['foo']));
 expectError($.s('unicorns', 'foo'));
 expectError($.s('unicorns', [true]));
 
-expectType<ExecaSyncResult<{}>>($.s('unicorns', {}));
-expectType<ExecaSyncResult<{}>>($.s('unicorns', [], {}));
+expectType<SyncResult<{}>>($.s('unicorns', {}));
+expectType<SyncResult<{}>>($.s('unicorns', [], {}));
 expectError($.s('unicorns', [], []));
 expectError($.s('unicorns', {other: true}));
 
-expectType<ExecaSyncResult<{}>>($.s`unicorns`);
-expectType<ExecaSyncResult<{}>>($.s('unicorns'));
-expectType<ExecaSyncResult<{}>>($.s`unicorns`);
+expectType<SyncResult<{}>>($.s`unicorns`);
+expectType<SyncResult<{}>>($.s('unicorns'));
+expectType<SyncResult<{}>>($.s`unicorns`);
 
 expectAssignable<typeof $.s>($.s({}));
-expectType<ExecaSyncResult<{}>>($.s({})('unicorns'));
-expectType<ExecaSyncResult<{}>>($({}).s('unicorns'));
-expectType<ExecaSyncResult<{}>>($.s({})`unicorns`);
-expectType<ExecaSyncResult<{}>>($({}).s`unicorns`);
+expectType<SyncResult<{}>>($.s({})('unicorns'));
+expectType<SyncResult<{}>>($({}).s('unicorns'));
+expectType<SyncResult<{}>>($.s({})`unicorns`);
+expectType<SyncResult<{}>>($({}).s`unicorns`);
 
 expectAssignable<{stdout: string}>($.s('unicorns'));
 expectAssignable<{stdout: Uint8Array}>($.s('unicorns', {encoding: 'buffer'}));
@@ -51,14 +51,14 @@ expectAssignable<{stdout: Uint8Array}>($({})({encoding: 'buffer'}).s`unicorns`);
 expectAssignable<{stdout: Uint8Array}>($.s({encoding: 'buffer'})({})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>($({encoding: 'buffer'}).s({})`unicorns`);
 
-expectType<ExecaSyncResult<{}>>($.s`${'unicorns'}`);
-expectType<ExecaSyncResult<{}>>($.s`unicorns ${'foo'}`);
-expectType<ExecaSyncResult<{}>>($.s`unicorns ${'foo'} ${'bar'}`);
-expectType<ExecaSyncResult<{}>>($.s`unicorns ${1}`);
-expectType<ExecaSyncResult<{}>>($.s`unicorns ${stringArray}`);
-expectType<ExecaSyncResult<{}>>($.s`unicorns ${[1, 2]}`);
-expectType<ExecaSyncResult<{}>>($.s`unicorns ${false.toString()}`);
+expectType<SyncResult<{}>>($.s`${'unicorns'}`);
+expectType<SyncResult<{}>>($.s`unicorns ${'foo'}`);
+expectType<SyncResult<{}>>($.s`unicorns ${'foo'} ${'bar'}`);
+expectType<SyncResult<{}>>($.s`unicorns ${1}`);
+expectType<SyncResult<{}>>($.s`unicorns ${stringArray}`);
+expectType<SyncResult<{}>>($.s`unicorns ${[1, 2]}`);
+expectType<SyncResult<{}>>($.s`unicorns ${false.toString()}`);
 expectError($.s`unicorns ${false}`);
 
-expectType<ExecaSyncResult<{}>>($.s`unicorns ${$.s`echo foo`}`);
-expectType<ExecaSyncResult<{}>>($.s`unicorns ${[$.s`echo foo`, 'bar']}`);
+expectType<SyncResult<{}>>($.s`unicorns ${$.s`echo foo`}`);
+expectType<SyncResult<{}>>($.s`unicorns ${[$.s`echo foo`, 'bar']}`);

--- a/test-d/methods/script-sync.test-d.ts
+++ b/test-d/methods/script-sync.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectError, expectAssignable} from 'tsd';
-import {$, type ExecaSyncResult} from '../../index.js';
+import {$, type SyncResult} from '../../index.js';
 
 const fileUrl = new URL('file:///test');
 const stringArray = ['foo', 'bar'] as const;
@@ -7,28 +7,28 @@ const stringArray = ['foo', 'bar'] as const;
 expectError($.sync());
 expectError($.sync(true));
 expectError($.sync(['unicorns', 'arg']));
-expectType<ExecaSyncResult<{}>>($.sync('unicorns'));
-expectType<ExecaSyncResult<{}>>($.sync(fileUrl));
+expectType<SyncResult<{}>>($.sync('unicorns'));
+expectType<SyncResult<{}>>($.sync(fileUrl));
 
-expectType<ExecaSyncResult<{}>>($.sync('unicorns', []));
-expectType<ExecaSyncResult<{}>>($.sync('unicorns', ['foo']));
+expectType<SyncResult<{}>>($.sync('unicorns', []));
+expectType<SyncResult<{}>>($.sync('unicorns', ['foo']));
 expectError($.sync('unicorns', 'foo'));
 expectError($.sync('unicorns', [true]));
 
-expectType<ExecaSyncResult<{}>>($.sync('unicorns', {}));
-expectType<ExecaSyncResult<{}>>($.sync('unicorns', [], {}));
+expectType<SyncResult<{}>>($.sync('unicorns', {}));
+expectType<SyncResult<{}>>($.sync('unicorns', [], {}));
 expectError($.sync('unicorns', [], []));
 expectError($.sync('unicorns', {other: true}));
 
-expectType<ExecaSyncResult<{}>>($.sync`unicorns`);
-expectType<ExecaSyncResult<{}>>($.sync('unicorns'));
-expectType<ExecaSyncResult<{}>>($.sync`unicorns`);
+expectType<SyncResult<{}>>($.sync`unicorns`);
+expectType<SyncResult<{}>>($.sync('unicorns'));
+expectType<SyncResult<{}>>($.sync`unicorns`);
 
 expectAssignable<typeof $.sync>($.sync({}));
-expectType<ExecaSyncResult<{}>>($.sync({})('unicorns'));
-expectType<ExecaSyncResult<{}>>($({}).sync('unicorns'));
-expectType<ExecaSyncResult<{}>>($.sync({})`unicorns`);
-expectType<ExecaSyncResult<{}>>($({}).sync`unicorns`);
+expectType<SyncResult<{}>>($.sync({})('unicorns'));
+expectType<SyncResult<{}>>($({}).sync('unicorns'));
+expectType<SyncResult<{}>>($.sync({})`unicorns`);
+expectType<SyncResult<{}>>($({}).sync`unicorns`);
 
 expectAssignable<{stdout: string}>($.sync('unicorns'));
 expectAssignable<{stdout: Uint8Array}>($.sync('unicorns', {encoding: 'buffer'}));
@@ -51,14 +51,14 @@ expectAssignable<{stdout: Uint8Array}>($({})({encoding: 'buffer'}).sync`unicorns
 expectAssignable<{stdout: Uint8Array}>($.sync({encoding: 'buffer'})({})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>($({encoding: 'buffer'}).sync({})`unicorns`);
 
-expectType<ExecaSyncResult<{}>>($.sync`${'unicorns'}`);
-expectType<ExecaSyncResult<{}>>($.sync`unicorns ${'foo'}`);
-expectType<ExecaSyncResult<{}>>($.sync`unicorns ${'foo'} ${'bar'}`);
-expectType<ExecaSyncResult<{}>>($.sync`unicorns ${1}`);
-expectType<ExecaSyncResult<{}>>($.sync`unicorns ${stringArray}`);
-expectType<ExecaSyncResult<{}>>($.sync`unicorns ${[1, 2]}`);
-expectType<ExecaSyncResult<{}>>($.sync`unicorns ${false.toString()}`);
+expectType<SyncResult<{}>>($.sync`${'unicorns'}`);
+expectType<SyncResult<{}>>($.sync`unicorns ${'foo'}`);
+expectType<SyncResult<{}>>($.sync`unicorns ${'foo'} ${'bar'}`);
+expectType<SyncResult<{}>>($.sync`unicorns ${1}`);
+expectType<SyncResult<{}>>($.sync`unicorns ${stringArray}`);
+expectType<SyncResult<{}>>($.sync`unicorns ${[1, 2]}`);
+expectType<SyncResult<{}>>($.sync`unicorns ${false.toString()}`);
 expectError($.sync`unicorns ${false}`);
 
-expectType<ExecaSyncResult<{}>>($.sync`unicorns ${$.sync`echo foo`}`);
-expectType<ExecaSyncResult<{}>>($.sync`unicorns ${[$.sync`echo foo`, 'bar']}`);
+expectType<SyncResult<{}>>($.sync`unicorns ${$.sync`echo foo`}`);
+expectType<SyncResult<{}>>($.sync`unicorns ${[$.sync`echo foo`, 'bar']}`);

--- a/test-d/methods/script.test-d.ts
+++ b/test-d/methods/script.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectError, expectAssignable} from 'tsd';
-import {$, type ExecaResult, type ExecaResultPromise} from '../../index.js';
+import {$, type Result, type ResultPromise} from '../../index.js';
 
 const fileUrl = new URL('file:///test');
 const stringArray = ['foo', 'bar'] as const;
@@ -7,26 +7,26 @@ const stringArray = ['foo', 'bar'] as const;
 expectError($());
 expectError($(true));
 expectError($(['unicorns', 'arg']));
-expectAssignable<ExecaResultPromise>($('unicorns'));
-expectAssignable<ExecaResultPromise>($(fileUrl));
+expectAssignable<ResultPromise>($('unicorns'));
+expectAssignable<ResultPromise>($(fileUrl));
 
-expectAssignable<ExecaResultPromise>($('unicorns', []));
-expectAssignable<ExecaResultPromise>($('unicorns', ['foo']));
+expectAssignable<ResultPromise>($('unicorns', []));
+expectAssignable<ResultPromise>($('unicorns', ['foo']));
 expectError($('unicorns', 'foo'));
 expectError($('unicorns', [true]));
 
-expectAssignable<ExecaResultPromise>($('unicorns', {}));
-expectAssignable<ExecaResultPromise>($('unicorns', [], {}));
+expectAssignable<ResultPromise>($('unicorns', {}));
+expectAssignable<ResultPromise>($('unicorns', [], {}));
 expectError($('unicorns', [], []));
 expectError($('unicorns', {other: true}));
 
-expectAssignable<ExecaResultPromise>($`unicorns`);
-expectType<ExecaResult<{}>>(await $('unicorns'));
-expectType<ExecaResult<{}>>(await $`unicorns`);
+expectAssignable<ResultPromise>($`unicorns`);
+expectType<Result<{}>>(await $('unicorns'));
+expectType<Result<{}>>(await $`unicorns`);
 
 expectAssignable<typeof $>($({}));
-expectAssignable<ExecaResultPromise>($({})('unicorns'));
-expectAssignable<ExecaResultPromise>($({})`unicorns`);
+expectAssignable<ResultPromise>($({})('unicorns'));
+expectAssignable<ResultPromise>($({})`unicorns`);
 
 expectAssignable<{stdout: string}>(await $('unicorns'));
 expectAssignable<{stdout: Uint8Array}>(await $('unicorns', {encoding: 'buffer'}));
@@ -41,16 +41,16 @@ expectAssignable<{stdout: Uint8Array}>(await $({encoding: 'buffer'})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(await $({})({encoding: 'buffer'})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(await $({encoding: 'buffer'})({})`unicorns`);
 
-expectType<ExecaResult<{}>>(await $`${'unicorns'}`);
-expectType<ExecaResult<{}>>(await $`unicorns ${'foo'}`);
-expectType<ExecaResult<{}>>(await $`unicorns ${'foo'} ${'bar'}`);
-expectType<ExecaResult<{}>>(await $`unicorns ${1}`);
-expectType<ExecaResult<{}>>(await $`unicorns ${stringArray}`);
-expectType<ExecaResult<{}>>(await $`unicorns ${[1, 2]}`);
-expectType<ExecaResult<{}>>(await $`unicorns ${false.toString()}`);
+expectType<Result<{}>>(await $`${'unicorns'}`);
+expectType<Result<{}>>(await $`unicorns ${'foo'}`);
+expectType<Result<{}>>(await $`unicorns ${'foo'} ${'bar'}`);
+expectType<Result<{}>>(await $`unicorns ${1}`);
+expectType<Result<{}>>(await $`unicorns ${stringArray}`);
+expectType<Result<{}>>(await $`unicorns ${[1, 2]}`);
+expectType<Result<{}>>(await $`unicorns ${false.toString()}`);
 expectError(await $`unicorns ${false}`);
 
-expectType<ExecaResult<{}>>(await $`unicorns ${await $`echo foo`}`);
+expectType<Result<{}>>(await $`unicorns ${await $`echo foo`}`);
 expectError(await $`unicorns ${$`echo foo`}`);
-expectType<ExecaResult<{}>>(await $`unicorns ${[await $`echo foo`, 'bar']}`);
+expectType<Result<{}>>(await $`unicorns ${[await $`echo foo`, 'bar']}`);
 expectError(await $`unicorns ${[$`echo foo`, 'bar']}`);

--- a/test-d/pipe.test-d.ts
+++ b/test-d/pipe.test-d.ts
@@ -4,7 +4,7 @@ import {
 	execa,
 	execaSync,
 	$,
-	type ExecaResult,
+	type Result,
 } from '../index.js';
 
 const fileUrl = new URL('file:///test');
@@ -17,8 +17,8 @@ const scriptSubprocess = $`unicorns`;
 
 const bufferResult = await bufferSubprocess;
 type BufferExecaReturnValue = typeof bufferResult;
-type EmptyExecaReturnValue = ExecaResult<{}>;
-type ShortcutExecaReturnValue = ExecaResult<typeof pipeOptions>;
+type EmptyExecaReturnValue = Result<{}>;
+type ShortcutExecaReturnValue = Result<typeof pipeOptions>;
 
 expectNotType<BufferExecaReturnValue>(await subprocess.pipe(subprocess));
 expectNotType<BufferExecaReturnValue>(await scriptSubprocess.pipe(subprocess));

--- a/test-d/return/result-main.test-d.ts
+++ b/test-d/return/result-main.test-d.ts
@@ -4,22 +4,22 @@ import {
 	execaSync,
 	ExecaError,
 	ExecaSyncError,
-	type ExecaResult,
-	type ExecaSyncResult,
+	type Result,
+	type SyncResult,
 } from '../../index.js';
 
 type AnyChunk = string | Uint8Array | string[] | unknown[] | undefined;
-expectType<AnyChunk>({} as ExecaResult['stdout']);
-expectType<AnyChunk>({} as ExecaResult['stderr']);
-expectType<AnyChunk>({} as ExecaResult['all']);
-expectAssignable<[undefined, AnyChunk, AnyChunk, ...AnyChunk[]]>({} as ExecaResult['stdio']);
-expectType<AnyChunk>({} as ExecaSyncResult['stdout']);
-expectType<AnyChunk>({} as ExecaSyncResult['stderr']);
-expectType<AnyChunk>({} as ExecaSyncResult['all']);
-expectAssignable<[undefined, AnyChunk, AnyChunk, ...AnyChunk[]]>({} as ExecaSyncResult['stdio']);
+expectType<AnyChunk>({} as Result['stdout']);
+expectType<AnyChunk>({} as Result['stderr']);
+expectType<AnyChunk>({} as Result['all']);
+expectAssignable<[undefined, AnyChunk, AnyChunk, ...AnyChunk[]]>({} as Result['stdio']);
+expectType<AnyChunk>({} as SyncResult['stdout']);
+expectType<AnyChunk>({} as SyncResult['stderr']);
+expectType<AnyChunk>({} as SyncResult['all']);
+expectAssignable<[undefined, AnyChunk, AnyChunk, ...AnyChunk[]]>({} as SyncResult['stdio']);
 
 const unicornsResult = await execa('unicorns', {all: true});
-expectAssignable<ExecaResult>(unicornsResult);
+expectAssignable<Result>(unicornsResult);
 expectType<string>(unicornsResult.command);
 expectType<string>(unicornsResult.escapedCommand);
 expectType<number | undefined>(unicornsResult.exitCode);
@@ -32,10 +32,10 @@ expectType<string | undefined>(unicornsResult.signal);
 expectType<string | undefined>(unicornsResult.signalDescription);
 expectType<string>(unicornsResult.cwd);
 expectType<number>(unicornsResult.durationMs);
-expectType<ExecaResult[]>(unicornsResult.pipedFrom);
+expectType<Result[]>(unicornsResult.pipedFrom);
 
 const unicornsResultSync = execaSync('unicorns', {all: true});
-expectAssignable<ExecaSyncResult>(unicornsResultSync);
+expectAssignable<SyncResult>(unicornsResultSync);
 expectType<string>(unicornsResultSync.command);
 expectType<string>(unicornsResultSync.escapedCommand);
 expectType<number | undefined>(unicornsResultSync.exitCode);
@@ -69,7 +69,7 @@ if (error instanceof ExecaError) {
 	expectType<string>(error.originalMessage);
 	expectType<string | undefined>(error.code);
 	expectType<unknown>(error.cause);
-	expectType<ExecaResult[]>(error.pipedFrom);
+	expectType<Result[]>(error.pipedFrom);
 }
 
 const errorSync = new Error('.');

--- a/test-d/subprocess/stdio.test-d.ts
+++ b/test-d/subprocess/stdio.test-d.ts
@@ -1,11 +1,11 @@
 import type {Readable, Writable} from 'node:stream';
 import {expectType, expectError} from 'tsd';
-import {execa, type ExecaSubprocess} from '../../index.js';
+import {execa, type Subprocess} from '../../index.js';
 
-expectType<Writable | null>({} as ExecaSubprocess['stdin']);
-expectType<Readable | null>({} as ExecaSubprocess['stdout']);
-expectType<Readable | null>({} as ExecaSubprocess['stderr']);
-expectType<Readable | undefined>({} as ExecaSubprocess['all']);
+expectType<Writable | null>({} as Subprocess['stdin']);
+expectType<Readable | null>({} as Subprocess['stdout']);
+expectType<Readable | null>({} as Subprocess['stderr']);
+expectType<Readable | undefined>({} as Subprocess['all']);
 
 const bufferSubprocess = execa('unicorns', {encoding: 'buffer', all: true});
 expectType<Writable>(bufferSubprocess.stdin);

--- a/test-d/subprocess/subprocess.test-d.ts
+++ b/test-d/subprocess/subprocess.test-d.ts
@@ -1,8 +1,8 @@
 import {expectType, expectError, expectAssignable} from 'tsd';
-import {execa, type ExecaSubprocess} from '../../index.js';
+import {execa, type Subprocess} from '../../index.js';
 
 const subprocess = execa('unicorns');
-expectAssignable<ExecaSubprocess>(subprocess);
+expectAssignable<Subprocess>(subprocess);
 
 expectType<number | undefined>(subprocess.pid);
 
@@ -21,7 +21,7 @@ expectError(subprocess.kill('SIGKILL', {}));
 expectError(subprocess.kill(null, new Error('test')));
 
 const ipcSubprocess = execa('unicorns', {ipc: true});
-expectAssignable<ExecaSubprocess>(subprocess);
+expectAssignable<Subprocess>(subprocess);
 
 expectType<boolean>(ipcSubprocess.send({}));
 execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', 'ipc']}).send({});

--- a/types/methods/command.d.ts
+++ b/types/methods/command.d.ts
@@ -1,17 +1,17 @@
 import type {Options, SyncOptions} from '../arguments/options';
-import type {ExecaSyncResult} from '../return/result';
-import type {ExecaResultPromise} from '../subprocess/subprocess';
+import type {SyncResult} from '../return/result';
+import type {ResultPromise} from '../subprocess/subprocess';
 import type {SimpleTemplateString} from './template';
 
 type ExecaCommand<OptionsType extends Options> = {
 	<NewOptionsType extends Options = {}>(options: NewOptionsType): ExecaCommand<OptionsType & NewOptionsType>;
 
-	(...templateString: SimpleTemplateString): ExecaResultPromise<OptionsType>;
+	(...templateString: SimpleTemplateString): ResultPromise<OptionsType>;
 
 	<NewOptionsType extends Options = {}>(
 		command: string,
 		options?: NewOptionsType,
-	): ExecaResultPromise<OptionsType & NewOptionsType>;
+	): ResultPromise<OptionsType & NewOptionsType>;
 };
 
 /**
@@ -22,7 +22,7 @@ This is only intended for very specific cases, such as a REPL. This should be av
 Just like `execa()`, this can bind options. It can also be run synchronously using `execaCommandSync()`.
 
 @param command - The program/script to execute and its arguments.
-@returns An `ExecaResultPromise` that is both:
+@returns A `ResultPromise` that is both:
 - the subprocess.
 - a `Promise` either resolving with its successful `result`, or rejecting with its `error`.
 @throws `ExecaError`
@@ -41,12 +41,12 @@ export declare const execaCommand: ExecaCommand<{}>;
 type ExecaCommandSync<OptionsType extends SyncOptions> = {
 	<NewOptionsType extends SyncOptions = {}>(options: NewOptionsType): ExecaCommandSync<OptionsType & NewOptionsType>;
 
-	(...templateString: SimpleTemplateString): ExecaSyncResult<OptionsType>;
+	(...templateString: SimpleTemplateString): SyncResult<OptionsType>;
 
 	<NewOptionsType extends SyncOptions = {}>(
 		command: string,
 		options?: NewOptionsType,
-	): ExecaSyncResult<OptionsType & NewOptionsType>;
+	): SyncResult<OptionsType & NewOptionsType>;
 };
 
 /**
@@ -55,7 +55,7 @@ Same as `execaCommand()` but synchronous.
 Returns or throws a subprocess `result`. The `subprocess` is not returned: its methods and properties are not available.
 
 @param command - The program/script to execute and its arguments.
-@returns `ExecaSyncResult`
+@returns `SyncResult`
 @throws `ExecaSyncError`
 
 @example

--- a/types/methods/main-async.d.ts
+++ b/types/methods/main-async.d.ts
@@ -1,22 +1,22 @@
 import type {Options} from '../arguments/options';
-import type {ExecaResultPromise} from '../subprocess/subprocess';
+import type {ResultPromise} from '../subprocess/subprocess';
 import type {TemplateString} from './template';
 
 type Execa<OptionsType extends Options> = {
 	<NewOptionsType extends Options = {}>(options: NewOptionsType): Execa<OptionsType & NewOptionsType>;
 
-	(...templateString: TemplateString): ExecaResultPromise<OptionsType>;
+	(...templateString: TemplateString): ResultPromise<OptionsType>;
 
 	<NewOptionsType extends Options = {}>(
 		file: string | URL,
 		arguments?: readonly string[],
 		options?: NewOptionsType,
-	): ExecaResultPromise<OptionsType & NewOptionsType>;
+	): ResultPromise<OptionsType & NewOptionsType>;
 
 	<NewOptionsType extends Options = {}>(
 		file: string | URL,
 		options?: NewOptionsType,
-	): ExecaResultPromise<OptionsType & NewOptionsType>;
+	): ResultPromise<OptionsType & NewOptionsType>;
 };
 
 /**
@@ -28,7 +28,7 @@ When `command` is a template string, it includes both the `file` and its `argume
 
 @param file - The program/script to execute, as a string or file URL
 @param arguments - Arguments to pass to `file` on execution.
-@returns An `ExecaResultPromise` that is both:
+@returns A `ResultPromise` that is both:
 - the subprocess.
 - a `Promise` either resolving with its successful `result`, or rejecting with its `error`.
 @throws `ExecaError`

--- a/types/methods/main-sync.d.ts
+++ b/types/methods/main-sync.d.ts
@@ -1,22 +1,22 @@
 import type {SyncOptions} from '../arguments/options';
-import type {ExecaSyncResult} from '../return/result';
+import type {SyncResult} from '../return/result';
 import type {TemplateString} from './template';
 
 type ExecaSync<OptionsType extends SyncOptions> = {
 	<NewOptionsType extends SyncOptions = {}>(options: NewOptionsType): ExecaSync<OptionsType & NewOptionsType>;
 
-	(...templateString: TemplateString): ExecaSyncResult<OptionsType>;
+	(...templateString: TemplateString): SyncResult<OptionsType>;
 
 	<NewOptionsType extends SyncOptions = {}>(
 		file: string | URL,
 		arguments?: readonly string[],
 		options?: NewOptionsType,
-	): ExecaSyncResult<OptionsType & NewOptionsType>;
+	): SyncResult<OptionsType & NewOptionsType>;
 
 	<NewOptionsType extends SyncOptions = {}>(
 		file: string | URL,
 		options?: NewOptionsType,
-	): ExecaSyncResult<OptionsType & NewOptionsType>;
+	): SyncResult<OptionsType & NewOptionsType>;
 };
 
 /**
@@ -26,7 +26,7 @@ Returns or throws a subprocess `result`. The `subprocess` is not returned: its m
 
 @param file - The program/script to execute, as a string or file URL
 @param arguments - Arguments to pass to `file` on execution.
-@returns `ExecaSyncResult`
+@returns `SyncResult`
 @throws `ExecaSyncError`
 
 @example

--- a/types/methods/node.d.ts
+++ b/types/methods/node.d.ts
@@ -1,22 +1,22 @@
 import type {Options} from '../arguments/options';
-import type {ExecaResultPromise} from '../subprocess/subprocess';
+import type {ResultPromise} from '../subprocess/subprocess';
 import type {TemplateString} from './template';
 
 type ExecaNode<OptionsType extends Options> = {
 	<NewOptionsType extends Options = {}>(options: NewOptionsType): ExecaNode<OptionsType & NewOptionsType>;
 
-	(...templateString: TemplateString): ExecaResultPromise<OptionsType>;
+	(...templateString: TemplateString): ResultPromise<OptionsType>;
 
 	<NewOptionsType extends Options = {}>(
 		scriptPath: string | URL,
 		arguments?: readonly string[],
 		options?: NewOptionsType,
-	): ExecaResultPromise<OptionsType & NewOptionsType>;
+	): ResultPromise<OptionsType & NewOptionsType>;
 
 	<NewOptionsType extends Options = {}>(
 		scriptPath: string | URL,
 		options?: NewOptionsType,
-	): ExecaResultPromise<OptionsType & NewOptionsType>;
+	): ResultPromise<OptionsType & NewOptionsType>;
 };
 
 /**
@@ -29,7 +29,7 @@ This is the preferred method when executing Node.js files.
 
 @param scriptPath - Node.js script to execute, as a string or file URL
 @param arguments - Arguments to pass to `scriptPath` on execution.
-@returns An `ExecaResultPromise` that is both:
+@returns A `ResultPromise` that is both:
 - the subprocess.
 - a `Promise` either resolving with its successful `result`, or rejecting with its `error`.
 @throws `ExecaError`

--- a/types/methods/script.d.ts
+++ b/types/methods/script.d.ts
@@ -4,42 +4,42 @@ import type {
 	SyncOptions,
 	StricterOptions,
 } from '../arguments/options';
-import type {ExecaSyncResult} from '../return/result';
-import type {ExecaResultPromise} from '../subprocess/subprocess';
+import type {SyncResult} from '../return/result';
+import type {ResultPromise} from '../subprocess/subprocess';
 import type {TemplateString} from './template';
 
 type ExecaScriptCommon<OptionsType extends CommonOptions> = {
 	<NewOptionsType extends CommonOptions = {}>(options: NewOptionsType): ExecaScript<OptionsType & NewOptionsType>;
 
-	(...templateString: TemplateString): ExecaResultPromise<StricterOptions<OptionsType, Options>>;
+	(...templateString: TemplateString): ResultPromise<StricterOptions<OptionsType, Options>>;
 
 	<NewOptionsType extends Options = {}>(
 		file: string | URL,
 		arguments?: readonly string[],
 		options?: NewOptionsType,
-	): ExecaResultPromise<StricterOptions<OptionsType & NewOptionsType, Options>>;
+	): ResultPromise<StricterOptions<OptionsType & NewOptionsType, Options>>;
 
 	<NewOptionsType extends Options = {}>(
 		file: string | URL,
 		options?: NewOptionsType,
-	): ExecaResultPromise<StricterOptions<OptionsType & NewOptionsType, Options>>;
+	): ResultPromise<StricterOptions<OptionsType & NewOptionsType, Options>>;
 };
 
 type ExecaScriptSync<OptionsType extends CommonOptions> = {
 	<NewOptionsType extends SyncOptions = {}>(options: NewOptionsType): ExecaScriptSync<OptionsType & NewOptionsType>;
 
-	(...templateString: TemplateString): ExecaSyncResult<StricterOptions<OptionsType, SyncOptions>>;
+	(...templateString: TemplateString): SyncResult<StricterOptions<OptionsType, SyncOptions>>;
 
 	<NewOptionsType extends SyncOptions = {}>(
 		file: string | URL,
 		arguments?: readonly string[],
 		options?: NewOptionsType,
-	): ExecaSyncResult<StricterOptions<OptionsType & NewOptionsType, SyncOptions>>;
+	): SyncResult<StricterOptions<OptionsType & NewOptionsType, SyncOptions>>;
 
 	<NewOptionsType extends SyncOptions = {}>(
 		file: string | URL,
 		options?: NewOptionsType,
-	): ExecaSyncResult<StricterOptions<OptionsType & NewOptionsType, SyncOptions>>;
+	): SyncResult<StricterOptions<OptionsType & NewOptionsType, SyncOptions>>;
 };
 
 type ExecaScript<OptionsType extends CommonOptions> = {
@@ -54,7 +54,7 @@ Just like `execa()`, this can use the template string syntax or bind options. It
 
 This is the preferred method when executing multiple commands in a script file.
 
-@returns An `ExecaResultPromise` that is both:
+@returns A `ResultPromise` that is both:
 - the subprocess.
 - a `Promise` either resolving with its successful `result`, or rejecting with its `error`.
 @throws `ExecaError`

--- a/types/pipe.d.ts
+++ b/types/pipe.d.ts
@@ -1,7 +1,7 @@
 import type {Options} from './arguments/options';
-import type {ExecaResult} from './return/result';
+import type {Result} from './return/result';
 import type {FromOption, ToOption} from './arguments/fd-options';
-import type {ExecaResultPromise} from './subprocess/subprocess';
+import type {ResultPromise} from './subprocess/subprocess';
 import type {TemplateExpression} from './methods/template';
 
 // `subprocess.pipe()` options
@@ -35,24 +35,24 @@ export type PipableSubprocess = {
 		file: string | URL,
 		arguments?: readonly string[],
 		options?: OptionsType,
-	): Promise<ExecaResult<OptionsType>> & PipableSubprocess;
+	): Promise<Result<OptionsType>> & PipableSubprocess;
 	pipe<OptionsType extends Options & PipeOptions = {}>(
 		file: string | URL,
 		options?: OptionsType,
-	): Promise<ExecaResult<OptionsType>> & PipableSubprocess;
+	): Promise<Result<OptionsType>> & PipableSubprocess;
 
 	/**
 	Like `subprocess.pipe(file, arguments?, options?)` but using a `command` template string instead. This follows the same syntax as `$`.
 	*/
 	pipe(templates: TemplateStringsArray, ...expressions: readonly TemplateExpression[]):
-	Promise<ExecaResult<{}>> & PipableSubprocess;
+	Promise<Result<{}>> & PipableSubprocess;
 	pipe<OptionsType extends Options & PipeOptions = {}>(options: OptionsType):
 	(templates: TemplateStringsArray, ...expressions: readonly TemplateExpression[])
-	=> Promise<ExecaResult<OptionsType>> & PipableSubprocess;
+	=> Promise<Result<OptionsType>> & PipableSubprocess;
 
 	/**
 	Like `subprocess.pipe(file, arguments?, options?)` but using the return value of another `execa()` call instead.
 	*/
-	pipe<Destination extends ExecaResultPromise>(destination: Destination, options?: PipeOptions):
+	pipe<Destination extends ResultPromise>(destination: Destination, options?: PipeOptions):
 	Promise<Awaited<Destination>> & PipableSubprocess;
 };

--- a/types/return/result.d.ts
+++ b/types/return/result.d.ts
@@ -52,7 +52,7 @@ export declare abstract class CommonResult<
 
 	This array is initially empty and is populated each time the `subprocess.pipe()` method resolves.
 	*/
-	pipedFrom: Unless<IsSync, ExecaResult[], []>;
+	pipedFrom: Unless<IsSync, Result[], []>;
 
 	/**
 	The file and arguments that were run.
@@ -179,11 +179,11 @@ Result of a subprocess successful execution.
 
 When the subprocess fails, it is rejected with an `ExecaError` instead.
 */
-export type ExecaResult<OptionsType extends Options = Options> = SuccessResult<false, OptionsType>;
+export type Result<OptionsType extends Options = Options> = SuccessResult<false, OptionsType>;
 
 /**
 Result of a subprocess successful execution.
 
 When the subprocess fails, it is rejected with an `ExecaError` instead.
 */
-export type ExecaSyncResult<OptionsType extends SyncOptions = SyncOptions> = SuccessResult<true, OptionsType>;
+export type SyncResult<OptionsType extends SyncOptions = SyncOptions> = SuccessResult<true, OptionsType>;

--- a/types/subprocess/subprocess.d.ts
+++ b/types/subprocess/subprocess.d.ts
@@ -2,7 +2,7 @@ import type {ChildProcess} from 'node:child_process';
 import type {Readable, Writable, Duplex} from 'node:stream';
 import type {StdioOptionsArray} from '../stdio/type';
 import type {Options} from '../arguments/options';
-import type {ExecaResult} from '../return/result';
+import type {Result} from '../return/result';
 import type {PipableSubprocess} from '../pipe';
 import type {
 	ReadableOptions,
@@ -118,7 +118,7 @@ type ExecaCustomSubprocess<OptionsType extends Options = Options> = {
 /**
 [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess) with additional methods and properties.
 */
-export type ExecaSubprocess<OptionsType extends Options = Options> =
+export type Subprocess<OptionsType extends Options = Options> =
 	& Omit<ChildProcess, keyof ExecaCustomSubprocess<OptionsType>>
 	& ExecaCustomSubprocess<OptionsType>;
 
@@ -127,6 +127,6 @@ The return value of all asynchronous methods is both:
 - the subprocess.
 - a `Promise` either resolving with its successful `result`, or rejecting with its `error`.
 */
-export type ExecaResultPromise<OptionsType extends Options = Options> =
-	& ExecaSubprocess<OptionsType>
-	& Promise<ExecaResult<OptionsType>>;
+export type ResultPromise<OptionsType extends Options = Options> =
+	& Subprocess<OptionsType>
+	& Promise<Result<OptionsType>>;


### PR DESCRIPTION
This PR renames the following types:
  - `ExecaSubprocess` -> `Subprocess`
  - `ExecaResultPromise` -> `ResultPromise`
  - `ExecaResult` -> `Result`
  - `ExecaSyncResult` -> `SyncResult`

Those 4 types are already being renamed by the upcoming release, those were previously named `ExecaChildProcess`, `ExecaChildPromise`, `ExecaReturnValue` and `ExecaSyncReturnValue`. So this PR does not introduce a new breaking change.

Namespacing the types with the library's name is not necessary. The module system, i.e. calling `import 'execa'`, already provides with that namespace. If two libraries export the same type name, the user can use `import {Result as ...}` to resolve the naming conflict.

Also, the `Options` and `SyncOptions` types are not prefixed with `Execa`, so we're being inconsistent.