### PR TITLE
Add `Methods` type

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -8,11 +8,11 @@
 
 ## Available types
 
-The following types can be imported: [`ResultPromise`](api.md#return-value), [`Subprocess`](api.md#subprocess), [`Result`](api.md#result), [`ExecaError`](api.md#execaerror), [`Options`](api.md#options-1), [`StdinOption`](api.md#optionsstdin), [`StdoutStderrOption`](api.md#optionsstdout), [`TemplateExpression`](api.md#execacommand) and [`Message`](api.md#subprocesssendmessagemessage-sendmessageoptions).
+The following types can be imported: [`ResultPromise`](api.md#return-value), [`Subprocess`](api.md#subprocess), [`Result`](api.md#result), [`ExecaError`](api.md#execaerror), [`Options`](api.md#options-1), [`StdinOption`](api.md#optionsstdin), [`StdoutStderrOption`](api.md#optionsstdout), [`TemplateExpression`](api.md#execacommand), [`Message`](api.md#subprocesssendmessagemessage-sendmessageoptions), [`ExecaMethod`](api.md#execaoptions), [`ExecaNodeMethod`](api.md#execanodeoptions) and [`ExecaScriptMethod`](api.md#options).
 
 ```ts
 import {
-	execa,
+	execa as execa_,
 	ExecaError,
 	type ResultPromise,
 	type Result,
@@ -21,7 +21,10 @@ import {
 	type StdoutStderrOption,
 	type TemplateExpression,
 	type Message,
+	type ExecaMethod,
 } from 'execa';
+
+const execa: ExecaMethod = execa_({preferLocal: true});
 
 const options: Options = {
 	stdin: 'inherit' satisfies StdinOption,
@@ -47,18 +50,21 @@ try {
 
 ## Synchronous execution
 
-Their [synchronous](#synchronous-execution) counterparts are [`SyncResult`](api.md#result), [`ExecaSyncError`](api.md#execasyncerror), [`SyncOptions`](api.md#options-1), [`StdinSyncOption`](api.md#optionsstdin), [`StdoutStderrSyncOption`](api.md#optionsstdout) and [`TemplateExpression`](api.md#execacommand).
+Their [synchronous](#synchronous-execution) counterparts are [`SyncResult`](api.md#result), [`ExecaSyncError`](api.md#execasyncerror), [`SyncOptions`](api.md#options-1), [`StdinSyncOption`](api.md#optionsstdin), [`StdoutStderrSyncOption`](api.md#optionsstdout), [`TemplateExpression`](api.md#execacommand), [`ExecaSyncMethod`](api.md#execasyncoptions) and [`ExecaScriptSyncMethod`](api.md#syncoptions).
 
 ```ts
 import {
-	execaSync,
+	execaSync as execaSync_,
 	ExecaSyncError,
 	type SyncResult,
 	type SyncOptions,
 	type StdinSyncOption,
 	type StdoutStderrSyncOption,
 	type TemplateExpression,
+	type ExecaSyncMethod,
 } from 'execa';
+
+const execaSync: ExecaSyncMethod = execaSync_({preferLocal: true});
 
 const options: SyncOptions = {
 	stdin: 'inherit' satisfies StdinSyncOption,
@@ -84,10 +90,12 @@ The above examples demonstrate those types. However, types are automatically inf
 
 ```ts
 import {
-	execa,
+	execa as execa_,
 	ExecaError,
 	type Result,
 } from 'execa';
+
+const execa = execa_({preferLocal: true});
 
 const printResultStdout = (result: Result) => {
 	console.log('Stdout', result.stdout);

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,11 +11,11 @@ export type {Result, SyncResult} from './types/return/result.js';
 export type {ResultPromise, Subprocess} from './types/subprocess/subprocess.js';
 export {ExecaError, ExecaSyncError} from './types/return/final-error.js';
 
-export {execa} from './types/methods/main-async.js';
-export {execaSync} from './types/methods/main-sync.js';
+export {execa, type ExecaMethod} from './types/methods/main-async.js';
+export {execaSync, type ExecaSyncMethod} from './types/methods/main-sync.js';
 export {execaCommand, execaCommandSync, parseCommandString} from './types/methods/command.js';
-export {$} from './types/methods/script.js';
-export {execaNode} from './types/methods/node.js';
+export {$, type ExecaScriptMethod, type ExecaScriptSyncMethod} from './types/methods/script.js';
+export {execaNode, type ExecaNodeMethod} from './types/methods/node.js';
 
 export {
 	sendMessage,

--- a/test-d/methods/list.test-d.ts
+++ b/test-d/methods/list.test-d.ts
@@ -1,0 +1,63 @@
+import {expectAssignable} from 'tsd';
+import {
+	type ExecaMethod,
+	type ExecaSyncMethod,
+	type ExecaNodeMethod,
+	type ExecaScriptMethod,
+	type ExecaScriptSyncMethod,
+	execa,
+	execaSync,
+	execaNode,
+	$,
+} from '../../index.js';
+
+const options = {preferLocal: true} as const;
+const secondOptions = {node: true} as const;
+
+expectAssignable<ExecaMethod>(execa);
+expectAssignable<ExecaMethod>(execa({}));
+expectAssignable<ExecaMethod>(execa({})({}));
+expectAssignable<ExecaMethod>(execa(options));
+expectAssignable<ExecaMethod>(execa(options)(secondOptions));
+expectAssignable<ExecaMethod>(execa(options)({}));
+expectAssignable<ExecaMethod>(execa({})(options));
+
+expectAssignable<ExecaSyncMethod>(execaSync);
+expectAssignable<ExecaSyncMethod>(execaSync({}));
+expectAssignable<ExecaSyncMethod>(execaSync({})({}));
+expectAssignable<ExecaSyncMethod>(execaSync(options));
+expectAssignable<ExecaSyncMethod>(execaSync(options)(secondOptions));
+expectAssignable<ExecaSyncMethod>(execaSync(options)({}));
+expectAssignable<ExecaSyncMethod>(execaSync({})(options));
+
+expectAssignable<ExecaNodeMethod>(execaNode);
+expectAssignable<ExecaNodeMethod>(execaNode({}));
+expectAssignable<ExecaNodeMethod>(execaNode({})({}));
+expectAssignable<ExecaNodeMethod>(execaNode(options));
+expectAssignable<ExecaNodeMethod>(execaNode(options)(secondOptions));
+expectAssignable<ExecaNodeMethod>(execaNode(options)({}));
+expectAssignable<ExecaNodeMethod>(execaNode({})(options));
+
+expectAssignable<ExecaScriptMethod>($);
+expectAssignable<ExecaScriptMethod>($({}));
+expectAssignable<ExecaScriptMethod>($({})({}));
+expectAssignable<ExecaScriptMethod>($(options));
+expectAssignable<ExecaScriptMethod>($(options)(secondOptions));
+expectAssignable<ExecaScriptMethod>($(options)({}));
+expectAssignable<ExecaScriptMethod>($({})(options));
+
+expectAssignable<ExecaScriptSyncMethod>($.sync);
+expectAssignable<ExecaScriptSyncMethod>($.sync({}));
+expectAssignable<ExecaScriptSyncMethod>($.sync({})({}));
+expectAssignable<ExecaScriptSyncMethod>($.sync(options));
+expectAssignable<ExecaScriptSyncMethod>($.sync(options)(secondOptions));
+expectAssignable<ExecaScriptSyncMethod>($.sync(options)({}));
+expectAssignable<ExecaScriptSyncMethod>($.sync({})(options));
+
+expectAssignable<ExecaScriptSyncMethod>($.s);
+expectAssignable<ExecaScriptSyncMethod>($.s({}));
+expectAssignable<ExecaScriptSyncMethod>($.s({})({}));
+expectAssignable<ExecaScriptSyncMethod>($.s(options));
+expectAssignable<ExecaScriptSyncMethod>($.s(options)(secondOptions));
+expectAssignable<ExecaScriptSyncMethod>($.s(options)({}));
+expectAssignable<ExecaScriptSyncMethod>($.s({})(options));

--- a/types/methods/main-async.d.ts
+++ b/types/methods/main-async.d.ts
@@ -324,7 +324,7 @@ export declare const execa: ExecaMethod<{}>;
 /**
 `execa()` method either exported by Execa, or bound using `execa(options)`.
 */
-type ExecaMethod<OptionsType extends Options> =
+export type ExecaMethod<OptionsType extends Options = Options> =
 	& ExecaBind<OptionsType>
 	& ExecaTemplate<OptionsType>
 	& ExecaArrayLong<OptionsType>

--- a/types/methods/main-sync.d.ts
+++ b/types/methods/main-sync.d.ts
@@ -32,7 +32,7 @@ export declare const execaSync: ExecaSyncMethod<{}>;
 
 // For the moment, we purposely do not export `ExecaSyncMethod` and `ExecaScriptSyncMethod`.
 // This is because synchronous invocation is discouraged.
-type ExecaSyncMethod<OptionsType extends SyncOptions> =
+export type ExecaSyncMethod<OptionsType extends SyncOptions = SyncOptions> =
 	& ExecaSyncBind<OptionsType>
 	& ExecaSyncTemplate<OptionsType>
 	& ExecaSyncArrayLong<OptionsType>

--- a/types/methods/node.d.ts
+++ b/types/methods/node.d.ts
@@ -35,7 +35,7 @@ export declare const execaNode: ExecaNodeMethod<{}>;
 /**
 `execaNode()` method either exported by Execa, or bound using `execaNode(options)`.
 */
-type ExecaNodeMethod<OptionsType extends Options> =
+export type ExecaNodeMethod<OptionsType extends Options = Options> =
 	& ExecaNodeBind<OptionsType>
 	& ExecaNodeTemplate<OptionsType>
 	& ExecaNodeArrayLong<OptionsType>

--- a/types/methods/script.d.ts
+++ b/types/methods/script.d.ts
@@ -55,7 +55,7 @@ export const $: ExecaScriptMethod<{}>;
 /**
 `$()` method either exported by Execa, or bound using `$(options)`.
 */
-type ExecaScriptMethod<OptionsType extends CommonOptions> =
+export type ExecaScriptMethod<OptionsType extends CommonOptions = CommonOptions> =
 	& ExecaScriptBind<OptionsType>
 	& ExecaScriptTemplate<OptionsType>
 	& ExecaScriptArrayLong<OptionsType>
@@ -88,7 +88,7 @@ type ExecaScriptArrayShort<OptionsType extends CommonOptions> =
 /**
 `$.sync()` method either exported by Execa, or bound using `$.sync(options)`.
 */
-type ExecaScriptSyncMethod<OptionsType extends CommonOptions> =
+export type ExecaScriptSyncMethod<OptionsType extends CommonOptions = CommonOptions> =
 	& ExecaScriptSyncBind<OptionsType>
 	& ExecaScriptSyncTemplate<OptionsType>
 	& ExecaScriptSyncArrayLong<OptionsType>


### PR DESCRIPTION
Fixes #1062.

This PR adds the `Methods['execa']`, `Methods['execaNode']` and `Methods['$']` types. Those are the types of `execa`/`execa(options)`, and so on.

This is useful for TypeScript users passing bound/curried instances of `execa` around.

Using `ReturnType<execa>` does not work due to the overloading of the `execa()` function (`execa(options)`, `execa(file, args, options)`, template string syntax). So, `ReturnType<execa>` is the return type of `execa(options)` but also of `execa(file, args, options)` (i.e. a `ResultPromise`), which makes assigning it not work.