### PR TITLE
Rename a few more types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 export type {
 	StdinOption,
-	StdinOptionSync,
+	StdinSyncOption,
 	StdoutStderrOption,
-	StdoutStderrOptionSync,
+	StdoutStderrSyncOption,
 } from './types/stdio/type';
 export type {Options, SyncOptions} from './types/arguments/options';
 export type {Result, SyncResult} from './types/return/result';

--- a/test-d/stdio/direction.test-d.ts
+++ b/test-d/stdio/direction.test-d.ts
@@ -4,9 +4,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../index.js';
 
 await execa('unicorns', {stdio: [new Readable(), 'pipe', 'pipe']});
@@ -36,6 +36,6 @@ expectError(await execa('unicorns', {stdio: [['pipe'], ['pipe'], [new Readable()
 expectError(execaSync('unicorns', {stdio: [['pipe'], ['pipe'], [new Readable()]]}));
 
 expectAssignable<StdinOption | StdoutStderrOption>([new Uint8Array(), new Uint8Array()]);
-expectAssignable<StdinOptionSync | StdoutStderrOptionSync>([new Uint8Array(), new Uint8Array()]);
+expectAssignable<StdinSyncOption | StdoutStderrSyncOption>([new Uint8Array(), new Uint8Array()]);
 expectNotAssignable<StdinOption | StdoutStderrOption>([new Writable(), new Uint8Array()]);
-expectNotAssignable<StdinOptionSync | StdoutStderrOptionSync>([new Writable(), new Uint8Array()]);
+expectNotAssignable<StdinSyncOption | StdoutStderrSyncOption>([new Writable(), new Uint8Array()]);

--- a/test-d/stdio/option/array-binary.test-d.ts
+++ b/test-d/stdio/option/array-binary.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const binaryArray = [new Uint8Array(), new Uint8Array()] as const;
@@ -25,7 +25,7 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [[binaryArray]]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [[binaryArray]]]}));
 
 expectAssignable<StdinOption>([binaryArray]);
-expectAssignable<StdinOptionSync>([binaryArray]);
+expectAssignable<StdinSyncOption>([binaryArray]);
 
 expectNotAssignable<StdoutStderrOption>([binaryArray]);
-expectNotAssignable<StdoutStderrOptionSync>([binaryArray]);
+expectNotAssignable<StdoutStderrSyncOption>([binaryArray]);

--- a/test-d/stdio/option/array-object.test-d.ts
+++ b/test-d/stdio/option/array-object.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const objectArray = [{}, {}] as const;
@@ -25,7 +25,7 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [[objectArray]]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [[objectArray]]]}));
 
 expectAssignable<StdinOption>([objectArray]);
-expectAssignable<StdinOptionSync>([objectArray]);
+expectAssignable<StdinSyncOption>([objectArray]);
 
 expectNotAssignable<StdoutStderrOption>([objectArray]);
-expectNotAssignable<StdoutStderrOptionSync>([objectArray]);
+expectNotAssignable<StdoutStderrSyncOption>([objectArray]);

--- a/test-d/stdio/option/array-string.test-d.ts
+++ b/test-d/stdio/option/array-string.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const stringArray = ['foo', 'bar'] as const;
@@ -25,7 +25,7 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [[stringArray]]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [[stringArray]]]}));
 
 expectAssignable<StdinOption>([stringArray]);
-expectAssignable<StdinOptionSync>([stringArray]);
+expectAssignable<StdinSyncOption>([stringArray]);
 
 expectNotAssignable<StdoutStderrOption>([stringArray]);
-expectNotAssignable<StdoutStderrOptionSync>([stringArray]);
+expectNotAssignable<StdoutStderrSyncOption>([stringArray]);

--- a/test-d/stdio/option/duplex-invalid.test-d.ts
+++ b/test-d/stdio/option/duplex-invalid.test-d.ts
@@ -4,9 +4,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const duplexWithInvalidObjectMode = {
@@ -38,11 +38,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [duplexWith
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [duplexWithInvalidObjectMode]]}));
 
 expectNotAssignable<StdinOption>(duplexWithInvalidObjectMode);
-expectNotAssignable<StdinOptionSync>(duplexWithInvalidObjectMode);
+expectNotAssignable<StdinSyncOption>(duplexWithInvalidObjectMode);
 expectNotAssignable<StdinOption>([duplexWithInvalidObjectMode]);
-expectNotAssignable<StdinOptionSync>([duplexWithInvalidObjectMode]);
+expectNotAssignable<StdinSyncOption>([duplexWithInvalidObjectMode]);
 
 expectNotAssignable<StdoutStderrOption>(duplexWithInvalidObjectMode);
-expectNotAssignable<StdoutStderrOptionSync>(duplexWithInvalidObjectMode);
+expectNotAssignable<StdoutStderrSyncOption>(duplexWithInvalidObjectMode);
 expectNotAssignable<StdoutStderrOption>([duplexWithInvalidObjectMode]);
-expectNotAssignable<StdoutStderrOptionSync>([duplexWithInvalidObjectMode]);
+expectNotAssignable<StdoutStderrSyncOption>([duplexWithInvalidObjectMode]);

--- a/test-d/stdio/option/duplex-object.test-d.ts
+++ b/test-d/stdio/option/duplex-object.test-d.ts
@@ -4,9 +4,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const duplexObjectProperty = {
@@ -38,11 +38,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [duplexObjectProperty]]
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [duplexObjectProperty]]}));
 
 expectAssignable<StdinOption>(duplexObjectProperty);
-expectNotAssignable<StdinOptionSync>(duplexObjectProperty);
+expectNotAssignable<StdinSyncOption>(duplexObjectProperty);
 expectAssignable<StdinOption>([duplexObjectProperty]);
-expectNotAssignable<StdinOptionSync>([duplexObjectProperty]);
+expectNotAssignable<StdinSyncOption>([duplexObjectProperty]);
 
 expectAssignable<StdoutStderrOption>(duplexObjectProperty);
-expectNotAssignable<StdoutStderrOptionSync>(duplexObjectProperty);
+expectNotAssignable<StdoutStderrSyncOption>(duplexObjectProperty);
 expectAssignable<StdoutStderrOption>([duplexObjectProperty]);
-expectNotAssignable<StdoutStderrOptionSync>([duplexObjectProperty]);
+expectNotAssignable<StdoutStderrSyncOption>([duplexObjectProperty]);

--- a/test-d/stdio/option/duplex-transform.test-d.ts
+++ b/test-d/stdio/option/duplex-transform.test-d.ts
@@ -4,9 +4,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const duplexTransform = {transform: new Transform()} as const;
@@ -35,11 +35,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [duplexTransform]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [duplexTransform]]}));
 
 expectAssignable<StdinOption>(duplexTransform);
-expectNotAssignable<StdinOptionSync>(duplexTransform);
+expectNotAssignable<StdinSyncOption>(duplexTransform);
 expectAssignable<StdinOption>([duplexTransform]);
-expectNotAssignable<StdinOptionSync>([duplexTransform]);
+expectNotAssignable<StdinSyncOption>([duplexTransform]);
 
 expectAssignable<StdoutStderrOption>(duplexTransform);
-expectNotAssignable<StdoutStderrOptionSync>(duplexTransform);
+expectNotAssignable<StdoutStderrSyncOption>(duplexTransform);
 expectAssignable<StdoutStderrOption>([duplexTransform]);
-expectNotAssignable<StdoutStderrOptionSync>([duplexTransform]);
+expectNotAssignable<StdoutStderrSyncOption>([duplexTransform]);

--- a/test-d/stdio/option/duplex.test-d.ts
+++ b/test-d/stdio/option/duplex.test-d.ts
@@ -4,9 +4,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const duplex = {transform: new Duplex()} as const;
@@ -35,11 +35,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [duplex]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [duplex]]}));
 
 expectAssignable<StdinOption>(duplex);
-expectNotAssignable<StdinOptionSync>(duplex);
+expectNotAssignable<StdinSyncOption>(duplex);
 expectAssignable<StdinOption>([duplex]);
-expectNotAssignable<StdinOptionSync>([duplex]);
+expectNotAssignable<StdinSyncOption>([duplex]);
 
 expectAssignable<StdoutStderrOption>(duplex);
-expectNotAssignable<StdoutStderrOptionSync>(duplex);
+expectNotAssignable<StdoutStderrSyncOption>(duplex);
 expectAssignable<StdoutStderrOption>([duplex]);
-expectNotAssignable<StdoutStderrOptionSync>([duplex]);
+expectNotAssignable<StdoutStderrSyncOption>([duplex]);

--- a/test-d/stdio/option/fd-integer-0.test-d.ts
+++ b/test-d/stdio/option/fd-integer-0.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 0});
@@ -32,21 +32,21 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [0]]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [0]]});
 
 expectAssignable<StdinOption>(0);
-expectAssignable<StdinOptionSync>(0);
+expectAssignable<StdinSyncOption>(0);
 expectAssignable<StdinOption>([0]);
-expectAssignable<StdinOptionSync>([0]);
+expectAssignable<StdinSyncOption>([0]);
 
 expectNotAssignable<StdinOption>(0.5);
-expectNotAssignable<StdinOptionSync>(-1);
+expectNotAssignable<StdinSyncOption>(-1);
 expectNotAssignable<StdinOption>(Number.POSITIVE_INFINITY);
-expectNotAssignable<StdinOptionSync>(Number.NaN);
+expectNotAssignable<StdinSyncOption>(Number.NaN);
 
 expectNotAssignable<StdoutStderrOption>(0);
-expectNotAssignable<StdoutStderrOptionSync>(0);
+expectNotAssignable<StdoutStderrSyncOption>(0);
 expectNotAssignable<StdoutStderrOption>([0]);
-expectNotAssignable<StdoutStderrOptionSync>([0]);
+expectNotAssignable<StdoutStderrSyncOption>([0]);
 
 expectNotAssignable<StdoutStderrOption>(0.5);
-expectNotAssignable<StdoutStderrOptionSync>(-1);
+expectNotAssignable<StdoutStderrSyncOption>(-1);
 expectNotAssignable<StdoutStderrOption>(Number.POSITIVE_INFINITY);
-expectNotAssignable<StdoutStderrOptionSync>(Number.NaN);
+expectNotAssignable<StdoutStderrSyncOption>(Number.NaN);

--- a/test-d/stdio/option/fd-integer-1.test-d.ts
+++ b/test-d/stdio/option/fd-integer-1.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: 1}));
@@ -32,11 +32,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [1]]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [1]]});
 
 expectNotAssignable<StdinOption>(1);
-expectNotAssignable<StdinOptionSync>(1);
+expectNotAssignable<StdinSyncOption>(1);
 expectNotAssignable<StdinOption>([1]);
-expectNotAssignable<StdinOptionSync>([1]);
+expectNotAssignable<StdinSyncOption>([1]);
 
 expectAssignable<StdoutStderrOption>(1);
-expectAssignable<StdoutStderrOptionSync>(1);
+expectAssignable<StdoutStderrSyncOption>(1);
 expectAssignable<StdoutStderrOption>([1]);
-expectAssignable<StdoutStderrOptionSync>([1]);
+expectAssignable<StdoutStderrSyncOption>([1]);

--- a/test-d/stdio/option/fd-integer-2.test-d.ts
+++ b/test-d/stdio/option/fd-integer-2.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: 2}));
@@ -32,11 +32,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [2]]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [2]]});
 
 expectNotAssignable<StdinOption>(2);
-expectNotAssignable<StdinOptionSync>(2);
+expectNotAssignable<StdinSyncOption>(2);
 expectNotAssignable<StdinOption>([2]);
-expectNotAssignable<StdinOptionSync>([2]);
+expectNotAssignable<StdinSyncOption>([2]);
 
 expectAssignable<StdoutStderrOption>(2);
-expectAssignable<StdoutStderrOptionSync>(2);
+expectAssignable<StdoutStderrSyncOption>(2);
 expectAssignable<StdoutStderrOption>([2]);
-expectAssignable<StdoutStderrOptionSync>([2]);
+expectAssignable<StdoutStderrSyncOption>([2]);

--- a/test-d/stdio/option/fd-integer-3.test-d.ts
+++ b/test-d/stdio/option/fd-integer-3.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 3});
@@ -32,11 +32,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [3]]}));
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [3]]});
 
 expectAssignable<StdinOption>(3);
-expectAssignable<StdinOptionSync>(3);
+expectAssignable<StdinSyncOption>(3);
 expectNotAssignable<StdinOption>([3]);
-expectAssignable<StdinOptionSync>([3]);
+expectAssignable<StdinSyncOption>([3]);
 
 expectAssignable<StdoutStderrOption>(3);
-expectAssignable<StdoutStderrOptionSync>(3);
+expectAssignable<StdoutStderrSyncOption>(3);
 expectNotAssignable<StdoutStderrOption>([3]);
-expectAssignable<StdoutStderrOptionSync>([3]);
+expectAssignable<StdoutStderrSyncOption>([3]);

--- a/test-d/stdio/option/file-object-invalid.test-d.ts
+++ b/test-d/stdio/option/file-object-invalid.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const invalidFileObject = {file: new URL('file:///test')} as const;
@@ -34,11 +34,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [invalidFil
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [invalidFileObject]]}));
 
 expectNotAssignable<StdinOption>(invalidFileObject);
-expectNotAssignable<StdinOptionSync>(invalidFileObject);
+expectNotAssignable<StdinSyncOption>(invalidFileObject);
 expectNotAssignable<StdinOption>([invalidFileObject]);
-expectNotAssignable<StdinOptionSync>([invalidFileObject]);
+expectNotAssignable<StdinSyncOption>([invalidFileObject]);
 
 expectNotAssignable<StdoutStderrOption>(invalidFileObject);
-expectNotAssignable<StdoutStderrOptionSync>(invalidFileObject);
+expectNotAssignable<StdoutStderrSyncOption>(invalidFileObject);
 expectNotAssignable<StdoutStderrOption>([invalidFileObject]);
-expectNotAssignable<StdoutStderrOptionSync>([invalidFileObject]);
+expectNotAssignable<StdoutStderrSyncOption>([invalidFileObject]);

--- a/test-d/stdio/option/file-object.test-d.ts
+++ b/test-d/stdio/option/file-object.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const fileObject = {file: './test'} as const;
@@ -34,11 +34,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [fileObject]]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [fileObject]]});
 
 expectAssignable<StdinOption>(fileObject);
-expectAssignable<StdinOptionSync>(fileObject);
+expectAssignable<StdinSyncOption>(fileObject);
 expectAssignable<StdinOption>([fileObject]);
-expectAssignable<StdinOptionSync>([fileObject]);
+expectAssignable<StdinSyncOption>([fileObject]);
 
 expectAssignable<StdoutStderrOption>(fileObject);
-expectAssignable<StdoutStderrOptionSync>(fileObject);
+expectAssignable<StdoutStderrSyncOption>(fileObject);
 expectAssignable<StdoutStderrOption>([fileObject]);
-expectAssignable<StdoutStderrOptionSync>([fileObject]);
+expectAssignable<StdoutStderrSyncOption>([fileObject]);

--- a/test-d/stdio/option/file-url.test-d.ts
+++ b/test-d/stdio/option/file-url.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const fileUrl = new URL('file:///test');
@@ -34,11 +34,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [fileUrl]]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [fileUrl]]});
 
 expectAssignable<StdinOption>(fileUrl);
-expectAssignable<StdinOptionSync>(fileUrl);
+expectAssignable<StdinSyncOption>(fileUrl);
 expectAssignable<StdinOption>([fileUrl]);
-expectAssignable<StdinOptionSync>([fileUrl]);
+expectAssignable<StdinSyncOption>([fileUrl]);
 
 expectAssignable<StdoutStderrOption>(fileUrl);
-expectAssignable<StdoutStderrOptionSync>(fileUrl);
+expectAssignable<StdoutStderrSyncOption>(fileUrl);
 expectAssignable<StdoutStderrOption>([fileUrl]);
-expectAssignable<StdoutStderrOptionSync>([fileUrl]);
+expectAssignable<StdoutStderrSyncOption>([fileUrl]);

--- a/test-d/stdio/option/final-async-full.test-d.ts
+++ b/test-d/stdio/option/final-async-full.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const asyncFinalFull = {
@@ -41,11 +41,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncFinalFull]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncFinalFull]]}));
 
 expectAssignable<StdinOption>(asyncFinalFull);
-expectNotAssignable<StdinOptionSync>(asyncFinalFull);
+expectNotAssignable<StdinSyncOption>(asyncFinalFull);
 expectAssignable<StdinOption>([asyncFinalFull]);
-expectNotAssignable<StdinOptionSync>([asyncFinalFull]);
+expectNotAssignable<StdinSyncOption>([asyncFinalFull]);
 
 expectAssignable<StdoutStderrOption>(asyncFinalFull);
-expectNotAssignable<StdoutStderrOptionSync>(asyncFinalFull);
+expectNotAssignable<StdoutStderrSyncOption>(asyncFinalFull);
 expectAssignable<StdoutStderrOption>([asyncFinalFull]);
-expectNotAssignable<StdoutStderrOptionSync>([asyncFinalFull]);
+expectNotAssignable<StdoutStderrSyncOption>([asyncFinalFull]);

--- a/test-d/stdio/option/final-invalid-full.test-d.ts
+++ b/test-d/stdio/option/final-invalid-full.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const invalidReturnFinalFull = {
@@ -42,11 +42,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [invalidRet
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [invalidReturnFinalFull]]}));
 
 expectNotAssignable<StdinOption>(invalidReturnFinalFull);
-expectNotAssignable<StdinOptionSync>(invalidReturnFinalFull);
+expectNotAssignable<StdinSyncOption>(invalidReturnFinalFull);
 expectNotAssignable<StdinOption>([invalidReturnFinalFull]);
-expectNotAssignable<StdinOptionSync>([invalidReturnFinalFull]);
+expectNotAssignable<StdinSyncOption>([invalidReturnFinalFull]);
 
 expectNotAssignable<StdoutStderrOption>(invalidReturnFinalFull);
-expectNotAssignable<StdoutStderrOptionSync>(invalidReturnFinalFull);
+expectNotAssignable<StdoutStderrSyncOption>(invalidReturnFinalFull);
 expectNotAssignable<StdoutStderrOption>([invalidReturnFinalFull]);
-expectNotAssignable<StdoutStderrOptionSync>([invalidReturnFinalFull]);
+expectNotAssignable<StdoutStderrSyncOption>([invalidReturnFinalFull]);

--- a/test-d/stdio/option/final-object-full.test-d.ts
+++ b/test-d/stdio/option/final-object-full.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const objectFinalFull = {
@@ -42,11 +42,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [objectFinalFull]]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [objectFinalFull]]});
 
 expectAssignable<StdinOption>(objectFinalFull);
-expectAssignable<StdinOptionSync>(objectFinalFull);
+expectAssignable<StdinSyncOption>(objectFinalFull);
 expectAssignable<StdinOption>([objectFinalFull]);
-expectAssignable<StdinOptionSync>([objectFinalFull]);
+expectAssignable<StdinSyncOption>([objectFinalFull]);
 
 expectAssignable<StdoutStderrOption>(objectFinalFull);
-expectAssignable<StdoutStderrOptionSync>(objectFinalFull);
+expectAssignable<StdoutStderrSyncOption>(objectFinalFull);
 expectAssignable<StdoutStderrOption>([objectFinalFull]);
-expectAssignable<StdoutStderrOptionSync>([objectFinalFull]);
+expectAssignable<StdoutStderrSyncOption>([objectFinalFull]);

--- a/test-d/stdio/option/final-unknown-full.test-d.ts
+++ b/test-d/stdio/option/final-unknown-full.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const unknownFinalFull = {
@@ -42,11 +42,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [unknownFinalFull]]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [unknownFinalFull]]});
 
 expectAssignable<StdinOption>(unknownFinalFull);
-expectAssignable<StdinOptionSync>(unknownFinalFull);
+expectAssignable<StdinSyncOption>(unknownFinalFull);
 expectAssignable<StdinOption>([unknownFinalFull]);
-expectAssignable<StdinOptionSync>([unknownFinalFull]);
+expectAssignable<StdinSyncOption>([unknownFinalFull]);
 
 expectAssignable<StdoutStderrOption>(unknownFinalFull);
-expectAssignable<StdoutStderrOptionSync>(unknownFinalFull);
+expectAssignable<StdoutStderrSyncOption>(unknownFinalFull);
 expectAssignable<StdoutStderrOption>([unknownFinalFull]);
-expectAssignable<StdoutStderrOptionSync>([unknownFinalFull]);
+expectAssignable<StdoutStderrSyncOption>([unknownFinalFull]);

--- a/test-d/stdio/option/generator-async-full.test-d.ts
+++ b/test-d/stdio/option/generator-async-full.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const asyncGeneratorFull = {
@@ -38,11 +38,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncGeneratorFull]]})
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncGeneratorFull]]}));
 
 expectAssignable<StdinOption>(asyncGeneratorFull);
-expectNotAssignable<StdinOptionSync>(asyncGeneratorFull);
+expectNotAssignable<StdinSyncOption>(asyncGeneratorFull);
 expectAssignable<StdinOption>([asyncGeneratorFull]);
-expectNotAssignable<StdinOptionSync>([asyncGeneratorFull]);
+expectNotAssignable<StdinSyncOption>([asyncGeneratorFull]);
 
 expectAssignable<StdoutStderrOption>(asyncGeneratorFull);
-expectNotAssignable<StdoutStderrOptionSync>(asyncGeneratorFull);
+expectNotAssignable<StdoutStderrSyncOption>(asyncGeneratorFull);
 expectAssignable<StdoutStderrOption>([asyncGeneratorFull]);
-expectNotAssignable<StdoutStderrOptionSync>([asyncGeneratorFull]);
+expectNotAssignable<StdoutStderrSyncOption>([asyncGeneratorFull]);

--- a/test-d/stdio/option/generator-async.test-d.ts
+++ b/test-d/stdio/option/generator-async.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const asyncGenerator = async function * (line: unknown) {
@@ -36,11 +36,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncGenerator]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncGenerator]]}));
 
 expectAssignable<StdinOption>(asyncGenerator);
-expectNotAssignable<StdinOptionSync>(asyncGenerator);
+expectNotAssignable<StdinSyncOption>(asyncGenerator);
 expectAssignable<StdinOption>([asyncGenerator]);
-expectNotAssignable<StdinOptionSync>([asyncGenerator]);
+expectNotAssignable<StdinSyncOption>([asyncGenerator]);
 
 expectAssignable<StdoutStderrOption>(asyncGenerator);
-expectNotAssignable<StdoutStderrOptionSync>(asyncGenerator);
+expectNotAssignable<StdoutStderrSyncOption>(asyncGenerator);
 expectAssignable<StdoutStderrOption>([asyncGenerator]);
-expectNotAssignable<StdoutStderrOptionSync>([asyncGenerator]);
+expectNotAssignable<StdoutStderrSyncOption>([asyncGenerator]);

--- a/test-d/stdio/option/generator-binary-invalid.test-d.ts
+++ b/test-d/stdio/option/generator-binary-invalid.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const transformWithInvalidBinary = {
@@ -39,11 +39,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformW
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformWithInvalidBinary]]}));
 
 expectNotAssignable<StdinOption>(transformWithInvalidBinary);
-expectNotAssignable<StdinOptionSync>(transformWithInvalidBinary);
+expectNotAssignable<StdinSyncOption>(transformWithInvalidBinary);
 expectNotAssignable<StdinOption>([transformWithInvalidBinary]);
-expectNotAssignable<StdinOptionSync>([transformWithInvalidBinary]);
+expectNotAssignable<StdinSyncOption>([transformWithInvalidBinary]);
 
 expectNotAssignable<StdoutStderrOption>(transformWithInvalidBinary);
-expectNotAssignable<StdoutStderrOptionSync>(transformWithInvalidBinary);
+expectNotAssignable<StdoutStderrSyncOption>(transformWithInvalidBinary);
 expectNotAssignable<StdoutStderrOption>([transformWithInvalidBinary]);
-expectNotAssignable<StdoutStderrOptionSync>([transformWithInvalidBinary]);
+expectNotAssignable<StdoutStderrSyncOption>([transformWithInvalidBinary]);

--- a/test-d/stdio/option/generator-binary.test-d.ts
+++ b/test-d/stdio/option/generator-binary.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const transformWithBinary = {
@@ -39,11 +39,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformWithBinary]]}
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformWithBinary]]});
 
 expectAssignable<StdinOption>(transformWithBinary);
-expectAssignable<StdinOptionSync>(transformWithBinary);
+expectAssignable<StdinSyncOption>(transformWithBinary);
 expectAssignable<StdinOption>([transformWithBinary]);
-expectAssignable<StdinOptionSync>([transformWithBinary]);
+expectAssignable<StdinSyncOption>([transformWithBinary]);
 
 expectAssignable<StdoutStderrOption>(transformWithBinary);
-expectAssignable<StdoutStderrOptionSync>(transformWithBinary);
+expectAssignable<StdoutStderrSyncOption>(transformWithBinary);
 expectAssignable<StdoutStderrOption>([transformWithBinary]);
-expectAssignable<StdoutStderrOptionSync>([transformWithBinary]);
+expectAssignable<StdoutStderrSyncOption>([transformWithBinary]);

--- a/test-d/stdio/option/generator-boolean-full.test-d.ts
+++ b/test-d/stdio/option/generator-boolean-full.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const booleanGeneratorFull = {
@@ -38,11 +38,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [booleanGen
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [booleanGeneratorFull]]}));
 
 expectNotAssignable<StdinOption>(booleanGeneratorFull);
-expectNotAssignable<StdinOptionSync>(booleanGeneratorFull);
+expectNotAssignable<StdinSyncOption>(booleanGeneratorFull);
 expectNotAssignable<StdinOption>([booleanGeneratorFull]);
-expectNotAssignable<StdinOptionSync>([booleanGeneratorFull]);
+expectNotAssignable<StdinSyncOption>([booleanGeneratorFull]);
 
 expectNotAssignable<StdoutStderrOption>(booleanGeneratorFull);
-expectNotAssignable<StdoutStderrOptionSync>(booleanGeneratorFull);
+expectNotAssignable<StdoutStderrSyncOption>(booleanGeneratorFull);
 expectNotAssignable<StdoutStderrOption>([booleanGeneratorFull]);
-expectNotAssignable<StdoutStderrOptionSync>([booleanGeneratorFull]);
+expectNotAssignable<StdoutStderrSyncOption>([booleanGeneratorFull]);

--- a/test-d/stdio/option/generator-boolean.test-d.ts
+++ b/test-d/stdio/option/generator-boolean.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const booleanGenerator = function * (line: boolean) {
@@ -36,11 +36,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [booleanGen
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [booleanGenerator]]}));
 
 expectNotAssignable<StdinOption>(booleanGenerator);
-expectNotAssignable<StdinOptionSync>(booleanGenerator);
+expectNotAssignable<StdinSyncOption>(booleanGenerator);
 expectNotAssignable<StdinOption>([booleanGenerator]);
-expectNotAssignable<StdinOptionSync>([booleanGenerator]);
+expectNotAssignable<StdinSyncOption>([booleanGenerator]);
 
 expectNotAssignable<StdoutStderrOption>(booleanGenerator);
-expectNotAssignable<StdoutStderrOptionSync>(booleanGenerator);
+expectNotAssignable<StdoutStderrSyncOption>(booleanGenerator);
 expectNotAssignable<StdoutStderrOption>([booleanGenerator]);
-expectNotAssignable<StdoutStderrOptionSync>([booleanGenerator]);
+expectNotAssignable<StdoutStderrSyncOption>([booleanGenerator]);

--- a/test-d/stdio/option/generator-empty.test-d.ts
+++ b/test-d/stdio/option/generator-empty.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: {}}));
@@ -32,11 +32,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [{}]]}));
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [{}]]}));
 
 expectNotAssignable<StdinOption>({});
-expectNotAssignable<StdinOptionSync>({});
+expectNotAssignable<StdinSyncOption>({});
 expectNotAssignable<StdinOption>([{}]);
-expectNotAssignable<StdinOptionSync>([{}]);
+expectNotAssignable<StdinSyncOption>([{}]);
 
 expectNotAssignable<StdoutStderrOption>({});
-expectNotAssignable<StdoutStderrOptionSync>({});
+expectNotAssignable<StdoutStderrSyncOption>({});
 expectNotAssignable<StdoutStderrOption>([{}]);
-expectNotAssignable<StdoutStderrOptionSync>([{}]);
+expectNotAssignable<StdoutStderrSyncOption>([{}]);

--- a/test-d/stdio/option/generator-invalid-full.test-d.ts
+++ b/test-d/stdio/option/generator-invalid-full.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const invalidReturnGeneratorFull = {
@@ -39,11 +39,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [invalidRet
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [invalidReturnGeneratorFull]]}));
 
 expectNotAssignable<StdinOption>(invalidReturnGeneratorFull);
-expectNotAssignable<StdinOptionSync>(invalidReturnGeneratorFull);
+expectNotAssignable<StdinSyncOption>(invalidReturnGeneratorFull);
 expectNotAssignable<StdinOption>([invalidReturnGeneratorFull]);
-expectNotAssignable<StdinOptionSync>([invalidReturnGeneratorFull]);
+expectNotAssignable<StdinSyncOption>([invalidReturnGeneratorFull]);
 
 expectNotAssignable<StdoutStderrOption>(invalidReturnGeneratorFull);
-expectNotAssignable<StdoutStderrOptionSync>(invalidReturnGeneratorFull);
+expectNotAssignable<StdoutStderrSyncOption>(invalidReturnGeneratorFull);
 expectNotAssignable<StdoutStderrOption>([invalidReturnGeneratorFull]);
-expectNotAssignable<StdoutStderrOptionSync>([invalidReturnGeneratorFull]);
+expectNotAssignable<StdoutStderrSyncOption>([invalidReturnGeneratorFull]);

--- a/test-d/stdio/option/generator-invalid.test-d.ts
+++ b/test-d/stdio/option/generator-invalid.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const invalidReturnGenerator = function * (line: unknown) {
@@ -37,11 +37,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [invalidRet
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [invalidReturnGenerator]]}));
 
 expectNotAssignable<StdinOption>(invalidReturnGenerator);
-expectNotAssignable<StdinOptionSync>(invalidReturnGenerator);
+expectNotAssignable<StdinSyncOption>(invalidReturnGenerator);
 expectNotAssignable<StdinOption>([invalidReturnGenerator]);
-expectNotAssignable<StdinOptionSync>([invalidReturnGenerator]);
+expectNotAssignable<StdinSyncOption>([invalidReturnGenerator]);
 
 expectNotAssignable<StdoutStderrOption>(invalidReturnGenerator);
-expectNotAssignable<StdoutStderrOptionSync>(invalidReturnGenerator);
+expectNotAssignable<StdoutStderrSyncOption>(invalidReturnGenerator);
 expectNotAssignable<StdoutStderrOption>([invalidReturnGenerator]);
-expectNotAssignable<StdoutStderrOptionSync>([invalidReturnGenerator]);
+expectNotAssignable<StdoutStderrSyncOption>([invalidReturnGenerator]);

--- a/test-d/stdio/option/generator-object-full.test-d.ts
+++ b/test-d/stdio/option/generator-object-full.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const objectGeneratorFull = {
@@ -39,11 +39,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [objectGeneratorFull]]}
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [objectGeneratorFull]]});
 
 expectAssignable<StdinOption>(objectGeneratorFull);
-expectAssignable<StdinOptionSync>(objectGeneratorFull);
+expectAssignable<StdinSyncOption>(objectGeneratorFull);
 expectAssignable<StdinOption>([objectGeneratorFull]);
-expectAssignable<StdinOptionSync>([objectGeneratorFull]);
+expectAssignable<StdinSyncOption>([objectGeneratorFull]);
 
 expectAssignable<StdoutStderrOption>(objectGeneratorFull);
-expectAssignable<StdoutStderrOptionSync>(objectGeneratorFull);
+expectAssignable<StdoutStderrSyncOption>(objectGeneratorFull);
 expectAssignable<StdoutStderrOption>([objectGeneratorFull]);
-expectAssignable<StdoutStderrOptionSync>([objectGeneratorFull]);
+expectAssignable<StdoutStderrSyncOption>([objectGeneratorFull]);

--- a/test-d/stdio/option/generator-object-mode-invalid.test-d.ts
+++ b/test-d/stdio/option/generator-object-mode-invalid.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const transformWithInvalidObjectMode = {
@@ -39,11 +39,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformW
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformWithInvalidObjectMode]]}));
 
 expectNotAssignable<StdinOption>(transformWithInvalidObjectMode);
-expectNotAssignable<StdinOptionSync>(transformWithInvalidObjectMode);
+expectNotAssignable<StdinSyncOption>(transformWithInvalidObjectMode);
 expectNotAssignable<StdinOption>([transformWithInvalidObjectMode]);
-expectNotAssignable<StdinOptionSync>([transformWithInvalidObjectMode]);
+expectNotAssignable<StdinSyncOption>([transformWithInvalidObjectMode]);
 
 expectNotAssignable<StdoutStderrOption>(transformWithInvalidObjectMode);
-expectNotAssignable<StdoutStderrOptionSync>(transformWithInvalidObjectMode);
+expectNotAssignable<StdoutStderrSyncOption>(transformWithInvalidObjectMode);
 expectNotAssignable<StdoutStderrOption>([transformWithInvalidObjectMode]);
-expectNotAssignable<StdoutStderrOptionSync>([transformWithInvalidObjectMode]);
+expectNotAssignable<StdoutStderrSyncOption>([transformWithInvalidObjectMode]);

--- a/test-d/stdio/option/generator-object-mode.test-d.ts
+++ b/test-d/stdio/option/generator-object-mode.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const transformWithObjectMode = {
@@ -39,11 +39,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformWithObjectMod
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformWithObjectMode]]});
 
 expectAssignable<StdinOption>(transformWithObjectMode);
-expectAssignable<StdinOptionSync>(transformWithObjectMode);
+expectAssignable<StdinSyncOption>(transformWithObjectMode);
 expectAssignable<StdinOption>([transformWithObjectMode]);
-expectAssignable<StdinOptionSync>([transformWithObjectMode]);
+expectAssignable<StdinSyncOption>([transformWithObjectMode]);
 
 expectAssignable<StdoutStderrOption>(transformWithObjectMode);
-expectAssignable<StdoutStderrOptionSync>(transformWithObjectMode);
+expectAssignable<StdoutStderrSyncOption>(transformWithObjectMode);
 expectAssignable<StdoutStderrOption>([transformWithObjectMode]);
-expectAssignable<StdoutStderrOptionSync>([transformWithObjectMode]);
+expectAssignable<StdoutStderrSyncOption>([transformWithObjectMode]);

--- a/test-d/stdio/option/generator-object.test-d.ts
+++ b/test-d/stdio/option/generator-object.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const objectGenerator = function * (line: unknown) {
@@ -36,11 +36,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [objectGenerator]]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [objectGenerator]]});
 
 expectAssignable<StdinOption>(objectGenerator);
-expectAssignable<StdinOptionSync>(objectGenerator);
+expectAssignable<StdinSyncOption>(objectGenerator);
 expectAssignable<StdinOption>([objectGenerator]);
-expectAssignable<StdinOptionSync>([objectGenerator]);
+expectAssignable<StdinSyncOption>([objectGenerator]);
 
 expectAssignable<StdoutStderrOption>(objectGenerator);
-expectAssignable<StdoutStderrOptionSync>(objectGenerator);
+expectAssignable<StdoutStderrSyncOption>(objectGenerator);
 expectAssignable<StdoutStderrOption>([objectGenerator]);
-expectAssignable<StdoutStderrOptionSync>([objectGenerator]);
+expectAssignable<StdoutStderrSyncOption>([objectGenerator]);

--- a/test-d/stdio/option/generator-only-binary.test-d.ts
+++ b/test-d/stdio/option/generator-only-binary.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const binaryOnly = {binary: true} as const;
@@ -34,11 +34,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [binaryOnly
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [binaryOnly]]}));
 
 expectNotAssignable<StdinOption>(binaryOnly);
-expectNotAssignable<StdinOptionSync>(binaryOnly);
+expectNotAssignable<StdinSyncOption>(binaryOnly);
 expectNotAssignable<StdinOption>([binaryOnly]);
-expectNotAssignable<StdinOptionSync>([binaryOnly]);
+expectNotAssignable<StdinSyncOption>([binaryOnly]);
 
 expectNotAssignable<StdoutStderrOption>(binaryOnly);
-expectNotAssignable<StdoutStderrOptionSync>(binaryOnly);
+expectNotAssignable<StdoutStderrSyncOption>(binaryOnly);
 expectNotAssignable<StdoutStderrOption>([binaryOnly]);
-expectNotAssignable<StdoutStderrOptionSync>([binaryOnly]);
+expectNotAssignable<StdoutStderrSyncOption>([binaryOnly]);

--- a/test-d/stdio/option/generator-only-final.test-d.ts
+++ b/test-d/stdio/option/generator-only-final.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const finalOnly = {
@@ -38,11 +38,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [finalOnly]
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [finalOnly]]}));
 
 expectNotAssignable<StdinOption>(finalOnly);
-expectNotAssignable<StdinOptionSync>(finalOnly);
+expectNotAssignable<StdinSyncOption>(finalOnly);
 expectNotAssignable<StdinOption>([finalOnly]);
-expectNotAssignable<StdinOptionSync>([finalOnly]);
+expectNotAssignable<StdinSyncOption>([finalOnly]);
 
 expectNotAssignable<StdoutStderrOption>(finalOnly);
-expectNotAssignable<StdoutStderrOptionSync>(finalOnly);
+expectNotAssignable<StdoutStderrSyncOption>(finalOnly);
 expectNotAssignable<StdoutStderrOption>([finalOnly]);
-expectNotAssignable<StdoutStderrOptionSync>([finalOnly]);
+expectNotAssignable<StdoutStderrSyncOption>([finalOnly]);

--- a/test-d/stdio/option/generator-only-object-mode.test-d.ts
+++ b/test-d/stdio/option/generator-only-object-mode.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const objectModeOnly = {objectMode: true} as const;
@@ -34,11 +34,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [objectMode
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [objectModeOnly]]}));
 
 expectNotAssignable<StdinOption>(objectModeOnly);
-expectNotAssignable<StdinOptionSync>(objectModeOnly);
+expectNotAssignable<StdinSyncOption>(objectModeOnly);
 expectNotAssignable<StdinOption>([objectModeOnly]);
-expectNotAssignable<StdinOptionSync>([objectModeOnly]);
+expectNotAssignable<StdinSyncOption>([objectModeOnly]);
 
 expectNotAssignable<StdoutStderrOption>(objectModeOnly);
-expectNotAssignable<StdoutStderrOptionSync>(objectModeOnly);
+expectNotAssignable<StdoutStderrSyncOption>(objectModeOnly);
 expectNotAssignable<StdoutStderrOption>([objectModeOnly]);
-expectNotAssignable<StdoutStderrOptionSync>([objectModeOnly]);
+expectNotAssignable<StdoutStderrSyncOption>([objectModeOnly]);

--- a/test-d/stdio/option/generator-only-preserve.test-d.ts
+++ b/test-d/stdio/option/generator-only-preserve.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const preserveNewlinesOnly = {preserveNewlines: true} as const;
@@ -34,11 +34,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [preserveNe
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [preserveNewlinesOnly]]}));
 
 expectNotAssignable<StdinOption>(preserveNewlinesOnly);
-expectNotAssignable<StdinOptionSync>(preserveNewlinesOnly);
+expectNotAssignable<StdinSyncOption>(preserveNewlinesOnly);
 expectNotAssignable<StdinOption>([preserveNewlinesOnly]);
-expectNotAssignable<StdinOptionSync>([preserveNewlinesOnly]);
+expectNotAssignable<StdinSyncOption>([preserveNewlinesOnly]);
 
 expectNotAssignable<StdoutStderrOption>(preserveNewlinesOnly);
-expectNotAssignable<StdoutStderrOptionSync>(preserveNewlinesOnly);
+expectNotAssignable<StdoutStderrSyncOption>(preserveNewlinesOnly);
 expectNotAssignable<StdoutStderrOption>([preserveNewlinesOnly]);
-expectNotAssignable<StdoutStderrOptionSync>([preserveNewlinesOnly]);
+expectNotAssignable<StdoutStderrSyncOption>([preserveNewlinesOnly]);

--- a/test-d/stdio/option/generator-preserve-invalid.test-d.ts
+++ b/test-d/stdio/option/generator-preserve-invalid.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const transformWithInvalidPreserveNewlines = {
@@ -39,11 +39,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformW
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformWithInvalidPreserveNewlines]]}));
 
 expectNotAssignable<StdinOption>(transformWithInvalidPreserveNewlines);
-expectNotAssignable<StdinOptionSync>(transformWithInvalidPreserveNewlines);
+expectNotAssignable<StdinSyncOption>(transformWithInvalidPreserveNewlines);
 expectNotAssignable<StdinOption>([transformWithInvalidPreserveNewlines]);
-expectNotAssignable<StdinOptionSync>([transformWithInvalidPreserveNewlines]);
+expectNotAssignable<StdinSyncOption>([transformWithInvalidPreserveNewlines]);
 
 expectNotAssignable<StdoutStderrOption>(transformWithInvalidPreserveNewlines);
-expectNotAssignable<StdoutStderrOptionSync>(transformWithInvalidPreserveNewlines);
+expectNotAssignable<StdoutStderrSyncOption>(transformWithInvalidPreserveNewlines);
 expectNotAssignable<StdoutStderrOption>([transformWithInvalidPreserveNewlines]);
-expectNotAssignable<StdoutStderrOptionSync>([transformWithInvalidPreserveNewlines]);
+expectNotAssignable<StdoutStderrSyncOption>([transformWithInvalidPreserveNewlines]);

--- a/test-d/stdio/option/generator-preserve.test-d.ts
+++ b/test-d/stdio/option/generator-preserve.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const transformWithPreserveNewlines = {
@@ -39,11 +39,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformWithPreserveN
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [transformWithPreserveNewlines]]});
 
 expectAssignable<StdinOption>(transformWithPreserveNewlines);
-expectAssignable<StdinOptionSync>(transformWithPreserveNewlines);
+expectAssignable<StdinSyncOption>(transformWithPreserveNewlines);
 expectAssignable<StdinOption>([transformWithPreserveNewlines]);
-expectAssignable<StdinOptionSync>([transformWithPreserveNewlines]);
+expectAssignable<StdinSyncOption>([transformWithPreserveNewlines]);
 
 expectAssignable<StdoutStderrOption>(transformWithPreserveNewlines);
-expectAssignable<StdoutStderrOptionSync>(transformWithPreserveNewlines);
+expectAssignable<StdoutStderrSyncOption>(transformWithPreserveNewlines);
 expectAssignable<StdoutStderrOption>([transformWithPreserveNewlines]);
-expectAssignable<StdoutStderrOptionSync>([transformWithPreserveNewlines]);
+expectAssignable<StdoutStderrSyncOption>([transformWithPreserveNewlines]);

--- a/test-d/stdio/option/generator-string-full.test-d.ts
+++ b/test-d/stdio/option/generator-string-full.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const stringGeneratorFull = {
@@ -38,11 +38,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGene
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGeneratorFull]]}));
 
 expectNotAssignable<StdinOption>(stringGeneratorFull);
-expectNotAssignable<StdinOptionSync>(stringGeneratorFull);
+expectNotAssignable<StdinSyncOption>(stringGeneratorFull);
 expectNotAssignable<StdinOption>([stringGeneratorFull]);
-expectNotAssignable<StdinOptionSync>([stringGeneratorFull]);
+expectNotAssignable<StdinSyncOption>([stringGeneratorFull]);
 
 expectNotAssignable<StdoutStderrOption>(stringGeneratorFull);
-expectNotAssignable<StdoutStderrOptionSync>(stringGeneratorFull);
+expectNotAssignable<StdoutStderrSyncOption>(stringGeneratorFull);
 expectNotAssignable<StdoutStderrOption>([stringGeneratorFull]);
-expectNotAssignable<StdoutStderrOptionSync>([stringGeneratorFull]);
+expectNotAssignable<StdoutStderrSyncOption>([stringGeneratorFull]);

--- a/test-d/stdio/option/generator-string.test-d.ts
+++ b/test-d/stdio/option/generator-string.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const stringGenerator = function * (line: string) {
@@ -36,11 +36,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGene
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGenerator]]}));
 
 expectNotAssignable<StdinOption>(stringGenerator);
-expectNotAssignable<StdinOptionSync>(stringGenerator);
+expectNotAssignable<StdinSyncOption>(stringGenerator);
 expectNotAssignable<StdinOption>([stringGenerator]);
-expectNotAssignable<StdinOptionSync>([stringGenerator]);
+expectNotAssignable<StdinSyncOption>([stringGenerator]);
 
 expectNotAssignable<StdoutStderrOption>(stringGenerator);
-expectNotAssignable<StdoutStderrOptionSync>(stringGenerator);
+expectNotAssignable<StdoutStderrSyncOption>(stringGenerator);
 expectNotAssignable<StdoutStderrOption>([stringGenerator]);
-expectNotAssignable<StdoutStderrOptionSync>([stringGenerator]);
+expectNotAssignable<StdoutStderrSyncOption>([stringGenerator]);

--- a/test-d/stdio/option/generator-unknown-full.test-d.ts
+++ b/test-d/stdio/option/generator-unknown-full.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const unknownGeneratorFull = {
@@ -39,11 +39,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [unknownGeneratorFull]]
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [unknownGeneratorFull]]});
 
 expectAssignable<StdinOption>(unknownGeneratorFull);
-expectAssignable<StdinOptionSync>(unknownGeneratorFull);
+expectAssignable<StdinSyncOption>(unknownGeneratorFull);
 expectAssignable<StdinOption>([unknownGeneratorFull]);
-expectAssignable<StdinOptionSync>([unknownGeneratorFull]);
+expectAssignable<StdinSyncOption>([unknownGeneratorFull]);
 
 expectAssignable<StdoutStderrOption>(unknownGeneratorFull);
-expectAssignable<StdoutStderrOptionSync>(unknownGeneratorFull);
+expectAssignable<StdoutStderrSyncOption>(unknownGeneratorFull);
 expectAssignable<StdoutStderrOption>([unknownGeneratorFull]);
-expectAssignable<StdoutStderrOptionSync>([unknownGeneratorFull]);
+expectAssignable<StdoutStderrSyncOption>([unknownGeneratorFull]);

--- a/test-d/stdio/option/generator-unknown.test-d.ts
+++ b/test-d/stdio/option/generator-unknown.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const unknownGenerator = function * (line: unknown) {
@@ -36,11 +36,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [unknownGenerator]]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [unknownGenerator]]});
 
 expectAssignable<StdinOption>(unknownGenerator);
-expectAssignable<StdinOptionSync>(unknownGenerator);
+expectAssignable<StdinSyncOption>(unknownGenerator);
 expectAssignable<StdinOption>([unknownGenerator]);
-expectAssignable<StdinOptionSync>([unknownGenerator]);
+expectAssignable<StdinSyncOption>([unknownGenerator]);
 
 expectAssignable<StdoutStderrOption>(unknownGenerator);
-expectAssignable<StdoutStderrOptionSync>(unknownGenerator);
+expectAssignable<StdoutStderrSyncOption>(unknownGenerator);
 expectAssignable<StdoutStderrOption>([unknownGenerator]);
-expectAssignable<StdoutStderrOptionSync>([unknownGenerator]);
+expectAssignable<StdoutStderrSyncOption>([unknownGenerator]);

--- a/test-d/stdio/option/ignore.test-d.ts
+++ b/test-d/stdio/option/ignore.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 'ignore'});
@@ -32,11 +32,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['ignore']]
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['ignore']]}));
 
 expectAssignable<StdinOption>('ignore');
-expectAssignable<StdinOptionSync>('ignore');
+expectAssignable<StdinSyncOption>('ignore');
 expectNotAssignable<StdinOption>(['ignore']);
-expectNotAssignable<StdinOptionSync>(['ignore']);
+expectNotAssignable<StdinSyncOption>(['ignore']);
 
 expectAssignable<StdoutStderrOption>('ignore');
-expectAssignable<StdoutStderrOptionSync>('ignore');
+expectAssignable<StdoutStderrSyncOption>('ignore');
 expectNotAssignable<StdoutStderrOption>(['ignore']);
-expectNotAssignable<StdoutStderrOptionSync>(['ignore']);
+expectNotAssignable<StdoutStderrSyncOption>(['ignore']);

--- a/test-d/stdio/option/inherit.test-d.ts
+++ b/test-d/stdio/option/inherit.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 'inherit'});
@@ -32,11 +32,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['inherit']
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['inherit']]});
 
 expectAssignable<StdinOption>('inherit');
-expectAssignable<StdinOptionSync>('inherit');
+expectAssignable<StdinSyncOption>('inherit');
 expectAssignable<StdinOption>(['inherit']);
-expectAssignable<StdinOptionSync>(['inherit']);
+expectAssignable<StdinSyncOption>(['inherit']);
 
 expectAssignable<StdoutStderrOption>('inherit');
-expectAssignable<StdoutStderrOptionSync>('inherit');
+expectAssignable<StdoutStderrSyncOption>('inherit');
 expectAssignable<StdoutStderrOption>(['inherit']);
-expectAssignable<StdoutStderrOptionSync>(['inherit']);
+expectAssignable<StdoutStderrSyncOption>(['inherit']);

--- a/test-d/stdio/option/ipc.test-d.ts
+++ b/test-d/stdio/option/ipc.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 'ipc'});
@@ -32,11 +32,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['ipc']]}))
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['ipc']]}));
 
 expectAssignable<StdinOption>('ipc');
-expectNotAssignable<StdinOptionSync>('ipc');
+expectNotAssignable<StdinSyncOption>('ipc');
 expectNotAssignable<StdinOption>(['ipc']);
-expectNotAssignable<StdinOptionSync>(['ipc']);
+expectNotAssignable<StdinSyncOption>(['ipc']);
 
 expectAssignable<StdoutStderrOption>('ipc');
-expectNotAssignable<StdoutStderrOptionSync>('ipc');
+expectNotAssignable<StdoutStderrSyncOption>('ipc');
 expectNotAssignable<StdoutStderrOption>(['ipc']);
-expectNotAssignable<StdoutStderrOptionSync>(['ipc']);
+expectNotAssignable<StdoutStderrSyncOption>(['ipc']);

--- a/test-d/stdio/option/iterable-async-binary.test-d.ts
+++ b/test-d/stdio/option/iterable-async-binary.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const asyncBinaryIterableFunction = async function * () {
@@ -38,11 +38,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncBinaryIterable]]}
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncBinaryIterable]]}));
 
 expectAssignable<StdinOption>(asyncBinaryIterable);
-expectNotAssignable<StdinOptionSync>(asyncBinaryIterable);
+expectNotAssignable<StdinSyncOption>(asyncBinaryIterable);
 expectAssignable<StdinOption>([asyncBinaryIterable]);
-expectNotAssignable<StdinOptionSync>([asyncBinaryIterable]);
+expectNotAssignable<StdinSyncOption>([asyncBinaryIterable]);
 
 expectNotAssignable<StdoutStderrOption>(asyncBinaryIterable);
-expectNotAssignable<StdoutStderrOptionSync>(asyncBinaryIterable);
+expectNotAssignable<StdoutStderrSyncOption>(asyncBinaryIterable);
 expectNotAssignable<StdoutStderrOption>([asyncBinaryIterable]);
-expectNotAssignable<StdoutStderrOptionSync>([asyncBinaryIterable]);
+expectNotAssignable<StdoutStderrSyncOption>([asyncBinaryIterable]);

--- a/test-d/stdio/option/iterable-async-object.test-d.ts
+++ b/test-d/stdio/option/iterable-async-object.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const asyncObjectIterableFunction = async function * () {
@@ -38,11 +38,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncObjectIterable]]}
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncObjectIterable]]}));
 
 expectAssignable<StdinOption>(asyncObjectIterable);
-expectNotAssignable<StdinOptionSync>(asyncObjectIterable);
+expectNotAssignable<StdinSyncOption>(asyncObjectIterable);
 expectAssignable<StdinOption>([asyncObjectIterable]);
-expectNotAssignable<StdinOptionSync>([asyncObjectIterable]);
+expectNotAssignable<StdinSyncOption>([asyncObjectIterable]);
 
 expectNotAssignable<StdoutStderrOption>(asyncObjectIterable);
-expectNotAssignable<StdoutStderrOptionSync>(asyncObjectIterable);
+expectNotAssignable<StdoutStderrSyncOption>(asyncObjectIterable);
 expectNotAssignable<StdoutStderrOption>([asyncObjectIterable]);
-expectNotAssignable<StdoutStderrOptionSync>([asyncObjectIterable]);
+expectNotAssignable<StdoutStderrSyncOption>([asyncObjectIterable]);

--- a/test-d/stdio/option/iterable-async-string.test-d.ts
+++ b/test-d/stdio/option/iterable-async-string.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const asyncStringIterableFunction = async function * () {
@@ -38,11 +38,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncStringIterable]]}
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [asyncStringIterable]]}));
 
 expectAssignable<StdinOption>(asyncStringIterable);
-expectNotAssignable<StdinOptionSync>(asyncStringIterable);
+expectNotAssignable<StdinSyncOption>(asyncStringIterable);
 expectAssignable<StdinOption>([asyncStringIterable]);
-expectNotAssignable<StdinOptionSync>([asyncStringIterable]);
+expectNotAssignable<StdinSyncOption>([asyncStringIterable]);
 
 expectNotAssignable<StdoutStderrOption>(asyncStringIterable);
-expectNotAssignable<StdoutStderrOptionSync>(asyncStringIterable);
+expectNotAssignable<StdoutStderrSyncOption>(asyncStringIterable);
 expectNotAssignable<StdoutStderrOption>([asyncStringIterable]);
-expectNotAssignable<StdoutStderrOptionSync>([asyncStringIterable]);
+expectNotAssignable<StdoutStderrSyncOption>([asyncStringIterable]);

--- a/test-d/stdio/option/iterable-binary.test-d.ts
+++ b/test-d/stdio/option/iterable-binary.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const binaryIterableFunction = function * () {
@@ -38,11 +38,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [binaryIterable]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [binaryIterable]]}));
 
 expectAssignable<StdinOption>(binaryIterable);
-expectAssignable<StdinOptionSync>(binaryIterable);
+expectAssignable<StdinSyncOption>(binaryIterable);
 expectAssignable<StdinOption>([binaryIterable]);
-expectAssignable<StdinOptionSync>([binaryIterable]);
+expectAssignable<StdinSyncOption>([binaryIterable]);
 
 expectNotAssignable<StdoutStderrOption>(binaryIterable);
-expectNotAssignable<StdoutStderrOptionSync>(binaryIterable);
+expectNotAssignable<StdoutStderrSyncOption>(binaryIterable);
 expectNotAssignable<StdoutStderrOption>([binaryIterable]);
-expectNotAssignable<StdoutStderrOptionSync>([binaryIterable]);
+expectNotAssignable<StdoutStderrSyncOption>([binaryIterable]);

--- a/test-d/stdio/option/iterable-object.test-d.ts
+++ b/test-d/stdio/option/iterable-object.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const objectIterableFunction = function * () {
@@ -38,11 +38,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [objectIterable]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [objectIterable]]}));
 
 expectAssignable<StdinOption>(objectIterable);
-expectAssignable<StdinOptionSync>(objectIterable);
+expectAssignable<StdinSyncOption>(objectIterable);
 expectAssignable<StdinOption>([objectIterable]);
-expectAssignable<StdinOptionSync>([objectIterable]);
+expectAssignable<StdinSyncOption>([objectIterable]);
 
 expectNotAssignable<StdoutStderrOption>(objectIterable);
-expectNotAssignable<StdoutStderrOptionSync>(objectIterable);
+expectNotAssignable<StdoutStderrSyncOption>(objectIterable);
 expectNotAssignable<StdoutStderrOption>([objectIterable]);
-expectNotAssignable<StdoutStderrOptionSync>([objectIterable]);
+expectNotAssignable<StdoutStderrSyncOption>([objectIterable]);

--- a/test-d/stdio/option/iterable-string.test-d.ts
+++ b/test-d/stdio/option/iterable-string.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const stringIterableFunction = function * () {
@@ -38,11 +38,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringIterable]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringIterable]]}));
 
 expectAssignable<StdinOption>(stringIterable);
-expectAssignable<StdinOptionSync>(stringIterable);
+expectAssignable<StdinSyncOption>(stringIterable);
 expectAssignable<StdinOption>([stringIterable]);
-expectAssignable<StdinOptionSync>([stringIterable]);
+expectAssignable<StdinSyncOption>([stringIterable]);
 
 expectNotAssignable<StdoutStderrOption>(stringIterable);
-expectNotAssignable<StdoutStderrOptionSync>(stringIterable);
+expectNotAssignable<StdoutStderrSyncOption>(stringIterable);
 expectNotAssignable<StdoutStderrOption>([stringIterable]);
-expectNotAssignable<StdoutStderrOptionSync>([stringIterable]);
+expectNotAssignable<StdoutStderrSyncOption>([stringIterable]);

--- a/test-d/stdio/option/null.test-d.ts
+++ b/test-d/stdio/option/null.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: null}));
@@ -32,11 +32,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [null]]}));
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [null]]}));
 
 expectNotAssignable<StdinOption>(null);
-expectNotAssignable<StdinOptionSync>(null);
+expectNotAssignable<StdinSyncOption>(null);
 expectNotAssignable<StdinOption>([null]);
-expectNotAssignable<StdinOptionSync>([null]);
+expectNotAssignable<StdinSyncOption>([null]);
 
 expectNotAssignable<StdoutStderrOption>(null);
-expectNotAssignable<StdoutStderrOptionSync>(null);
+expectNotAssignable<StdoutStderrSyncOption>(null);
 expectNotAssignable<StdoutStderrOption>([null]);
-expectNotAssignable<StdoutStderrOptionSync>([null]);
+expectNotAssignable<StdoutStderrSyncOption>([null]);

--- a/test-d/stdio/option/overlapped.test-d.ts
+++ b/test-d/stdio/option/overlapped.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 'overlapped'});
@@ -32,11 +32,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['overlapped']]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['overlapped']]}));
 
 expectAssignable<StdinOption>('overlapped');
-expectNotAssignable<StdinOptionSync>('overlapped');
+expectNotAssignable<StdinSyncOption>('overlapped');
 expectAssignable<StdinOption>(['overlapped']);
-expectNotAssignable<StdinOptionSync>(['overlapped']);
+expectNotAssignable<StdinSyncOption>(['overlapped']);
 
 expectAssignable<StdoutStderrOption>('overlapped');
-expectNotAssignable<StdoutStderrOptionSync>('overlapped');
+expectNotAssignable<StdoutStderrSyncOption>('overlapped');
 expectAssignable<StdoutStderrOption>(['overlapped']);
-expectNotAssignable<StdoutStderrOptionSync>(['overlapped']);
+expectNotAssignable<StdoutStderrSyncOption>(['overlapped']);

--- a/test-d/stdio/option/pipe-inherit.test-d.ts
+++ b/test-d/stdio/option/pipe-inherit.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const pipeInherit = ['pipe', 'inherit'] as const;
@@ -23,7 +23,7 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', pipeInherit
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', pipeInherit]});
 
 expectAssignable<StdinOption>(pipeInherit);
-expectAssignable<StdinOptionSync>(pipeInherit);
+expectAssignable<StdinSyncOption>(pipeInherit);
 
 expectAssignable<StdoutStderrOption>(pipeInherit);
-expectAssignable<StdoutStderrOptionSync>(pipeInherit);
+expectAssignable<StdoutStderrSyncOption>(pipeInherit);

--- a/test-d/stdio/option/pipe-undefined.test-d.ts
+++ b/test-d/stdio/option/pipe-undefined.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const pipeUndefined = ['pipe', undefined] as const;
@@ -23,7 +23,7 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', pipeUndefined]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', pipeUndefined]});
 
 expectAssignable<StdinOption>(pipeUndefined);
-expectAssignable<StdinOptionSync>(pipeUndefined);
+expectAssignable<StdinSyncOption>(pipeUndefined);
 
 expectAssignable<StdoutStderrOption>(pipeUndefined);
-expectAssignable<StdoutStderrOptionSync>(pipeUndefined);
+expectAssignable<StdoutStderrSyncOption>(pipeUndefined);

--- a/test-d/stdio/option/pipe.test-d.ts
+++ b/test-d/stdio/option/pipe.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: 'pipe'});
@@ -32,11 +32,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['pipe']]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['pipe']]});
 
 expectAssignable<StdinOption>('pipe');
-expectAssignable<StdinOptionSync>('pipe');
+expectAssignable<StdinSyncOption>('pipe');
 expectAssignable<StdinOption>(['pipe']);
-expectAssignable<StdinOptionSync>(['pipe']);
+expectAssignable<StdinSyncOption>(['pipe']);
 
 expectAssignable<StdoutStderrOption>('pipe');
-expectAssignable<StdoutStderrOptionSync>('pipe');
+expectAssignable<StdoutStderrSyncOption>('pipe');
 expectAssignable<StdoutStderrOption>(['pipe']);
-expectAssignable<StdoutStderrOptionSync>(['pipe']);
+expectAssignable<StdoutStderrSyncOption>(['pipe']);

--- a/test-d/stdio/option/process-stderr.test-d.ts
+++ b/test-d/stdio/option/process-stderr.test-d.ts
@@ -4,9 +4,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: process.stderr}));
@@ -33,11 +33,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [process.stderr]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [process.stderr]]}));
 
 expectNotAssignable<StdinOption>(process.stderr);
-expectNotAssignable<StdinOptionSync>(process.stderr);
+expectNotAssignable<StdinSyncOption>(process.stderr);
 expectNotAssignable<StdinOption>([process.stderr]);
-expectNotAssignable<StdinOptionSync>([process.stderr]);
+expectNotAssignable<StdinSyncOption>([process.stderr]);
 
 expectAssignable<StdoutStderrOption>(process.stderr);
-expectAssignable<StdoutStderrOptionSync>(process.stderr);
+expectAssignable<StdoutStderrSyncOption>(process.stderr);
 expectAssignable<StdoutStderrOption>([process.stderr]);
-expectNotAssignable<StdoutStderrOptionSync>([process.stderr]);
+expectNotAssignable<StdoutStderrSyncOption>([process.stderr]);

--- a/test-d/stdio/option/process-stdin.test-d.ts
+++ b/test-d/stdio/option/process-stdin.test-d.ts
@@ -4,9 +4,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: process.stdin});
@@ -33,11 +33,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [process.stdin]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [process.stdin]]}));
 
 expectAssignable<StdinOption>(process.stdin);
-expectAssignable<StdinOptionSync>(process.stdin);
+expectAssignable<StdinSyncOption>(process.stdin);
 expectAssignable<StdinOption>([process.stdin]);
-expectNotAssignable<StdinOptionSync>([process.stdin]);
+expectNotAssignable<StdinSyncOption>([process.stdin]);
 
 expectNotAssignable<StdoutStderrOption>(process.stdin);
-expectNotAssignable<StdoutStderrOptionSync>(process.stdin);
+expectNotAssignable<StdoutStderrSyncOption>(process.stdin);
 expectNotAssignable<StdoutStderrOption>([process.stdin]);
-expectNotAssignable<StdoutStderrOptionSync>([process.stdin]);
+expectNotAssignable<StdoutStderrSyncOption>([process.stdin]);

--- a/test-d/stdio/option/process-stdout.test-d.ts
+++ b/test-d/stdio/option/process-stdout.test-d.ts
@@ -4,9 +4,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: process.stdout}));
@@ -33,11 +33,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [process.stdout]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [process.stdout]]}));
 
 expectNotAssignable<StdinOption>(process.stdout);
-expectNotAssignable<StdinOptionSync>(process.stdout);
+expectNotAssignable<StdinSyncOption>(process.stdout);
 expectNotAssignable<StdinOption>([process.stdout]);
-expectNotAssignable<StdinOptionSync>([process.stdout]);
+expectNotAssignable<StdinSyncOption>([process.stdout]);
 
 expectAssignable<StdoutStderrOption>(process.stdout);
-expectAssignable<StdoutStderrOptionSync>(process.stdout);
+expectAssignable<StdoutStderrSyncOption>(process.stdout);
 expectAssignable<StdoutStderrOption>([process.stdout]);
-expectNotAssignable<StdoutStderrOptionSync>([process.stdout]);
+expectNotAssignable<StdoutStderrSyncOption>([process.stdout]);

--- a/test-d/stdio/option/readable-stream.test-d.ts
+++ b/test-d/stdio/option/readable-stream.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: new ReadableStream()});
@@ -32,11 +32,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [new ReadableStream()]]
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [new ReadableStream()]]}));
 
 expectAssignable<StdinOption>(new ReadableStream());
-expectNotAssignable<StdinOptionSync>(new ReadableStream());
+expectNotAssignable<StdinSyncOption>(new ReadableStream());
 expectAssignable<StdinOption>([new ReadableStream()]);
-expectNotAssignable<StdinOptionSync>([new ReadableStream()]);
+expectNotAssignable<StdinSyncOption>([new ReadableStream()]);
 
 expectNotAssignable<StdoutStderrOption>(new ReadableStream());
-expectNotAssignable<StdoutStderrOptionSync>(new ReadableStream());
+expectNotAssignable<StdoutStderrSyncOption>(new ReadableStream());
 expectNotAssignable<StdoutStderrOption>([new ReadableStream()]);
-expectNotAssignable<StdoutStderrOptionSync>([new ReadableStream()]);
+expectNotAssignable<StdoutStderrSyncOption>([new ReadableStream()]);

--- a/test-d/stdio/option/readable.test-d.ts
+++ b/test-d/stdio/option/readable.test-d.ts
@@ -4,9 +4,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: new Readable()});
@@ -33,11 +33,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [new Readable()]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [new Readable()]]}));
 
 expectAssignable<StdinOption>(new Readable());
-expectAssignable<StdinOptionSync>(new Readable());
+expectAssignable<StdinSyncOption>(new Readable());
 expectAssignable<StdinOption>([new Readable()]);
-expectNotAssignable<StdinOptionSync>([new Readable()]);
+expectNotAssignable<StdinSyncOption>([new Readable()]);
 
 expectNotAssignable<StdoutStderrOption>(new Readable());
-expectNotAssignable<StdoutStderrOptionSync>(new Readable());
+expectNotAssignable<StdoutStderrSyncOption>(new Readable());
 expectNotAssignable<StdoutStderrOption>([new Readable()]);
-expectNotAssignable<StdoutStderrOptionSync>([new Readable()]);
+expectNotAssignable<StdoutStderrSyncOption>([new Readable()]);

--- a/test-d/stdio/option/uint-array.test-d.ts
+++ b/test-d/stdio/option/uint-array.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: new Uint8Array()});
@@ -32,11 +32,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [new Uint8Array()]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [new Uint8Array()]]}));
 
 expectAssignable<StdinOption>(new Uint8Array());
-expectAssignable<StdinOptionSync>(new Uint8Array());
+expectAssignable<StdinSyncOption>(new Uint8Array());
 expectAssignable<StdinOption>([new Uint8Array()]);
-expectAssignable<StdinOptionSync>([new Uint8Array()]);
+expectAssignable<StdinSyncOption>([new Uint8Array()]);
 
 expectNotAssignable<StdoutStderrOption>(new Uint8Array());
-expectNotAssignable<StdoutStderrOptionSync>(new Uint8Array());
+expectNotAssignable<StdoutStderrSyncOption>(new Uint8Array());
 expectNotAssignable<StdoutStderrOption>([new Uint8Array()]);
-expectNotAssignable<StdoutStderrOptionSync>([new Uint8Array()]);
+expectNotAssignable<StdoutStderrSyncOption>([new Uint8Array()]);

--- a/test-d/stdio/option/undefined.test-d.ts
+++ b/test-d/stdio/option/undefined.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 await execa('unicorns', {stdin: undefined});
@@ -32,11 +32,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [undefined]]});
 execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [undefined]]});
 
 expectAssignable<StdinOption>(undefined);
-expectAssignable<StdinOptionSync>(undefined);
+expectAssignable<StdinSyncOption>(undefined);
 expectAssignable<StdinOption>([undefined]);
-expectAssignable<StdinOptionSync>([undefined]);
+expectAssignable<StdinSyncOption>([undefined]);
 
 expectAssignable<StdoutStderrOption>(undefined);
-expectAssignable<StdoutStderrOptionSync>(undefined);
+expectAssignable<StdoutStderrSyncOption>(undefined);
 expectAssignable<StdoutStderrOption>([undefined]);
-expectAssignable<StdoutStderrOptionSync>([undefined]);
+expectAssignable<StdoutStderrSyncOption>([undefined]);

--- a/test-d/stdio/option/unknown.test-d.ts
+++ b/test-d/stdio/option/unknown.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: 'unknown'}));
@@ -32,11 +32,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['unknown']
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', ['unknown']]}));
 
 expectNotAssignable<StdinOption>('unknown');
-expectNotAssignable<StdinOptionSync>('unknown');
+expectNotAssignable<StdinSyncOption>('unknown');
 expectNotAssignable<StdinOption>(['unknown']);
-expectNotAssignable<StdinOptionSync>(['unknown']);
+expectNotAssignable<StdinSyncOption>(['unknown']);
 
 expectNotAssignable<StdoutStderrOption>('unknown');
-expectNotAssignable<StdoutStderrOptionSync>('unknown');
+expectNotAssignable<StdoutStderrSyncOption>('unknown');
 expectNotAssignable<StdoutStderrOption>(['unknown']);
-expectNotAssignable<StdoutStderrOptionSync>(['unknown']);
+expectNotAssignable<StdoutStderrSyncOption>(['unknown']);

--- a/test-d/stdio/option/web-transform-instance.test-d.ts
+++ b/test-d/stdio/option/web-transform-instance.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const webTransformInstance = new TransformStream();
@@ -34,11 +34,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [webTransformInstance]]
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [webTransformInstance]]}));
 
 expectAssignable<StdinOption>(webTransformInstance);
-expectNotAssignable<StdinOptionSync>(webTransformInstance);
+expectNotAssignable<StdinSyncOption>(webTransformInstance);
 expectAssignable<StdinOption>([webTransformInstance]);
-expectNotAssignable<StdinOptionSync>([webTransformInstance]);
+expectNotAssignable<StdinSyncOption>([webTransformInstance]);
 
 expectAssignable<StdoutStderrOption>(webTransformInstance);
-expectNotAssignable<StdoutStderrOptionSync>(webTransformInstance);
+expectNotAssignable<StdoutStderrSyncOption>(webTransformInstance);
 expectAssignable<StdoutStderrOption>([webTransformInstance]);
-expectNotAssignable<StdoutStderrOptionSync>([webTransformInstance]);
+expectNotAssignable<StdoutStderrSyncOption>([webTransformInstance]);

--- a/test-d/stdio/option/web-transform-invalid.test-d.ts
+++ b/test-d/stdio/option/web-transform-invalid.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const webTransformWithInvalidObjectMode = {
@@ -37,11 +37,11 @@ expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [webTransfo
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [webTransformWithInvalidObjectMode]]}));
 
 expectNotAssignable<StdinOption>(webTransformWithInvalidObjectMode);
-expectNotAssignable<StdinOptionSync>(webTransformWithInvalidObjectMode);
+expectNotAssignable<StdinSyncOption>(webTransformWithInvalidObjectMode);
 expectNotAssignable<StdinOption>([webTransformWithInvalidObjectMode]);
-expectNotAssignable<StdinOptionSync>([webTransformWithInvalidObjectMode]);
+expectNotAssignable<StdinSyncOption>([webTransformWithInvalidObjectMode]);
 
 expectNotAssignable<StdoutStderrOption>(webTransformWithInvalidObjectMode);
-expectNotAssignable<StdoutStderrOptionSync>(webTransformWithInvalidObjectMode);
+expectNotAssignable<StdoutStderrSyncOption>(webTransformWithInvalidObjectMode);
 expectNotAssignable<StdoutStderrOption>([webTransformWithInvalidObjectMode]);
-expectNotAssignable<StdoutStderrOptionSync>([webTransformWithInvalidObjectMode]);
+expectNotAssignable<StdoutStderrSyncOption>([webTransformWithInvalidObjectMode]);

--- a/test-d/stdio/option/web-transform-object.test-d.ts
+++ b/test-d/stdio/option/web-transform-object.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const webTransformObject = {
@@ -37,11 +37,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [webTransformObject]]})
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [webTransformObject]]}));
 
 expectAssignable<StdinOption>(webTransformObject);
-expectNotAssignable<StdinOptionSync>(webTransformObject);
+expectNotAssignable<StdinSyncOption>(webTransformObject);
 expectAssignable<StdinOption>([webTransformObject]);
-expectNotAssignable<StdinOptionSync>([webTransformObject]);
+expectNotAssignable<StdinSyncOption>([webTransformObject]);
 
 expectAssignable<StdoutStderrOption>(webTransformObject);
-expectNotAssignable<StdoutStderrOptionSync>(webTransformObject);
+expectNotAssignable<StdoutStderrSyncOption>(webTransformObject);
 expectAssignable<StdoutStderrOption>([webTransformObject]);
-expectNotAssignable<StdoutStderrOptionSync>([webTransformObject]);
+expectNotAssignable<StdoutStderrSyncOption>([webTransformObject]);

--- a/test-d/stdio/option/web-transform.test-d.ts
+++ b/test-d/stdio/option/web-transform.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 const webTransform = {transform: new TransformStream()} as const;
@@ -34,11 +34,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [webTransform]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [webTransform]]}));
 
 expectAssignable<StdinOption>(webTransform);
-expectNotAssignable<StdinOptionSync>(webTransform);
+expectNotAssignable<StdinSyncOption>(webTransform);
 expectAssignable<StdinOption>([webTransform]);
-expectNotAssignable<StdinOptionSync>([webTransform]);
+expectNotAssignable<StdinSyncOption>([webTransform]);
 
 expectAssignable<StdoutStderrOption>(webTransform);
-expectNotAssignable<StdoutStderrOptionSync>(webTransform);
+expectNotAssignable<StdoutStderrSyncOption>(webTransform);
 expectAssignable<StdoutStderrOption>([webTransform]);
-expectNotAssignable<StdoutStderrOptionSync>([webTransform]);
+expectNotAssignable<StdoutStderrSyncOption>([webTransform]);

--- a/test-d/stdio/option/writable-stream.test-d.ts
+++ b/test-d/stdio/option/writable-stream.test-d.ts
@@ -3,9 +3,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: new WritableStream()}));
@@ -32,11 +32,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [new WritableStream()]]
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [new WritableStream()]]}));
 
 expectNotAssignable<StdinOption>(new WritableStream());
-expectNotAssignable<StdinOptionSync>(new WritableStream());
+expectNotAssignable<StdinSyncOption>(new WritableStream());
 expectNotAssignable<StdinOption>([new WritableStream()]);
-expectNotAssignable<StdinOptionSync>([new WritableStream()]);
+expectNotAssignable<StdinSyncOption>([new WritableStream()]);
 
 expectAssignable<StdoutStderrOption>(new WritableStream());
-expectNotAssignable<StdoutStderrOptionSync>(new WritableStream());
+expectNotAssignable<StdoutStderrSyncOption>(new WritableStream());
 expectAssignable<StdoutStderrOption>([new WritableStream()]);
-expectNotAssignable<StdoutStderrOptionSync>([new WritableStream()]);
+expectNotAssignable<StdoutStderrSyncOption>([new WritableStream()]);

--- a/test-d/stdio/option/writable.test-d.ts
+++ b/test-d/stdio/option/writable.test-d.ts
@@ -4,9 +4,9 @@ import {
 	execa,
 	execaSync,
 	type StdinOption,
-	type StdinOptionSync,
+	type StdinSyncOption,
 	type StdoutStderrOption,
-	type StdoutStderrOptionSync,
+	type StdoutStderrSyncOption,
 } from '../../../index.js';
 
 expectError(await execa('unicorns', {stdin: new Writable()}));
@@ -33,11 +33,11 @@ await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [new Writable()]]});
 expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [new Writable()]]}));
 
 expectNotAssignable<StdinOption>(new Writable());
-expectNotAssignable<StdinOptionSync>(new Writable());
+expectNotAssignable<StdinSyncOption>(new Writable());
 expectNotAssignable<StdinOption>([new Writable()]);
-expectNotAssignable<StdinOptionSync>([new Writable()]);
+expectNotAssignable<StdinSyncOption>([new Writable()]);
 
 expectAssignable<StdoutStderrOption>(new Writable());
-expectAssignable<StdoutStderrOptionSync>(new Writable());
+expectAssignable<StdoutStderrSyncOption>(new Writable());
 expectAssignable<StdoutStderrOption>([new Writable()]);
-expectNotAssignable<StdoutStderrOptionSync>([new Writable()]);
+expectNotAssignable<StdoutStderrSyncOption>([new Writable()]);

--- a/types/stdio/type.d.ts
+++ b/types/stdio/type.d.ts
@@ -107,7 +107,7 @@ export type StdinOptionCommon<
 // `options.stdin`, async
 export type StdinOption = StdinOptionCommon<false, false>;
 // `options.stdin`, sync
-export type StdinOptionSync = StdinOptionCommon<true, false>;
+export type StdinSyncOption = StdinOptionCommon<true, false>;
 
 // `options.stdout|stderr` array items
 type StdoutStderrSingleOption<
@@ -129,7 +129,7 @@ export type StdoutStderrOptionCommon<
 // `options.stdout|stderr`, async
 export type StdoutStderrOption = StdoutStderrOptionCommon<false, false>;
 // `options.stdout|stderr`, sync
-export type StdoutStderrOptionSync = StdoutStderrOptionCommon<true, false>;
+export type StdoutStderrSyncOption = StdoutStderrOptionCommon<true, false>;
 
 // `options.stdio[3+]`
 type StdioExtraOptionCommon<IsSync extends boolean = boolean> =


### PR DESCRIPTION
This PR renames the following types:
  - `StdinOptionSync` -> `StdinSyncOption`
  - `StdoutStderrOptionSync` -> `StdoutStderrSyncOption`

This makes it consistent with the names of the other synchronous types, in particular `SyncOptions`, but also `SyncResult` and `ExecaSyncError`.

`StdinOptionSync` and `StdoutStderrOptionSync` are new types added by the upcoming release, so this is not a breaking change.