### PR TITLE
Improve `buffer: false` option with IPC

### DIFF
--- a/lib/ipc/buffer-messages.js
+++ b/lib/ipc/buffer-messages.js
@@ -1,7 +1,6 @@
 import {checkIpcMaxBuffer} from '../io/max-buffer.js';
 import {shouldLogIpc, logIpcOutput} from '../verbose/ipc.js';
 import {loopOnMessages} from './get-each.js';
-import {waitForDisconnect} from './forward.js';
 
 // Iterate through IPC messages sent by the subprocess
 export const waitForIpcOutput = async ({
@@ -19,11 +18,6 @@ export const waitForIpcOutput = async ({
 	const isVerbose = shouldLogIpc(verboseInfo);
 	const buffer = bufferArray.at(-1);
 	const maxBuffer = maxBufferArray.at(-1);
-
-	if (!isVerbose && !buffer) {
-		await waitForDisconnect(subprocess);
-		return ipcOutput;
-	}
 
 	for await (const message of loopOnMessages({
 		anyProcess: subprocess,

--- a/lib/ipc/forward.js
+++ b/lib/ipc/forward.js
@@ -1,4 +1,4 @@
-import {EventEmitter, once} from 'node:events';
+import {EventEmitter} from 'node:events';
 import {onMessage, onDisconnect} from './incoming.js';
 import {undoAddedReferences} from './reference.js';
 
@@ -47,21 +47,4 @@ export const isConnected = anyProcess => {
 	return ipcEmitter === undefined
 		? anyProcess.channel !== null
 		: ipcEmitter.connected;
-};
-
-// Wait for `disconnect` event, including debounced messages processing during disconnection.
-// But does not set up message proxying.
-export const waitForDisconnect = async subprocess => {
-	// Unlike `once()`, this does not stop on `error` events
-	await new Promise(resolve => {
-		subprocess.once('disconnect', resolve);
-	});
-
-	const ipcEmitter = IPC_EMITTERS.get(subprocess);
-	if (ipcEmitter === undefined || !ipcEmitter.connected) {
-		return;
-	}
-
-	// This never emits an `error` event
-	await once(ipcEmitter, 'disconnect');
 };

--- a/lib/ipc/incoming.js
+++ b/lib/ipc/incoming.js
@@ -3,8 +3,24 @@ import {scheduler} from 'node:timers/promises';
 import {waitForOutgoingMessages} from './outgoing.js';
 import {redoAddedReferences} from './reference.js';
 
-// Debounce the `message` event so it is emitted at most once per macrotask.
-// This allows users to call `await getOneMessage()`/`getEachMessage()` multiple times in a row.
+// By default, Node.js buffers `message` events.
+//  - Buffering happens when there is a `message` event is emitted but there is no handler.
+//  - As soon as a `message` event handler is set, all buffered `message` events are emitted, emptying the buffer.
+//  - This happens both in the current process and the subprocess.
+//  - See https://github.com/nodejs/node/blob/501546e8f37059cd577041e23941b640d0d4d406/lib/internal/child_process.js#L719
+// This is helpful. Notably, this allows sending messages to a subprocess that's still initializing.
+// However, it has several problems.
+//  - This works with `events.on()` but not `events.once()` since all buffered messages are emitted at once.
+//    For example, users cannot call `await getOneMessage()`/`getEachMessage()` multiple times in a row.
+//  - When a user intentionally starts listening to `message` at a specific point in time, past `message` events are replayed, which might be unexpected.
+//  - Buffering is unlimited, which might lead to an out-of-memory crash.
+//  - This does not work well with multiple consumers.
+//    For example, Execa consumes events with both `result.ipcOutput` and manual IPC calls like `getOneMessage()`.
+//    Since `result.ipcOutput` reads all incoming messages, no buffering happens for manual IPC calls.
+//  - Forgetting to setup a `message` listener, or setting it up too late, is a programming mistake.
+//    The default behavior does not allow users to realize they made that mistake.
+// To solve those problems, instead of buffering messages, we debounce them.
+// The `message` event so it is emitted at most once per macrotask.
 export const onMessage = async (anyProcess, ipcEmitter, message) => {
 	if (!INCOMING_MESSAGES.has(anyProcess)) {
 		INCOMING_MESSAGES.set(anyProcess, []);

--- a/test/fixtures/ipc-replay.js
+++ b/test/fixtures/ipc-replay.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import {setTimeout} from 'node:timers/promises';
+import {sendMessage, getOneMessage} from '../../index.js';
+
+await sendMessage(await getOneMessage());
+await setTimeout(1e3);
+await sendMessage(await getOneMessage());

--- a/test/fixtures/ipc-send-native.js
+++ b/test/fixtures/ipc-send-native.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import process from 'node:process';
+
+process.send('.');

--- a/test/fixtures/ipc-send-print.js
+++ b/test/fixtures/ipc-send-print.js
@@ -3,9 +3,8 @@ import process from 'node:process';
 import {sendMessage, getOneMessage} from '../../index.js';
 import {foobarString} from '../helpers/input.js';
 
-const promise = getOneMessage();
 await sendMessage(foobarString);
 
 process.stdout.write('.');
 
-await promise;
+await getOneMessage();

--- a/test/ipc/get-each.js
+++ b/test/ipc/get-each.js
@@ -172,12 +172,12 @@ test('Exiting the subprocess stops subprocess.getEachMessage()', async t => {
 const testCleanupListeners = async (t, buffer) => {
 	const subprocess = execa('ipc-send.js', {ipc: true, buffer});
 
-	t.is(subprocess.listenerCount('message'), buffer ? 1 : 0);
+	t.is(subprocess.listenerCount('message'), 1);
 	t.is(subprocess.listenerCount('disconnect'), 1);
 
 	const promise = iterateAllMessages(subprocess);
 	t.is(subprocess.listenerCount('message'), 1);
-	t.is(subprocess.listenerCount('disconnect'), buffer ? 1 : 2);
+	t.is(subprocess.listenerCount('disconnect'), 1);
 	t.deepEqual(await promise, [foobarString]);
 
 	t.is(subprocess.listenerCount('message'), 0);

--- a/test/ipc/pending.js
+++ b/test/ipc/pending.js
@@ -1,0 +1,60 @@
+import {once} from 'node:events';
+import {setTimeout} from 'node:timers/promises';
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
+import {foobarString} from '../helpers/input.js';
+
+setFixtureDirectory();
+
+const testBufferInitial = async (t, buffer) => {
+	const subprocess = execa('ipc-echo-wait.js', {ipc: true, buffer, ipcInput: foobarString});
+	t.is(await subprocess.getOneMessage(), foobarString);
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, buffer ? [foobarString] : []);
+};
+
+test('Buffers initial message to subprocess, buffer false', testBufferInitial, false);
+test('Buffers initial message to subprocess, buffer true', testBufferInitial, true);
+
+const testNoBufferInitial = async (t, buffer) => {
+	const subprocess = execa('ipc-send-print.js', {ipc: true, buffer});
+	const [chunk] = await once(subprocess.stdout, 'data');
+	t.is(chunk.toString(), '.');
+	await setTimeout(1e3);
+	t.is(await Promise.race([setTimeout(0), subprocess.getOneMessage()]), undefined);
+	await subprocess.sendMessage('.');
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, buffer ? [foobarString] : []);
+};
+
+test.serial('Does not buffer initial message to current process, buffer false', testNoBufferInitial, false);
+test.serial('Does not buffer initial message to current process, buffer true', testNoBufferInitial, true);
+
+const testReplay = async (t, buffer) => {
+	const subprocess = execa('ipc-replay.js', {ipc: true, buffer, ipcInput: foobarString});
+	t.is(await subprocess.getOneMessage(), foobarString);
+	await subprocess.sendMessage('.');
+	await setTimeout(2e3);
+	await subprocess.sendMessage(foobarString);
+	t.is(await subprocess.getOneMessage(), foobarString);
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, buffer ? [foobarString, foobarString] : []);
+};
+
+test.serial('Does not replay missed messages in subprocess, buffer false', testReplay, false);
+test.serial('Does not replay missed messages in subprocess, buffer true', testReplay, true);
+
+const testFastSend = async (t, buffer) => {
+	const subprocess = execa('ipc-send-native.js', {ipc: true, buffer});
+	t.is(await subprocess.getOneMessage(), '.');
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, buffer ? ['.'] : []);
+};
+
+test('Subprocess can send messages right away, buffer false', testFastSend, false);
+test('Subprocess can send messages right away, buffer true', testFastSend, true);


### PR DESCRIPTION
This PR is a continuation of #1092.

It improves the behavior of `buffer: false` with IPC, but in a simpler way than implemented in #1092.

It also adds more code comments explaining the logic on how Node.js buffers IPC messages, and how Execa differs from that default behavior.

Finally, this PR adds more tests related to that logic.