### PR TITLE
Update required Node.js semver range to "^18.19.0 || >=20.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	},
 	"sideEffects": false,
 	"engines": {
-		"node": ">=18"
+		"node": "^18.19.0 || >=20.5.0"
 	},
 	"scripts": {
 		"test": "npm run lint && npm run unit && npm run type",


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/execa/issues/1097 by updating the `package.json` `engines.node` semver range to match the currently supported Node.js versions: `^18.19.0 || >=20.5.0`