### PR TITLE
Fix type of `forceKillAfterDelay` option

### DIFF
--- a/test-d/arguments/options.test-d.ts
+++ b/test-d/arguments/options.test-d.ts
@@ -150,6 +150,10 @@ expectError(execaSync('unicorns', {killSignal: 'SIGRT1'}));
 
 await execa('unicorns', {forceKillAfterDelay: false});
 expectError(execaSync('unicorns', {forceKillAfterDelay: false}));
+await execa('unicorns', {forceKillAfterDelay: true});
+expectError(execaSync('unicorns', {forceKillAfterDelay: true}));
+await execa('unicorns', {forceKillAfterDelay: false as boolean});
+expectError(execaSync('unicorns', {forceKillAfterDelay: false as boolean}));
 await execa('unicorns', {forceKillAfterDelay: 42});
 expectError(execaSync('unicorns', {forceKillAfterDelay: 42}));
 expectError(await execa('unicorns', {forceKillAfterDelay: 'true'}));

--- a/types/arguments/options.d.ts
+++ b/types/arguments/options.d.ts
@@ -297,7 +297,7 @@ export type CommonOptions<IsSync extends boolean = boolean> = {
 
 	@default 5000
 	*/
-	readonly forceKillAfterDelay?: Unless<IsSync, number | false>;
+	readonly forceKillAfterDelay?: Unless<IsSync, number | boolean>;
 
 	/**
 	Default [signal](https://en.wikipedia.org/wiki/Signal_(IPC)) used to terminate the subprocess.


### PR DESCRIPTION
This PR fixes the type of the `forceKillAfterDelay` option, since `true` is an allowed value.