### PR TITLE
Rename `result.ipc` to `result.ipcOutput`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -467,7 +467,7 @@ Items are arrays when their corresponding `stdio` option is a [transform in obje
 
 [More info.](output.md#additional-file-descriptors)
 
-### result.ipc
+### result.ipcOutput
 
 _Type_: [`Message[]`](ipc.md#message-type)
 

--- a/docs/execution.md
+++ b/docs/execution.md
@@ -126,7 +126,7 @@ Synchronous execution is generally discouraged as it holds the CPU and prevents 
 - Signal termination: [`subprocess.kill()`](api.md#subprocesskillerror), [`subprocess.pid`](api.md#subprocesspid), [`cleanup`](api.md#optionscleanup) option, [`cancelSignal`](api.md#optionscancelsignal) option, [`forceKillAfterDelay`](api.md#optionsforcekillafterdelay) option.
 - Piping multiple subprocesses: [`subprocess.pipe()`](api.md#subprocesspipefile-arguments-options).
 - [`subprocess.iterable()`](lines.md#progressive-splitting).
-- [`ipc`](api.md#optionsipc) and [`serialization`](api.md#optionsserialization) options.
+- [IPC](ipc.md): [`sendMessage()`](api.md#sendmessagemessage), [`getOneMessage()`](api.md#getonemessage), [`getEachMessage()`](api.md#geteachmessage), [`result.ipcOutput`](output.md#any-output-type), [`ipc`](api.md#optionsipc) option, [`serialization`](api.md#optionsserialization) option, [`ipcInput`](input.md#any-input-type) option.
 - [`result.all`](api.md#resultall) is not interleaved.
 - [`detached`](api.md#optionsdetached) option.
 - The [`maxBuffer`](api.md#optionsmaxbuffer) option is always measured in bytes, not in characters, [lines](api.md#optionslines) nor [objects](transform.md#object-mode). Also, it ignores transforms and the [`encoding`](api.md#optionsencoding) option.

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -69,15 +69,15 @@ for await (const message of getEachMessage()) {
 
 ## Retrieve all messages
 
-The [`result.ipc`](api.md#resultipc) array contains all the messages sent by the subprocess. In many situations, this is simpler than using [`subprocess.getOneMessage()`](api.md#subprocessgetonemessage) and [`subprocess.getEachMessage()`](api.md#subprocessgeteachmessage).
+The [`result.ipcOutput`](api.md#resultipcoutput) array contains all the messages sent by the subprocess. In many situations, this is simpler than using [`subprocess.getOneMessage()`](api.md#subprocessgetonemessage) and [`subprocess.getEachMessage()`](api.md#subprocessgeteachmessage).
 
 ```js
 // main.js
 import {execaNode} from 'execa';
 
-const {ipc} = await execaNode`build.js`;
-console.log(ipc[0]); // {kind: 'start', timestamp: date}
-console.log(ipc[1]); // {kind: 'stop', timestamp: date}
+const {ipcOutput} = await execaNode`build.js`;
+console.log(ipcOutput[0]); // {kind: 'start', timestamp: date}
+console.log(ipcOutput[1]); // {kind: 'stop', timestamp: date}
 ```
 
 ```js
@@ -125,7 +125,7 @@ const subprocess = execaNode({serialization: 'json'})`child.js`;
 
 When the [`verbose`](api.md#optionsverbose) option is `'full'`, the IPC messages sent by the subprocess to the current process are [printed on the console](debugging.md#full-mode).
 
-Also, when the subprocess [failed](errors.md#subprocess-failure), [`error.ipc`](api.md) contains all the messages sent by the subprocess. Those are also shown at the end of the [error message](errors.md#error-message).
+Also, when the subprocess [failed](errors.md#subprocess-failure), [`error.ipcOutput`](api.md) contains all the messages sent by the subprocess. Those are also shown at the end of the [error message](errors.md#error-message).
 
 <hr>
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -57,15 +57,15 @@ await execa({stdout: 1, stderr: 1})`npm run build`;
 
 ## Any output type
 
-If the subprocess uses Node.js, [IPC](ipc.md) can be used to return [almost any type](ipc.md#message-type) from the subprocess. The [`result.ipc`](api.md#resultipc) array contains all the messages sent by the subprocess.
+If the subprocess uses Node.js, [IPC](ipc.md) can be used to return [almost any type](ipc.md#message-type) from the subprocess. The [`result.ipcOutput`](api.md#resultipcoutput) array contains all the messages sent by the subprocess.
 
 ```js
 // main.js
 import {execaNode} from 'execa';
 
-const {ipc} = await execaNode`build.js`;
-console.log(ipc[0]); // {kind: 'start', timestamp: date}
-console.log(ipc[1]); // {kind: 'stop', timestamp: date}
+const {ipcOutput} = await execaNode`build.js`;
+console.log(ipcOutput[0]); // {kind: 'start', timestamp: date}
+console.log(ipcOutput[1]); // {kind: 'stop', timestamp: date}
 ```
 
 ```js
@@ -162,14 +162,14 @@ await execa({stdin: 'ignore', stdout: 'ignore', stderr: 'ignore'})`npm run build
 
 To prevent high memory consumption, a maximum output size can be set using the [`maxBuffer`](api.md#optionsmaxbuffer) option. It defaults to 100MB.
 
-When this threshold is hit, the subprocess fails and [`error.isMaxBuffer`](api.md#errorismaxbuffer) becomes `true`. The truncated output is still available using [`error.stdout`](api.md#resultstdout), [`error.stderr`](api.md#resultstderr) and [`error.ipc`](api.md#resultipc).
+When this threshold is hit, the subprocess fails and [`error.isMaxBuffer`](api.md#errorismaxbuffer) becomes `true`. The truncated output is still available using [`error.stdout`](api.md#resultstdout), [`error.stderr`](api.md#resultstderr) and [`error.ipcOutput`](api.md#resultipcoutput).
 
 This is measured:
 - By default: in [characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length).
 - If the [`encoding`](binary.md#encoding) option is `'buffer'`: in bytes.
 - If the [`lines`](lines.md#simple-splitting) option is `true`: in lines.
 - If a [transform in object mode](transform.md#object-mode) is used: in objects.
-- With [`error.ipc`](ipc.md#retrieve-all-messages): in messages.
+- With [`error.ipcOutput`](ipc.md#retrieve-all-messages): in messages.
 
 ```js
 try {
@@ -187,7 +187,7 @@ try {
 
 ## Low memory
 
-When the [`buffer`](api.md#optionsbuffer) option is `false`, [`result.stdout`](api.md#resultstdout), [`result.stderr`](api.md#resultstderr), [`result.all`](api.md#resultall), [`result.stdio[*]`](api.md#resultstdio) and [`result.ipc`](api.md#resultipc) properties are empty.
+When the [`buffer`](api.md#optionsbuffer) option is `false`, [`result.stdout`](api.md#resultstdout), [`result.stderr`](api.md#resultstderr), [`result.all`](api.md#resultall), [`result.stdio[*]`](api.md#resultstdio) and [`result.ipcOutput`](api.md#resultipcoutput) properties are empty.
 
 This prevents high memory consumption when the output is big. However, the output must be either ignored, [redirected](#file-output), [streamed](streams.md) or [listened to](ipc.md#listening-to-messages). If streamed, this should be done right away to avoid missing any data.
 

--- a/lib/io/max-buffer.js
+++ b/lib/io/max-buffer.js
@@ -35,9 +35,9 @@ const getMaxBufferUnit = (readableObjectMode, lines, encoding) => {
 	return 'characters';
 };
 
-// Check the `maxBuffer` option with `result.ipc`
-export const checkIpcMaxBuffer = (subprocess, ipcMessages, maxBuffer) => {
-	if (ipcMessages.length !== maxBuffer) {
+// Check the `maxBuffer` option with `result.ipcOutput`
+export const checkIpcMaxBuffer = (subprocess, ipcOutput, maxBuffer) => {
+	if (ipcOutput.length !== maxBuffer) {
 		return;
 	}
 

--- a/lib/ipc/buffer-messages.js
+++ b/lib/ipc/buffer-messages.js
@@ -1,18 +1,18 @@
 import {checkIpcMaxBuffer} from '../io/max-buffer.js';
-import {shouldLogIpc, logIpcMessage} from '../verbose/ipc.js';
+import {shouldLogIpc, logIpcOutput} from '../verbose/ipc.js';
 import {loopOnMessages} from './get-each.js';
 
 // Iterate through IPC messages sent by the subprocess
-export const waitForIpcMessages = async ({
+export const waitForIpcOutput = async ({
 	subprocess,
 	buffer: bufferArray,
 	maxBuffer: maxBufferArray,
 	ipc,
-	ipcMessages,
+	ipcOutput,
 	verboseInfo,
 }) => {
 	if (!ipc) {
-		return ipcMessages;
+		return ipcOutput;
 	}
 
 	const isVerbose = shouldLogIpc(verboseInfo);
@@ -20,7 +20,7 @@ export const waitForIpcMessages = async ({
 	const maxBuffer = maxBufferArray.at(-1);
 
 	if (!isVerbose && !buffer) {
-		return ipcMessages;
+		return ipcOutput;
 	}
 
 	for await (const message of loopOnMessages({
@@ -30,14 +30,14 @@ export const waitForIpcMessages = async ({
 		shouldAwait: false,
 	})) {
 		if (buffer) {
-			checkIpcMaxBuffer(subprocess, ipcMessages, maxBuffer);
-			ipcMessages.push(message);
+			checkIpcMaxBuffer(subprocess, ipcOutput, maxBuffer);
+			ipcOutput.push(message);
 		}
 
 		if (isVerbose) {
-			logIpcMessage(message, verboseInfo);
+			logIpcOutput(message, verboseInfo);
 		}
 	}
 
-	return ipcMessages;
+	return ipcOutput;
 };

--- a/lib/methods/main-async.js
+++ b/lib/methods/main-async.js
@@ -137,7 +137,7 @@ const handlePromise = async ({subprocess, options, startTime, verboseInfo, fileD
 		[exitCode, signal],
 		stdioResults,
 		allResult,
-		ipcMessages,
+		ipcOutput,
 	] = await waitForSubprocessResult({
 		subprocess,
 		options,
@@ -159,7 +159,7 @@ const handlePromise = async ({subprocess, options, startTime, verboseInfo, fileD
 		signal,
 		stdio,
 		all,
-		ipcMessages,
+		ipcOutput,
 		context,
 		options,
 		command,
@@ -169,7 +169,7 @@ const handlePromise = async ({subprocess, options, startTime, verboseInfo, fileD
 	return handleResult(result, verboseInfo, options);
 };
 
-const getAsyncResult = ({errorInfo, exitCode, signal, stdio, all, ipcMessages, context, options, command, escapedCommand, startTime}) => 'error' in errorInfo
+const getAsyncResult = ({errorInfo, exitCode, signal, stdio, all, ipcOutput, context, options, command, escapedCommand, startTime}) => 'error' in errorInfo
 	? makeError({
 		error: errorInfo.error,
 		command,
@@ -181,7 +181,7 @@ const getAsyncResult = ({errorInfo, exitCode, signal, stdio, all, ipcMessages, c
 		signal,
 		stdio,
 		all,
-		ipcMessages,
+		ipcOutput,
 		options,
 		startTime,
 		isSync: false,
@@ -191,7 +191,7 @@ const getAsyncResult = ({errorInfo, exitCode, signal, stdio, all, ipcMessages, c
 		escapedCommand,
 		stdio,
 		all,
-		ipcMessages,
+		ipcOutput,
 		options,
 		startTime,
 	});

--- a/lib/methods/main-sync.js
+++ b/lib/methods/main-sync.js
@@ -145,7 +145,7 @@ const getSyncResult = ({error, exitCode, signal, timedOut, isMaxBuffer, stdio, a
 		escapedCommand,
 		stdio,
 		all,
-		ipcMessages: [],
+		ipcOutput: [],
 		options,
 		startTime,
 	})
@@ -160,7 +160,7 @@ const getSyncResult = ({error, exitCode, signal, timedOut, isMaxBuffer, stdio, a
 		signal,
 		stdio,
 		all,
-		ipcMessages: [],
+		ipcOutput: [],
 		options,
 		startTime,
 		isSync: true,

--- a/lib/resolve/wait-subprocess.js
+++ b/lib/resolve/wait-subprocess.js
@@ -4,7 +4,7 @@ import {throwOnTimeout} from '../terminate/timeout.js';
 import {isStandardStream} from '../utils/standard-stream.js';
 import {TRANSFORM_TYPES} from '../stdio/type.js';
 import {getBufferedData} from '../io/contents.js';
-import {waitForIpcMessages} from '../ipc/buffer-messages.js';
+import {waitForIpcOutput} from '../ipc/buffer-messages.js';
 import {sendIpcInput} from '../ipc/ipc-input.js';
 import {waitForAllStream} from './all-async.js';
 import {waitForStdioStreams} from './stdio.js';
@@ -60,7 +60,7 @@ export const waitForSubprocessResult = async ({
 		verboseInfo,
 		streamInfo,
 	});
-	const ipcMessages = [];
+	const ipcOutput = [];
 	const originalPromises = waitForOriginalStreams(originalStreams, subprocess, streamInfo);
 	const customStreamsEndPromises = waitForCustomStreamsEnd(fileDescriptors, streamInfo);
 
@@ -71,12 +71,12 @@ export const waitForSubprocessResult = async ({
 				waitForSuccessfulExit(exitPromise),
 				Promise.all(stdioPromises),
 				allPromise,
-				waitForIpcMessages({
+				waitForIpcOutput({
 					subprocess,
 					buffer,
 					maxBuffer,
 					ipc,
-					ipcMessages,
+					ipcOutput,
 					verboseInfo,
 				}),
 				sendIpcInput(subprocess, ipcInput),
@@ -93,7 +93,7 @@ export const waitForSubprocessResult = async ({
 			exitPromise,
 			Promise.all(stdioPromises.map(stdioPromise => getBufferedData(stdioPromise))),
 			getBufferedData(allPromise),
-			ipcMessages,
+			ipcOutput,
 			Promise.allSettled(originalPromises),
 			Promise.allSettled(customStreamsEndPromises),
 		]);

--- a/lib/return/message.js
+++ b/lib/return/message.js
@@ -10,7 +10,7 @@ import {DiscardedError, isExecaError} from './final-error.js';
 export const createMessages = ({
 	stdio,
 	all,
-	ipcMessages,
+	ipcOutput,
 	originalError,
 	signal,
 	signalDescription,
@@ -44,7 +44,7 @@ export const createMessages = ({
 		shortMessage,
 		...messageStdio,
 		...stdio.slice(3),
-		ipcMessages.map(ipcMessage => serializeIpcMessage(ipcMessage)).join('\n'),
+		ipcOutput.map(ipcMessage => serializeIpcMessage(ipcMessage)).join('\n'),
 	]
 		.map(messagePart => escapeLines(stripFinalNewline(serializeMessagePart(messagePart))))
 		.filter(Boolean)

--- a/lib/return/result.js
+++ b/lib/return/result.js
@@ -9,7 +9,7 @@ export const makeSuccessResult = ({
 	escapedCommand,
 	stdio,
 	all,
-	ipcMessages,
+	ipcOutput,
 	options: {cwd},
 	startTime,
 }) => omitUndefinedProperties({
@@ -27,7 +27,7 @@ export const makeSuccessResult = ({
 	stderr: stdio[2],
 	all,
 	stdio,
-	ipc: ipcMessages,
+	ipcOutput,
 	pipedFrom: [],
 });
 
@@ -49,7 +49,7 @@ export const makeEarlyError = ({
 	isCanceled: false,
 	isMaxBuffer: false,
 	stdio: Array.from({length: fileDescriptors.length}),
-	ipcMessages: [],
+	ipcOutput: [],
 	options,
 	isSync,
 });
@@ -67,7 +67,7 @@ export const makeError = ({
 	signal: rawSignal,
 	stdio,
 	all,
-	ipcMessages,
+	ipcOutput,
 	options: {timeoutDuration, timeout = timeoutDuration, cwd, maxBuffer},
 	isSync,
 }) => {
@@ -75,7 +75,7 @@ export const makeError = ({
 	const {originalMessage, shortMessage, message} = createMessages({
 		stdio,
 		all,
-		ipcMessages,
+		ipcOutput,
 		originalError,
 		signal,
 		signalDescription,
@@ -102,7 +102,7 @@ export const makeError = ({
 		signalDescription,
 		stdio,
 		all,
-		ipcMessages,
+		ipcOutput,
 		cwd,
 		originalMessage,
 		shortMessage,
@@ -123,7 +123,7 @@ const getErrorProperties = ({
 	signalDescription,
 	stdio,
 	all,
-	ipcMessages,
+	ipcOutput,
 	cwd,
 	originalMessage,
 	shortMessage,
@@ -147,7 +147,7 @@ const getErrorProperties = ({
 	stderr: stdio[2],
 	all,
 	stdio,
-	ipc: ipcMessages,
+	ipcOutput,
 	pipedFrom: [],
 });
 

--- a/lib/verbose/ipc.js
+++ b/lib/verbose/ipc.js
@@ -3,6 +3,6 @@ import {verboseLog, serializeLogMessage} from './log.js';
 // When `verbose` is `'full'`, print IPC messages from the subprocess
 export const shouldLogIpc = ({verbose}) => verbose.at(-1) === 'full';
 
-export const logIpcMessage = (message, {verboseId}) => {
+export const logIpcOutput = (message, {verboseId}) => {
 	verboseLog(serializeLogMessage(message), verboseId, 'ipc');
 };

--- a/readme.md
+++ b/readme.md
@@ -309,9 +309,9 @@ const ipcInput = await getOneMessage();
 // main.js
 import {execaNode} from 'execa';
 
-const {ipc} = await execaNode`build.js`;
-console.log(ipc[0]); // {kind: 'start', timestamp: date}
-console.log(ipc[1]); // {kind: 'stop', timestamp: date}
+const {ipcOutput} = await execaNode`build.js`;
+console.log(ipcOutput[0]); // {kind: 'start', timestamp: date}
+console.log(ipcOutput[1]); // {kind: 'stop', timestamp: date}
 ```
 
 ```js

--- a/test-d/return/result-ipc.ts
+++ b/test-d/return/result-ipc.ts
@@ -11,69 +11,69 @@ import {
 } from '../../index.js';
 
 const ipcResult = await execa('unicorns', {ipc: true});
-expectType<Array<Message<'advanced'>>>(ipcResult.ipc);
+expectType<Array<Message<'advanced'>>>(ipcResult.ipcOutput);
 
 const ipcFdResult = await execa('unicorns', {ipc: true, buffer: {stdout: false}});
-expectType<Array<Message<'advanced'>>>(ipcFdResult.ipc);
+expectType<Array<Message<'advanced'>>>(ipcFdResult.ipcOutput);
 
 const advancedResult = await execa('unicorns', {ipc: true, serialization: 'advanced'});
-expectType<Array<Message<'advanced'>>>(advancedResult.ipc);
+expectType<Array<Message<'advanced'>>>(advancedResult.ipcOutput);
 
 const jsonResult = await execa('unicorns', {ipc: true, serialization: 'json'});
-expectType<Array<Message<'json'>>>(jsonResult.ipc);
+expectType<Array<Message<'json'>>>(jsonResult.ipcOutput);
 
 const inputResult = await execa('unicorns', {ipcInput: ''});
-expectType<Array<Message<'advanced'>>>(inputResult.ipc);
+expectType<Array<Message<'advanced'>>>(inputResult.ipcOutput);
 
 const genericInputResult = await execa('unicorns', {ipcInput: '' as Message});
-expectType<Array<Message<'advanced'>>>(genericInputResult.ipc);
+expectType<Array<Message<'advanced'>>>(genericInputResult.ipcOutput);
 
 const genericResult = await execa('unicorns', {} as Options);
-expectType<Message[] | []>(genericResult.ipc);
+expectType<Message[] | []>(genericResult.ipcOutput);
 
 const genericIpc = await execa('unicorns', {ipc: true as boolean});
-expectType<Array<Message<'advanced'>> | []>(genericIpc.ipc);
+expectType<Array<Message<'advanced'>> | []>(genericIpc.ipcOutput);
 
 const maybeInputResult = await execa('unicorns', {ipcInput: '' as '' | undefined});
-expectType<Array<Message<'advanced'>> | []>(maybeInputResult.ipc);
+expectType<Array<Message<'advanced'>> | []>(maybeInputResult.ipcOutput);
 
 const falseIpcResult = await execa('unicorns', {ipc: false});
-expectType<[]>(falseIpcResult.ipc);
+expectType<[]>(falseIpcResult.ipcOutput);
 
 const noIpcResult = await execa('unicorns');
-expectType<[]>(noIpcResult.ipc);
+expectType<[]>(noIpcResult.ipcOutput);
 
 const emptyIpcResult = await execa('unicorns', {});
-expectType<[]>(emptyIpcResult.ipc);
+expectType<[]>(emptyIpcResult.ipcOutput);
 
 const undefinedInputResult = await execa('unicorns', {ipcInput: undefined});
-expectType<[]>(undefinedInputResult.ipc);
+expectType<[]>(undefinedInputResult.ipcOutput);
 
 const inputNoIpcResult = await execa('unicorns', {ipc: false, ipcInput: ''});
-expectType<[]>(inputNoIpcResult.ipc);
+expectType<[]>(inputNoIpcResult.ipcOutput);
 
 const noBufferResult = await execa('unicorns', {ipc: true, buffer: false});
-expectType<[]>(noBufferResult.ipc);
+expectType<[]>(noBufferResult.ipcOutput);
 
 const noBufferFdResult = await execa('unicorns', {ipc: true, buffer: {ipc: false}});
-expectType<[]>(noBufferFdResult.ipc);
+expectType<[]>(noBufferFdResult.ipcOutput);
 
 const syncResult = execaSync('unicorns');
-expectType<[]>(syncResult.ipc);
+expectType<[]>(syncResult.ipcOutput);
 
-expectType<Message[] | []>({} as Result['ipc']);
-expectAssignable<Message[]>({} as Result['ipc']);
-expectType<[]>({} as unknown as SyncResult['ipc']);
+expectType<Message[] | []>({} as Result['ipcOutput']);
+expectAssignable<Message[]>({} as Result['ipcOutput']);
+expectType<[]>({} as unknown as SyncResult['ipcOutput']);
 
 const ipcError = new Error('.') as ExecaError<{ipc: true}>;
-expectType<Array<Message<'advanced'>>>(ipcError.ipc);
+expectType<Array<Message<'advanced'>>>(ipcError.ipcOutput);
 
 const ipcFalseError = new Error('.') as ExecaError<{ipc: false}>;
-expectType<[]>(ipcFalseError.ipc);
+expectType<[]>(ipcFalseError.ipcOutput);
 
 const asyncError = new Error('.') as ExecaError;
-expectType<Message[] | []>(asyncError.ipc);
-expectAssignable<Message[]>(asyncError.ipc);
+expectType<Message[] | []>(asyncError.ipcOutput);
+expectAssignable<Message[]>(asyncError.ipcOutput);
 
 const syncError = new Error('.') as ExecaSyncError;
-expectType<[]>(syncError.ipc);
+expectType<[]>(syncError.ipcOutput);

--- a/test/io/max-buffer.js
+++ b/test/io/max-buffer.js
@@ -267,27 +267,27 @@ test('error.isMaxBuffer is false on early errors', async t => {
 	t.false(isMaxBuffer);
 });
 
-test('maxBuffer works with result.ipc', async t => {
+test('maxBuffer works with result.ipcOutput', async t => {
 	const {
 		isMaxBuffer,
 		shortMessage,
 		message,
 		stderr,
-		ipc,
+		ipcOutput,
 	} = await t.throwsAsync(execa('ipc-send-twice-wait.js', {ipc: true, maxBuffer: {ipc: 1}}));
 	t.true(isMaxBuffer);
 	t.is(shortMessage, 'Command\'s IPC output was larger than 1 messages: ipc-send-twice-wait.js\nmaxBuffer exceeded');
 	t.true(message.endsWith(`\n\n${foobarString}`));
 	t.true(stderr.includes('Error: getOneMessage() could not complete'));
-	t.deepEqual(ipc, [foobarString]);
+	t.deepEqual(ipcOutput, [foobarString]);
 });
 
-test('maxBuffer is ignored with result.ipc if buffer is false', async t => {
+test('maxBuffer is ignored with result.ipcOutput if buffer is false', async t => {
 	const subprocess = execa('ipc-send-twice-wait.js', {ipc: true, maxBuffer: {ipc: 1}, buffer: false});
 	t.is(await subprocess.getOneMessage(), foobarString);
 	t.is(await subprocess.getOneMessage(), foobarString);
 	await subprocess.sendMessage(foobarString);
 
-	const {ipc} = await subprocess;
-	t.deepEqual(ipc, []);
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, []);
 });

--- a/test/ipc/buffer-messages.js
+++ b/test/ipc/buffer-messages.js
@@ -6,53 +6,53 @@ import {foobarString, foobarArray} from '../helpers/input.js';
 setFixtureDirectory();
 
 const testResultIpc = async (t, options) => {
-	const {ipc} = await execa('ipc-send-twice.js', {...options, ipc: true});
-	t.deepEqual(ipc, foobarArray);
+	const {ipcOutput} = await execa('ipc-send-twice.js', {...options, ipc: true});
+	t.deepEqual(ipcOutput, foobarArray);
 };
 
-test('Sets result.ipc', testResultIpc, {});
-test('Sets result.ipc, fd-specific buffer', testResultIpc, {buffer: {stdout: false}});
+test('Sets result.ipcOutput', testResultIpc, {});
+test('Sets result.ipcOutput, fd-specific buffer', testResultIpc, {buffer: {stdout: false}});
 
 const testResultNoBuffer = async (t, options) => {
-	const {ipc} = await execa('ipc-send.js', {...options, ipc: true});
-	t.deepEqual(ipc, []);
+	const {ipcOutput} = await execa('ipc-send.js', {...options, ipc: true});
+	t.deepEqual(ipcOutput, []);
 };
 
-test('Sets empty result.ipc if buffer is false', testResultNoBuffer, {buffer: false});
-test('Sets empty result.ipc if buffer is false, fd-specific buffer', testResultNoBuffer, {buffer: {ipc: false}});
+test('Sets empty result.ipcOutput if buffer is false', testResultNoBuffer, {buffer: false});
+test('Sets empty result.ipcOutput if buffer is false, fd-specific buffer', testResultNoBuffer, {buffer: {ipc: false}});
 
-test('Sets empty result.ipc if ipc is false', async t => {
-	const {ipc} = await execa('empty.js');
-	t.deepEqual(ipc, []);
+test('Sets empty result.ipcOutput if ipc is false', async t => {
+	const {ipcOutput} = await execa('empty.js');
+	t.deepEqual(ipcOutput, []);
 });
 
-test('Sets empty result.ipc, sync', t => {
-	const {ipc} = execaSync('empty.js');
-	t.deepEqual(ipc, []);
+test('Sets empty result.ipcOutput, sync', t => {
+	const {ipcOutput} = execaSync('empty.js');
+	t.deepEqual(ipcOutput, []);
 });
 
 const testErrorIpc = async (t, options) => {
-	const {ipc} = await t.throwsAsync(execa('ipc-send-fail.js', {...options, ipc: true}));
-	t.deepEqual(ipc, [foobarString]);
+	const {ipcOutput} = await t.throwsAsync(execa('ipc-send-fail.js', {...options, ipc: true}));
+	t.deepEqual(ipcOutput, [foobarString]);
 };
 
-test('Sets error.ipc', testErrorIpc, {});
-test('Sets error.ipc, fd-specific buffer', testErrorIpc, {buffer: {stdout: false}});
+test('Sets error.ipcOutput', testErrorIpc, {});
+test('Sets error.ipcOutput, fd-specific buffer', testErrorIpc, {buffer: {stdout: false}});
 
 const testErrorNoBuffer = async (t, options) => {
-	const {ipc} = await t.throwsAsync(execa('ipc-send-fail.js', {...options, ipc: true}));
-	t.deepEqual(ipc, []);
+	const {ipcOutput} = await t.throwsAsync(execa('ipc-send-fail.js', {...options, ipc: true}));
+	t.deepEqual(ipcOutput, []);
 };
 
-test('Sets empty error.ipc if buffer is false', testErrorNoBuffer, {buffer: false});
-test('Sets empty error.ipc if buffer is false, fd-specific buffer', testErrorNoBuffer, {buffer: {ipc: false}});
+test('Sets empty error.ipcOutput if buffer is false', testErrorNoBuffer, {buffer: false});
+test('Sets empty error.ipcOutput if buffer is false, fd-specific buffer', testErrorNoBuffer, {buffer: {ipc: false}});
 
-test('Sets empty error.ipc if ipc is false', async t => {
-	const {ipc} = await t.throwsAsync(execa('fail.js'));
-	t.deepEqual(ipc, []);
+test('Sets empty error.ipcOutput if ipc is false', async t => {
+	const {ipcOutput} = await t.throwsAsync(execa('fail.js'));
+	t.deepEqual(ipcOutput, []);
 });
 
-test('Sets empty error.ipc, sync', t => {
-	const {ipc} = t.throws(() => execaSync('fail.js'));
-	t.deepEqual(ipc, []);
+test('Sets empty error.ipcOutput, sync', t => {
+	const {ipcOutput} = t.throws(() => execaSync('fail.js'));
+	t.deepEqual(ipcOutput, []);
 });

--- a/test/ipc/get-each.js
+++ b/test/ipc/get-each.js
@@ -13,8 +13,8 @@ test('Can iterate over IPC messages', async t => {
 		t.is(message, foobarArray[count++]);
 	}
 
-	const {ipc} = await subprocess;
-	t.deepEqual(ipc, foobarArray);
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, foobarArray);
 });
 
 test('Can iterate over IPC messages in subprocess', async t => {
@@ -24,8 +24,8 @@ test('Can iterate over IPC messages in subprocess', async t => {
 	await subprocess.sendMessage('.');
 	await subprocess.sendMessage(foobarString);
 
-	const {ipc} = await subprocess;
-	t.deepEqual(ipc, ['.', '.']);
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, ['.', '.']);
 });
 
 test('Can iterate multiple times over IPC messages in subprocess', async t => {
@@ -40,8 +40,8 @@ test('Can iterate multiple times over IPC messages in subprocess', async t => {
 	await subprocess.sendMessage(foobarString);
 	t.is(await subprocess.getOneMessage(), foobarString);
 
-	const {ipc} = await subprocess;
-	t.deepEqual(ipc, ['.', foobarString, '.', foobarString]);
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, ['.', foobarString, '.', foobarString]);
 });
 
 test('subprocess.getEachMessage() can be called twice at the same time', async t => {
@@ -51,8 +51,8 @@ test('subprocess.getEachMessage() can be called twice at the same time', async t
 		[foobarArray, foobarArray],
 	);
 
-	const {ipc} = await subprocess;
-	t.deepEqual(ipc, foobarArray);
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, foobarArray);
 });
 
 const HIGH_CONCURRENCY_COUNT = 100;
@@ -62,8 +62,8 @@ test('Can send many messages at once with exports.getEachMessage()', async t => 
 	await Promise.all(Array.from({length: HIGH_CONCURRENCY_COUNT}, (_, index) => subprocess.sendMessage(index)));
 	await subprocess.sendMessage(foobarString);
 
-	const {ipc} = await subprocess;
-	t.deepEqual(ipc, Array.from({length: HIGH_CONCURRENCY_COUNT}, (_, index) => index));
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, Array.from({length: HIGH_CONCURRENCY_COUNT}, (_, index) => index));
 });
 
 test('Disconnecting in the current process stops exports.getEachMessage()', async t => {
@@ -82,8 +82,8 @@ test('Disconnecting in the subprocess stops subprocess.getEachMessage()', async 
 		t.is(message, foobarString);
 	}
 
-	const {ipc} = await subprocess;
-	t.deepEqual(ipc, [foobarString]);
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, [foobarString]);
 });
 
 test('Exiting the subprocess stops subprocess.getEachMessage()', async t => {
@@ -92,8 +92,8 @@ test('Exiting the subprocess stops subprocess.getEachMessage()', async t => {
 		t.is(message, foobarString);
 	}
 
-	const {ipc} = await subprocess;
-	t.deepEqual(ipc, [foobarString]);
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, [foobarString]);
 });
 
 const loopAndBreak = async (t, subprocess) => {
@@ -106,9 +106,9 @@ const loopAndBreak = async (t, subprocess) => {
 
 test('Breaking from subprocess.getEachMessage() awaits the subprocess', async t => {
 	const subprocess = execa('ipc-send-fail.js', {ipc: true});
-	const {exitCode, ipc} = await t.throwsAsync(loopAndBreak(t, subprocess));
+	const {exitCode, ipcOutput} = await t.throwsAsync(loopAndBreak(t, subprocess));
 	t.is(exitCode, 1);
-	t.deepEqual(ipc, [foobarString]);
+	t.deepEqual(ipcOutput, [foobarString]);
 });
 
 const testCleanupListeners = async (t, buffer) => {

--- a/test/ipc/get-one.js
+++ b/test/ipc/get-one.js
@@ -47,8 +47,8 @@ test('Does not buffer initial message to current process, buffer true', async t 
 	t.is(chunk.toString(), '.');
 	t.is(await Promise.race([setTimeout(1e3), subprocess.getOneMessage()]), undefined);
 	await subprocess.sendMessage('.');
-	const {ipc} = await subprocess;
-	t.deepEqual(ipc, [foobarString]);
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, [foobarString]);
 });
 
 const HIGH_CONCURRENCY_COUNT = 100;
@@ -66,8 +66,8 @@ test.serial('Can retrieve initial IPC messages under heavy load, buffer false', 
 test.serial('Can retrieve initial IPC messages under heavy load, buffer true', async t => {
 	await Promise.all(
 		Array.from({length: HIGH_CONCURRENCY_COUNT}, async (_, index) => {
-			const {ipc} = await execa('ipc-send-argv.js', [`${index}`], {ipc: true});
-			t.deepEqual(ipc, [`${index}`]);
+			const {ipcOutput} = await execa('ipc-send-argv.js', [`${index}`], {ipc: true});
+			t.deepEqual(ipcOutput, [`${index}`]);
 		}),
 	);
 });
@@ -108,7 +108,7 @@ const testCleanupListeners = async (t, buffer) => {
 test('Cleans up subprocess.getOneMessage() listeners, buffer false', testCleanupListeners, false);
 test('Cleans up subprocess.getOneMessage() listeners, buffer true', testCleanupListeners, true);
 
-test('"error" event interrupts result.ipc', async t => {
+test('"error" event interrupts result.ipcOutput', async t => {
 	const subprocess = execa('ipc-echo-twice.js', {ipcInput: foobarString});
 	t.is(await subprocess.getOneMessage(), foobarString);
 
@@ -116,7 +116,7 @@ test('"error" event interrupts result.ipc', async t => {
 	subprocess.emit('error', cause);
 	const error = await t.throwsAsync(subprocess);
 	t.is(error.cause, cause);
-	t.deepEqual(error.ipc, [foobarString]);
+	t.deepEqual(error.ipcOutput, [foobarString]);
 });
 
 const testParentDisconnect = async (t, buffer) => {

--- a/test/ipc/ipc-input.js
+++ b/test/ipc/ipc-input.js
@@ -6,8 +6,8 @@ import {foobarString} from '../helpers/input.js';
 setFixtureDirectory();
 
 const testSuccess = async (t, options) => {
-	const {ipc} = await execa('ipc-echo.js', {ipcInput: foobarString, ...options});
-	t.deepEqual(ipc, [foobarString]);
+	const {ipcOutput} = await execa('ipc-echo.js', {ipcInput: foobarString, ...options});
+	t.deepEqual(ipcOutput, [foobarString]);
 };
 
 test('Sends a message with the "ipcInput" option, ipc undefined', testSuccess, {});

--- a/test/ipc/send.js
+++ b/test/ipc/send.js
@@ -39,8 +39,8 @@ test('Handles backpressure', async t => {
 	const subprocess = execa('ipc-iterate.js', {ipc: true});
 	await subprocess.sendMessage(BIG_PAYLOAD_SIZE);
 	t.true(subprocess.send(foobarString));
-	const {ipc} = await subprocess;
-	t.deepEqual(ipc, [BIG_PAYLOAD_SIZE]);
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, [BIG_PAYLOAD_SIZE]);
 });
 
 test('Disconnects IPC on exports.sendMessage() error', async t => {

--- a/test/return/message.js
+++ b/test/return/message.js
@@ -95,24 +95,24 @@ test('Original error.message is kept', async t => {
 	t.is(originalMessage, 'The "options.uid" property must be int32. Received type boolean (true)');
 });
 
-const testIpcMessage = async (t, doubles, ipcInput, returnedMessage) => {
+const testIpcOutput = async (t, doubles, ipcInput, returnedMessage) => {
 	const fixtureName = doubles ? 'ipc-echo-twice-fail.js' : 'ipc-echo-fail.js';
-	const {exitCode, message, ipc} = await t.throwsAsync(execa(fixtureName, {ipcInput}));
+	const {exitCode, message, ipcOutput} = await t.throwsAsync(execa(fixtureName, {ipcInput}));
 	t.is(exitCode, 1);
 	t.true(message.endsWith(`\n\n${doubles ? `${returnedMessage}\n${returnedMessage}` : returnedMessage}`));
-	t.deepEqual(ipc, doubles ? [ipcInput, ipcInput] : [ipcInput]);
+	t.deepEqual(ipcOutput, doubles ? [ipcInput, ipcInput] : [ipcInput]);
 };
 
-test('error.message contains IPC messages, single string', testIpcMessage, false, foobarString, foobarString);
-test('error.message contains IPC messages, two strings', testIpcMessage, true, foobarString, foobarString);
-test('error.message contains IPC messages, single object', testIpcMessage, false, foobarObject, foobarObjectInspect);
-test('error.message contains IPC messages, two objects', testIpcMessage, true, foobarObject, foobarObjectInspect);
-test('error.message contains IPC messages, multiline string', testIpcMessage, false, `${foobarString}\n${foobarString}`, `${foobarString}\n${foobarString}`);
-test('error.message contains IPC messages, control characters', testIpcMessage, false, '\0', '\\u0000');
+test('error.message contains IPC messages, single string', testIpcOutput, false, foobarString, foobarString);
+test('error.message contains IPC messages, two strings', testIpcOutput, true, foobarString, foobarString);
+test('error.message contains IPC messages, single object', testIpcOutput, false, foobarObject, foobarObjectInspect);
+test('error.message contains IPC messages, two objects', testIpcOutput, true, foobarObject, foobarObjectInspect);
+test('error.message contains IPC messages, multiline string', testIpcOutput, false, `${foobarString}\n${foobarString}`, `${foobarString}\n${foobarString}`);
+test('error.message contains IPC messages, control characters', testIpcOutput, false, '\0', '\\u0000');
 
 test('error.message does not contain IPC messages, buffer false', async t => {
-	const {exitCode, message, ipc} = await t.throwsAsync(execa('ipc-echo-fail.js', {ipcInput: foobarString, buffer: false}));
+	const {exitCode, message, ipcOutput} = await t.throwsAsync(execa('ipc-echo-fail.js', {ipcInput: foobarString, buffer: false}));
 	t.is(exitCode, 1);
 	t.true(message.endsWith('ipc-echo-fail.js'));
-	t.deepEqual(ipc, []);
+	t.deepEqual(ipcOutput, []);
 });

--- a/test/return/output.js
+++ b/test/return/output.js
@@ -122,13 +122,13 @@ test('error.stdout/stderr/stdio is defined, sync', testErrorOutput, execaSync);
 test('ipc on subprocess spawning errors', async t => {
 	const error = await t.throwsAsync(getEarlyErrorSubprocess({ipc: true}));
 	t.like(error, expectedEarlyError);
-	t.deepEqual(error.ipc, []);
+	t.deepEqual(error.ipcOutput, []);
 });
 
 const testEarlyErrorNoIpc = async (t, options) => {
 	const error = await t.throwsAsync(getEarlyErrorSubprocess(options));
 	t.like(error, expectedEarlyError);
-	t.deepEqual(error.ipc, []);
+	t.deepEqual(error.ipcOutput, []);
 };
 
 test('ipc on subprocess spawning errors, ipc false', testEarlyErrorNoIpc, {ipc: false});

--- a/test/return/result.js
+++ b/test/return/result.js
@@ -25,7 +25,7 @@ const testSuccessShape = async (t, execaMethod) => {
 		'stderr',
 		'all',
 		'stdio',
-		'ipc',
+		'ipcOutput',
 		'pipedFrom',
 	]);
 };
@@ -54,7 +54,7 @@ const testErrorShape = async (t, execaMethod) => {
 		'stderr',
 		'all',
 		'stdio',
-		'ipc',
+		'ipcOutput',
 		'pipedFrom',
 	]);
 };

--- a/types/methods/main-async.d.ts
+++ b/types/methods/main-async.d.ts
@@ -226,9 +226,9 @@ const ipcInput = await getOneMessage();
 // main.js
 import {execaNode} from 'execa';
 
-const {ipc} = await execaNode`build.js`;
-console.log(ipc[0]); // {kind: 'start', timestamp: date}
-console.log(ipc[1]); // {kind: 'stop', timestamp: date}
+const {ipcOutput} = await execaNode`build.js`;
+console.log(ipcOutput[0]); // {kind: 'start', timestamp: date}
+console.log(ipcOutput[1]); // {kind: 'stop', timestamp: date}
 ```
 
 ```

--- a/types/return/result-ipc.d.ts
+++ b/types/return/result-ipc.d.ts
@@ -2,10 +2,10 @@ import type {FdSpecificOption} from '../arguments/specific.js';
 import type {CommonOptions, Options, StricterOptions} from '../arguments/options.js';
 import type {Message, HasIpc} from '../ipc.js';
 
-// `result.ipc`
+// `result.ipcOutput`
 // This is empty unless the `ipc` option is `true`.
 // Also, this is empty if the `buffer` option is `false`.
-export type ResultIpc<
+export type ResultIpcOutput<
 	IsSync extends boolean,
 	OptionsType extends CommonOptions,
 > = IsSync extends true

--- a/types/return/result.d.ts
+++ b/types/return/result.d.ts
@@ -5,7 +5,7 @@ import type {ErrorProperties} from './final-error.js';
 import type {ResultAll} from './result-all.js';
 import type {ResultStdioArray} from './result-stdio.js';
 import type {ResultStdioNotAll} from './result-stdout.js';
-import type {ResultIpc} from './result-ipc.js';
+import type {ResultIpcOutput} from './result-ipc.js';
 
 export declare abstract class CommonResult<
 	IsSync extends boolean,
@@ -54,7 +54,7 @@ export declare abstract class CommonResult<
 
 	This is empty unless the `ipc` option is `true`. Also, this is empty if the `buffer` option is `false`.
 	*/
-	ipc: ResultIpc<IsSync, OptionsType>;
+	ipcOutput: ResultIpcOutput<IsSync, OptionsType>;
 
 	/**
 	Results of the other subprocesses that were piped into this subprocess.


### PR DESCRIPTION
This PR renames `result.ipc` to `result.ipcOutput`. The reasons are:
- This reflects the naming of the `ipcInput` option, which is its counterpart.
- It distinguishes it from the `ipc` option, which currently has the exact same name.
- It makes it clearer that `result.ipcOutput` only contains IPC messages sent by the subprocess to the current process (output), not the other way around (input).

`result.ipc` has not been released yet, so this is not breaking.