### PR TITLE
Better error message on IPC `EPIPE`

### DIFF
--- a/lib/ipc/send.js
+++ b/lib/ipc/send.js
@@ -1,5 +1,6 @@
 import {
 	validateIpcMethod,
+	handleEpipeError,
 	handleSerializationError,
 	disconnect,
 } from './validation.js';
@@ -33,6 +34,7 @@ const sendMessageAsync = async ({anyProcess, anyProcessSend, isSubprocess, messa
 		await anyProcessSend(message);
 	} catch (error) {
 		disconnect(anyProcess);
+		handleEpipeError(error, isSubprocess);
 		handleSerializationError(error, isSubprocess, message);
 		throw error;
 	} finally {

--- a/lib/ipc/validation.js
+++ b/lib/ipc/validation.js
@@ -28,6 +28,13 @@ const getNamespaceName = isSubprocess => isSubprocess ? '' : 'subprocess.';
 
 const getOtherProcessName = isSubprocess => isSubprocess ? 'parent process' : 'subprocess';
 
+// EPIPE can happen when sending a message to a subprocess that is closing but has not disconnected yet
+export const handleEpipeError = (error, isSubprocess) => {
+	if (error.code === 'EPIPE') {
+		throw new Error(`${getNamespaceName(isSubprocess)}sendMessage() cannot be used: the ${getOtherProcessName(isSubprocess)} is disconnecting.`, {cause: error});
+	}
+};
+
 // Better error message when sending messages which cannot be serialized.
 // Works with both `serialization: 'advanced'` and `serialization: 'json'`.
 export const handleSerializationError = (error, isSubprocess, message) => {


### PR DESCRIPTION
When `sendMessage()` is sent exactly: 
  - After the subprocess has started disconnecting
  - But before it has emitted the `disconnect` event, set `subprocess.connected false` nor set `subprocess.channel null`

Then an `EPIPE` error is emitted.

```
Error: write EPIPE
    at target._send (node:internal/child_process:879:20)
    at target.send (node:internal/child_process:752:19)
    at node:internal/util:430:21
    at new Promise (<anonymous>)
    at bound  (node:internal/util:416:12)
    at ...
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  errno: -32,
  code: 'EPIPE',
  syscall: 'write'
}
```

This PR provides with a better error message instead:

```
Error: subprocess.sendMessage() cannot be used: the subprocess is disconnecting.
    at ...
  [cause]: Error: write EPIPE
      at target._send (node:internal/child_process:879:20)
      at target.send (node:internal/child_process:752:19)
      at node:internal/util:430:21
      at new Promise (<anonymous>)
      at bound  (node:internal/util:416:12)
      at ...
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
    errno: -32,
    code: 'EPIPE',
    syscall: 'write'
  }
}
```