### PR TITLE
Fix deadlocks with IPC

### DIFF
--- a/lib/ipc/incoming.js
+++ b/lib/ipc/incoming.js
@@ -40,7 +40,7 @@ export const onMessage = async ({anyProcess, channel, isSubprocess, ipcEmitter},
 
 	while (incomingMessages.length > 0) {
 		// eslint-disable-next-line no-await-in-loop
-		await waitForOutgoingMessages(anyProcess, ipcEmitter);
+		await waitForOutgoingMessages(anyProcess, ipcEmitter, wrappedMessage);
 		// eslint-disable-next-line no-await-in-loop
 		await scheduler.yield();
 

--- a/lib/ipc/outgoing.js
+++ b/lib/ipc/outgoing.js
@@ -1,30 +1,35 @@
 import {createDeferred} from '../utils/deferred.js';
 import {SUBPROCESS_OPTIONS} from '../arguments/fd-options.js';
+import {validateStrictDeadlock} from './strict.js';
 
 // When `sendMessage()` is ongoing, any `message` being received waits before being emitted.
 // This allows calling one or multiple `await sendMessage()` followed by `await getOneMessage()`/`await getEachMessage()`.
 // Without running into a race condition when the other process sends a response too fast, before the current process set up a listener.
-export const startSendMessage = anyProcess => {
+export const startSendMessage = (anyProcess, wrappedMessage, strict) => {
 	if (!OUTGOING_MESSAGES.has(anyProcess)) {
 		OUTGOING_MESSAGES.set(anyProcess, new Set());
 	}
 
 	const outgoingMessages = OUTGOING_MESSAGES.get(anyProcess);
 	const onMessageSent = createDeferred();
-	outgoingMessages.add(onMessageSent);
-	return {outgoingMessages, onMessageSent};
+	const id = strict ? wrappedMessage.id : undefined;
+	const outgoingMessage = {onMessageSent, id};
+	outgoingMessages.add(outgoingMessage);
+	return {outgoingMessages, outgoingMessage};
 };
 
-export const endSendMessage = ({outgoingMessages, onMessageSent}) => {
-	outgoingMessages.delete(onMessageSent);
-	onMessageSent.resolve();
+export const endSendMessage = ({outgoingMessages, outgoingMessage}) => {
+	outgoingMessages.delete(outgoingMessage);
+	outgoingMessage.onMessageSent.resolve();
 };
 
 // Await while `sendMessage()` is ongoing, unless there is already a `message` listener
-export const waitForOutgoingMessages = async (anyProcess, ipcEmitter) => {
+export const waitForOutgoingMessages = async (anyProcess, ipcEmitter, wrappedMessage) => {
 	while (!hasMessageListeners(anyProcess, ipcEmitter) && OUTGOING_MESSAGES.get(anyProcess)?.size > 0) {
+		const outgoingMessages = [...OUTGOING_MESSAGES.get(anyProcess)];
+		validateStrictDeadlock(outgoingMessages, wrappedMessage);
 		// eslint-disable-next-line no-await-in-loop
-		await Promise.all(OUTGOING_MESSAGES.get(anyProcess));
+		await Promise.all(outgoingMessages.map(({onMessageSent}) => onMessageSent));
 	}
 };
 

--- a/lib/ipc/send.js
+++ b/lib/ipc/send.js
@@ -30,7 +30,6 @@ export const sendMessage = ({anyProcess, channel, isSubprocess, ipc}, message, {
 };
 
 const sendMessageAsync = async ({anyProcess, channel, isSubprocess, message, strict}) => {
-	const outgoingMessagesState = startSendMessage(anyProcess);
 	const sendMethod = getSendMethod(anyProcess);
 	const wrappedMessage = handleSendStrict({
 		anyProcess,
@@ -39,6 +38,7 @@ const sendMessageAsync = async ({anyProcess, channel, isSubprocess, message, str
 		message,
 		strict,
 	});
+	const outgoingMessagesState = startSendMessage(anyProcess, wrappedMessage, strict);
 
 	try {
 		await Promise.all([

--- a/lib/ipc/strict.js
+++ b/lib/ipc/strict.js
@@ -2,7 +2,7 @@ import {once} from 'node:events';
 import {createDeferred} from '../utils/deferred.js';
 import {incrementMaxListeners} from '../utils/max-listeners.js';
 import {sendMessage} from './send.js';
-import {throwOnMissingStrict, throwOnStrictDisconnect} from './validation.js';
+import {throwOnMissingStrict, throwOnStrictDisconnect, throwOnStrictDeadlockError} from './validation.js';
 import {getIpcEmitter} from './forward.js';
 import {hasMessageListeners} from './outgoing.js';
 
@@ -12,15 +12,35 @@ export const handleSendStrict = ({anyProcess, channel, isSubprocess, message, st
 		return message;
 	}
 
-	getIpcEmitter(anyProcess, channel, isSubprocess);
-	return {id: count++, type: REQUEST_TYPE, message};
+	const ipcEmitter = getIpcEmitter(anyProcess, channel, isSubprocess);
+	const hasListeners = hasMessageListeners(anyProcess, ipcEmitter);
+	return {
+		id: count++,
+		type: REQUEST_TYPE,
+		message,
+		hasListeners,
+	};
 };
 
 let count = 0n;
 
+// Handles when both processes are calling `sendMessage()` with `strict` at the same time.
+// If neither process is listening, this would create a deadlock. We detect it and throw.
+export const validateStrictDeadlock = (outgoingMessages, wrappedMessage) => {
+	if (wrappedMessage?.type !== REQUEST_TYPE || wrappedMessage.hasListeners) {
+		return;
+	}
+
+	for (const {id} of outgoingMessages) {
+		if (id !== undefined) {
+			STRICT_RESPONSES[id].resolve({isDeadlock: true, hasListeners: false});
+		}
+	}
+};
+
 // The other process then sends the acknowledgment back as a response
 export const handleStrictRequest = async ({wrappedMessage, anyProcess, channel, isSubprocess, ipcEmitter}) => {
-	if (wrappedMessage?.type !== REQUEST_TYPE) {
+	if (wrappedMessage?.type !== REQUEST_TYPE || !anyProcess.connected) {
 		return wrappedMessage;
 	}
 
@@ -48,7 +68,7 @@ export const handleStrictResponse = wrappedMessage => {
 	}
 
 	const {id, message: hasListeners} = wrappedMessage;
-	STRICT_RESPONSES[id].resolve(hasListeners);
+	STRICT_RESPONSES[id]?.resolve({isDeadlock: false, hasListeners});
 	return true;
 };
 
@@ -60,19 +80,23 @@ export const waitForStrictResponse = async (wrappedMessage, anyProcess, isSubpro
 
 	const deferred = createDeferred();
 	STRICT_RESPONSES[wrappedMessage.id] = deferred;
+	const controller = new AbortController();
 
 	try {
-		const controller = new AbortController();
-		const hasListeners = await Promise.race([
+		const {isDeadlock, hasListeners} = await Promise.race([
 			deferred,
 			throwOnDisconnect(anyProcess, isSubprocess, controller),
 		]);
-		controller.abort();
+
+		if (isDeadlock) {
+			throwOnStrictDeadlockError(isSubprocess);
+		}
 
 		if (!hasListeners) {
 			throwOnMissingStrict(isSubprocess);
 		}
 	} finally {
+		controller.abort();
 		delete STRICT_RESPONSES[wrappedMessage.id];
 	}
 };

--- a/lib/ipc/validation.js
+++ b/lib/ipc/validation.js
@@ -24,6 +24,17 @@ export const throwOnEarlyDisconnect = isSubprocess => {
 	throw new Error(`${getNamespaceName(isSubprocess)}getOneMessage() could not complete: the ${getOtherProcessName(isSubprocess)} exited or disconnected.`);
 };
 
+// When both processes use `sendMessage()` with `strict` at the same time
+export const throwOnStrictDeadlockError = isSubprocess => {
+	throw new Error(`${getNamespaceName(isSubprocess)}sendMessage() failed: the ${getOtherProcessName(isSubprocess)} is sending a message too, instead of listening to incoming messages.
+This can be fixed by both sending a message and listening to incoming messages at the same time:
+
+const [receivedMessage] = await Promise.all([
+	${getNamespaceName(isSubprocess)}getOneMessage(),
+	${getNamespaceName(isSubprocess)}sendMessage(message, {strict: true}),
+]);`);
+};
+
 // When the other process used `strict` but the current process had I/O error calling `sendMessage()` for the response
 export const getStrictResponseError = (error, isSubprocess) => new Error(`${getNamespaceName(isSubprocess)}sendMessage() failed when sending an acknowledgment response to the ${getOtherProcessName(isSubprocess)}.`, {cause: error});
 

--- a/test/fixtures/ipc-send-strict-listen.js
+++ b/test/fixtures/ipc-send-strict-listen.js
@@ -2,7 +2,7 @@
 import {sendMessage, getOneMessage} from '../../index.js';
 import {foobarString} from '../helpers/input.js';
 
-const [message] = await Promise.race([
+const [message] = await Promise.all([
 	getOneMessage(),
 	sendMessage(foobarString, {strict: true}),
 ]);

--- a/test/ipc/ipc-input.js
+++ b/test/ipc/ipc-input.js
@@ -47,7 +47,7 @@ test('Handles "ipcInput" option during sending', async t => {
 	t.true(cause.cause.message.includes('The "message" argument must be one of type string'));
 });
 
-test('Can use "ipcInput" option even if the subprocess is not listening to messages', async t => {
+test.serial('Can use "ipcInput" option even if the subprocess is not listening to messages', async t => {
 	const {ipcOutput} = await execa('empty.js', {ipcInput: foobarString});
 	t.deepEqual(ipcOutput, []);
 });


### PR DESCRIPTION
When both the current process and the subprocess call `sendMessage(message, {strict: true})` at the same time, they hang forever. This PR fixes this.