### PR TITLE
Fix "Preventing exceptions" example

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -28,7 +28,7 @@ try {
 When the [`reject`](api.md#optionsreject) option is `false`, the `error` is returned instead.
 
 ```js
-const resultOrError = await execa`npm run build`;
+const resultOrError = await execa({reject: false})`npm run build`;
 if (resultOrError.failed) {
 	console.error(resultOrError);
 }


### PR DESCRIPTION
Thanks for Execa, amazing project!

IIUC, this is a quick PR to fix the "Preventing exceptions" example, which states:

> When the [reject](https://github.com/sindresorhus/execa/blob/main/docs/api.md#optionsreject) option is false, the error is returned instead.

The current example uses `execa` without setting `reject: false`