### PR TITLE
Handle exceptions from the `filter` option of `getOneMessage()`

### DIFF
--- a/lib/ipc/get-one.js
+++ b/lib/ipc/get-one.js
@@ -1,5 +1,5 @@
 import {once, on} from 'node:events';
-import {validateIpcMethod, throwOnEarlyDisconnect} from './validation.js';
+import {validateIpcMethod, throwOnEarlyDisconnect, disconnect} from './validation.js';
 import {getIpcEmitter, isConnected} from './forward.js';
 import {addReference, removeReference} from './reference.js';
 
@@ -24,6 +24,9 @@ const getOneMessageAsync = async (anyProcess, isSubprocess, filter) => {
 			getMessage(ipcEmitter, filter, controller),
 			throwOnDisconnect(ipcEmitter, isSubprocess, controller),
 		]);
+	} catch (error) {
+		disconnect(anyProcess);
+		throw error;
 	} finally {
 		controller.abort();
 		removeReference(anyProcess);

--- a/test/fixtures/ipc-get-filter-throw.js
+++ b/test/fixtures/ipc-get-filter-throw.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import {getOneMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+await getOneMessage({
+	filter() {
+		throw new Error(foobarString);
+	},
+});

--- a/test/fixtures/ipc-send-get.js
+++ b/test/fixtures/ipc-send-get.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import {sendMessage, getOneMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+await Promise.all([
+	getOneMessage(),
+	sendMessage(foobarString),
+]);


### PR DESCRIPTION
This PR improves error handling when the `filter` option of `getOneMessage()` throws.