### PR TITLE
Fix `break` statement with `subprocess.getEachMessage()`

### DIFF
--- a/lib/io/max-buffer.js
+++ b/lib/io/max-buffer.js
@@ -1,5 +1,4 @@
 import {MaxBufferError} from 'get-stream';
-import {disconnect} from '../ipc/validation.js';
 import {getStreamName} from '../utils/standard-stream.js';
 
 // When the `maxBuffer` option is hit, a MaxBufferError is thrown.
@@ -41,7 +40,6 @@ export const checkIpcMaxBuffer = (subprocess, ipcOutput, maxBuffer) => {
 		return;
 	}
 
-	disconnect(subprocess);
 	const error = new MaxBufferError();
 	error.maxBufferInfo = {fdNumber: 'ipc'};
 	throw error;

--- a/lib/ipc/get-each.js
+++ b/lib/ipc/get-each.js
@@ -20,7 +20,12 @@ export const loopOnMessages = ({anyProcess, isSubprocess, ipc, shouldAwait}) => 
 
 	const controller = new AbortController();
 	stopOnExit(anyProcess, controller);
-	return iterateOnMessages(anyProcess, shouldAwait, controller);
+	return iterateOnMessages({
+		anyProcess,
+		isSubprocess,
+		shouldAwait,
+		controller,
+	});
 };
 
 const stopOnExit = async (anyProcess, controller) => {
@@ -33,7 +38,7 @@ const stopOnExit = async (anyProcess, controller) => {
 	}
 };
 
-const iterateOnMessages = async function * (anyProcess, shouldAwait, controller) {
+const iterateOnMessages = async function * ({anyProcess, isSubprocess, shouldAwait, controller}) {
 	try {
 		for await (const [message] of on(anyProcess, 'message', {signal: controller.signal})) {
 			yield message;
@@ -46,6 +51,10 @@ const iterateOnMessages = async function * (anyProcess, shouldAwait, controller)
 		}
 	} finally {
 		controller.abort();
+
+		if (!isSubprocess) {
+			disconnect(anyProcess);
+		}
 
 		if (shouldAwait) {
 			await anyProcess;

--- a/test/fixtures/ipc-echo-twice.js
+++ b/test/fixtures/ipc-echo-twice.js
@@ -3,4 +3,4 @@ import {sendMessage, getOneMessage, exchangeMessage} from '../../index.js';
 
 const message = await getOneMessage();
 const secondMessage = await exchangeMessage(message);
-await sendMessage(await secondMessage);
+await sendMessage(secondMessage);

--- a/test/fixtures/ipc-iterate-send.js
+++ b/test/fixtures/ipc-iterate-send.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import {sendMessage, getEachMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+const iterable = getEachMessage();
+await sendMessage(foobarString);
+
+for await (const message of iterable) {
+	console.log(message);
+}


### PR DESCRIPTION
When the current process is iterating over the subprocess IPC messages using `subprocess.getEachMessage()`, any `break` statement, `return` statement or exception should disconnect the IPC connection, allowing the subprocess to cleanup.