### PR TITLE
Avoid using NodeJS global type

### DIFF
--- a/test-d/return/result-main.test-d.ts
+++ b/test-d/return/result-main.test-d.ts
@@ -1,3 +1,4 @@
+import type {SignalConstants} from 'node:os';
 import {expectType, expectAssignable} from 'tsd';
 import {
 	execa,
@@ -28,7 +29,7 @@ expectType<boolean>(unicornsResult.timedOut);
 expectType<boolean>(unicornsResult.isCanceled);
 expectType<boolean>(unicornsResult.isTerminated);
 expectType<boolean>(unicornsResult.isMaxBuffer);
-expectType<NodeJS.Signals | undefined>(unicornsResult.signal);
+expectType<keyof SignalConstants | undefined>(unicornsResult.signal);
 expectType<string | undefined>(unicornsResult.signalDescription);
 expectType<string>(unicornsResult.cwd);
 expectType<number>(unicornsResult.durationMs);
@@ -44,7 +45,7 @@ expectType<boolean>(unicornsResultSync.timedOut);
 expectType<boolean>(unicornsResultSync.isCanceled);
 expectType<boolean>(unicornsResultSync.isTerminated);
 expectType<boolean>(unicornsResultSync.isMaxBuffer);
-expectType<NodeJS.Signals | undefined>(unicornsResultSync.signal);
+expectType<keyof SignalConstants | undefined>(unicornsResultSync.signal);
 expectType<string | undefined>(unicornsResultSync.signalDescription);
 expectType<string>(unicornsResultSync.cwd);
 expectType<number>(unicornsResultSync.durationMs);
@@ -61,7 +62,7 @@ if (error instanceof ExecaError) {
 	expectType<boolean>(error.isCanceled);
 	expectType<boolean>(error.isTerminated);
 	expectType<boolean>(error.isMaxBuffer);
-	expectType<NodeJS.Signals | undefined>(error.signal);
+	expectType<keyof SignalConstants | undefined>(error.signal);
 	expectType<string | undefined>(error.signalDescription);
 	expectType<string>(error.cwd);
 	expectType<number>(error.durationMs);
@@ -83,7 +84,7 @@ if (errorSync instanceof ExecaSyncError) {
 	expectType<boolean>(errorSync.isCanceled);
 	expectType<boolean>(errorSync.isTerminated);
 	expectType<boolean>(errorSync.isMaxBuffer);
-	expectType<NodeJS.Signals | undefined>(errorSync.signal);
+	expectType<keyof SignalConstants | undefined>(errorSync.signal);
 	expectType<string | undefined>(errorSync.signalDescription);
 	expectType<string>(errorSync.cwd);
 	expectType<number>(errorSync.durationMs);

--- a/types/arguments/options.d.ts
+++ b/types/arguments/options.d.ts
@@ -1,3 +1,5 @@
+import type {SignalConstants} from 'node:os';
+import type {env} from 'node:process';
 import type {Readable} from 'node:stream';
 import type {Unless} from '../utils';
 import type {StdinOptionCommon, StdoutStderrOptionCommon, StdioOptionsProperty} from '../stdio/type';
@@ -73,7 +75,7 @@ export type CommonOptions<IsSync extends boolean = boolean> = {
 
 	@default [process.env](https://nodejs.org/api/process.html#processenv)
 	*/
-	readonly env?: NodeJS.ProcessEnv;
+	readonly env?: typeof env;
 
 	/**
 	If `true`, the subprocess uses both the `env` option and the current process' environment variables ([`process.env`](https://nodejs.org/api/process.html#processenv)).
@@ -278,7 +280,7 @@ export type CommonOptions<IsSync extends boolean = boolean> = {
 
 	@default 'SIGTERM'
 	*/
-	readonly killSignal?: NodeJS.Signals | number;
+	readonly killSignal?: keyof SignalConstants | number;
 
 	/**
 	Run the subprocess independently from the current process.

--- a/types/return/result.d.ts
+++ b/types/return/result.d.ts
@@ -1,3 +1,4 @@
+import type {SignalConstants} from 'node:os';
 import type {Unless} from '../utils';
 import type {CommonOptions, Options, SyncOptions} from '../arguments/options';
 import type {ErrorProperties} from './final-error';
@@ -117,7 +118,7 @@ export declare abstract class CommonResult<
 
 	If a signal terminated the subprocess, this property is defined and included in the error message. Otherwise it is `undefined`.
 	*/
-	signal?: NodeJS.Signals;
+	signal?: keyof SignalConstants;
 
 	/**
 	A human-friendly description of the signal that was used to terminate the subprocess.

--- a/types/subprocess/subprocess.d.ts
+++ b/types/subprocess/subprocess.d.ts
@@ -1,4 +1,5 @@
 import type {ChildProcess} from 'node:child_process';
+import type {SignalConstants} from 'node:os';
 import type {Readable, Writable, Duplex} from 'node:stream';
 import type {StdioOptionsArray} from '../stdio/type';
 import type {Options} from '../arguments/options';
@@ -86,7 +87,7 @@ type ExecaCustomSubprocess<OptionsType extends Options = Options> = {
 
 	[More info.](https://nodejs.org/api/child_process.html#subprocesskillsignal)
 	*/
-	kill(signal?: NodeJS.Signals | number, error?: Error): boolean;
+	kill(signal?: keyof SignalConstants | number, error?: Error): boolean;
 	kill(error?: Error): boolean;
 
 	/**


### PR DESCRIPTION
This PR uses imports for types that currently use the global `NodeJS` namespace.

This is mostly a matter of preference, but it feels like it's always a good idea to avoid globals and use explicit imports when possible.