### PR TITLE
Improve documentation of shell escaping

### DIFF
--- a/docs/escaping.md
+++ b/docs/escaping.md
@@ -65,6 +65,11 @@ await execa`${parseCommandString('npm run task\\ with\\ space')}`;
 - Globbing: `*`, `**`
 - Expressions: `$?`, `~`
 
+```js
+// This prints `$TASK_NAME`, not `build`
+await execa({env: {TASK_NAME: 'build'}})`echo $TASK_NAME`;
+```
+
 If you do set the `shell` option, arguments will not be automatically escaped anymore. Instead, they will be concatenated as a single string using spaces as delimiters.
 
 ```js

--- a/docs/execution.md
+++ b/docs/execution.md
@@ -66,6 +66,15 @@ await execa`npm run build
 	--fail-fast`;
 ```
 
+### Shells
+
+By default, any shell-specific syntax has no special meaning and does not need to be escaped. This prevents [shell injections](https://en.wikipedia.org/wiki/Code_injection#Shell_injection). [More info.](escaping.md#shells)
+
+```js
+// This prints `$TASK_NAME`, not `build`
+await execa({env: {TASK_NAME: 'build'}})`echo $TASK_NAME`;
+```
+
 ## Options
 
 [Options](api.md#options) can be passed to influence the execution's behavior.


### PR DESCRIPTION
From #1081 and #1093, it seems like some users get the wrong assumption that commands are run in a shell by default.

I think the underlying problem is that the template string syntax gives a feeling that's close to typing commands in a terminal. Some users might not distinguish the difference between executing a process as is (`exec*` syscalls) vs through a shell. So they assume that if `$variable` does not work, there's something wrong with Execa, then create an issue.

It's hard to completely eliminate this misunderstanding. Execa takes a no-shell approach that (I think) is better in many ways, but is also different from the usual experience of other tools/libraries running everything in shells (even when not strictly needed).

This PR adds more documentation to try to help a little (on the very first and second pages of the docs), although I think we might still keep getting new issues along the lines of the ones above, since not everyone reads the documentation.