### PR TITLE
Add promise-based IPC

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -92,6 +92,37 @@ Split a `command` string into an array. For example, `'npm run build'` returns `
 
 [More info.](escaping.md#user-defined-input)
 
+### sendMessage(message)
+
+`message`: [`Message`](ipc.md#message-type)\
+_Returns_: `Promise<void>`
+
+Send a `message` to the parent process.
+
+This requires the [`ipc`](#optionsipc) option to be `true`. The [type](ipc.md#message-type) of `message` depends on the [`serialization`](#optionsserialization) option.
+
+[More info.](ipc.md#exchanging-messages)
+
+### getOneMessage()
+
+_Returns_: [`Promise<Message>`](ipc.md#message-type)
+
+Receive a single `message` from the parent process.
+
+This requires the [`ipc`](#optionsipc) option to be `true`. The [type](ipc.md#message-type) of `message` depends on the [`serialization`](#optionsserialization) option.
+
+[More info.](ipc.md#exchanging-messages)
+
+### getEachMessage()
+
+_Returns_: [`AsyncIterable<Message>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)
+
+Iterate over each `message` from the parent process.
+
+This requires the [`ipc`](#optionsipc) option to be `true`. The [type](ipc.md#message-type) of `message` depends on the [`serialization`](#optionsserialization) option.
+
+[More info.](ipc.md#listening-to-messages)
+
 ## Return value
 
 _TypeScript:_ [`ResultPromise`](typescript.md)\
@@ -217,30 +248,36 @@ This is `undefined` if the subprocess failed to spawn.
 
 [More info.](termination.md#inter-process-termination)
 
-### subprocess.send(message)
+### subprocess.sendMessage(message)
 
-`message`: `unknown`\
-_Returns_: `boolean`
+`message`: [`Message`](ipc.md#message-type)\
+_Returns_: `Promise<void>`
 
-Send a `message` to the subprocess. The type of `message` depends on the [`serialization`](#optionsserialization) option.
-The subprocess receives it as a [`message` event](https://nodejs.org/api/process.html#event-message).
+Send a `message` to the subprocess.
 
-This returns `true` on success.
-
-This requires the [`ipc`](#optionsipc) option to be `true`.
+This requires the [`ipc`](#optionsipc) option to be `true`. The [type](ipc.md#message-type) of `message` depends on the [`serialization`](#optionsserialization) option.
 
 [More info.](ipc.md#exchanging-messages)
 
-### subprocess.on('message', (message) => void)
+### subprocess.getOneMessage()
 
-`message`: `unknown`
+_Returns_: [`Promise<Message>`](ipc.md#message-type)
 
-Receives a `message` from the subprocess. The type of `message` depends on the [`serialization`](#optionsserialization) option.
-The subprocess sends it using [`process.send(message)`](https://nodejs.org/api/process.html#processsendmessage-sendhandle-options-callback).
+Receive a single `message` from the subprocess.
 
-This requires the [`ipc`](#optionsipc) option to be `true`.
+This requires the [`ipc`](#optionsipc) option to be `true`. The [type](ipc.md#message-type) of `message` depends on the [`serialization`](#optionsserialization) option.
 
 [More info.](ipc.md#exchanging-messages)
+
+### subprocess.getEachMessage()
+
+_Returns_: [`AsyncIterable<Message>`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)
+
+Iterate over each `message` from the subprocess.
+
+This requires the [`ipc`](#optionsipc) option to be `true`. The [type](ipc.md#message-type) of `message` depends on the [`serialization`](#optionsserialization) option.
+
+[More info.](ipc.md#listening-to-messages)
 
 ### subprocess.stdin
 
@@ -853,7 +890,7 @@ By default, this applies to both `stdout` and `stderr`, but [different values ca
 _Type:_ `boolean`\
 _Default:_ `true` if the [`node`](#optionsnode) option is enabled, `false` otherwise
 
-Enables exchanging messages with the subprocess using [`subprocess.send(message)`](#subprocesssendmessage) and [`subprocess.on('message', (message) => {})`](#subprocessonmessage-message--void).
+Enables exchanging messages with the subprocess using [`subprocess.sendMessage(message)`](#subprocesssendmessagemessage), [`subprocess.getOneMessage()`](#subprocessgetonemessage) and [`subprocess.getEachMessage()`](#subprocessgeteachmessage).
 
 [More info.](ipc.md)
 

--- a/docs/bash.md
+++ b/docs/bash.md
@@ -792,11 +792,11 @@ await $({detached: true})`npm run build`;
 
 ```js
 // Execa
-const subprocess = $({ipc: true})`node script.js`;
+const subprocess = $({node: true})`script.js`;
 
-subprocess.on('message', message => {
+for await (const message of subprocess.getEachMessage()) {
 	if (message === 'ping') {
-		subprocess.send('pong');
+		await subprocess.sendMessage('pong');
 	}
 });
 ```

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -8,7 +8,7 @@
 
 ## Available types
 
-The following types can be imported: [`ResultPromise`](api.md#return-value), [`Subprocess`](api.md#subprocess), [`Result`](api.md#result), [`ExecaError`](api.md#execaerror), [`Options`](api.md#options), [`StdinOption`](api.md#optionsstdin), [`StdoutStderrOption`](api.md#optionsstdout) and [`TemplateExpression`](api.md#execacommand).
+The following types can be imported: [`ResultPromise`](api.md#return-value), [`Subprocess`](api.md#subprocess), [`Result`](api.md#result), [`ExecaError`](api.md#execaerror), [`Options`](api.md#options), [`StdinOption`](api.md#optionsstdin), [`StdoutStderrOption`](api.md#optionsstdout), [`TemplateExpression`](api.md#execacommand) and [`Message`](api.md#subprocesssendmessagemessage).
 
 ```ts
 import {
@@ -20,6 +20,7 @@ import {
 	type StdinOption,
 	type StdoutStderrOption,
 	type TemplateExpression,
+	type Message,
 } from 'execa';
 
 const options: Options = {
@@ -27,11 +28,14 @@ const options: Options = {
 	stdout: 'pipe' satisfies StdoutStderrOption,
 	stderr: 'pipe' satisfies StdoutStderrOption,
 	timeout: 1000,
+	ipc: true,
 };
 const task: TemplateExpression = 'build';
+const message: Message = 'hello world';
 
 try {
 	const subprocess: ResultPromise = execa(options)`npm run ${task}`;
+	await subprocess.sendMessage(message);
 	const result: Result = await subprocess;
 	console.log(result.stdout);
 } catch (error) {
@@ -94,11 +98,14 @@ const options = {
 	stdout: 'pipe',
 	stderr: 'pipe',
 	timeout: 1000,
+	ipc: true,
 } as const;
 const task = 'build';
+const message = 'hello world';
 
 try {
 	const subprocess = execa(options)`npm run ${task}`;
+	await subprocess.sendMessage(message);
 	const result = await subprocess;
 	printResultStdout(result);
 } catch (error) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,12 +5,21 @@ export type {
 	StdoutStderrSyncOption,
 } from './types/stdio/type.js';
 export type {Options, SyncOptions} from './types/arguments/options.js';
+export type {TemplateExpression} from './types/methods/template.js';
+
 export type {Result, SyncResult} from './types/return/result.js';
 export type {ResultPromise, Subprocess} from './types/subprocess/subprocess.js';
 export {ExecaError, ExecaSyncError} from './types/return/final-error.js';
-export type {TemplateExpression} from './types/methods/template.js';
+
 export {execa} from './types/methods/main-async.js';
 export {execaSync} from './types/methods/main-sync.js';
 export {execaCommand, execaCommandSync, parseCommandString} from './types/methods/command.js';
 export {$} from './types/methods/script.js';
 export {execaNode} from './types/methods/node.js';
+
+export {
+	sendMessage,
+	getOneMessage,
+	getEachMessage,
+	type Message,
+} from './types/ipc.js';

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import {createExeca} from './lib/methods/create.js';
 import {mapCommandAsync, mapCommandSync} from './lib/methods/command.js';
 import {mapNode} from './lib/methods/node.js';
 import {mapScriptAsync, setScriptSync, deepScriptOptions} from './lib/methods/script.js';
+import {getIpcExport} from './lib/ipc/methods.js';
 
 export {parseCommandString} from './lib/methods/command.js';
 export {ExecaError, ExecaSyncError} from './lib/return/final-error.js';
@@ -12,3 +13,6 @@ export const execaCommand = createExeca(mapCommandAsync);
 export const execaCommandSync = createExeca(mapCommandSync);
 export const execaNode = createExeca(mapNode);
 export const $ = createExeca(mapScriptAsync, {}, deepScriptOptions, setScriptSync);
+
+const {sendMessage, getOneMessage, getEachMessage} = getIpcExport();
+export {sendMessage, getOneMessage, getEachMessage};

--- a/lib/ipc/array.js
+++ b/lib/ipc/array.js
@@ -1,0 +1,4 @@
+// The `ipc` option adds an `ipc` item to the `stdio` option
+export const normalizeIpcStdioArray = (stdioArray, ipc) => ipc && !stdioArray.includes('ipc')
+	? [...stdioArray, 'ipc']
+	: stdioArray;

--- a/lib/ipc/get-each.js
+++ b/lib/ipc/get-each.js
@@ -1,0 +1,43 @@
+import {once, on} from 'node:events';
+import {validateIpcOption, validateConnection} from './validation.js';
+
+// Like `[sub]process.on('message')` but promise-based
+export const getEachMessage = function ({anyProcess, isSubprocess, ipc}) {
+	const methodName = 'getEachMessage';
+	validateIpcOption(methodName, isSubprocess, ipc);
+	validateConnection(methodName, isSubprocess, anyProcess.channel !== null);
+
+	const controller = new AbortController();
+	stopOnExit(anyProcess, isSubprocess, controller);
+
+	return iterateOnMessages(anyProcess, isSubprocess, controller);
+};
+
+const stopOnExit = async (anyProcess, isSubprocess, controller) => {
+	try {
+		const onDisconnect = once(anyProcess, 'disconnect', {signal: controller.signal});
+		await (isSubprocess
+			? onDisconnect
+			: Promise.race([onDisconnect, anyProcess]));
+	} catch {} finally {
+		controller.abort();
+	}
+};
+
+const iterateOnMessages = async function * (anyProcess, isSubprocess, controller) {
+	try {
+		for await (const [message] of on(anyProcess, 'message', {signal: controller.signal})) {
+			yield message;
+		}
+	} catch (error) {
+		if (!controller.signal.aborted) {
+			throw error;
+		}
+	} finally {
+		if (!isSubprocess) {
+			await anyProcess;
+		}
+
+		controller.abort();
+	}
+};

--- a/lib/ipc/get-one.js
+++ b/lib/ipc/get-one.js
@@ -1,0 +1,16 @@
+import {once} from 'node:events';
+import {validateIpcOption, validateConnection} from './validation.js';
+
+// Like `[sub]process.once('message')` but promise-based
+export const getOneMessage = ({anyProcess, isSubprocess, ipc}) => {
+	const methodName = 'getOneMessage';
+	validateIpcOption(methodName, isSubprocess, ipc);
+	validateConnection(methodName, isSubprocess, anyProcess.channel !== null);
+
+	return onceMessage(anyProcess);
+};
+
+const onceMessage = async anyProcess => {
+	const [message] = await once(anyProcess, 'message');
+	return message;
+};

--- a/lib/ipc/methods.js
+++ b/lib/ipc/methods.js
@@ -1,0 +1,30 @@
+import process from 'node:process';
+import {promisify} from 'node:util';
+import {sendMessage} from './send.js';
+import {getOneMessage} from './get-one.js';
+import {getEachMessage} from './get-each.js';
+
+// Add promise-based IPC methods in current process
+export const addIpcMethods = (subprocess, {ipc}) => {
+	Object.assign(subprocess, getIpcMethods(subprocess, false, ipc));
+};
+
+// Get promise-based IPC in the subprocess
+export const getIpcExport = () => getIpcMethods(process, true, process.channel !== undefined);
+
+// Retrieve the `ipc` shared by both the current process and the subprocess
+const getIpcMethods = (anyProcess, isSubprocess, ipc) => {
+	const anyProcessSend = anyProcess.send === undefined
+		? undefined
+		: promisify(anyProcess.send.bind(anyProcess));
+	return {
+		sendMessage: sendMessage.bind(undefined, {
+			anyProcess,
+			anyProcessSend,
+			isSubprocess,
+			ipc,
+		}),
+		getOneMessage: getOneMessage.bind(undefined, {anyProcess, isSubprocess, ipc}),
+		getEachMessage: getEachMessage.bind(undefined, {anyProcess, isSubprocess, ipc}),
+	};
+};

--- a/lib/ipc/send.js
+++ b/lib/ipc/send.js
@@ -1,0 +1,26 @@
+import {
+	validateIpcOption,
+	validateConnection,
+	handleSerializationError,
+} from './validation.js';
+
+// Like `[sub]process.send()` but promise-based.
+// We do not `await subprocess` during `.sendMessage()` nor `.getOneMessage()` since those methods are transient.
+// Users would still need to `await subprocess` after the method is done.
+// Also, this would prevent `unhandledRejection` event from being emitted, making it silent.
+export const sendMessage = ({anyProcess, anyProcessSend, isSubprocess, ipc}, message) => {
+	const methodName = 'sendMessage';
+	validateIpcOption(methodName, isSubprocess, ipc);
+	validateConnection(methodName, isSubprocess, anyProcess.connected);
+
+	return sendOneMessage(anyProcessSend, isSubprocess, message);
+};
+
+const sendOneMessage = async (anyProcessSend, isSubprocess, message) => {
+	try {
+		await anyProcessSend(message);
+	} catch (error) {
+		handleSerializationError(error, isSubprocess, message);
+		throw error;
+	}
+};

--- a/lib/ipc/validation.js
+++ b/lib/ipc/validation.js
@@ -1,0 +1,46 @@
+// Better error message when forgetting to set `ipc: true` and using the IPC methods
+export const validateIpcOption = (methodName, isSubprocess, ipc) => {
+	if (!ipc) {
+		throw new Error(`${getNamespaceName(isSubprocess)}${methodName}() can only be used if the \`ipc\` option is \`true\`.`);
+	}
+};
+
+// Better error message when one process does not send/receive messages once the other process has disconnected
+export const validateConnection = (methodName, isSubprocess, isConnected) => {
+	if (!isConnected) {
+		throw new Error(`${getNamespaceName(isSubprocess)}${methodName}() cannot be used: the ${getOtherProcessName(isSubprocess)} has already exited or disconnected.`);
+	}
+};
+
+const getNamespaceName = isSubprocess => isSubprocess ? '' : 'subprocess.';
+
+const getOtherProcessName = isSubprocess => isSubprocess ? 'parent process' : 'subprocess';
+
+// Better error message when sending messages which cannot be serialized.
+// Works with both `serialization: 'advanced'` and `serialization: 'json'`.
+export const handleSerializationError = (error, isSubprocess, message) => {
+	if (isSerializationError(error)) {
+		error.message = `${getNamespaceName(isSubprocess)}sendMessage()'s argument type is invalid: the message cannot be serialized: ${String(message)}.\n${error.message}`;
+	}
+};
+
+const isSerializationError = ({code, message}) => SERIALIZATION_ERROR_CODES.has(code)
+	|| SERIALIZATION_ERROR_MESSAGES.some(serializationErrorMessage => message.includes(serializationErrorMessage));
+
+// `error.code` set by Node.js when it failed to serialize the message
+const SERIALIZATION_ERROR_CODES = new Set([
+	// Message is `undefined`
+	'ERR_MISSING_ARGS',
+	// Message is a function, a bigint, a symbol
+	'ERR_INVALID_ARG_TYPE',
+]);
+
+// `error.message` set by Node.js when it failed to serialize the message
+const SERIALIZATION_ERROR_MESSAGES = [
+	// Message is a promise or a proxy, with `serialization: 'advanced'`
+	'could not be cloned',
+	// Message has cycles, with `serialization: 'json'`
+	'circular structure',
+	// Message has cycles inside toJSON(), with `serialization: 'json'`
+	'call stack size exceeded',
+];

--- a/lib/methods/main-async.js
+++ b/lib/methods/main-async.js
@@ -4,6 +4,7 @@ import {MaxBufferError} from 'get-stream';
 import {handleCommand} from '../arguments/command.js';
 import {normalizeOptions} from '../arguments/options.js';
 import {SUBPROCESS_OPTIONS} from '../arguments/fd-options.js';
+import {addIpcMethods} from '../ipc/methods.js';
 import {makeError, makeSuccessResult} from '../return/result.js';
 import {handleResult} from '../return/reject.js';
 import {handleEarlyError} from '../return/early-error.js';
@@ -110,6 +111,7 @@ const spawnSubprocessAsync = ({file, commandArguments, options, startTime, verbo
 	});
 	subprocess.all = makeAllStream(subprocess, options);
 	addConvertedStreams(subprocess, options);
+	addIpcMethods(subprocess, options);
 
 	const promise = handlePromise({
 		subprocess,

--- a/lib/stdio/stdio-option.js
+++ b/lib/stdio/stdio-option.js
@@ -1,10 +1,13 @@
 import {STANDARD_STREAMS_ALIASES} from '../utils/standard-stream.js';
+import {normalizeIpcStdioArray} from '../ipc/array.js';
 
 // Add support for `stdin`/`stdout`/`stderr` as an alias for `stdio`.
 // Also normalize the `stdio` option.
 export const normalizeStdioOption = ({stdio, ipc, buffer, verbose, ...options}, isSync) => {
 	const stdioArray = getStdioArray(stdio, options).map((stdioOption, fdNumber) => addDefaultValue(stdioOption, fdNumber));
-	return isSync ? normalizeStdioSync(stdioArray, buffer, verbose) : normalizeStdioAsync(stdioArray, ipc);
+	return isSync
+		? normalizeStdioSync(stdioArray, buffer, verbose)
+		: normalizeIpcStdioArray(stdioArray, ipc);
 };
 
 const getStdioArray = (stdio, options) => {
@@ -54,8 +57,3 @@ const normalizeStdioSync = (stdioArray, buffer, verbose) => stdioArray.map((stdi
 
 const isOutputPipeOnly = stdioOption => stdioOption === 'pipe'
 	|| (Array.isArray(stdioOption) && stdioOption.every(item => item === 'pipe'));
-
-// The `ipc` option adds an `ipc` item to the `stdio` option
-const normalizeStdioAsync = (stdioArray, ipc) => ipc && !stdioArray.includes('ipc')
-	? [...stdioArray, 'ipc']
-	: stdioArray;

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
 		"c8": "^9.1.0",
 		"get-node": "^15.0.0",
 		"is-running": "^2.1.0",
-		"p-event": "^6.0.0",
 		"path-exists": "^5.0.0",
 		"path-key": "^4.0.0",
 		"tempfile": "^5.0.0",

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ One of the maintainers [@ehmicky](https://github.com/ehmicky) is looking for a r
 - [Transform or filter](#transformfilter-output) the input and output with [simple functions](docs/transform.md).
 - Redirect the [input](docs/input.md) and [output](docs/output.md) from/to [files](#files), [strings](#simple-input), [`Uint8Array`s](docs/binary.md#binary-input), [iterables](docs/streams.md#iterables-as-input) or [objects](docs/transform.md#object-mode).
 - Pass [Node.js streams](docs/streams.md#nodejs-streams) or [web streams](#web-streams) to subprocesses, or [convert](#convert-to-duplex-stream) subprocesses to [a stream](docs/streams.md#converting-a-subprocess-to-a-stream).
+- [Exchange messages](#exchange-messages) with the subprocess.
 - Ensure subprocesses exit even when they [intercept termination signals](docs/termination.md#forceful-termination), or when the current process [ends abruptly](docs/termination.md#current-process-exit).
 
 ## Install
@@ -250,6 +251,25 @@ await pipeline(
 	execa`node ./transform.js`.duplex(),
 	createWriteStream('./output.txt'),
 );
+```
+
+#### Exchange messages
+
+```js
+// parent.js
+import {execaNode} from 'execa';
+
+const subprocess = execaNode`child.js`;
+console.log(await subprocess.getOneMessage()); // 'Hello from child'
+await subprocess.sendMessage('Hello from parent');
+```
+
+```js
+// child.js
+import {sendMessage, getOneMessage} from 'execa';
+
+await sendMessage('Hello from child');
+console.log(await getOneMessage()); // 'Hello from parent'
 ```
 
 ### Debugging

--- a/test-d/ipc/get-each.test-d.ts
+++ b/test-d/ipc/get-each.test-d.ts
@@ -1,0 +1,23 @@
+import {expectType, expectError} from 'tsd';
+import {getEachMessage, execa, type Message} from '../../index.js';
+
+for await (const message of getEachMessage()) {
+	expectType<Message>(message);
+}
+
+expectError(getEachMessage(''));
+
+const subprocess = execa('test', {ipc: true});
+
+for await (const message of subprocess.getEachMessage()) {
+	expectType<Message<'advanced'>>(message);
+}
+
+for await (const message of execa('test', {ipc: true, serialization: 'json'}).getEachMessage()) {
+	expectType<Message<'json'>>(message);
+}
+
+expectError(subprocess.getEachMessage(''));
+expectError(await execa('test').getEachMessage());
+expectError(await execa('test', {ipc: false}).getEachMessage());
+

--- a/test-d/ipc/get-one.test-d.ts
+++ b/test-d/ipc/get-one.test-d.ts
@@ -1,0 +1,13 @@
+import {expectType, expectError} from 'tsd';
+import {getOneMessage, execa, type Message} from '../../index.js';
+
+expectType<Promise<Message>>(getOneMessage());
+expectError(await getOneMessage(''));
+
+const subprocess = execa('test', {ipc: true});
+expectType<Message<'advanced'>>(await subprocess.getOneMessage());
+expectType<Message<'json'>>(await execa('test', {ipc: true, serialization: 'json'}).getOneMessage());
+
+expectError(await subprocess.getOneMessage(''));
+expectError(await execa('test').getOneMessage());
+expectError(await execa('test', {ipc: false}).getOneMessage());

--- a/test-d/ipc/message.test-d.ts
+++ b/test-d/ipc/message.test-d.ts
@@ -1,0 +1,133 @@
+import {File} from 'node:buffer';
+import {expectAssignable, expectNotAssignable} from 'tsd';
+import {sendMessage, type Message} from '../../index.js';
+
+await sendMessage('');
+expectAssignable<Message>('');
+expectAssignable<Message<'advanced'>>('');
+expectAssignable<Message<'json'>>('');
+
+await sendMessage(0);
+expectAssignable<Message>(0);
+expectAssignable<Message<'advanced'>>(0);
+expectAssignable<Message<'json'>>(0);
+
+await sendMessage(true);
+expectAssignable<Message>(true);
+expectAssignable<Message<'advanced'>>(true);
+expectAssignable<Message<'json'>>(true);
+
+await sendMessage([] as const);
+expectAssignable<Message>([] as const);
+expectAssignable<Message<'advanced'>>([] as const);
+expectAssignable<Message<'json'>>([] as const);
+
+await sendMessage([true] as const);
+expectAssignable<Message>([true] as const);
+expectAssignable<Message<'advanced'>>([true] as const);
+expectAssignable<Message<'json'>>([true] as const);
+
+await sendMessage([undefined] as const);
+expectAssignable<Message>([undefined] as const);
+expectAssignable<Message<'advanced'>>([undefined] as const);
+expectNotAssignable<Message<'json'>>([undefined] as const);
+
+await sendMessage([0n] as const);
+expectAssignable<Message>([0n] as const);
+expectAssignable<Message<'advanced'>>([0n] as const);
+expectNotAssignable<Message<'json'>>([0n] as const);
+
+await sendMessage({} as const);
+expectAssignable<Message>({} as const);
+expectAssignable<Message<'advanced'>>({} as const);
+expectAssignable<Message<'json'>>({} as const);
+
+await sendMessage({test: true} as const);
+expectAssignable<Message>({test: true} as const);
+expectAssignable<Message<'advanced'>>({test: true} as const);
+expectAssignable<Message<'json'>>({test: true} as const);
+
+await sendMessage({test: undefined} as const);
+expectAssignable<Message>({test: undefined} as const);
+expectAssignable<Message<'advanced'>>({test: undefined} as const);
+expectNotAssignable<Message<'json'>>({test: undefined} as const);
+
+await sendMessage({test: 0n} as const);
+expectAssignable<Message>({test: 0n} as const);
+expectAssignable<Message<'advanced'>>({test: 0n} as const);
+expectNotAssignable<Message<'json'>>({test: 0n} as const);
+
+await sendMessage(null);
+expectAssignable<Message>(null);
+expectAssignable<Message<'advanced'>>(null);
+expectAssignable<Message<'json'>>(null);
+
+await sendMessage(Number.NaN);
+expectAssignable<Message>(Number.NaN);
+expectAssignable<Message<'advanced'>>(Number.NaN);
+expectAssignable<Message<'json'>>(Number.NaN);
+
+await sendMessage(Number.POSITIVE_INFINITY);
+expectAssignable<Message>(Number.POSITIVE_INFINITY);
+expectAssignable<Message<'advanced'>>(Number.POSITIVE_INFINITY);
+expectAssignable<Message<'json'>>(Number.POSITIVE_INFINITY);
+
+await sendMessage(new Map());
+expectAssignable<Message>(new Map());
+expectAssignable<Message<'advanced'>>(new Map());
+expectNotAssignable<Message<'json'>>(new Map());
+
+await sendMessage(new Set());
+expectAssignable<Message>(new Set());
+expectAssignable<Message<'advanced'>>(new Set());
+expectNotAssignable<Message<'json'>>(new Set());
+
+await sendMessage(new Date());
+expectAssignable<Message>(new Date());
+expectAssignable<Message<'advanced'>>(new Date());
+expectNotAssignable<Message<'json'>>(new Date());
+
+await sendMessage(/regexp/);
+expectAssignable<Message>(/regexp/);
+expectAssignable<Message<'advanced'>>(/regexp/);
+expectNotAssignable<Message<'json'>>(/regexp/);
+
+await sendMessage(new Blob());
+expectAssignable<Message>(new Blob());
+expectAssignable<Message<'advanced'>>(new Blob());
+expectNotAssignable<Message<'json'>>(new Blob());
+
+await sendMessage(new File([], ''));
+expectAssignable<Message>(new File([], ''));
+expectAssignable<Message<'advanced'>>(new File([], ''));
+expectNotAssignable<Message<'json'>>(new File([], ''));
+
+await sendMessage(new DataView(new ArrayBuffer(0)));
+expectAssignable<Message>(new DataView(new ArrayBuffer(0)));
+expectAssignable<Message<'advanced'>>(new DataView(new ArrayBuffer(0)));
+expectNotAssignable<Message<'json'>>(new DataView(new ArrayBuffer(0)));
+
+await sendMessage(new ArrayBuffer(0));
+expectAssignable<Message>(new ArrayBuffer(0));
+expectAssignable<Message<'advanced'>>(new ArrayBuffer(0));
+expectNotAssignable<Message<'json'>>(new ArrayBuffer(0));
+
+await sendMessage(new SharedArrayBuffer(0));
+expectAssignable<Message>(new SharedArrayBuffer(0));
+expectAssignable<Message<'advanced'>>(new SharedArrayBuffer(0));
+expectNotAssignable<Message<'json'>>(new SharedArrayBuffer(0));
+
+await sendMessage(new Uint8Array());
+expectAssignable<Message>(new Uint8Array());
+expectAssignable<Message<'advanced'>>(new Uint8Array());
+expectNotAssignable<Message<'json'>>(new Uint8Array());
+
+await sendMessage(AbortSignal.abort());
+expectAssignable<Message>(AbortSignal.abort());
+expectAssignable<Message<'advanced'>>(AbortSignal.abort());
+expectNotAssignable<Message<'json'>>(AbortSignal.abort());
+
+await sendMessage(new Error('test'));
+expectAssignable<Message>(new Error('test'));
+expectAssignable<Message<'advanced'>>(new Error('test'));
+expectNotAssignable<Message<'json'>>(new Error('test'));

--- a/test-d/ipc/send.test-d.ts
+++ b/test-d/ipc/send.test-d.ts
@@ -1,0 +1,16 @@
+import {expectType, expectError} from 'tsd';
+import {sendMessage, execa} from '../../index.js';
+
+expectType<Promise<void>>(sendMessage(''));
+
+expectError(await sendMessage());
+expectError(await sendMessage(undefined));
+expectError(await sendMessage(0n));
+expectError(await sendMessage(Symbol('test')));
+
+const subprocess = execa('test', {ipc: true});
+expectType<void>(await subprocess.sendMessage(''));
+
+expectError(await subprocess.sendMessage());
+expectError(await execa('test').sendMessage(''));
+expectError(await execa('test', {ipc: false}).sendMessage(''));

--- a/test-d/subprocess/subprocess.test-d.ts
+++ b/test-d/subprocess/subprocess.test-d.ts
@@ -28,13 +28,3 @@ expectError(subprocess.kill(null, new Error('test')));
 
 const ipcSubprocess = execa('unicorns', {ipc: true});
 expectAssignable<Subprocess>(subprocess);
-
-expectType<boolean>(ipcSubprocess.send({}));
-execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', 'ipc']}).send({});
-execa('unicorns', {stdio: ['pipe', 'pipe', 'ipc', 'pipe']}).send({});
-ipcSubprocess.send('message');
-ipcSubprocess.send({}, undefined, {keepOpen: true});
-expectError(ipcSubprocess.send({}, true));
-expectType<undefined>(execa('unicorns', {}).send);
-expectType<undefined>(execa('unicorns', {ipc: false}).send);
-expectType<undefined>(execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', 'pipe']}).send);

--- a/test/fixtures/ipc-any.js
+++ b/test/fixtures/ipc-any.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import * as execaExports from '../../index.js';
+
+const methodName = process.argv[2];
+await execaExports[methodName]();

--- a/test/fixtures/ipc-disconnect.js
+++ b/test/fixtures/ipc-disconnect.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {once} from 'node:events';
+import * as execaExports from '../../index.js';
+
+const methodName = process.argv[2];
+
+if (process.channel !== null) {
+	await once(process, 'disconnect');
+}
+
+await execaExports[methodName]();

--- a/test/fixtures/ipc-echo-item.js
+++ b/test/fixtures/ipc-echo-item.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
 import {sendMessage, getOneMessage} from '../../index.js';
 
-await sendMessage(await getOneMessage());
+const [message] = await getOneMessage();
+await sendMessage(message);

--- a/test/fixtures/ipc-echo-twice.js
+++ b/test/fixtures/ipc-echo-twice.js
@@ -2,3 +2,4 @@
 import {sendMessage, getOneMessage} from '../../index.js';
 
 await sendMessage(await getOneMessage());
+await sendMessage(await getOneMessage());

--- a/test/fixtures/ipc-echo-wait.js
+++ b/test/fixtures/ipc-echo-wait.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import {setTimeout} from 'node:timers/promises';
 import {sendMessage, getOneMessage} from '../../index.js';
 
+await setTimeout(1e3);
 await sendMessage(await getOneMessage());

--- a/test/fixtures/ipc-exit.js
+++ b/test/fixtures/ipc-exit.js
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-import process from 'node:process';
-
-process.once('message', message => {
-	process.send(message);
-});

--- a/test/fixtures/ipc-iterate-error.js
+++ b/test/fixtures/ipc-iterate-error.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {sendMessage, getEachMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+// @todo: replace with Array.fromAsync(subprocess.getEachMessage()) after dropping support for Node <22.0.0
+const iterateAllMessages = async () => {
+	const messages = [];
+	for await (const message of getEachMessage()) {
+		messages.push(message);
+	}
+
+	return messages;
+};
+
+const cause = new Error(foobarString);
+try {
+	await Promise.all([
+		iterateAllMessages(),
+		process.emit('error', cause),
+	]);
+} catch (error) {
+	await sendMessage(error);
+}

--- a/test/fixtures/ipc-iterate-twice.js
+++ b/test/fixtures/ipc-iterate-twice.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {sendMessage, getEachMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+for (let index = 0; index < 2; index += 1) {
+	// eslint-disable-next-line no-await-in-loop
+	for await (const message of getEachMessage()) {
+		if (message === foobarString) {
+			break;
+		}
+
+		process.stdout.write(message);
+	}
+
+	// eslint-disable-next-line no-await-in-loop
+	await sendMessage('.');
+}

--- a/test/fixtures/ipc-iterate.js
+++ b/test/fixtures/ipc-iterate.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {getEachMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+for await (const message of getEachMessage()) {
+	if (message === foobarString) {
+		break;
+	}
+
+	process.stdout.write(`${message}`);
+}

--- a/test/fixtures/ipc-process-error.js
+++ b/test/fixtures/ipc-process-error.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {sendMessage, getOneMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+const cause = new Error(foobarString);
+try {
+	await Promise.all([
+		getOneMessage(),
+		process.emit('error', cause),
+	]);
+} catch (error) {
+	await sendMessage(error);
+}

--- a/test/fixtures/ipc-send-disconnect.js
+++ b/test/fixtures/ipc-send-disconnect.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {sendMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+await sendMessage(foobarString);
+
+process.disconnect();

--- a/test/fixtures/ipc-send-fail.js
+++ b/test/fixtures/ipc-send-fail.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {sendMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+await sendMessage(foobarString);
+process.exitCode = 1;

--- a/test/fixtures/ipc-send-iterate.js
+++ b/test/fixtures/ipc-send-iterate.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {sendMessage, getEachMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+await sendMessage(foobarString);
+
+for await (const message of getEachMessage()) {
+	if (message === foobarString) {
+		break;
+	}
+
+	process.stdout.write(`${message}`);
+}

--- a/test/fixtures/ipc-send-pid.js
+++ b/test/fixtures/ipc-send-pid.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {execa} from '../../index.js';
+import {execa, sendMessage} from '../../index.js';
 
 const cleanup = process.argv[2] === 'true';
 const detached = process.argv[3] === 'true';
 const subprocess = execa('forever.js', {cleanup, detached});
-process.send(subprocess.pid);
+await sendMessage(subprocess.pid);
 await subprocess;

--- a/test/fixtures/ipc-send-twice.js
+++ b/test/fixtures/ipc-send-twice.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import {sendMessage} from '../../index.js';
+import {foobarArray} from '../helpers/input.js';
+
+await sendMessage(foobarArray[0]);
+await sendMessage(foobarArray[1]);

--- a/test/fixtures/ipc-send.js
+++ b/test/fixtures/ipc-send.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import {sendMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+await sendMessage(foobarString);

--- a/test/fixtures/nested-sync.js
+++ b/test/fixtures/nested-sync.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {execaSync} from '../../index.js';
+import {execaSync, sendMessage} from '../../index.js';
 
 const [options, file, ...commandArguments] = process.argv.slice(2);
 try {
 	const result = execaSync(file, commandArguments, JSON.parse(options));
-	process.send({result});
+	await sendMessage({result});
 } catch (error) {
-	process.send({error});
+	await sendMessage({error});
 }

--- a/test/fixtures/nested.js
+++ b/test/fixtures/nested.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import {execa} from '../../index.js';
+import {execa, sendMessage} from '../../index.js';
 
 const [options, file, ...commandArguments] = process.argv.slice(2);
 try {
 	const result = await execa(file, commandArguments, JSON.parse(options));
-	process.send({result});
+	await sendMessage({result});
 } catch (error) {
-	process.send({error});
+	await sendMessage({error});
 }

--- a/test/fixtures/no-killable.js
+++ b/test/fixtures/no-killable.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 import process from 'node:process';
+import {sendMessage} from '../../index.js';
 
 const noop = () => {};
 
 process.on('SIGTERM', noop);
 process.on('SIGINT', noop);
 
-process.send('');
+await sendMessage('');
 console.log('.');
 
 setTimeout(noop, 1e8);

--- a/test/fixtures/noop-fd-ipc.js
+++ b/test/fixtures/noop-fd-ipc.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 import process from 'node:process';
+import {promisify} from 'node:util';
+import {sendMessage} from '../../index.js';
 import {getWriteStream} from '../helpers/fs.js';
 import {foobarString} from '../helpers/input.js';
 
 const fdNumber = Number(process.argv[2]);
 const bytes = process.argv[3] || foobarString;
-getWriteStream(fdNumber).write(bytes, () => {
-	process.send('');
-});
+const stream = getWriteStream(fdNumber);
+await promisify(stream.write.bind(stream))(bytes);
+await sendMessage('');

--- a/test/fixtures/send.js
+++ b/test/fixtures/send.js
@@ -1,8 +1,0 @@
-#!/usr/bin/env node
-import process from 'node:process';
-
-process.once('message', message => {
-	console.log(message);
-});
-
-process.send('');

--- a/test/fixtures/worker.js
+++ b/test/fixtures/worker.js
@@ -1,4 +1,3 @@
-import {once} from 'node:events';
 import {workerData, parentPort} from 'node:worker_threads';
 import {execa} from '../../index.js';
 import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
@@ -8,7 +7,7 @@ setFixtureDirectory();
 const {nodeFile, commandArguments, options} = workerData;
 try {
 	const subprocess = execa(nodeFile, commandArguments, options);
-	const [parentResult, [{result, error}]] = await Promise.all([subprocess, once(subprocess, 'message')]);
+	const [parentResult, {result, error}] = await Promise.all([subprocess, subprocess.getOneMessage()]);
 	parentPort.postMessage({parentResult, result, error});
 } catch (parentError) {
 	parentPort.postMessage({parentError});

--- a/test/ipc/get-each.js
+++ b/test/ipc/get-each.js
@@ -1,0 +1,120 @@
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
+import {foobarString, foobarArray} from '../helpers/input.js';
+
+setFixtureDirectory();
+
+// @todo: replace with Array.fromAsync(subprocess.getEachMessage()) after dropping support for Node <22.0.0
+const iterateAllMessages = async subprocess => {
+	const messages = [];
+	for await (const message of subprocess.getEachMessage()) {
+		messages.push(message);
+	}
+
+	return messages;
+};
+
+test('Can iterate over IPC messages', async t => {
+	let count = 0;
+	const subprocess = execa('ipc-send-twice.js', {ipc: true});
+	for await (const message of subprocess.getEachMessage()) {
+		t.is(message, foobarArray[count++]);
+	}
+});
+
+test('Can iterate over IPC messages in subprocess', async t => {
+	const subprocess = execa('ipc-iterate.js', {ipc: true});
+
+	await subprocess.sendMessage('.');
+	await subprocess.sendMessage('.');
+	await subprocess.sendMessage(foobarString);
+
+	const {stdout} = await subprocess;
+	t.is(stdout, '..');
+});
+
+test('Can iterate multiple times over IPC messages in subprocess', async t => {
+	const subprocess = execa('ipc-iterate-twice.js', {ipc: true});
+
+	await subprocess.sendMessage('.');
+	await subprocess.sendMessage(foobarString);
+	t.is(await subprocess.getOneMessage(), '.');
+	await subprocess.sendMessage('.');
+	await subprocess.sendMessage(foobarString);
+	t.is(await subprocess.getOneMessage(), '.');
+
+	const {stdout} = await subprocess;
+	t.is(stdout, '..');
+});
+
+const HIGH_CONCURRENCY_COUNT = 100;
+
+test('Can send many messages at once with exports.getEachMessage()', async t => {
+	const subprocess = execa('ipc-iterate.js', {ipc: true});
+	await Promise.all(Array.from({length: HIGH_CONCURRENCY_COUNT}, (_, index) => subprocess.sendMessage(index)));
+	await subprocess.sendMessage(foobarString);
+	const {stdout} = await subprocess;
+	const expectedStdout = Array.from({length: HIGH_CONCURRENCY_COUNT}, (_, index) => `${index}`).join('');
+	t.is(stdout, expectedStdout);
+});
+
+test('Disconnecting in the current process stops exports.getEachMessage()', async t => {
+	const subprocess = execa('ipc-send-iterate.js', {ipc: true});
+	t.is(await subprocess.getOneMessage(), foobarString);
+	await subprocess.sendMessage('.');
+	subprocess.disconnect();
+	const {stdout} = await subprocess;
+	t.is(stdout, '.');
+});
+
+test('Disconnecting in the subprocess stops subprocess.getEachMessage()', async t => {
+	const subprocess = execa('ipc-send-disconnect.js', {ipc: true});
+	for await (const message of subprocess.getEachMessage()) {
+		t.is(message, foobarString);
+	}
+});
+
+test('Exiting the subprocess stops subprocess.getEachMessage()', async t => {
+	const subprocess = execa('ipc-send.js', {ipc: true});
+	for await (const message of subprocess.getEachMessage()) {
+		t.is(message, foobarString);
+	}
+});
+
+const loopAndBreak = async (t, subprocess) => {
+	// eslint-disable-next-line no-unreachable-loop
+	for await (const message of subprocess.getEachMessage()) {
+		t.is(message, foobarString);
+		break;
+	}
+};
+
+test('Breaking from subprocess.getEachMessage() awaits the subprocess', async t => {
+	const subprocess = execa('ipc-send-fail.js', {ipc: true});
+	const {exitCode} = await t.throwsAsync(loopAndBreak(t, subprocess));
+	t.is(exitCode, 1);
+});
+
+test('Cleans up subprocess.getEachMessage() listeners', async t => {
+	const subprocess = execa('ipc-send.js', {ipc: true});
+
+	t.is(subprocess.listenerCount('message'), 0);
+	t.is(subprocess.listenerCount('disconnect'), 0);
+
+	const promise = iterateAllMessages(subprocess);
+	t.is(subprocess.listenerCount('message'), 1);
+	t.is(subprocess.listenerCount('disconnect'), 1);
+	t.deepEqual(await promise, [foobarString]);
+
+	t.is(subprocess.listenerCount('message'), 0);
+	t.is(subprocess.listenerCount('disconnect'), 0);
+});
+
+test('"error" event interrupts subprocess.getEachMessage()', async t => {
+	const subprocess = execa('ipc-echo.js', {ipc: true});
+	await subprocess.sendMessage(foobarString);
+	const cause = new Error(foobarString);
+	t.like(await t.throwsAsync(Promise.all([iterateAllMessages(subprocess), subprocess.emit('error', cause)])), {cause});
+	t.like(await t.throwsAsync(subprocess), {cause});
+});

--- a/test/ipc/get-one.js
+++ b/test/ipc/get-one.js
@@ -1,0 +1,56 @@
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
+import {foobarString} from '../helpers/input.js';
+
+setFixtureDirectory();
+
+test('subprocess.getOneMessage() keeps the subprocess alive', async t => {
+	const subprocess = execa('ipc-echo-twice.js', {ipc: true});
+	await subprocess.sendMessage(foobarString);
+	t.is(await subprocess.getOneMessage(), foobarString);
+	await subprocess.sendMessage(foobarString);
+	t.is(await subprocess.getOneMessage(), foobarString);
+	await subprocess;
+});
+
+test('Buffers initial message to subprocess', async t => {
+	const subprocess = execa('ipc-echo-wait.js', {ipc: true});
+	await subprocess.sendMessage(foobarString);
+	t.is(await subprocess.getOneMessage(), foobarString);
+	await subprocess;
+});
+
+test('Cleans up subprocess.getOneMessage() listeners', async t => {
+	const subprocess = execa('ipc-send.js', {ipc: true});
+
+	t.is(subprocess.listenerCount('message'), 0);
+	t.is(subprocess.listenerCount('disconnect'), 0);
+
+	const promise = subprocess.getOneMessage();
+	t.is(subprocess.listenerCount('message'), 1);
+	t.is(subprocess.listenerCount('disconnect'), 0);
+	t.is(await promise, foobarString);
+
+	t.is(subprocess.listenerCount('message'), 0);
+	t.is(subprocess.listenerCount('disconnect'), 0);
+
+	await subprocess;
+});
+
+test('"error" event interrupts subprocess.getOneMessage()', async t => {
+	const subprocess = execa('ipc-echo.js', {ipc: true});
+	await subprocess.sendMessage(foobarString);
+	const cause = new Error(foobarString);
+	t.is(await t.throwsAsync(Promise.all([subprocess.getOneMessage(), subprocess.emit('error', cause)])), cause);
+	t.like(await t.throwsAsync(subprocess), {cause});
+});
+
+const testSubprocessError = async (t, fixtureName) => {
+	const subprocess = execa(fixtureName, {ipc: true});
+	t.like(await subprocess.getOneMessage(), {message: 'foobar'});
+	await subprocess;
+};
+
+test('"error" event interrupts exports.getOneMessage()', testSubprocessError, 'ipc-process-error.js');
+test('"error" event interrupts exports.getEachMessage()', testSubprocessError, 'ipc-iterate-error.js');

--- a/test/ipc/send.js
+++ b/test/ipc/send.js
@@ -1,0 +1,44 @@
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
+import {foobarString} from '../helpers/input.js';
+
+setFixtureDirectory();
+
+test('Can exchange IPC messages', async t => {
+	const subprocess = execa('ipc-echo.js', {ipc: true});
+	await subprocess.sendMessage(foobarString);
+	t.is(await subprocess.getOneMessage(), foobarString);
+	await subprocess;
+});
+
+const HIGH_CONCURRENCY_COUNT = 100;
+
+test.serial('Can exchange IPC messages under heavy load', async t => {
+	await Promise.all(
+		Array.from({length: HIGH_CONCURRENCY_COUNT}, async (_, index) => {
+			const subprocess = execa('ipc-echo.js', {ipc: true});
+			await subprocess.sendMessage(index);
+			t.is(await subprocess.getOneMessage(), index);
+			await subprocess;
+		}),
+	);
+});
+
+test('Can use "serialization: json" option', async t => {
+	const subprocess = execa('ipc-echo.js', {ipc: true, serialization: 'json'});
+	const date = new Date();
+	await subprocess.sendMessage(date);
+	t.is(await subprocess.getOneMessage(), date.toJSON());
+	await subprocess;
+});
+
+const BIG_PAYLOAD_SIZE = '.'.repeat(1e6);
+
+test('Handles backpressure', async t => {
+	const subprocess = execa('ipc-iterate.js', {ipc: true});
+	await subprocess.sendMessage(BIG_PAYLOAD_SIZE);
+	t.true(subprocess.send(foobarString));
+	const {stdout} = await subprocess;
+	t.is(stdout, BIG_PAYLOAD_SIZE);
+});

--- a/test/ipc/validation.js
+++ b/test/ipc/validation.js
@@ -1,0 +1,92 @@
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
+import {foobarString} from '../helpers/input.js';
+import {getStdio} from '../helpers/stdio.js';
+
+setFixtureDirectory();
+
+const stdioIpc = getStdio(3, 'ipc');
+
+const testRequiredIpcSubprocess = async (t, methodName, options) => {
+	const subprocess = execa('empty.js', options);
+	const {message} = await t.throws(() => subprocess[methodName]());
+	t.true(message.includes(`subprocess.${methodName}() can only be used`));
+	await subprocess;
+};
+
+test('Cannot use subprocess.sendMessage() without ipc option', testRequiredIpcSubprocess, 'sendMessage', {});
+test('Cannot use subprocess.sendMessage() with ipc: false', testRequiredIpcSubprocess, 'sendMessage', {ipc: false});
+test('Cannot use subprocess.sendMessage() with stdio: [..., "ipc"]', testRequiredIpcSubprocess, 'sendMessage', stdioIpc);
+test('Cannot use subprocess.getOneMessage() without ipc option', testRequiredIpcSubprocess, 'getOneMessage', {});
+test('Cannot use subprocess.getOneMessage() with ipc: false', testRequiredIpcSubprocess, 'getOneMessage', {ipc: false});
+test('Cannot use subprocess.getOneMessage() with stdio: [..., "ipc"]', testRequiredIpcSubprocess, 'getOneMessage', stdioIpc);
+test('Cannot use subprocess.getEachMessage() without ipc option', testRequiredIpcSubprocess, 'getEachMessage', {});
+test('Cannot use subprocess.getEachMessage() with ipc: false', testRequiredIpcSubprocess, 'getEachMessage', {ipc: false});
+test('Cannot use subprocess.getEachMessage() with stdio: [..., "ipc"]', testRequiredIpcSubprocess, 'getEachMessage', stdioIpc);
+
+const testRequiredIpcExports = async (t, methodName, options) => {
+	const {message} = await t.throwsAsync(execa('ipc-any.js', [methodName], options));
+	t.true(message.includes(`${methodName}() can only be used`));
+};
+
+test('Cannot use exports.sendMessage() without ipc option', testRequiredIpcExports, 'sendMessage', {});
+test('Cannot use exports.sendMessage() with ipc: false', testRequiredIpcExports, 'sendMessage', {ipc: false});
+test('Cannot use exports.getOneMessage() without ipc option', testRequiredIpcExports, 'getOneMessage', {});
+test('Cannot use exports.getOneMessage() with ipc: false', testRequiredIpcExports, 'getOneMessage', {ipc: false});
+test('Cannot use exports.getEachMessage() without ipc option', testRequiredIpcExports, 'getEachMessage', {});
+test('Cannot use exports.getEachMessage() with ipc: false', testRequiredIpcExports, 'getEachMessage', {ipc: false});
+
+const testPostDisconnection = async (t, methodName) => {
+	const subprocess = execa('empty.js', {ipc: true});
+	await subprocess;
+	const {message} = t.throws(() => subprocess[methodName](foobarString));
+	t.true(message.includes(`subprocess.${methodName}() cannot be used`));
+};
+
+test('subprocess.sendMessage() after disconnection', testPostDisconnection, 'sendMessage');
+test('subprocess.getOneMessage() after disconnection', testPostDisconnection, 'getOneMessage');
+test('subprocess.getEachMessage() after disconnection', testPostDisconnection, 'getEachMessage');
+
+const testPostDisconnectionSubprocess = async (t, methodName) => {
+	const subprocess = execa('ipc-disconnect.js', [methodName], {ipc: true});
+	subprocess.disconnect();
+	const {message} = await t.throwsAsync(subprocess);
+	t.true(message.includes(`${methodName}() cannot be used`));
+};
+
+test('exports.sendMessage() after disconnection', testPostDisconnectionSubprocess, 'sendMessage');
+test('exports.getOneMessage() after disconnection', testPostDisconnectionSubprocess, 'getOneMessage');
+test('exports.getEachMessage() after disconnection', testPostDisconnectionSubprocess, 'getEachMessage');
+
+const testInvalidPayload = async (t, serialization, message) => {
+	const subprocess = execa('empty.js', {ipc: true, serialization});
+	await t.throwsAsync(subprocess.sendMessage(message), {message: /type is invalid/});
+	await subprocess;
+};
+
+const cycleObject = {};
+cycleObject.self = cycleObject;
+const toJsonCycle = {toJSON: () => ({test: true, toJsonCycle})};
+
+test('subprocess.sendMessage() cannot send undefined', testInvalidPayload, 'advanced', undefined);
+test('subprocess.sendMessage() cannot send bigints', testInvalidPayload, 'advanced', 0n);
+test('subprocess.sendMessage() cannot send symbols', testInvalidPayload, 'advanced', Symbol('test'));
+test('subprocess.sendMessage() cannot send functions', testInvalidPayload, 'advanced', () => {});
+test('subprocess.sendMessage() cannot send promises', testInvalidPayload, 'advanced', Promise.resolve());
+test('subprocess.sendMessage() cannot send proxies', testInvalidPayload, 'advanced', new Proxy({}, {}));
+test('subprocess.sendMessage() cannot send Intl', testInvalidPayload, 'advanced', new Intl.Collator());
+test('subprocess.sendMessage() cannot send undefined, JSON', testInvalidPayload, 'json', undefined);
+test('subprocess.sendMessage() cannot send bigints, JSON', testInvalidPayload, 'json', 0n);
+test('subprocess.sendMessage() cannot send symbols, JSON', testInvalidPayload, 'json', Symbol('test'));
+test('subprocess.sendMessage() cannot send functions, JSON', testInvalidPayload, 'json', () => {});
+test('subprocess.sendMessage() cannot send cycles, JSON', testInvalidPayload, 'json', cycleObject);
+test('subprocess.sendMessage() cannot send cycles in toJSON(), JSON', testInvalidPayload, 'json', toJsonCycle);
+
+test('exports.sendMessage() validates payload', async t => {
+	const subprocess = execa('ipc-echo-item.js', {ipc: true});
+	await subprocess.sendMessage([undefined]);
+	await t.throwsAsync(subprocess, {
+		message: /sendMessage\(\)'s argument type is invalid/,
+	});
+});

--- a/test/resolve/no-buffer.js
+++ b/test/resolve/no-buffer.js
@@ -3,15 +3,20 @@ import test from 'ava';
 import getStream from 'get-stream';
 import {execa, execaSync} from '../../index.js';
 import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
-import {fullStdio, getStdio} from '../helpers/stdio.js';
+import {fullStdio} from '../helpers/stdio.js';
 import {foobarString, foobarUppercase, foobarUppercaseUint8Array} from '../helpers/input.js';
 import {resultGenerator, uppercaseGenerator, uppercaseBufferGenerator} from '../helpers/generator.js';
 
 setFixtureDirectory();
 
 const testLateStream = async (t, fdNumber, all) => {
-	const subprocess = execa('noop-fd-ipc.js', [`${fdNumber}`, foobarString], {...getStdio(4, 'ipc', 4), buffer: false, all});
-	await once(subprocess, 'message');
+	const subprocess = execa('noop-fd-ipc.js', [`${fdNumber}`, foobarString], {
+		...fullStdio,
+		ipc: true,
+		buffer: false,
+		all,
+	});
+	await subprocess.getOneMessage();
 	const [output, allOutput] = await Promise.all([
 		getStream(subprocess.stdio[fdNumber]),
 		all ? getStream(subprocess.all) : undefined,

--- a/test/terminate/cleanup.js
+++ b/test/terminate/cleanup.js
@@ -1,7 +1,6 @@
 import process from 'node:process';
 import {setTimeout} from 'node:timers/promises';
 import test from 'ava';
-import {pEvent} from 'p-event';
 import isRunning from 'is-running';
 import {execa, execaSync} from '../../index.js';
 import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
@@ -29,9 +28,9 @@ test('spawnAndExit cleanup detached, worker', spawnAndExit, nestedWorker, true, 
 
 // When current process exits before subprocess
 const spawnAndKill = async (t, [signal, cleanup, detached, isKilled]) => {
-	const subprocess = execa('subprocess.js', [cleanup, detached], {stdio: 'ignore', ipc: true});
+	const subprocess = execa('ipc-send-pid.js', [cleanup, detached], {stdio: 'ignore', ipc: true});
 
-	const pid = await pEvent(subprocess, 'message');
+	const pid = await subprocess.getOneMessage();
 	t.true(Number.isInteger(pid));
 	t.true(isRunning(pid));
 

--- a/test/terminate/kill-force.js
+++ b/test/terminate/kill-force.js
@@ -3,7 +3,6 @@ import {once, defaultMaxListeners} from 'node:events';
 import {constants} from 'node:os';
 import {setTimeout} from 'node:timers/promises';
 import test from 'ava';
-import {pEvent} from 'p-event';
 import isRunning from 'is-running';
 import {execa} from '../../index.js';
 import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
@@ -19,7 +18,7 @@ const spawnNoKillable = async (forceKillAfterDelay, options) => {
 		forceKillAfterDelay,
 		...options,
 	});
-	await pEvent(subprocess, 'message');
+	await subprocess.getOneMessage();
 	return {subprocess};
 };
 

--- a/types/arguments/options.d.ts
+++ b/types/arguments/options.d.ts
@@ -198,7 +198,7 @@ export type CommonOptions<IsSync extends boolean = boolean> = {
 	readonly buffer?: FdGenericOption<boolean>;
 
 	/**
-	Enables exchanging messages with the subprocess using `subprocess.send(message)` and `subprocess.on('message', (message) => {})`.
+	Enables exchanging messages with the subprocess using `subprocess.sendMessage(message)`, `subprocess.getOneMessage()` and `subprocess.getEachMessage()`.
 
 	@default `true` if the `node` option is enabled, `false` otherwise
 	*/

--- a/types/ipc.d.ts
+++ b/types/ipc.d.ts
@@ -1,0 +1,85 @@
+import type {Options} from './arguments/options.js';
+
+// Message when the `serialization` option is `'advanced'`
+type AdvancedMessage =
+	| string
+	| number
+	| boolean
+	| null
+	| object;
+
+// Message when the `serialization` option is `'json'`
+type JsonMessage =
+	| string
+	| number
+	| boolean
+	| null
+	| readonly JsonMessage[]
+	| {readonly [key: string | number]: JsonMessage};
+
+/**
+Type of messages exchanged between a process and its subprocess using `sendMessage()`, `getOneMessage()` and `getEachMessage()`.
+
+This requires the `ipc` option to be `true`. The type of `message` depends on the `serialization` option.
+*/
+export type Message<
+	Serialization extends Options['serialization'] = Options['serialization'],
+> = Serialization extends 'json' ? JsonMessage : AdvancedMessage;
+
+// IPC methods in subprocess
+/**
+Send a `message` to the parent process.
+
+This requires the `ipc` option to be `true`. The type of `message` depends on the `serialization` option.
+*/
+export function sendMessage(message: Message): Promise<void>;
+
+/**
+Receive a single `message` from the parent process.
+
+This requires the `ipc` option to be `true`. The type of `message` depends on the `serialization` option.
+*/
+export function getOneMessage(): Promise<Message>;
+
+/**
+Iterate over each `message` from the parent process.
+
+This requires the `ipc` option to be `true`. The type of `message` depends on the `serialization` option.
+*/
+export function getEachMessage(): AsyncIterableIterator<Message>;
+
+// IPC methods in the current process
+export type IpcMethods<
+	IpcOption extends Options['ipc'],
+	Serialization extends Options['serialization'],
+> = IpcOption extends true
+	? {
+		/**
+		Send a `message` to the subprocess.
+
+		This requires the `ipc` option to be `true`. The type of `message` depends on the `serialization` option.
+		*/
+		sendMessage(message: Message<Serialization>): Promise<void>;
+
+		/**
+		Receive a single `message` from the subprocess.
+
+		This requires the `ipc` option to be `true`. The type of `message` depends on the `serialization` option.
+		*/
+		getOneMessage(): Promise<Message<Serialization>>;
+
+		/**
+		Iterate over each `message` from the subprocess.
+
+		This requires the `ipc` option to be `true`. The type of `message` depends on the `serialization` option.
+		*/
+		getEachMessage(): AsyncIterableIterator<Message<Serialization>>;
+	}
+	// Those methods only work if the `ipc` option is `true`.
+	// At runtime, they are actually defined, in order to provide with a nice error message.
+	// At type check time, they are typed as `never` to prevent calling them.
+	: {
+		sendMessage: never;
+		getOneMessage: never;
+		getEachMessage: never;
+	};

--- a/types/subprocess/subprocess.d.ts
+++ b/types/subprocess/subprocess.d.ts
@@ -11,6 +11,7 @@ import type {
 	DuplexOptions,
 	SubprocessAsyncIterable,
 } from '../convert.js';
+import type {IpcMethods} from '../ipc.js';
 import type {SubprocessStdioStream} from './stdout.js';
 import type {SubprocessStdioArray} from './stdio.js';
 import type {SubprocessAll} from './all.js';
@@ -28,18 +29,6 @@ type ExecaCustomSubprocess<OptionsType extends Options> = {
 	This is `undefined` if the subprocess failed to spawn.
 	*/
 	pid?: number;
-
-	/**
-	Send a `message` to the subprocess. The type of `message` depends on the `serialization` option.
-	The subprocess receives it as a [`message` event](https://nodejs.org/api/process.html#event-message).
-
-	This returns `true` on success.
-
-	This requires the `ipc` option to be `true`.
-
-	[More info.](https://nodejs.org/api/child_process.html#subprocesssendmessage-sendhandle-options-callback)
-	*/
-	send: HasIpc<OptionsType> extends true ? ChildProcess['send'] : undefined;
 
 	/**
 	The subprocess [`stdin`](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)) as a stream.
@@ -114,7 +103,9 @@ type ExecaCustomSubprocess<OptionsType extends Options> = {
 	Converts the subprocess to a duplex stream.
 	*/
 	duplex(duplexOptions?: DuplexOptions): Duplex;
-} & PipableSubprocess;
+}
+& IpcMethods<OptionsType['ipc'], OptionsType['serialization']>
+& PipableSubprocess;
 
 /**
 [`child_process` instance](https://nodejs.org/api/child_process.html#child_process_class_childprocess) with additional methods and properties.


### PR DESCRIPTION
Fixes #1053.

This adds the following methods:
  - In the current process: `subprocess.sendMessage(message)`, `subprocess.getOneMessage()`, `subprocess.getEachMessage()`.
  - In the subprocess, Execa exports the following methods instead: `sendMessage(message)`, `getOneMessage()`, `getEachMessage()`.

This also exports a new type `Message` representing IPC messages.

The old IPC methods are undocumented but kept. This PR does not have any breaking change.