### PR TITLE
Fix PR commit status failing due to Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  notify:
+    after_n_builds: 6


### PR DESCRIPTION
Codecov seems to take more than 1 hour to merge the test coverage from Linux + macOS + Windows. Due to this, the PR commit status initially fails.

I cannot find an easy to fix this, so this PR fixes it by reverting to the old behavior of only uploading the test coverage on Linux. This means Codecov will report ~99.90% test coverage even though it is actually 100%, but that's ok. :/

This also means the test coverage will decrease with this PR, making the commit status of this PR fail with Codecov.