### PR TITLE
Fix type of `result.ipc`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -469,7 +469,7 @@ Items are arrays when their corresponding `stdio` option is a [transform in obje
 
 ### result.ipc
 
-_Type_: `unknown[]`
+_Type_: [`Message[]`](ipc.md#message-type)
 
 All the messages [sent by the subprocess](#sendmessagemessage) to the current process.
 

--- a/test-d/return/result-ipc.ts
+++ b/test-d/return/result-ipc.ts
@@ -6,13 +6,20 @@ import {
 	type SyncResult,
 	type ExecaError,
 	type ExecaSyncError,
+	type Message,
 } from '../../index.js';
 
 const ipcResult = await execa('unicorns', {ipc: true});
-expectType<unknown[]>(ipcResult.ipc);
+expectType<Array<Message<'advanced'>>>(ipcResult.ipc);
 
 const ipcFdResult = await execa('unicorns', {ipc: true, buffer: {stdout: false}});
-expectType<unknown[]>(ipcFdResult.ipc);
+expectType<Array<Message<'advanced'>>>(ipcFdResult.ipc);
+
+const advancedResult = await execa('unicorns', {ipc: true, serialization: 'advanced'});
+expectType<Array<Message<'advanced'>>>(advancedResult.ipc);
+
+const jsonResult = await execa('unicorns', {ipc: true, serialization: 'json'});
+expectType<Array<Message<'json'>>>(jsonResult.ipc);
 
 const falseIpcResult = await execa('unicorns', {ipc: false});
 expectType<[]>(falseIpcResult.ipc);
@@ -29,19 +36,19 @@ expectType<[]>(noBufferFdResult.ipc);
 const syncResult = execaSync('unicorns');
 expectType<[]>(syncResult.ipc);
 
-expectType<unknown[] | []>({} as Result['ipc']);
-expectAssignable<unknown[]>({} as Result['ipc']);
+expectType<Message[] | []>({} as Result['ipc']);
+expectAssignable<Message[]>({} as Result['ipc']);
 expectType<[]>({} as unknown as SyncResult['ipc']);
 
 const ipcError = new Error('.') as ExecaError<{ipc: true}>;
-expectType<unknown[]>(ipcError.ipc);
+expectType<Array<Message<'advanced'>>>(ipcError.ipc);
 
 const ipcFalseError = new Error('.') as ExecaError<{ipc: false}>;
 expectType<[]>(ipcFalseError.ipc);
 
 const asyncError = new Error('.') as ExecaError;
-expectType<unknown[] | []>(asyncError.ipc);
-expectAssignable<unknown[]>(asyncError.ipc);
+expectType<Message[] | []>(asyncError.ipc);
+expectAssignable<Message[]>(asyncError.ipc);
 
 const syncError = new Error('.') as ExecaSyncError;
 expectType<[]>(syncError.ipc);

--- a/types/return/result-ipc.d.ts
+++ b/types/return/result-ipc.d.ts
@@ -1,5 +1,6 @@
 import type {FdSpecificOption} from '../arguments/specific.js';
 import type {CommonOptions} from '../arguments/options.js';
+import type {Message} from '../ipc.js';
 
 // `result.ipc`
 // This is empty unless the `ipc` option is `true`.
@@ -9,13 +10,18 @@ export type ResultIpc<
 	OptionsType extends CommonOptions,
 > = IsSync extends true
 	? []
-	: ResultIpcAsync<FdSpecificOption<OptionsType['buffer'], 'ipc'>, OptionsType['ipc']>;
+	: ResultIpcAsync<
+	FdSpecificOption<OptionsType['buffer'], 'ipc'>,
+	OptionsType['ipc'],
+	OptionsType['serialization']
+	>;
 
 type ResultIpcAsync<
 	BufferOption extends boolean | undefined,
 	IpcOption extends boolean | undefined,
+	SerializationOption extends CommonOptions['serialization'],
 > = BufferOption extends false
 	? []
 	: IpcOption extends true
-		? unknown[]
+		? Array<Message<SerializationOption>>
 		: [];


### PR DESCRIPTION
The type of `result.ipc` is currently `unknown[]`. It should be `Message[]` instead.