### PR TITLE
Split CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm test
+      - run: npm run lint
+      - run: npm run type
+      - run: npm run unit
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
 		"node": ">=18"
 	},
 	"scripts": {
-		"test": "xo && c8 ava && tsd && tsc && npx --yes tsd@0.29.0 && npx --yes --package typescript@5.1 tsc"
+		"test": "npm run lint && npm run unit && npm run type",
+		"lint": "xo",
+		"unit": "c8 ava",
+		"type": "tsd && tsc && npx --yes tsd@0.29.0 && npx --yes --package typescript@5.1 tsc"
 	},
 	"files": [
 		"index.js",


### PR DESCRIPTION
This PR splits the linting, type checking and automated testing into separate tasks locally and in CI.

This makes it simpler to follow the CI. Also it allows running all the type checking logic, without running the automated tests.