### PR TITLE
Document `SIGQUIT`

### DIFF
--- a/docs/termination.md
+++ b/docs/termination.md
@@ -87,6 +87,14 @@ process.on('SIGTERM', () => {
 subprocess.kill('SIGKILL');
 ```
 
+### SIGQUIT
+
+[`SIGQUIT`](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGQUIT) is like [`SIGTERM`](#sigterm) except it creates a [core dump](https://en.wikipedia.org/wiki/Core_dump).
+
+```js
+subprocess.kill('SIGQUIT');
+```
+
 ### Other signals
 
 Other signals can be passed as argument. However, most other signals do not fully [work on Windows](https://github.com/ehmicky/cross-platform-node-guide/blob/main/docs/6_networking_ipc/signals.md#cross-platform-signals).

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -26,7 +26,7 @@ Although Windows does not natively support shebangs, Execa adds support for them
 
 ## Signals
 
-Only few [signals](termination.md#other-signals) work on Windows with Node.js: [`SIGTERM`](termination.md#sigterm), [`SIGKILL`](termination.md#sigkill) and [`SIGINT`](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGINT). Also, sending signals from other processes is [not supported](termination.md#signal-name-and-description). Finally, the [`forceKillAfterDelay`](api.md#optionsforcekillafterdelay) option [is a noop](termination.md#forceful-termination) on Windows.
+Only few [signals](termination.md#other-signals) work on Windows with Node.js: [`SIGTERM`](termination.md#sigterm), [`SIGKILL`](termination.md#sigkill), [`SIGINT`](https://en.wikipedia.org/wiki/Signal_(IPC)#SIGINT) and [`SIGQUIT`](termination.md#sigquit). Also, sending signals from other processes is [not supported](termination.md#signal-name-and-description). Finally, the [`forceKillAfterDelay`](api.md#optionsforcekillafterdelay) option [is a noop](termination.md#forceful-termination) on Windows.
 
 ## Asynchronous I/O
 


### PR DESCRIPTION
I just discovered that `SIGQUIT` is cross-platform with Node.js. In November 2022, support for it was added to libuv: https://github.com/libuv/libuv/pull/3840.

This PR fixes the termination documentation accordingly, since we currently mention that only `SIGINT`, `SIGTERM` and `SIGKILL` are cross-platform.