### PR TITLE
Simplify types

### DIFF
--- a/test-d/transform/object-mode.test-d.ts
+++ b/test-d/transform/object-mode.test-d.ts
@@ -22,7 +22,7 @@ const objectFinal = function * () {
 	yield {};
 };
 
-const objectTransformLinesStdoutResult = await execa('unicorns', {lines: true, stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}});
+const objectTransformLinesStdoutResult = await execa('unicorns', {lines: true, stdout: {transform: objectGenerator, final: objectFinal, objectMode: true} as const});
 expectType<unknown[]>(objectTransformLinesStdoutResult.stdout);
 expectType<[undefined, unknown[], string[]]>(objectTransformLinesStdoutResult.stdio);
 
@@ -38,7 +38,7 @@ const objectDuplexPropertyStdoutResult = await execa('unicorns', {stdout: duplex
 expectType<unknown[]>(objectDuplexPropertyStdoutResult.stdout);
 expectType<[undefined, unknown[], string]>(objectDuplexPropertyStdoutResult.stdio);
 
-const objectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}});
+const objectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true} as const});
 expectType<unknown[]>(objectTransformStdoutResult.stdout);
 expectType<[undefined, unknown[], string]>(objectTransformStdoutResult.stdio);
 
@@ -54,7 +54,7 @@ const objectDuplexPropertyStderrResult = await execa('unicorns', {stderr: duplex
 expectType<unknown[]>(objectDuplexPropertyStderrResult.stderr);
 expectType<[undefined, string, unknown[]]>(objectDuplexPropertyStderrResult.stdio);
 
-const objectTransformStderrResult = await execa('unicorns', {stderr: {transform: objectGenerator, final: objectFinal, objectMode: true}});
+const objectTransformStderrResult = await execa('unicorns', {stderr: {transform: objectGenerator, final: objectFinal, objectMode: true} as const});
 expectType<unknown[]>(objectTransformStderrResult.stderr);
 expectType<[undefined, string, unknown[]]>(objectTransformStderrResult.stdio);
 
@@ -70,7 +70,7 @@ const objectDuplexPropertyStdioResult = await execa('unicorns', {stdio: ['pipe',
 expectType<unknown[]>(objectDuplexPropertyStdioResult.stderr);
 expectType<[undefined, string, unknown[]]>(objectDuplexPropertyStdioResult.stdio);
 
-const objectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, final: objectFinal, objectMode: true}]});
+const objectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, final: objectFinal, objectMode: true} as const]});
 expectType<unknown[]>(objectTransformStdioResult.stderr);
 expectType<[undefined, string, unknown[]]>(objectTransformStdioResult.stdio);
 
@@ -86,7 +86,7 @@ const singleObjectDuplexPropertyStdoutResult = await execa('unicorns', {stdout: 
 expectType<unknown[]>(singleObjectDuplexPropertyStdoutResult.stdout);
 expectType<[undefined, unknown[], string]>(singleObjectDuplexPropertyStdoutResult.stdio);
 
-const singleObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, final: objectFinal, objectMode: true}]});
+const singleObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, final: objectFinal, objectMode: true} as const]});
 expectType<unknown[]>(singleObjectTransformStdoutResult.stdout);
 expectType<[undefined, unknown[], string]>(singleObjectTransformStdoutResult.stdio);
 
@@ -102,7 +102,7 @@ const manyObjectDuplexPropertyStdoutResult = await execa('unicorns', {stdout: [d
 expectType<unknown[]>(manyObjectDuplexPropertyStdoutResult.stdout);
 expectType<[undefined, unknown[], string]>(manyObjectDuplexPropertyStdoutResult.stdio);
 
-const manyObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, final: objectFinal, objectMode: true}, {transform: objectGenerator, final: objectFinal, objectMode: true}]});
+const manyObjectTransformStdoutResult = await execa('unicorns', {stdout: [{transform: objectGenerator, final: objectFinal, objectMode: true} as const, {transform: objectGenerator, final: objectFinal, objectMode: true} as const]});
 expectType<unknown[]>(manyObjectTransformStdoutResult.stdout);
 expectType<[undefined, unknown[], string]>(manyObjectTransformStdoutResult.stdio);
 
@@ -118,7 +118,7 @@ const falseObjectDuplexPropertyStdoutResult = await execa('unicorns', {stdout: d
 expectType<string>(falseObjectDuplexPropertyStdoutResult.stdout);
 expectType<[undefined, string, string]>(falseObjectDuplexPropertyStdoutResult.stdio);
 
-const falseObjectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: false}});
+const falseObjectTransformStdoutResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: false} as const});
 expectType<string>(falseObjectTransformStdoutResult.stdout);
 expectType<[undefined, string, string]>(falseObjectTransformStdoutResult.stdio);
 
@@ -134,7 +134,7 @@ const falseObjectDuplexPropertyStderrResult = await execa('unicorns', {stderr: d
 expectType<string>(falseObjectDuplexPropertyStderrResult.stderr);
 expectType<[undefined, string, string]>(falseObjectDuplexPropertyStderrResult.stdio);
 
-const falseObjectTransformStderrResult = await execa('unicorns', {stderr: {transform: objectGenerator, final: objectFinal, objectMode: false}});
+const falseObjectTransformStderrResult = await execa('unicorns', {stderr: {transform: objectGenerator, final: objectFinal, objectMode: false} as const});
 expectType<string>(falseObjectTransformStderrResult.stderr);
 expectType<[undefined, string, string]>(falseObjectTransformStderrResult.stdio);
 
@@ -150,7 +150,7 @@ const falseObjectDuplexPropertyStdioResult = await execa('unicorns', {stdio: ['p
 expectType<string>(falseObjectDuplexPropertyStdioResult.stderr);
 expectType<[undefined, string, string]>(falseObjectDuplexPropertyStdioResult.stdio);
 
-const falseObjectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, final: objectFinal, objectMode: false}]});
+const falseObjectTransformStdioResult = await execa('unicorns', {stdio: ['pipe', 'pipe', {transform: objectGenerator, final: objectFinal, objectMode: false} as const]});
 expectType<string>(falseObjectTransformStdioResult.stderr);
 expectType<[undefined, string, string]>(falseObjectTransformStdioResult.stdio);
 
@@ -174,50 +174,50 @@ const noObjectTransformStdoutResult = await execa('unicorns', {stdout: objectGen
 expectType<string>(noObjectTransformStdoutResult.stdout);
 expectType<[undefined, string, string]>(noObjectTransformStdoutResult.stdio);
 
-const trueTrueObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}, stderr: {transform: objectGenerator, final: objectFinal, objectMode: true}, all: true});
+const trueTrueObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true} as const, stderr: {transform: objectGenerator, final: objectFinal, objectMode: true} as const, all: true});
 expectType<unknown[]>(trueTrueObjectTransformResult.stdout);
 expectType<unknown[]>(trueTrueObjectTransformResult.stderr);
 expectType<unknown[]>(trueTrueObjectTransformResult.all);
 expectType<[undefined, unknown[], unknown[]]>(trueTrueObjectTransformResult.stdio);
 
-const trueFalseObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true}, stderr: {transform: objectGenerator, final: objectFinal, objectMode: false}, all: true});
+const trueFalseObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: true} as const, stderr: {transform: objectGenerator, final: objectFinal, objectMode: false} as const, all: true});
 expectType<unknown[]>(trueFalseObjectTransformResult.stdout);
 expectType<string>(trueFalseObjectTransformResult.stderr);
 expectType<unknown[]>(trueFalseObjectTransformResult.all);
 expectType<[undefined, unknown[], string]>(trueFalseObjectTransformResult.stdio);
 
-const falseTrueObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: false}, stderr: {transform: objectGenerator, final: objectFinal, objectMode: true}, all: true});
+const falseTrueObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: false} as const, stderr: {transform: objectGenerator, final: objectFinal, objectMode: true} as const, all: true});
 expectType<string>(falseTrueObjectTransformResult.stdout);
 expectType<unknown[]>(falseTrueObjectTransformResult.stderr);
 expectType<unknown[]>(falseTrueObjectTransformResult.all);
 expectType<[undefined, string, unknown[]]>(falseTrueObjectTransformResult.stdio);
 
-const falseFalseObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: false}, stderr: {transform: objectGenerator, final: objectFinal, objectMode: false}, all: true});
+const falseFalseObjectTransformResult = await execa('unicorns', {stdout: {transform: objectGenerator, final: objectFinal, objectMode: false} as const, stderr: {transform: objectGenerator, final: objectFinal, objectMode: false} as const, all: true});
 expectType<string>(falseFalseObjectTransformResult.stdout);
 expectType<string>(falseFalseObjectTransformResult.stderr);
 expectType<string>(falseFalseObjectTransformResult.all);
 expectType<[undefined, string, string]>(falseFalseObjectTransformResult.stdio);
 
-const objectTransformStdoutError = new Error('.') as ExecaError<{stdout: {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: true}}>;
+const objectTransformStdoutError = new Error('.') as ExecaError<{stdout: {transform: typeof objectGenerator; final: typeof objectFinal; readonly objectMode: true}}>;
 expectType<unknown[]>(objectTransformStdoutError.stdout);
 expectType<[undefined, unknown[], string]>(objectTransformStdoutError.stdio);
 
-const objectTransformStderrError = new Error('.') as ExecaError<{stderr: {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: true}}>;
+const objectTransformStderrError = new Error('.') as ExecaError<{stderr: {transform: typeof objectGenerator; final: typeof objectFinal; readonly objectMode: true}}>;
 expectType<unknown[]>(objectTransformStderrError.stderr);
 expectType<[undefined, string, unknown[]]>(objectTransformStderrError.stdio);
 
-const objectTransformStdioError = new Error('.') as ExecaError<{stdio: ['pipe', 'pipe', {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: true}]}>;
+const objectTransformStdioError = new Error('.') as ExecaError<{stdio: ['pipe', 'pipe', {transform: typeof objectGenerator; final: typeof objectFinal; readonly objectMode: true}]}>;
 expectType<unknown[]>(objectTransformStdioError.stderr);
 expectType<[undefined, string, unknown[]]>(objectTransformStdioError.stdio);
 
-const falseObjectTransformStdoutError = new Error('.') as ExecaError<{stdout: {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: false}}>;
+const falseObjectTransformStdoutError = new Error('.') as ExecaError<{stdout: {transform: typeof objectGenerator; final: typeof objectFinal; readonly objectMode: false}}>;
 expectType<string>(falseObjectTransformStdoutError.stdout);
 expectType<[undefined, string, string]>(falseObjectTransformStdoutError.stdio);
 
-const falseObjectTransformStderrError = new Error('.') as ExecaError<{stderr: {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: false}}>;
+const falseObjectTransformStderrError = new Error('.') as ExecaError<{stderr: {transform: typeof objectGenerator; final: typeof objectFinal; readonly objectMode: false}}>;
 expectType<string>(falseObjectTransformStderrError.stderr);
 expectType<[undefined, string, string]>(falseObjectTransformStderrError.stdio);
 
-const falseObjectTransformStdioError = new Error('.') as ExecaError<{stdio: ['pipe', 'pipe', {transform: typeof objectGenerator; final: typeof objectFinal; objectMode: false}]}>;
+const falseObjectTransformStdioError = new Error('.') as ExecaError<{stdio: ['pipe', 'pipe', {transform: typeof objectGenerator; final: typeof objectFinal; readonly objectMode: false}]}>;
 expectType<string>(falseObjectTransformStdioError.stderr);
 expectType<[undefined, string, string]>(falseObjectTransformStdioError.stdio);

--- a/types/arguments/specific.d.ts
+++ b/types/arguments/specific.d.ts
@@ -1,22 +1,22 @@
 import type {FromOption} from './fd-options.js';
 
 // Options which can be fd-specific like `{verbose: {stdout: 'none', stderr: 'full'}}`
-export type FdGenericOption<OptionType = unknown> = OptionType | GenericOptionObject<OptionType>;
+export type FdGenericOption<OptionType> = OptionType | GenericOptionObject<OptionType>;
 
-type GenericOptionObject<OptionType = unknown> = {
+type GenericOptionObject<OptionType> = {
 	readonly [FdName in FromOption]?: OptionType
 };
 
 // Retrieve fd-specific option's value
 export type FdSpecificOption<
-	GenericOption extends FdGenericOption,
+	GenericOption extends FdGenericOption<unknown>,
 	FdNumber extends string,
-> = GenericOption extends GenericOptionObject
+> = GenericOption extends GenericOptionObject<unknown>
 	? FdSpecificObjectOption<GenericOption, FdNumber>
 	: GenericOption;
 
 type FdSpecificObjectOption<
-	GenericOption extends GenericOptionObject,
+	GenericOption extends GenericOptionObject<unknown>,
 	FdNumber extends string,
 > = keyof GenericOption extends FromOption
 	? FdNumberToFromOption<FdNumber, keyof GenericOption> extends never

--- a/types/methods/template.d.ts
+++ b/types/methods/template.d.ts
@@ -1,11 +1,13 @@
+import type {CommonOptions} from '../arguments/options.js';
 import type {CommonResultInstance} from '../return/result.js';
 
 // Values allowed inside `...${...}...` template syntax
-export type TemplateExpression =
+type TemplateExpressionItem =
 	| string
 	| number
-	| CommonResultInstance
-	| ReadonlyArray<string | number | CommonResultInstance>;
+	| CommonResultInstance<boolean, CommonOptions>;
+
+export type TemplateExpression = TemplateExpressionItem | readonly TemplateExpressionItem[];
 
 // `...${...}...` template syntax
 export type TemplateString = readonly [TemplateStringsArray, ...readonly TemplateExpression[]];

--- a/types/return/final-error.d.ts
+++ b/types/return/final-error.d.ts
@@ -2,15 +2,21 @@ import type {CommonOptions, Options, SyncOptions} from '../arguments/options.js'
 import {CommonResult} from './result.js';
 
 declare abstract class CommonError<
-	IsSync extends boolean = boolean,
-	OptionsType extends CommonOptions = CommonOptions,
+	IsSync extends boolean,
+	OptionsType extends CommonOptions,
 > extends CommonResult<IsSync, OptionsType> {
-	message: NonNullable<CommonResult['message']>;
-	shortMessage: NonNullable<CommonResult['shortMessage']>;
-	originalMessage: NonNullable<CommonResult['originalMessage']>;
-	readonly name: NonNullable<CommonResult['name']>;
-	stack: NonNullable<CommonResult['stack']>;
+	message: CommonErrorProperty<IsSync, OptionsType, 'message'>;
+	shortMessage: CommonErrorProperty<IsSync, OptionsType, 'shortMessage'>;
+	originalMessage: CommonErrorProperty<IsSync, OptionsType, 'originalMessage'>;
+	readonly name: CommonErrorProperty<IsSync, OptionsType, 'name'>;
+	stack: CommonErrorProperty<IsSync, OptionsType, 'stack'>;
 }
+
+type CommonErrorProperty<
+	IsSync extends boolean,
+	OptionsType extends CommonOptions,
+	PropertyName extends keyof CommonResult<IsSync, OptionsType>,
+> = NonNullable<CommonResult<IsSync, OptionsType>[PropertyName]>;
 
 // `result.*` defined only on failure, i.e. on `error.*`
 export type ErrorProperties =

--- a/types/return/ignore.d.ts
+++ b/types/return/ignore.d.ts
@@ -7,7 +7,7 @@ import type {CommonOptions} from '../arguments/options.js';
 // Whether `result.stdin|stdout|stderr|all|stdio[*]` is `undefined`
 export type IgnoresResultOutput<
 	FdNumber extends string,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = FdSpecificOption<OptionsType['buffer'], FdNumber> extends false
 	? true
 	: IsInputFd<FdNumber, OptionsType> extends true
@@ -17,7 +17,7 @@ export type IgnoresResultOutput<
 // Whether `subprocess.stdout|stderr|all` is `undefined|null`
 export type IgnoresSubprocessOutput<
 	FdNumber extends string,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = IgnoresOutput<FdNumber, FdStdioOption<FdNumber, OptionsType>>;
 
 type IgnoresOutput<

--- a/types/return/result-all.d.ts
+++ b/types/return/result-all.d.ts
@@ -5,12 +5,12 @@ import type {IgnoresResultOutput} from './ignore.js';
 import type {ResultStdio} from './result-stdout.js';
 
 // `result.all`
-export type ResultAll<OptionsType extends CommonOptions = CommonOptions> =
+export type ResultAll<OptionsType extends CommonOptions> =
 	ResultAllProperty<OptionsType['all'], OptionsType>;
 
 type ResultAllProperty<
-	AllOption extends CommonOptions['all'] = CommonOptions['all'],
-	OptionsType extends CommonOptions = CommonOptions,
+	AllOption extends CommonOptions['all'],
+	OptionsType extends CommonOptions,
 > = AllOption extends true
 	? ResultStdio<
 	AllMainFd<OptionsType>,
@@ -20,11 +20,11 @@ type ResultAllProperty<
 	>
 	: undefined;
 
-type AllMainFd<OptionsType extends CommonOptions = CommonOptions> =
+type AllMainFd<OptionsType extends CommonOptions> =
 	IgnoresResultOutput<'1', OptionsType> extends true ? '2' : '1';
 
-type AllObjectFd<OptionsType extends CommonOptions = CommonOptions> =
+type AllObjectFd<OptionsType extends CommonOptions> =
 	IsObjectFd<'1', OptionsType> extends true ? '1' : '2';
 
-type AllLinesFd<OptionsType extends CommonOptions = CommonOptions> =
+type AllLinesFd<OptionsType extends CommonOptions> =
 	FdSpecificOption<OptionsType['lines'], '1'> extends true ? '1' : '2';

--- a/types/return/result-stdio.d.ts
+++ b/types/return/result-stdio.d.ts
@@ -4,12 +4,12 @@ import type {CommonOptions} from '../arguments/options.js';
 import type {ResultStdioNotAll} from './result-stdout.js';
 
 // `result.stdio`
-export type ResultStdioArray<OptionsType extends CommonOptions = CommonOptions> =
+export type ResultStdioArray<OptionsType extends CommonOptions> =
 	MapResultStdio<StdioOptionNormalizedArray<OptionsType>, OptionsType>;
 
 type MapResultStdio<
 	StdioOptionsArrayType extends StdioOptionsArray,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = {
 	-readonly [FdNumber in keyof StdioOptionsArrayType]: ResultStdioNotAll<
 	FdNumber extends string ? FdNumber : string,

--- a/types/return/result-stdout.d.ts
+++ b/types/return/result-stdout.d.ts
@@ -7,7 +7,7 @@ import type {IgnoresResultOutput} from './ignore.js';
 // `result.stdout|stderr|stdio`
 export type ResultStdioNotAll<
 	FdNumber extends string,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = ResultStdio<FdNumber, FdNumber, FdNumber, OptionsType>;
 
 // `result.stdout|stderr|stdio|all`
@@ -15,7 +15,7 @@ export type ResultStdio<
 	MainFdNumber extends string,
 	ObjectFdNumber extends string,
 	LinesFdNumber extends string,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = ResultStdioProperty<
 ObjectFdNumber,
 LinesFdNumber,
@@ -27,7 +27,7 @@ type ResultStdioProperty<
 	ObjectFdNumber extends string,
 	LinesFdNumber extends string,
 	StreamOutputIgnored extends boolean,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = StreamOutputIgnored extends true
 	? undefined
 	: ResultStdioItem<

--- a/types/return/result.d.ts
+++ b/types/return/result.d.ts
@@ -7,8 +7,8 @@ import type {ResultStdioArray} from './result-stdio.js';
 import type {ResultStdioNotAll} from './result-stdout.js';
 
 export declare abstract class CommonResult<
-	IsSync extends boolean = boolean,
-	OptionsType extends CommonOptions = CommonOptions,
+	IsSync extends boolean,
+	OptionsType extends CommonOptions,
 > {
 	/**
 	The output of the subprocess on [`stdout`](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)).
@@ -162,13 +162,13 @@ export declare abstract class CommonResult<
 }
 
 export type CommonResultInstance<
-	IsSync extends boolean = boolean,
-	OptionsType extends CommonOptions = CommonOptions,
+	IsSync extends boolean,
+	OptionsType extends CommonOptions,
 > = InstanceType<typeof CommonResult<IsSync, OptionsType>>;
 
 type SuccessResult<
-	IsSync extends boolean = boolean,
-	OptionsType extends CommonOptions = CommonOptions,
+	IsSync extends boolean,
+	OptionsType extends CommonOptions,
 > = CommonResultInstance<IsSync, OptionsType> & OmitErrorIfReject<OptionsType['reject']>;
 
 type OmitErrorIfReject<RejectOption extends CommonOptions['reject']> = RejectOption extends false

--- a/types/stdio/array.d.ts
+++ b/types/stdio/array.d.ts
@@ -2,9 +2,9 @@ import type {CommonOptions} from '../arguments/options.js';
 import type {StdinOptionCommon, StdoutStderrOptionCommon, StdioOptionsArray} from './type.js';
 
 // `options.stdio`, normalized as an array
-export type StdioOptionNormalizedArray<OptionsType extends CommonOptions = CommonOptions> = StdioOptionNormalized<OptionsType['stdio']>;
+export type StdioOptionNormalizedArray<OptionsType extends CommonOptions> = StdioOptionNormalized<OptionsType['stdio']>;
 
-type StdioOptionNormalized<StdioOption extends CommonOptions['stdio'] = CommonOptions['stdio']> = StdioOption extends StdioOptionsArray
+type StdioOptionNormalized<StdioOption extends CommonOptions['stdio']> = StdioOption extends StdioOptionsArray
 	? StdioOption
 	: StdioOption extends StdinOptionCommon
 		? StdioOption extends StdoutStderrOptionCommon

--- a/types/stdio/direction.d.ts
+++ b/types/stdio/direction.d.ts
@@ -6,7 +6,7 @@ import type {FdStdioArrayOption} from './option.js';
 // Whether `result.stdio[FdNumber]` is an input stream
 export type IsInputFd<
 	FdNumber extends string,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = FdNumber extends '0'
 	? true
 	: Intersects<StdioSingleOptionItems<FdStdioArrayOption<FdNumber, OptionsType>>, InputStdioOption>;

--- a/types/stdio/option.d.ts
+++ b/types/stdio/option.d.ts
@@ -10,12 +10,12 @@ import type {
 // `options.stdin|stdout|stderr|stdio` for a given file descriptor
 export type FdStdioOption<
 	FdNumber extends string,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = Extract<FdStdioOptionProperty<FdNumber, OptionsType>, StdioOptionCommon>;
 
 type FdStdioOptionProperty<
 	FdNumber extends string,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = string extends FdNumber ? StdioOptionCommon
 	: FdNumber extends keyof StandardStreams
 		? StandardStreams[FdNumber] extends keyof OptionsType
@@ -28,7 +28,7 @@ type FdStdioOptionProperty<
 // `options.stdio[FdNumber]`, excluding `options.stdin|stdout|stderr`
 export type FdStdioArrayOption<
 	FdNumber extends string,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = Extract<FdStdioArrayOptionProperty<FdNumber, StdioOptionNormalizedArray<OptionsType>>, StdioOptionCommon>;
 
 type FdStdioArrayOptionProperty<
@@ -39,7 +39,7 @@ type FdStdioArrayOptionProperty<
 	: StdioOptionsType extends StdioOptionsArray
 		? FdNumber extends keyof StdioOptionsType
 			? StdioOptionsType[FdNumber]
-			: StdioOptionNormalizedArray extends StdioOptionsType
+			: StdioOptionNormalizedArray<CommonOptions> extends StdioOptionsType
 				? StdioOptionsType[number]
 				: undefined
 		: undefined;

--- a/types/stdio/type.d.ts
+++ b/types/stdio/type.d.ts
@@ -89,9 +89,9 @@ type OutputStdioOption<
 
 // `options.stdin` array items
 type StdinSingleOption<
-	IsSync extends boolean = boolean,
-	IsExtra extends boolean = boolean,
-	IsArray extends boolean = boolean,
+	IsSync extends boolean,
+	IsExtra extends boolean,
+	IsArray extends boolean,
 > =
 	| CommonStdioOption<IsSync, IsExtra, IsArray>
 	| InputStdioOption<IsSync, IsExtra, IsArray>;
@@ -111,9 +111,9 @@ export type StdinSyncOption = StdinOptionCommon<true, false>;
 
 // `options.stdout|stderr` array items
 type StdoutStderrSingleOption<
-	IsSync extends boolean = boolean,
-	IsExtra extends boolean = boolean,
-	IsArray extends boolean = boolean,
+	IsSync extends boolean,
+	IsExtra extends boolean,
+	IsArray extends boolean,
 > =
   | CommonStdioOption<IsSync, IsExtra, IsArray>
   | OutputStdioOption<IsSync, IsArray>;
@@ -132,7 +132,7 @@ export type StdoutStderrOption = StdoutStderrOptionCommon<false, false>;
 export type StdoutStderrSyncOption = StdoutStderrOptionCommon<true, false>;
 
 // `options.stdio[3+]`
-type StdioExtraOptionCommon<IsSync extends boolean = boolean> =
+type StdioExtraOptionCommon<IsSync extends boolean> =
 	| StdinOptionCommon<IsSync, true>
 	| StdoutStderrOptionCommon<IsSync, true>;
 

--- a/types/subprocess/all.d.ts
+++ b/types/subprocess/all.d.ts
@@ -3,13 +3,13 @@ import type {IgnoresSubprocessOutput} from '../return/ignore.js';
 import type {Options} from '../arguments/options.js';
 
 // `subprocess.all`
-export type SubprocessAll<OptionsType extends Options = Options> = AllStream<AllIgnored<OptionsType['all'], OptionsType>>;
+export type SubprocessAll<OptionsType extends Options> = AllStream<AllIgnored<OptionsType['all'], OptionsType>>;
 
 type AllStream<IsIgnored> = IsIgnored extends true ? undefined : Readable;
 
 type AllIgnored<
-	AllOption extends Options['all'] = Options['all'],
-	OptionsType extends Options = Options,
+	AllOption extends Options['all'],
+	OptionsType extends Options,
 > = AllOption extends true
 	? IgnoresSubprocessOutput<'1', OptionsType> extends true
 		? IgnoresSubprocessOutput<'2', OptionsType>

--- a/types/subprocess/stdio.d.ts
+++ b/types/subprocess/stdio.d.ts
@@ -4,12 +4,12 @@ import type {Options} from '../arguments/options.js';
 import type {SubprocessStdioStream} from './stdout.js';
 
 // `subprocess.stdio`
-export type SubprocessStdioArray<OptionsType extends Options = Options> = MapStdioStreams<StdioOptionNormalizedArray<OptionsType>, OptionsType>;
+export type SubprocessStdioArray<OptionsType extends Options> = MapStdioStreams<StdioOptionNormalizedArray<OptionsType>, OptionsType>;
 
 // We cannot use mapped types because it must be compatible with Node.js `ChildProcess["stdio"]` which uses a tuple with exactly 5 items
 type MapStdioStreams<
 	StdioOptionsArrayType extends StdioOptionsArray,
-	OptionsType extends Options = Options,
+	OptionsType extends Options,
 > = [
 	SubprocessStdioStream<'0', OptionsType>,
 	SubprocessStdioStream<'1', OptionsType>,

--- a/types/subprocess/stdout.d.ts
+++ b/types/subprocess/stdout.d.ts
@@ -6,13 +6,13 @@ import type {Options} from '../arguments/options.js';
 // `subprocess.stdin|stdout|stderr|stdio`
 export type SubprocessStdioStream<
 	FdNumber extends string,
-	OptionsType extends Options = Options,
+	OptionsType extends Options,
 > = SubprocessStream<FdNumber, IgnoresSubprocessOutput<FdNumber, OptionsType>, OptionsType>;
 
 type SubprocessStream<
 	FdNumber extends string,
 	StreamResultIgnored extends boolean,
-	OptionsType extends Options = Options,
+	OptionsType extends Options,
 > = StreamResultIgnored extends true
 	? null
 	: InputOutputStream<IsInputFd<FdNumber, OptionsType>>;

--- a/types/subprocess/subprocess.d.ts
+++ b/types/subprocess/subprocess.d.ts
@@ -21,7 +21,7 @@ type HasIpc<OptionsType extends Options> = OptionsType['ipc'] extends true
 		? 'ipc' extends OptionsType['stdio'][number] ? true : false
 		: false;
 
-type ExecaCustomSubprocess<OptionsType extends Options = Options> = {
+type ExecaCustomSubprocess<OptionsType extends Options> = {
 	/**
 	Process identifier ([PID](https://en.wikipedia.org/wiki/Process_identifier)).
 

--- a/types/transform/normalize.d.ts
+++ b/types/transform/normalize.d.ts
@@ -11,6 +11,13 @@ type GeneratorFinal<IsSync extends boolean> = () =>
 | Unless<IsSync, AsyncGenerator<unknown, void, void>>
 | Generator<unknown, void, void>;
 
+export type TransformCommon = {
+	/**
+	If `true`, allow `transformOptions.transform` and `transformOptions.final` to return any type, not just `string` or `Uint8Array`.
+	*/
+	readonly objectMode?: boolean;
+};
+
 /**
 A transform or an array of transforms can be passed to the `stdin`, `stdout`, `stderr` or `stdio` option.
 
@@ -36,21 +43,14 @@ export type GeneratorTransformFull<IsSync extends boolean> = {
 	If `true`, keep newlines in each `line` argument. Also, this allows multiple `yield`s to produces a single line.
 	*/
 	readonly preserveNewlines?: boolean;
-
-	/**
-	If `true`, allow `transformOptions.transform` and `transformOptions.final` to return any type, not just `string` or `Uint8Array`.
-	*/
-	readonly objectMode?: boolean;
-};
+} & TransformCommon;
 
 // `options.std*: Duplex`
 export type DuplexTransform = {
 	readonly transform: Duplex;
-	readonly objectMode?: boolean;
-};
+} & TransformCommon;
 
 // `options.std*: TransformStream`
 export type WebTransform = {
 	readonly transform: TransformStream;
-	readonly objectMode?: boolean;
-};
+} & TransformCommon;

--- a/types/transform/object-mode.d.ts
+++ b/types/transform/object-mode.d.ts
@@ -1,18 +1,18 @@
 import type {StdioSingleOption, StdioOptionCommon, StdioSingleOptionItems} from '../stdio/type.js';
 import type {FdStdioOption} from '../stdio/option.js';
 import type {CommonOptions} from '../arguments/options.js';
-import type {DuplexTransform} from './normalize.js';
+import type {DuplexTransform, TransformCommon} from './normalize.js';
 
 // Whether a file descriptor is in object mode
 // I.e. whether `result.stdout|stderr|stdio|all` is an array of `unknown` due to `objectMode: true`
 export type IsObjectFd<
 	FdNumber extends string,
-	OptionsType extends CommonOptions = CommonOptions,
+	OptionsType extends CommonOptions,
 > = IsObjectStdioOption<FdStdioOption<FdNumber, OptionsType>>;
 
 type IsObjectStdioOption<StdioOptionType extends StdioOptionCommon> = IsObjectStdioSingleOption<StdioSingleOptionItems<StdioOptionType>>;
 
-type IsObjectStdioSingleOption<StdioSingleOptionType extends StdioSingleOption> = StdioSingleOptionType extends {objectMode?: boolean}
+type IsObjectStdioSingleOption<StdioSingleOptionType extends StdioSingleOption> = StdioSingleOptionType extends TransformCommon
 	? BooleanObjectMode<StdioSingleOptionType['objectMode']>
 	: StdioSingleOptionType extends DuplexTransform
 		? StdioSingleOptionType['transform']['readableObjectMode']


### PR DESCRIPTION
This PR simplifies the types. It only refactors them, it does not change any type behavior.

It mostly removes a bunch of default types that are currently unused. It does not change default types for exported types.