### PR TITLE
Add tests for I/O errors during `sendMessage()`

### DIFF
--- a/lib/ipc/methods.js
+++ b/lib/ipc/methods.js
@@ -1,5 +1,4 @@
 import process from 'node:process';
-import {promisify} from 'node:util';
 import {sendMessage} from './send.js';
 import {getOneMessage} from './get-one.js';
 import {getEachMessage} from './get-each.js';
@@ -13,29 +12,22 @@ export const addIpcMethods = (subprocess, {ipc}) => {
 export const getIpcExport = () => getIpcMethods(process, true, process.channel !== undefined);
 
 // Retrieve the `ipc` shared by both the current process and the subprocess
-const getIpcMethods = (anyProcess, isSubprocess, ipc) => {
-	const anyProcessSend = anyProcess.send === undefined
-		? undefined
-		: promisify(anyProcess.send.bind(anyProcess));
-	const {channel} = anyProcess;
-	return {
-		sendMessage: sendMessage.bind(undefined, {
-			anyProcess,
-			anyProcessSend,
-			isSubprocess,
-			ipc,
-		}),
-		getOneMessage: getOneMessage.bind(undefined, {
-			anyProcess,
-			channel,
-			isSubprocess,
-			ipc,
-		}),
-		getEachMessage: getEachMessage.bind(undefined, {
-			anyProcess,
-			channel,
-			isSubprocess,
-			ipc,
-		}),
-	};
-};
+const getIpcMethods = (anyProcess, isSubprocess, ipc) => ({
+	sendMessage: sendMessage.bind(undefined, {
+		anyProcess,
+		isSubprocess,
+		ipc,
+	}),
+	getOneMessage: getOneMessage.bind(undefined, {
+		anyProcess,
+		channel: anyProcess.channel,
+		isSubprocess,
+		ipc,
+	}),
+	getEachMessage: getEachMessage.bind(undefined, {
+		anyProcess,
+		channel: anyProcess.channel,
+		isSubprocess,
+		ipc,
+	}),
+});

--- a/lib/ipc/send.js
+++ b/lib/ipc/send.js
@@ -1,3 +1,4 @@
+import {promisify} from 'node:util';
 import {
 	validateIpcMethod,
 	handleEpipeError,
@@ -10,7 +11,7 @@ import {startSendMessage, endSendMessage} from './outgoing.js';
 // We do not `await subprocess` during `.sendMessage()` nor `.getOneMessage()` since those methods are transient.
 // Users would still need to `await subprocess` after the method is done.
 // Also, this would prevent `unhandledRejection` event from being emitted, making it silent.
-export const sendMessage = ({anyProcess, anyProcessSend, isSubprocess, ipc}, message) => {
+export const sendMessage = ({anyProcess, isSubprocess, ipc}, message) => {
 	validateIpcMethod({
 		methodName: 'sendMessage',
 		isSubprocess,
@@ -18,18 +19,14 @@ export const sendMessage = ({anyProcess, anyProcessSend, isSubprocess, ipc}, mes
 		isConnected: anyProcess.connected,
 	});
 
-	return sendMessageAsync({
-		anyProcess,
-		anyProcessSend,
-		isSubprocess,
-		message,
-	});
+	return sendMessageAsync({anyProcess, isSubprocess, message});
 };
 
-const sendMessageAsync = async ({anyProcess, anyProcessSend, isSubprocess, message}) => {
+const sendMessageAsync = async ({anyProcess, isSubprocess, message}) => {
 	const outgoingMessagesState = startSendMessage(anyProcess);
+	const sendMethod = getSendMethod(anyProcess);
 	try {
-		await anyProcessSend(message);
+		await sendMethod(message);
 	} catch (error) {
 		disconnect(anyProcess);
 		handleEpipeError(error, isSubprocess);
@@ -39,3 +36,16 @@ const sendMessageAsync = async ({anyProcess, anyProcessSend, isSubprocess, messa
 		endSendMessage(outgoingMessagesState);
 	}
 };
+
+// [sub]process.send() promisified, memoized
+const getSendMethod = anyProcess => {
+	if (PROCESS_SEND_METHODS.has(anyProcess)) {
+		return PROCESS_SEND_METHODS.get(anyProcess);
+	}
+
+	const sendMethod = promisify(anyProcess.send.bind(anyProcess));
+	PROCESS_SEND_METHODS.set(anyProcess, sendMethod);
+	return sendMethod;
+};
+
+const PROCESS_SEND_METHODS = new WeakMap();

--- a/test/fixtures/ipc-send-io-error.js
+++ b/test/fixtures/ipc-send-io-error.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {sendMessage} from '../../index.js';
+import {mockSendIoError} from '../helpers/ipc.js';
+
+mockSendIoError(process);
+await sendMessage('.');

--- a/test/helpers/ipc.js
+++ b/test/helpers/ipc.js
@@ -1,4 +1,5 @@
 import {getEachMessage} from '../../index.js';
+import {foobarString} from './input.js';
 
 // @todo: replace with Array.fromAsync(subprocess.getEachMessage()) after dropping support for Node <22.0.0
 export const iterateAllMessages = async subprocess => {
@@ -25,3 +26,15 @@ export const getFirst = async () => {
 export const subprocessGetOne = (subprocess, options) => subprocess.getOneMessage(options);
 
 export const alwaysPass = () => true;
+
+// `process.send()` can fail due to I/O errors.
+// However, I/O errors are seldom and hard to trigger predictably.
+// So we mock them.
+export const mockSendIoError = anyProcess => {
+	const error = new Error(foobarString);
+	anyProcess.send = () => {
+		throw error;
+	};
+
+	return error;
+};


### PR DESCRIPTION
`process.send()` can fail due to I/O errors, although I think this might be rare.
This PR adds more tests related to handling those errors.
It also does some minor refactoring of `sendMessage()`.