### PR TITLE
Add `strict` option to `sendMessage()`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -113,7 +113,7 @@ _Type_: `object`
 _Type_: `boolean`\
 _Default_: `false`
 
-If `true`, throws when the other process is not receiving or listening to messages.
+Throw when the other process is not receiving or listening to messages.
 
 [More info.](ipc.md#ensure-messages-are-received)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -92,9 +92,10 @@ Split a `command` string into an array. For example, `'npm run build'` returns `
 
 [More info.](escaping.md#user-defined-input)
 
-### sendMessage(message)
+### sendMessage(message, sendMessageOptions?)
 
 `message`: [`Message`](ipc.md#message-type)\
+`sendMessageOptions`: [`SendMessageOptions`](#sendmessageoptions)\
 _Returns_: `Promise<void>`
 
 Send a `message` to the parent process.
@@ -103,9 +104,22 @@ This requires the [`ipc`](#optionsipc) option to be `true`. The [type](ipc.md#me
 
 [More info.](ipc.md#exchanging-messages)
 
+#### sendMessageOptions
+
+_Type_: `object`
+
+#### sendMessageOptions.strict
+
+_Type_: `boolean`\
+_Default_: `false`
+
+If `true`, throws when the other process is not receiving or listening to messages.
+
+[More info.](ipc.md#ensure-messages-are-received)
+
 ### getOneMessage(getOneMessageOptions?)
 
-_getOneMessageOptions_: [`GetOneMessageOptions`](#getonemessageoptions)\
+`getOneMessageOptions`: [`GetOneMessageOptions`](#getonemessageoptions)\
 _Returns_: [`Promise<Message>`](ipc.md#message-type)
 
 Receive a single `message` from the parent process.
@@ -261,9 +275,10 @@ This is `undefined` if the subprocess failed to spawn.
 
 [More info.](termination.md#inter-process-termination)
 
-### subprocess.sendMessage(message)
+### subprocess.sendMessage(message, sendMessageOptions)
 
 `message`: [`Message`](ipc.md#message-type)\
+`sendMessageOptions`: [`SendMessageOptions`](#sendmessageoptions)\
 _Returns_: `Promise<void>`
 
 Send a `message` to the subprocess.
@@ -274,7 +289,7 @@ This requires the [`ipc`](#optionsipc) option to be `true`. The [type](ipc.md#me
 
 ### subprocess.getOneMessage(getOneMessageOptions?)
 
-_getOneMessageOptions_: [`GetOneMessageOptions`](#getonemessageoptions)\
+`getOneMessageOptions`: [`GetOneMessageOptions`](#getonemessageoptions)\
 _Returns_: [`Promise<Message>`](ipc.md#message-type)
 
 Receive a single `message` from the subprocess.
@@ -485,7 +500,7 @@ Items are arrays when their corresponding `stdio` option is a [transform in obje
 
 _Type_: [`Message[]`](ipc.md#message-type)
 
-All the messages [sent by the subprocess](#sendmessagemessage) to the current process.
+All the messages [sent by the subprocess](#sendmessagemessage-sendmessageoptions) to the current process.
 
 This is empty unless the [`ipc`](#optionsipc) option is `true`. Also, this is empty if the [`buffer`](#optionsbuffer) option is `false`.
 
@@ -914,7 +929,7 @@ By default, this applies to both `stdout` and `stderr`, but [different values ca
 _Type:_ `boolean`\
 _Default:_ `true` if either the [`node`](#optionsnode) option or the [`ipcInput`](#optionsipcinput) is set, `false` otherwise
 
-Enables exchanging messages with the subprocess using [`subprocess.sendMessage(message)`](#subprocesssendmessagemessage), [`subprocess.getOneMessage()`](#subprocessgetonemessagegetonemessageoptions) and [`subprocess.getEachMessage()`](#subprocessgeteachmessage).
+Enables exchanging messages with the subprocess using [`subprocess.sendMessage(message)`](#subprocesssendmessagemessage-sendmessageoptions), [`subprocess.getOneMessage()`](#subprocessgetonemessagegetonemessageoptions) and [`subprocess.getEachMessage()`](#subprocessgeteachmessage).
 
 The subprocess must be a Node.js file.
 

--- a/docs/execution.md
+++ b/docs/execution.md
@@ -135,7 +135,7 @@ Synchronous execution is generally discouraged as it holds the CPU and prevents 
 - Signal termination: [`subprocess.kill()`](api.md#subprocesskillerror), [`subprocess.pid`](api.md#subprocesspid), [`cleanup`](api.md#optionscleanup) option, [`cancelSignal`](api.md#optionscancelsignal) option, [`forceKillAfterDelay`](api.md#optionsforcekillafterdelay) option.
 - Piping multiple subprocesses: [`subprocess.pipe()`](api.md#subprocesspipefile-arguments-options).
 - [`subprocess.iterable()`](lines.md#progressive-splitting).
-- [IPC](ipc.md): [`sendMessage()`](api.md#sendmessagemessage), [`getOneMessage()`](api.md#getonemessagegetonemessageoptions), [`getEachMessage()`](api.md#geteachmessage), [`result.ipcOutput`](output.md#any-output-type), [`ipc`](api.md#optionsipc) option, [`serialization`](api.md#optionsserialization) option, [`ipcInput`](input.md#any-input-type) option.
+- [IPC](ipc.md): [`sendMessage()`](api.md#sendmessagemessage-sendmessageoptions), [`getOneMessage()`](api.md#getonemessagegetonemessageoptions), [`getEachMessage()`](api.md#geteachmessage), [`result.ipcOutput`](output.md#any-output-type), [`ipc`](api.md#optionsipc) option, [`serialization`](api.md#optionsserialization) option, [`ipcInput`](input.md#any-input-type) option.
 - [`result.all`](api.md#resultall) is not interleaved.
 - [`detached`](api.md#optionsdetached) option.
 - The [`maxBuffer`](api.md#optionsmaxbuffer) option is always measured in bytes, not in characters, [lines](api.md#optionslines) nor [objects](transform.md#object-mode). Also, it ignores transforms and the [`encoding`](api.md#optionsencoding) option.

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -96,7 +96,7 @@ for await (const message of getEachMessage()) {
 
 When a message is sent by one process, the other process must receive it using [`getOneMessage()`](#exchanging-messages), [`getEachMessage()`](#listening-to-messages), or automatically with [`result.ipcOutput`](api.md#resultipcoutput). If not, that message is silently discarded.
 
-If the [`strict: true`](api.md#sendmessageoptionsstrict) option is passed to [`subprocess.sendMessage(message)`](api.md#subprocesssendmessagemessage-sendmessageoptions) or [`sendMessage(message)`](api.md#sendmessagemessage-sendmessageoptions), an exception is thrown instead. This helps identifying subtle race conditions like the following example.
+If the [`strict: true`](api.md#sendmessageoptionsstrict) option is passed to [`subprocess.sendMessage(message)`](api.md#subprocesssendmessagemessage-sendmessageoptions) or [`sendMessage(message)`](api.md#sendmessagemessage-sendmessageoptions), an error is thrown instead. This helps identifying subtle race conditions like the following example.
 
 ```js
 // main.js

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -8,7 +8,7 @@
 
 ## Available types
 
-The following types can be imported: [`ResultPromise`](api.md#return-value), [`Subprocess`](api.md#subprocess), [`Result`](api.md#result), [`ExecaError`](api.md#execaerror), [`Options`](api.md#options), [`StdinOption`](api.md#optionsstdin), [`StdoutStderrOption`](api.md#optionsstdout), [`TemplateExpression`](api.md#execacommand) and [`Message`](api.md#subprocesssendmessagemessage).
+The following types can be imported: [`ResultPromise`](api.md#return-value), [`Subprocess`](api.md#subprocess), [`Result`](api.md#result), [`ExecaError`](api.md#execaerror), [`Options`](api.md#options), [`StdinOption`](api.md#optionsstdin), [`StdoutStderrOption`](api.md#optionsstdout), [`TemplateExpression`](api.md#execacommand) and [`Message`](api.md#subprocesssendmessagemessage-sendmessageoptions).
 
 ```ts
 import {

--- a/lib/ipc/forward.js
+++ b/lib/ipc/forward.js
@@ -30,11 +30,17 @@ const IPC_EMITTERS = new WeakMap();
 // However, unbuffering happens after one tick, so this give enough time for the caller to setup the listener on the proxy emitter first.
 // See https://github.com/nodejs/node/blob/2aaeaa863c35befa2ebaa98fb7737ec84df4d8e9/lib/internal/child_process.js#L721
 const forwardEvents = ({ipcEmitter, anyProcess, channel, isSubprocess}) => {
-	const boundOnMessage = onMessage.bind(undefined, anyProcess, ipcEmitter);
+	const boundOnMessage = onMessage.bind(undefined, {
+		anyProcess,
+		channel,
+		isSubprocess,
+		ipcEmitter,
+	});
 	anyProcess.on('message', boundOnMessage);
 	anyProcess.once('disconnect', onDisconnect.bind(undefined, {
 		anyProcess,
 		channel,
+		isSubprocess,
 		ipcEmitter,
 		boundOnMessage,
 	}));

--- a/lib/ipc/get-each.js
+++ b/lib/ipc/get-each.js
@@ -1,5 +1,5 @@
 import {once, on} from 'node:events';
-import {validateIpcMethod, disconnect} from './validation.js';
+import {validateIpcMethod, disconnect, getStrictResponseError} from './validation.js';
 import {getIpcEmitter, isConnected} from './forward.js';
 import {addReference, removeReference} from './reference.js';
 
@@ -24,7 +24,14 @@ export const loopOnMessages = ({anyProcess, channel, isSubprocess, ipc, shouldAw
 	addReference(channel);
 	const ipcEmitter = getIpcEmitter(anyProcess, channel, isSubprocess);
 	const controller = new AbortController();
+	const state = {};
 	stopOnDisconnect(anyProcess, ipcEmitter, controller);
+	abortOnStrictError({
+		ipcEmitter,
+		isSubprocess,
+		controller,
+		state,
+	});
 	return iterateOnMessages({
 		anyProcess,
 		channel,
@@ -32,6 +39,7 @@ export const loopOnMessages = ({anyProcess, channel, isSubprocess, ipc, shouldAw
 		isSubprocess,
 		shouldAwait,
 		controller,
+		state,
 	});
 };
 
@@ -42,12 +50,23 @@ const stopOnDisconnect = async (anyProcess, ipcEmitter, controller) => {
 	} catch {}
 };
 
-const iterateOnMessages = async function * ({anyProcess, channel, ipcEmitter, isSubprocess, shouldAwait, controller}) {
+const abortOnStrictError = async ({ipcEmitter, isSubprocess, controller, state}) => {
+	try {
+		const [error] = await once(ipcEmitter, 'strict:error', {signal: controller.signal});
+		state.error = getStrictResponseError(error, isSubprocess);
+		controller.abort();
+	} catch {}
+};
+
+const iterateOnMessages = async function * ({anyProcess, channel, ipcEmitter, isSubprocess, shouldAwait, controller, state}) {
 	try {
 		for await (const [message] of on(ipcEmitter, 'message', {signal: controller.signal})) {
+			throwIfStrictError(state);
 			yield message;
 		}
-	} catch {} finally {
+	} catch {
+		throwIfStrictError(state);
+	} finally {
 		controller.abort();
 		removeReference(channel);
 
@@ -58,5 +77,11 @@ const iterateOnMessages = async function * ({anyProcess, channel, ipcEmitter, is
 		if (shouldAwait) {
 			await anyProcess;
 		}
+	}
+};
+
+const throwIfStrictError = ({error}) => {
+	if (error) {
+		throw error;
 	}
 };

--- a/lib/ipc/get-one.js
+++ b/lib/ipc/get-one.js
@@ -1,5 +1,10 @@
 import {once, on} from 'node:events';
-import {validateIpcMethod, throwOnEarlyDisconnect, disconnect} from './validation.js';
+import {
+	validateIpcMethod,
+	throwOnEarlyDisconnect,
+	disconnect,
+	getStrictResponseError,
+} from './validation.js';
 import {getIpcEmitter, isConnected} from './forward.js';
 import {addReference, removeReference} from './reference.js';
 
@@ -28,6 +33,7 @@ const getOneMessageAsync = async ({anyProcess, channel, isSubprocess, filter}) =
 		return await Promise.race([
 			getMessage(ipcEmitter, filter, controller),
 			throwOnDisconnect(ipcEmitter, isSubprocess, controller),
+			throwOnStrictError(ipcEmitter, isSubprocess, controller),
 		]);
 	} catch (error) {
 		disconnect(anyProcess);
@@ -54,4 +60,9 @@ const getMessage = async (ipcEmitter, filter, {signal}) => {
 const throwOnDisconnect = async (ipcEmitter, isSubprocess, {signal}) => {
 	await once(ipcEmitter, 'disconnect', {signal});
 	throwOnEarlyDisconnect(isSubprocess);
+};
+
+const throwOnStrictError = async (ipcEmitter, isSubprocess, {signal}) => {
+	const [error] = await once(ipcEmitter, 'strict:error', {signal});
+	throw getStrictResponseError(error, isSubprocess);
 };

--- a/lib/ipc/incoming.js
+++ b/lib/ipc/incoming.js
@@ -2,6 +2,7 @@ import {once} from 'node:events';
 import {scheduler} from 'node:timers/promises';
 import {waitForOutgoingMessages} from './outgoing.js';
 import {redoAddedReferences} from './reference.js';
+import {handleStrictRequest, handleStrictResponse} from './strict.js';
 
 // By default, Node.js buffers `message` events.
 //  - Buffering happens when there is a `message` event is emitted but there is no handler.
@@ -21,13 +22,17 @@ import {redoAddedReferences} from './reference.js';
 //    The default behavior does not allow users to realize they made that mistake.
 // To solve those problems, instead of buffering messages, we debounce them.
 // The `message` event so it is emitted at most once per macrotask.
-export const onMessage = async (anyProcess, ipcEmitter, message) => {
+export const onMessage = async ({anyProcess, channel, isSubprocess, ipcEmitter}, wrappedMessage) => {
+	if (handleStrictResponse(wrappedMessage)) {
+		return;
+	}
+
 	if (!INCOMING_MESSAGES.has(anyProcess)) {
 		INCOMING_MESSAGES.set(anyProcess, []);
 	}
 
 	const incomingMessages = INCOMING_MESSAGES.get(anyProcess);
-	incomingMessages.push(message);
+	incomingMessages.push(wrappedMessage);
 
 	if (incomingMessages.length > 1) {
 		return;
@@ -38,22 +43,34 @@ export const onMessage = async (anyProcess, ipcEmitter, message) => {
 		await waitForOutgoingMessages(anyProcess);
 		// eslint-disable-next-line no-await-in-loop
 		await scheduler.yield();
-		ipcEmitter.emit('message', incomingMessages.shift());
+
+		// eslint-disable-next-line no-await-in-loop
+		const message = await handleStrictRequest({
+			wrappedMessage: incomingMessages[0],
+			anyProcess,
+			channel,
+			isSubprocess,
+			ipcEmitter,
+		});
+
+		incomingMessages.shift();
+		ipcEmitter.emit('message', message);
+		ipcEmitter.emit('message:done');
 	}
 };
 
-const INCOMING_MESSAGES = new WeakMap();
-
 // If the `message` event is currently debounced, the `disconnect` event must wait for it
-export const onDisconnect = async ({anyProcess, channel, ipcEmitter, boundOnMessage}) => {
+export const onDisconnect = async ({anyProcess, channel, isSubprocess, ipcEmitter, boundOnMessage}) => {
 	const incomingMessages = INCOMING_MESSAGES.get(anyProcess);
 	while (incomingMessages?.length > 0) {
 		// eslint-disable-next-line no-await-in-loop
-		await once(ipcEmitter, 'message');
+		await once(ipcEmitter, 'message:done');
 	}
 
 	anyProcess.removeListener('message', boundOnMessage);
-	redoAddedReferences(channel);
+	redoAddedReferences(channel, isSubprocess);
 	ipcEmitter.connected = false;
 	ipcEmitter.emit('disconnect');
 };
+
+const INCOMING_MESSAGES = new WeakMap();

--- a/lib/ipc/incoming.js
+++ b/lib/ipc/incoming.js
@@ -40,7 +40,7 @@ export const onMessage = async ({anyProcess, channel, isSubprocess, ipcEmitter},
 
 	while (incomingMessages.length > 0) {
 		// eslint-disable-next-line no-await-in-loop
-		await waitForOutgoingMessages(anyProcess);
+		await waitForOutgoingMessages(anyProcess, ipcEmitter);
 		// eslint-disable-next-line no-await-in-loop
 		await scheduler.yield();
 

--- a/lib/ipc/methods.js
+++ b/lib/ipc/methods.js
@@ -15,6 +15,7 @@ export const getIpcExport = () => getIpcMethods(process, true, process.channel !
 const getIpcMethods = (anyProcess, isSubprocess, ipc) => ({
 	sendMessage: sendMessage.bind(undefined, {
 		anyProcess,
+		channel: anyProcess.channel,
 		isSubprocess,
 		ipc,
 	}),

--- a/lib/ipc/outgoing.js
+++ b/lib/ipc/outgoing.js
@@ -1,4 +1,5 @@
 import {createDeferred} from '../utils/deferred.js';
+import {SUBPROCESS_OPTIONS} from '../arguments/fd-options.js';
 
 // When `sendMessage()` is ongoing, any `message` being received waits before being emitted.
 // This allows calling one or multiple `await sendMessage()` followed by `await getOneMessage()`/`await getEachMessage()`.
@@ -19,12 +20,22 @@ export const endSendMessage = ({outgoingMessages, onMessageSent}) => {
 	onMessageSent.resolve();
 };
 
-// Await while `sendMessage()` is ongoing
-export const waitForOutgoingMessages = async anyProcess => {
-	while (OUTGOING_MESSAGES.get(anyProcess)?.size > 0) {
+// Await while `sendMessage()` is ongoing, unless there is already a `message` listener
+export const waitForOutgoingMessages = async (anyProcess, ipcEmitter) => {
+	while (!hasMessageListeners(anyProcess, ipcEmitter) && OUTGOING_MESSAGES.get(anyProcess)?.size > 0) {
 		// eslint-disable-next-line no-await-in-loop
 		await Promise.all(OUTGOING_MESSAGES.get(anyProcess));
 	}
 };
 
 const OUTGOING_MESSAGES = new WeakMap();
+
+// Whether any `message` listener is setup
+export const hasMessageListeners = (anyProcess, ipcEmitter) => ipcEmitter.listenerCount('message') > getMinListenerCount(anyProcess);
+
+// When `buffer` is `false`, we set up a `message` listener that should be ignored.
+// That listener is only meant to intercept `strict` acknowledgement responses.
+const getMinListenerCount = anyProcess => SUBPROCESS_OPTIONS.has(anyProcess)
+	&& !SUBPROCESS_OPTIONS.get(anyProcess).options.buffer.at(-1)
+	? 1
+	: 0;

--- a/lib/ipc/send.js
+++ b/lib/ipc/send.js
@@ -6,12 +6,13 @@ import {
 	disconnect,
 } from './validation.js';
 import {startSendMessage, endSendMessage} from './outgoing.js';
+import {handleSendStrict, waitForStrictResponse} from './strict.js';
 
 // Like `[sub]process.send()` but promise-based.
 // We do not `await subprocess` during `.sendMessage()` nor `.getOneMessage()` since those methods are transient.
 // Users would still need to `await subprocess` after the method is done.
 // Also, this would prevent `unhandledRejection` event from being emitted, making it silent.
-export const sendMessage = ({anyProcess, isSubprocess, ipc}, message) => {
+export const sendMessage = ({anyProcess, channel, isSubprocess, ipc}, message, {strict = false} = {}) => {
 	validateIpcMethod({
 		methodName: 'sendMessage',
 		isSubprocess,
@@ -19,14 +20,31 @@ export const sendMessage = ({anyProcess, isSubprocess, ipc}, message) => {
 		isConnected: anyProcess.connected,
 	});
 
-	return sendMessageAsync({anyProcess, isSubprocess, message});
+	return sendMessageAsync({
+		anyProcess,
+		channel,
+		isSubprocess,
+		message,
+		strict,
+	});
 };
 
-const sendMessageAsync = async ({anyProcess, isSubprocess, message}) => {
+const sendMessageAsync = async ({anyProcess, channel, isSubprocess, message, strict}) => {
 	const outgoingMessagesState = startSendMessage(anyProcess);
 	const sendMethod = getSendMethod(anyProcess);
+	const wrappedMessage = handleSendStrict({
+		anyProcess,
+		channel,
+		isSubprocess,
+		message,
+		strict,
+	});
+
 	try {
-		await sendMethod(message);
+		await Promise.all([
+			waitForStrictResponse(wrappedMessage, anyProcess, isSubprocess),
+			sendMethod(wrappedMessage),
+		]);
 	} catch (error) {
 		disconnect(anyProcess);
 		handleEpipeError(error, isSubprocess);

--- a/lib/ipc/strict.js
+++ b/lib/ipc/strict.js
@@ -1,0 +1,97 @@
+import {once} from 'node:events';
+import {createDeferred} from '../utils/deferred.js';
+import {SUBPROCESS_OPTIONS} from '../arguments/fd-options.js';
+import {incrementMaxListeners} from '../utils/max-listeners.js';
+import {sendMessage} from './send.js';
+import {throwOnMissingStrict, throwOnStrictDisconnect} from './validation.js';
+import {getIpcEmitter} from './forward.js';
+
+// When using the `strict` option, wrap the message with metadata during `sendMessage()`
+export const handleSendStrict = ({anyProcess, channel, isSubprocess, message, strict}) => {
+	if (!strict) {
+		return message;
+	}
+
+	getIpcEmitter(anyProcess, channel, isSubprocess);
+	return {id: count++, type: REQUEST_TYPE, message};
+};
+
+let count = 0n;
+
+// The other process then sends the acknowledgment back as a response
+export const handleStrictRequest = async ({wrappedMessage, anyProcess, channel, isSubprocess, ipcEmitter}) => {
+	if (wrappedMessage?.type !== REQUEST_TYPE) {
+		return wrappedMessage;
+	}
+
+	const {id, message} = wrappedMessage;
+	const hasListeners = ipcEmitter.listenerCount('message') > getMinListenerCount(anyProcess);
+	const response = {id, type: RESPONSE_TYPE, message: hasListeners};
+
+	try {
+		await sendMessage({
+			anyProcess,
+			channel,
+			isSubprocess,
+			ipc: true,
+		}, response);
+	} catch (error) {
+		ipcEmitter.emit('strict:error', error);
+	}
+
+	return message;
+};
+
+// When `buffer` is `false`, we set up a `message` listener that should be ignored.
+// That listener is only meant to intercept `strict` acknowledgement responses.
+const getMinListenerCount = anyProcess => SUBPROCESS_OPTIONS.has(anyProcess)
+	&& !SUBPROCESS_OPTIONS.get(anyProcess).options.buffer.at(-1)
+	? 1
+	: 0;
+
+// Reception of the acknowledgment response
+export const handleStrictResponse = wrappedMessage => {
+	if (wrappedMessage?.type !== RESPONSE_TYPE) {
+		return false;
+	}
+
+	const {id, message: hasListeners} = wrappedMessage;
+	STRICT_RESPONSES[id].resolve(hasListeners);
+	return true;
+};
+
+// Wait for the other process to receive the message from `sendMessage()`
+export const waitForStrictResponse = async (wrappedMessage, anyProcess, isSubprocess) => {
+	if (wrappedMessage?.type !== REQUEST_TYPE) {
+		return;
+	}
+
+	const deferred = createDeferred();
+	STRICT_RESPONSES[wrappedMessage.id] = deferred;
+
+	try {
+		const controller = new AbortController();
+		const hasListeners = await Promise.race([
+			deferred,
+			throwOnDisconnect(anyProcess, isSubprocess, controller),
+		]);
+		controller.abort();
+
+		if (!hasListeners) {
+			throwOnMissingStrict(isSubprocess);
+		}
+	} finally {
+		delete STRICT_RESPONSES[wrappedMessage.id];
+	}
+};
+
+const STRICT_RESPONSES = {};
+
+const throwOnDisconnect = async (anyProcess, isSubprocess, {signal}) => {
+	incrementMaxListeners(anyProcess, 1, signal);
+	await once(anyProcess, 'disconnect', {signal});
+	throwOnStrictDisconnect(isSubprocess);
+};
+
+const REQUEST_TYPE = 'execa:ipc:request';
+const RESPONSE_TYPE = 'execa:ipc:response';

--- a/lib/ipc/strict.js
+++ b/lib/ipc/strict.js
@@ -1,10 +1,10 @@
 import {once} from 'node:events';
 import {createDeferred} from '../utils/deferred.js';
-import {SUBPROCESS_OPTIONS} from '../arguments/fd-options.js';
 import {incrementMaxListeners} from '../utils/max-listeners.js';
 import {sendMessage} from './send.js';
 import {throwOnMissingStrict, throwOnStrictDisconnect} from './validation.js';
 import {getIpcEmitter} from './forward.js';
+import {hasMessageListeners} from './outgoing.js';
 
 // When using the `strict` option, wrap the message with metadata during `sendMessage()`
 export const handleSendStrict = ({anyProcess, channel, isSubprocess, message, strict}) => {
@@ -25,8 +25,7 @@ export const handleStrictRequest = async ({wrappedMessage, anyProcess, channel, 
 	}
 
 	const {id, message} = wrappedMessage;
-	const hasListeners = ipcEmitter.listenerCount('message') > getMinListenerCount(anyProcess);
-	const response = {id, type: RESPONSE_TYPE, message: hasListeners};
+	const response = {id, type: RESPONSE_TYPE, message: hasMessageListeners(anyProcess, ipcEmitter)};
 
 	try {
 		await sendMessage({
@@ -41,13 +40,6 @@ export const handleStrictRequest = async ({wrappedMessage, anyProcess, channel, 
 
 	return message;
 };
-
-// When `buffer` is `false`, we set up a `message` listener that should be ignored.
-// That listener is only meant to intercept `strict` acknowledgement responses.
-const getMinListenerCount = anyProcess => SUBPROCESS_OPTIONS.has(anyProcess)
-	&& !SUBPROCESS_OPTIONS.get(anyProcess).options.buffer.at(-1)
-	? 1
-	: 0;
 
 // Reception of the acknowledgment response
 export const handleStrictResponse = wrappedMessage => {

--- a/lib/ipc/validation.js
+++ b/lib/ipc/validation.js
@@ -24,6 +24,19 @@ export const throwOnEarlyDisconnect = isSubprocess => {
 	throw new Error(`${getNamespaceName(isSubprocess)}getOneMessage() could not complete: the ${getOtherProcessName(isSubprocess)} exited or disconnected.`);
 };
 
+// When the other process used `strict` but the current process had I/O error calling `sendMessage()` for the response
+export const getStrictResponseError = (error, isSubprocess) => new Error(`${getNamespaceName(isSubprocess)}sendMessage() failed when sending an acknowledgment response to the ${getOtherProcessName(isSubprocess)}.`, {cause: error});
+
+// When using `strict` but the other process was not listening for messages
+export const throwOnMissingStrict = isSubprocess => {
+	throw new Error(`${getNamespaceName(isSubprocess)}sendMessage() failed: the ${getOtherProcessName(isSubprocess)} is not listening to incoming messages.`);
+};
+
+// When using `strict` but the other process disconnected before receiving the message
+export const throwOnStrictDisconnect = isSubprocess => {
+	throw new Error(`${getNamespaceName(isSubprocess)}sendMessage() failed: the ${getOtherProcessName(isSubprocess)} exited without listening to incoming messages.`);
+};
+
 const getNamespaceName = isSubprocess => isSubprocess ? '' : 'subprocess.';
 
 const getOtherProcessName = isSubprocess => isSubprocess ? 'parent process' : 'subprocess';

--- a/test-d/ipc/send.test-d.ts
+++ b/test-d/ipc/send.test-d.ts
@@ -30,3 +30,16 @@ expectType<undefined>(execa('test', {}).sendMessage);
 expectType<undefined>(execa('test', {ipc: false}).sendMessage);
 expectType<undefined>(execa('test', {ipcInput: undefined}).sendMessage);
 expectType<undefined>(execa('test', {ipc: false, ipcInput: ''}).sendMessage);
+
+await subprocess.sendMessage('', {} as const);
+await sendMessage('', {} as const);
+await subprocess.sendMessage('', {strict: true} as const);
+await sendMessage('', {strict: true} as const);
+expectError(await subprocess.sendMessage('', true));
+expectError(await sendMessage('', true));
+expectError(await subprocess.sendMessage('', {strict: 'true'}));
+expectError(await sendMessage('', {strict: 'true'}));
+expectError(await subprocess.sendMessage('', {unknown: true}));
+expectError(await sendMessage('', {unknown: true}));
+expectError(await subprocess.sendMessage('', {strict: true}, {}));
+expectError(await sendMessage('', {strict: true}, {}));

--- a/test/fixtures/ipc-echo-twice-wait.js
+++ b/test/fixtures/ipc-echo-twice-wait.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import {setTimeout} from 'node:timers/promises';
+import {sendMessage, getOneMessage} from '../../index.js';
+
+const message = await getOneMessage();
+await sendMessage(message);
+const secondMessage = await getOneMessage();
+await sendMessage(secondMessage);
+await setTimeout(1e3);
+await sendMessage('.');

--- a/test/fixtures/ipc-get-io-error.js
+++ b/test/fixtures/ipc-get-io-error.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {getOneMessage} from '../../index.js';
+import {mockSendIoError} from '../helpers/ipc.js';
+
+mockSendIoError(process);
+console.log(await getOneMessage());

--- a/test/fixtures/ipc-iterate-io-error.js
+++ b/test/fixtures/ipc-iterate-io-error.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {getEachMessage} from '../../index.js';
+import {mockSendIoError} from '../helpers/ipc.js';
+
+mockSendIoError(process);
+for await (const message of getEachMessage()) {
+	console.log(message);
+}

--- a/test/fixtures/ipc-send-echo-strict.js
+++ b/test/fixtures/ipc-send-echo-strict.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import {setTimeout} from 'node:timers/promises';
+import {sendMessage, getOneMessage} from '../../index.js';
+
+await sendMessage('.', {strict: true});
+await setTimeout(10);
+await sendMessage(await getOneMessage());

--- a/test/fixtures/ipc-send-echo-wait.js
+++ b/test/fixtures/ipc-send-echo-wait.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import {setTimeout} from 'node:timers/promises';
+import {sendMessage, getOneMessage} from '../../index.js';
+
+await sendMessage('.');
+await setTimeout(1e3);
+await sendMessage(await getOneMessage());

--- a/test/fixtures/ipc-send-strict-catch.js
+++ b/test/fixtures/ipc-send-strict-catch.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import {sendMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+try {
+	await sendMessage(foobarString, {strict: true});
+} catch {
+	await sendMessage(foobarString);
+}

--- a/test/fixtures/ipc-send-strict-get.js
+++ b/test/fixtures/ipc-send-strict-get.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import {sendMessage, getOneMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+await sendMessage(foobarString, {strict: true});
+await sendMessage(await getOneMessage());

--- a/test/fixtures/ipc-send-strict-listen.js
+++ b/test/fixtures/ipc-send-strict-listen.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+import {sendMessage, getOneMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+const [message] = await Promise.race([
+	getOneMessage(),
+	sendMessage(foobarString, {strict: true}),
+]);
+await sendMessage(message);

--- a/test/fixtures/ipc-send-strict.js
+++ b/test/fixtures/ipc-send-strict.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import {sendMessage} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+await sendMessage(foobarString, {strict: true});

--- a/test/ipc/get-one.js
+++ b/test/ipc/get-one.js
@@ -42,7 +42,7 @@ test('Throwing from subprocess.getOneMessage() filter disconnects', async t => {
 });
 
 test('Throwing from exports.getOneMessage() filter disconnects', async t => {
-	const subprocess = execa('ipc-get-filter-throw.js', {ipc: true, ipcInput: 0});
+	const subprocess = execa('ipc-get-filter-throw.js', {ipcInput: 0});
 	await t.throwsAsync(subprocess.getOneMessage(), {
 		message: /subprocess.getOneMessage\(\) could not complete/,
 	});

--- a/test/ipc/ipc-input.js
+++ b/test/ipc/ipc-input.js
@@ -46,3 +46,8 @@ test('Handles "ipcInput" option during sending', async t => {
 	t.true(message.includes('subprocess.sendMessage()\'s argument type is invalid: the message cannot be serialized: 0.'));
 	t.true(cause.cause.message.includes('The "message" argument must be one of type string'));
 });
+
+test('Can use "ipcInput" option even if the subprocess is not listening to messages', async t => {
+	const {ipcOutput} = await execa('empty.js', {ipcInput: foobarString});
+	t.deepEqual(ipcOutput, []);
+});

--- a/test/ipc/outgoing.js
+++ b/test/ipc/outgoing.js
@@ -36,7 +36,7 @@ test('Multiple parallel subprocess.sendMessage() + subprocess.getEachMessage(), 
 test('Multiple parallel subprocess.sendMessage() + subprocess.getEachMessage(), buffer true', testSendHoldParent, subprocessGetFirst, true, undefined);
 
 const testSendHoldSubprocess = async (t, filter, isGetEach) => {
-	const {ipcOutput} = await execa('ipc-iterate-back.js', [`${filter}`, `${isGetEach}`], {ipc: true, ipcInput: 0});
+	const {ipcOutput} = await execa('ipc-iterate-back.js', [`${filter}`, `${isGetEach}`], {ipcInput: 0});
 	const expectedOutput = [...Array.from({length: PARALLEL_COUNT + 1}, (_, index) => index), '.'];
 	t.deepEqual(ipcOutput, expectedOutput);
 };
@@ -78,7 +78,7 @@ test('Multiple serial subprocess.sendMessage() + subprocess.getEachMessage(), bu
 test('Multiple serial subprocess.sendMessage() + subprocess.getEachMessage(), buffer true', testSendHoldParentSerial, subprocessGetFirst, true, undefined);
 
 const testSendHoldSubprocessSerial = async (t, filter, isGetEach) => {
-	const {ipcOutput} = await execa('ipc-iterate-back-serial.js', [`${filter}`, `${isGetEach}`], {ipc: true, ipcInput: 0, stdout: 'inherit'});
+	const {ipcOutput} = await execa('ipc-iterate-back-serial.js', [`${filter}`, `${isGetEach}`], {ipcInput: 0});
 	const expectedOutput = [...Array.from({length: PARALLEL_COUNT + 2}, (_, index) => index), '.'];
 	t.deepEqual(ipcOutput, expectedOutput);
 };

--- a/test/ipc/reference.js
+++ b/test/ipc/reference.js
@@ -27,7 +27,7 @@ test('process.send() keeps the subprocess alive', async t => {
 });
 
 test('process.send() keeps the subprocess alive, after getOneMessage()', async t => {
-	const {ipcOutput, stdout} = await execa('ipc-process-send-get.js', {ipc: true, ipcInput: 0});
+	const {ipcOutput, stdout} = await execa('ipc-process-send-get.js', {ipcInput: 0});
 	t.deepEqual(ipcOutput, [foobarString]);
 	t.is(stdout, '.');
 });

--- a/test/ipc/strict.js
+++ b/test/ipc/strict.js
@@ -1,0 +1,192 @@
+import {once} from 'node:events';
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
+import {foobarString} from '../helpers/input.js';
+import {assertMaxListeners} from '../helpers/listeners.js';
+import {subprocessGetOne, subprocessGetFirst, mockSendIoError} from '../helpers/ipc.js';
+import {PARALLEL_COUNT} from '../helpers/parallel.js';
+
+setFixtureDirectory();
+
+const testStrictSuccessParentOne = async (t, buffer) => {
+	const subprocess = execa('ipc-echo.js', {ipc: true, buffer});
+	await subprocess.sendMessage(foobarString, {strict: true});
+	t.is(await subprocess.getOneMessage(), foobarString);
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, buffer ? [foobarString] : []);
+};
+
+test('subprocess.sendMessage() "strict" succeeds if the subprocess uses exports.getOneMessage(), buffer false', testStrictSuccessParentOne, false);
+test('subprocess.sendMessage() "strict" succeeds if the subprocess uses exports.getOneMessage(), buffer true', testStrictSuccessParentOne, true);
+
+const testStrictSuccessParentEach = async (t, buffer) => {
+	const subprocess = execa('ipc-iterate.js', {ipc: true, buffer});
+	await subprocess.sendMessage('.', {strict: true});
+	t.is(await subprocess.getOneMessage(), '.');
+	await subprocess.sendMessage(foobarString);
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, buffer ? ['.'] : []);
+};
+
+test('subprocess.sendMessage() "strict" succeeds if the subprocess uses exports.getEachMessage(), buffer false', testStrictSuccessParentEach, false);
+test('subprocess.sendMessage() "strict" succeeds if the subprocess uses exports.getEachMessage(), buffer true', testStrictSuccessParentEach, true);
+
+const testStrictMissingParent = async (t, buffer) => {
+	const subprocess = execa('ipc-echo-twice.js', {ipcInput: foobarString, buffer});
+	const promise = subprocess.getOneMessage();
+	const secondPromise = subprocess.sendMessage(foobarString, {strict: true});
+	const {message} = await t.throwsAsync(subprocess.sendMessage(foobarString, {strict: true}));
+	t.is(message, 'subprocess.sendMessage() failed: the subprocess is not listening to incoming messages.');
+	t.is(await promise, foobarString);
+	await secondPromise;
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, buffer ? [foobarString, foobarString] : []);
+};
+
+test('subprocess.sendMessage() "strict" fails if the subprocess is not listening, buffer false', testStrictMissingParent, false);
+test('subprocess.sendMessage() "strict" fails if the subprocess is not listening, buffer true', testStrictMissingParent, true);
+
+const testStrictExit = async (t, buffer) => {
+	const subprocess = execa('ipc-send.js', {ipc: true, buffer});
+	const {message} = await t.throwsAsync(subprocess.sendMessage(foobarString, {strict: true}));
+	t.is(message, 'subprocess.sendMessage() failed: the subprocess exited without listening to incoming messages.');
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, buffer ? [foobarString] : []);
+};
+
+test('subprocess.sendMessage() "strict" fails if the subprocess exits, buffer false', testStrictExit, false);
+test('subprocess.sendMessage() "strict" fails if the subprocess exits, buffer true', testStrictExit, true);
+
+const testStrictSuccessSubprocess = async (t, getMessage, buffer) => {
+	const subprocess = execa('ipc-send-strict.js', {ipc: true, buffer});
+	t.is(await getMessage(subprocess), foobarString);
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, buffer ? [foobarString] : []);
+};
+
+test('exports.sendMessage() "strict" succeeds if the current process uses subprocess.getOneMessage(), buffer false', testStrictSuccessSubprocess, subprocessGetOne, false);
+test('exports.sendMessage() "strict" succeeds if the current process uses subprocess.getOneMessage(), buffer true', testStrictSuccessSubprocess, subprocessGetOne, true);
+test('exports.sendMessage() "strict" succeeds if the current process uses subprocess.getEachMessage(), buffer false', testStrictSuccessSubprocess, subprocessGetFirst, false);
+test('exports.sendMessage() "strict" succeeds if the current process uses subprocess.getEachMessage(), buffer true', testStrictSuccessSubprocess, subprocessGetFirst, true);
+
+test('exports.sendMessage() "strict" succeeds if the current process uses result.ipcOutput', async t => {
+	const {ipcOutput} = await execa('ipc-send-strict.js', {ipc: true});
+	t.deepEqual(ipcOutput, [foobarString]);
+});
+
+test('exports.sendMessage() "strict" fails if the current process is not listening, buffer false', async t => {
+	const {exitCode, isTerminated, stderr, ipcOutput} = await t.throwsAsync(execa('ipc-send-strict.js', {ipc: true, buffer: {ipc: false}}));
+	t.is(exitCode, 1);
+	t.false(isTerminated);
+	t.true(stderr.includes('Error: sendMessage() failed: the parent process is not listening to incoming messages.'));
+	t.deepEqual(ipcOutput, []);
+});
+
+test.serial('Multiple subprocess.sendMessage() "strict" at once', async t => {
+	const checkMaxListeners = assertMaxListeners(t);
+
+	const subprocess = execa('ipc-iterate.js', {ipc: true});
+	const messages = Array.from({length: PARALLEL_COUNT}, (_, index) => index);
+	await Promise.all(messages.map(message => subprocess.sendMessage(message, {strict: true})));
+	await subprocess.sendMessage(foobarString);
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, messages);
+
+	checkMaxListeners();
+});
+
+test('subprocess.sendMessage() "strict" fails if the subprocess uses once()', async t => {
+	const subprocess = execa('ipc-once-message.js', {ipc: true});
+	const {message} = await t.throwsAsync(subprocess.sendMessage(foobarString, {strict: true}));
+	t.is(message, 'subprocess.sendMessage() failed: the subprocess exited without listening to incoming messages.');
+
+	const {ipcOutput} = await subprocess;
+	t.deepEqual(ipcOutput, ['.']);
+});
+
+test('exports.sendMessage() "strict" fails if the current process uses once() and buffer false', async t => {
+	const subprocess = execa('ipc-send-strict.js', {ipc: true, buffer: {ipc: false}});
+	const [message] = await once(subprocess, 'message');
+	t.deepEqual(message, {id: 0n, type: 'execa:ipc:request', message: foobarString});
+
+	const {exitCode, isTerminated, stderr, ipcOutput} = await t.throwsAsync(subprocess);
+	t.is(exitCode, 1);
+	t.false(isTerminated);
+	t.true(stderr.includes('Error: sendMessage() failed: the parent process is not listening to incoming messages.'));
+	t.deepEqual(ipcOutput, []);
+});
+
+test('subprocess.sendMessage() "strict" failure disconnects', async t => {
+	const subprocess = execa('ipc-echo-twice-wait.js', {ipcInput: foobarString});
+	const promise = subprocess.getOneMessage();
+	const secondPromise = subprocess.sendMessage(foobarString, {strict: true});
+	const {message} = await t.throwsAsync(subprocess.sendMessage(foobarString, {strict: true}));
+	t.is(message, 'subprocess.sendMessage() failed: the subprocess is not listening to incoming messages.');
+	t.is(await promise, foobarString);
+	await secondPromise;
+
+	const {exitCode, isTerminated, stderr, ipcOutput} = await t.throwsAsync(subprocess);
+	t.is(exitCode, 1);
+	t.false(isTerminated);
+	t.true(stderr.includes('Error: sendMessage() cannot be used: the parent process has already exited or disconnected.'));
+	t.deepEqual(ipcOutput, [foobarString, foobarString]);
+});
+
+test('exports.sendMessage() "strict" failure disconnects', async t => {
+	const {exitCode, isTerminated, stderr, ipcOutput} = await t.throwsAsync(execa('ipc-send-strict-catch.js', {ipc: true, buffer: {ipc: false}}));
+	t.is(exitCode, 1);
+	t.false(isTerminated);
+	t.true(stderr.includes('Error: sendMessage() cannot be used: the parent process has already exited or disconnected.'));
+	t.deepEqual(ipcOutput, []);
+});
+
+const testIoErrorParent = async (t, getMessage) => {
+	const subprocess = execa('ipc-send-strict.js', {ipc: true});
+	const cause = mockSendIoError(subprocess);
+	const error = await t.throwsAsync(getMessage(subprocess));
+	t.true(error.message.includes('subprocess.sendMessage() failed when sending an acknowledgment response to the subprocess.'));
+	t.is(getMessage === subprocessGetOne ? error.cause : error.cause.cause, cause);
+
+	const {exitCode, isTerminated, stderr, ipcOutput} = await t.throwsAsync(subprocess);
+	t.is(exitCode, 1);
+	t.false(isTerminated);
+	t.true(stderr.includes('Error: sendMessage() failed: the parent process exited without listening to incoming messages.'));
+	t.deepEqual(ipcOutput, []);
+};
+
+test('subprocess.getOneMessage() acknowledgment I/O error', testIoErrorParent, subprocessGetOne);
+test('subprocess.getEachMessage() acknowledgment I/O error', testIoErrorParent, subprocessGetFirst);
+
+const testIoErrorSubprocess = async (t, fixtureName) => {
+	const subprocess = execa(fixtureName, {ipc: true});
+	const {message} = await t.throwsAsync(subprocess.sendMessage(foobarString, {strict: true}));
+	t.is(message, 'subprocess.sendMessage() failed: the subprocess exited without listening to incoming messages.');
+
+	const {exitCode, isTerminated, stdout, stderr, ipcOutput} = await t.throwsAsync(subprocess);
+	t.is(exitCode, 1);
+	t.false(isTerminated);
+	t.is(stdout, '');
+	t.true(stderr.includes('Error: sendMessage() failed when sending an acknowledgment response to the parent process.'));
+	t.true(stderr.includes(`Error: ${foobarString}`));
+	t.deepEqual(ipcOutput, []);
+};
+
+test('exports.getOneMessage() acknowledgment I/O error', testIoErrorSubprocess, 'ipc-get-io-error.js');
+test('exports.getEachMessage() acknowledgment I/O error', testIoErrorSubprocess, 'ipc-iterate-io-error.js');
+
+test('Two sendMessage() "strict" at the same time create a deadlock', async t => {
+	const subprocess = execa('ipc-send-strict.js', {ipc: true, timeout: 1e3});
+	const {message} = await t.throwsAsync(subprocess.sendMessage(foobarString, {strict: true}));
+	t.is(message, 'subprocess.sendMessage() failed: the subprocess exited without listening to incoming messages.');
+
+	const {timedOut, ipcOutput} = await t.throwsAsync(subprocess);
+	t.true(timedOut);
+	t.deepEqual(ipcOutput, []);
+});

--- a/types/ipc.d.ts
+++ b/types/ipc.d.ts
@@ -31,7 +31,7 @@ Options to `sendMessage()` and `subprocess.sendMessage()`
 */
 type SendMessageOptions = {
 	/**
-	If `true`, throws when the other process is not receiving or listening to messages.
+	Throw when the other process is not receiving or listening to messages.
 
 	@default false
 	*/

--- a/types/ipc.d.ts
+++ b/types/ipc.d.ts
@@ -27,6 +27,26 @@ export type Message<
 > = Serialization extends 'json' ? JsonMessage : AdvancedMessage;
 
 /**
+Options to `sendMessage()` and `subprocess.sendMessage()`
+*/
+type SendMessageOptions = {
+	/**
+	If `true`, throws when the other process is not receiving or listening to messages.
+
+	@default false
+	*/
+	readonly strict?: boolean;
+};
+
+// IPC methods in subprocess
+/**
+Send a `message` to the parent process.
+
+This requires the `ipc` option to be `true`. The type of `message` depends on the `serialization` option.
+*/
+export function sendMessage(message: Message, sendMessageOptions?: SendMessageOptions): Promise<void>;
+
+/**
 Options to `getOneMessage()` and `subprocess.getOneMessage()`
 */
 type GetOneMessageOptions<
@@ -37,14 +57,6 @@ type GetOneMessageOptions<
 	*/
 	readonly filter?: (message: Message<Serialization>) => boolean;
 };
-
-// IPC methods in subprocess
-/**
-Send a `message` to the parent process.
-
-This requires the `ipc` option to be `true`. The type of `message` depends on the `serialization` option.
-*/
-export function sendMessage(message: Message): Promise<void>;
 
 /**
 Receive a single `message` from the parent process.
@@ -71,7 +83,7 @@ export type IpcMethods<
 
 		This requires the `ipc` option to be `true`. The type of `message` depends on the `serialization` option.
 		*/
-		sendMessage(message: Message<Serialization>): Promise<void>;
+		sendMessage(message: Message<Serialization>, sendMessageOptions?: SendMessageOptions): Promise<void>;
 
 		/**
 		Receive a single `message` from the subprocess.


### PR DESCRIPTION
This PR adds a `strict` option to `sendMessage()`.

When set to `true`, `sendMessage()` throws if the other process is not currently listening/receiving messages.

This is a measure that helps users identifying some timing-related race condition bugs, where they intend to listen to a message, but do it too late.