### PR TITLE
Fix type of result when using the `reject: false` option

### DIFF
--- a/test-d/methods/command.test-d.ts
+++ b/test-d/methods/command.test-d.ts
@@ -55,6 +55,7 @@ expectType<Result<{}>>(await execaCommand`unicorns ${false.toString()}`);
 expectError(await execaCommand`unicorns ${false}`);
 
 expectError(await execaCommand`unicorns ${await execaCommand`echo foo`}`);
+expectError(await execaCommand`unicorns ${await execaCommand({reject: false})`echo foo`}`);
 expectError(await execaCommand`unicorns ${execaCommand`echo foo`}`);
 expectError(await execaCommand`unicorns ${[await execaCommand`echo foo`, 'bar']}`);
 expectError(await execaCommand`unicorns ${[execaCommand`echo foo`, 'bar']}`);

--- a/test-d/methods/main-async.test-d.ts
+++ b/test-d/methods/main-async.test-d.ts
@@ -51,6 +51,7 @@ expectType<Result<{}>>(await execa`unicorns ${false.toString()}`);
 expectError(await execa`unicorns ${false}`);
 
 expectType<Result<{}>>(await execa`unicorns ${await execa`echo foo`}`);
+expectType<Result<{}>>(await execa`unicorns ${await execa({reject: false})`echo foo`}`);
 expectError(await execa`unicorns ${execa`echo foo`}`);
 expectType<Result<{}>>(await execa`unicorns ${[await execa`echo foo`, 'bar']}`);
 expectError(await execa`unicorns ${[execa`echo foo`, 'bar']}`);

--- a/test-d/methods/main-sync.test-d.ts
+++ b/test-d/methods/main-sync.test-d.ts
@@ -51,4 +51,5 @@ expectType<SyncResult<{}>>(execaSync`unicorns ${false.toString()}`);
 expectError(execaSync`unicorns ${false}`);
 
 expectType<SyncResult<{}>>(execaSync`unicorns ${execaSync`echo foo`}`);
+expectType<SyncResult<{}>>(execaSync`unicorns ${execaSync({reject: false})`echo foo`}`);
 expectType<SyncResult<{}>>(execaSync`unicorns ${[execaSync`echo foo`, 'bar']}`);

--- a/test-d/methods/node.test-d.ts
+++ b/test-d/methods/node.test-d.ts
@@ -51,6 +51,7 @@ expectType<Result<{}>>(await execaNode`unicorns ${false.toString()}`);
 expectError(await execaNode`unicorns ${false}`);
 
 expectType<Result<{}>>(await execaNode`unicorns ${await execaNode`echo foo`}`);
+expectType<Result<{}>>(await execaNode`unicorns ${await execaNode({reject: false})`echo foo`}`);
 expectError(await execaNode`unicorns ${execaNode`echo foo`}`);
 expectType<Result<{}>>(await execaNode`unicorns ${[await execaNode`echo foo`, 'bar']}`);
 expectError(await execaNode`unicorns ${[execaNode`echo foo`, 'bar']}`);

--- a/test-d/methods/script-s.test-d.ts
+++ b/test-d/methods/script-s.test-d.ts
@@ -61,4 +61,5 @@ expectType<SyncResult<{}>>($.s`unicorns ${false.toString()}`);
 expectError($.s`unicorns ${false}`);
 
 expectType<SyncResult<{}>>($.s`unicorns ${$.s`echo foo`}`);
+expectType<SyncResult<{}>>($.s`unicorns ${$.s({reject: false})`echo foo`}`);
 expectType<SyncResult<{}>>($.s`unicorns ${[$.s`echo foo`, 'bar']}`);

--- a/test-d/methods/script-sync.test-d.ts
+++ b/test-d/methods/script-sync.test-d.ts
@@ -61,4 +61,5 @@ expectType<SyncResult<{}>>($.sync`unicorns ${false.toString()}`);
 expectError($.sync`unicorns ${false}`);
 
 expectType<SyncResult<{}>>($.sync`unicorns ${$.sync`echo foo`}`);
+expectType<SyncResult<{}>>($.sync`unicorns ${$.sync({reject: false})`echo foo`}`);
 expectType<SyncResult<{}>>($.sync`unicorns ${[$.sync`echo foo`, 'bar']}`);

--- a/test-d/methods/script.test-d.ts
+++ b/test-d/methods/script.test-d.ts
@@ -51,6 +51,7 @@ expectType<Result<{}>>(await $`unicorns ${false.toString()}`);
 expectError(await $`unicorns ${false}`);
 
 expectType<Result<{}>>(await $`unicorns ${await $`echo foo`}`);
+expectType<Result<{}>>(await $`unicorns ${await $({reject: false})`echo foo`}`);
 expectError(await $`unicorns ${$`echo foo`}`);
 expectType<Result<{}>>(await $`unicorns ${[await $`echo foo`, 'bar']}`);
 expectError(await $`unicorns ${[$`echo foo`, 'bar']}`);

--- a/test-d/return/result-reject.test-d.ts
+++ b/test-d/return/result-reject.test-d.ts
@@ -1,7 +1,13 @@
-import {expectType, expectError} from 'tsd';
-import {execa, execaSync} from '../../index.js';
+import {expectType, expectError, expectAssignable} from 'tsd';
+import {
+	type Result,
+	type SyncResult,
+	execa,
+	execaSync,
+} from '../../index.js';
 
 const rejectsResult = await execa('unicorns');
+expectAssignable<Result>(rejectsResult);
 expectError(rejectsResult.stack?.toString());
 expectError(rejectsResult.message?.toString());
 expectError(rejectsResult.shortMessage?.toString());
@@ -10,6 +16,7 @@ expectError(rejectsResult.code?.toString());
 expectError(rejectsResult.cause?.valueOf());
 
 const noRejectsResult = await execa('unicorns', {reject: false});
+expectAssignable<Result>(noRejectsResult);
 expectType<string | undefined>(noRejectsResult.stack);
 expectType<string | undefined>(noRejectsResult.message);
 expectType<string | undefined>(noRejectsResult.shortMessage);
@@ -18,6 +25,7 @@ expectType<string | undefined>(noRejectsResult.code);
 expectType<unknown>(noRejectsResult.cause);
 
 const rejectsSyncResult = execaSync('unicorns');
+expectAssignable<SyncResult>(rejectsSyncResult);
 expectError(rejectsSyncResult.stack?.toString());
 expectError(rejectsSyncResult.message?.toString());
 expectError(rejectsSyncResult.shortMessage?.toString());
@@ -26,6 +34,7 @@ expectError(rejectsSyncResult.code?.toString());
 expectError(rejectsSyncResult.cause?.valueOf());
 
 const noRejectsSyncResult = execaSync('unicorns', {reject: false});
+expectAssignable<SyncResult>(noRejectsSyncResult);
 expectType<string | undefined>(noRejectsSyncResult.stack);
 expectType<string | undefined>(noRejectsSyncResult.message);
 expectType<string | undefined>(noRejectsSyncResult.shortMessage);

--- a/types/methods/template.d.ts
+++ b/types/methods/template.d.ts
@@ -1,11 +1,11 @@
-import type {CommonOptions} from '../arguments/options.js';
-import type {CommonResultInstance} from '../return/result.js';
+import type {Result, SyncResult} from '../return/result.js';
 
 // Values allowed inside `...${...}...` template syntax
 type TemplateExpressionItem =
 	| string
 	| number
-	| CommonResultInstance<boolean, CommonOptions>;
+	| Result
+	| SyncResult;
 
 export type TemplateExpression = TemplateExpressionItem | readonly TemplateExpressionItem[];
 

--- a/types/return/result.d.ts
+++ b/types/return/result.d.ts
@@ -161,19 +161,14 @@ export declare abstract class CommonResult<
 	stack?: Error['stack'];
 }
 
-export type CommonResultInstance<
-	IsSync extends boolean,
-	OptionsType extends CommonOptions,
-> = InstanceType<typeof CommonResult<IsSync, OptionsType>>;
-
 type SuccessResult<
 	IsSync extends boolean,
 	OptionsType extends CommonOptions,
-> = CommonResultInstance<IsSync, OptionsType> & OmitErrorIfReject<OptionsType['reject']>;
+> = InstanceType<typeof CommonResult<IsSync, OptionsType>> & OmitErrorIfReject<OptionsType['reject']>;
 
-type OmitErrorIfReject<RejectOption extends CommonOptions['reject']> = RejectOption extends false
-	? {}
-	: {[ErrorProperty in ErrorProperties]: never};
+type OmitErrorIfReject<RejectOption extends CommonOptions['reject']> = {
+	[ErrorProperty in ErrorProperties]: RejectOption extends false ? unknown : never
+};
 
 /**
 Result of a subprocess successful execution.


### PR DESCRIPTION
Fixes #1045.