### PR TITLE
Improve speed of types

### DIFF
--- a/types/return/ignore.d.ts
+++ b/types/return/ignore.d.ts
@@ -1,4 +1,4 @@
-import type {NoStreamStdioOption, StdioOptionCommon} from '../stdio/type.js';
+import type {NoStreamStdioOption} from '../stdio/type.js';
 import type {IsInputFd} from '../stdio/direction.js';
 import type {FdStdioOption} from '../stdio/option.js';
 import type {FdSpecificOption} from '../arguments/specific.js';
@@ -22,5 +22,5 @@ export type IgnoresSubprocessOutput<
 
 type IgnoresOutput<
 	FdNumber extends string,
-	StdioOptionType extends StdioOptionCommon,
+	StdioOptionType,
 > = StdioOptionType extends NoStreamStdioOption<FdNumber> ? true : false;

--- a/types/return/result-ipc.d.ts
+++ b/types/return/result-ipc.d.ts
@@ -6,7 +6,7 @@ import type {Message, HasIpc} from '../ipc.js';
 // This is empty unless the `ipc` option is `true`.
 // Also, this is empty if the `buffer` option is `false`.
 export type ResultIpcOutput<
-	IsSync extends boolean,
+	IsSync,
 	OptionsType extends CommonOptions,
 > = IsSync extends true
 	? []

--- a/types/return/result-stdio.d.ts
+++ b/types/return/result-stdio.d.ts
@@ -1,4 +1,3 @@
-import type {StdioOptionsArray} from '../stdio/type.js';
 import type {StdioOptionNormalizedArray} from '../stdio/array.js';
 import type {CommonOptions} from '../arguments/options.js';
 import type {ResultStdioNotAll} from './result-stdout.js';
@@ -8,7 +7,7 @@ export type ResultStdioArray<OptionsType extends CommonOptions> =
 	MapResultStdio<StdioOptionNormalizedArray<OptionsType>, OptionsType>;
 
 type MapResultStdio<
-	StdioOptionsArrayType extends StdioOptionsArray,
+	StdioOptionsArrayType,
 	OptionsType extends CommonOptions,
 > = {
 	-readonly [FdNumber in keyof StdioOptionsArrayType]: ResultStdioNotAll<

--- a/types/return/result-stdout.d.ts
+++ b/types/return/result-stdout.d.ts
@@ -26,7 +26,7 @@ OptionsType
 type ResultStdioProperty<
 	ObjectFdNumber extends string,
 	LinesFdNumber extends string,
-	StreamOutputIgnored extends boolean,
+	StreamOutputIgnored,
 	OptionsType extends CommonOptions,
 > = StreamOutputIgnored extends true
 	? undefined
@@ -37,7 +37,7 @@ type ResultStdioProperty<
 	>;
 
 type ResultStdioItem<
-	IsObjectResult extends boolean,
+	IsObjectResult,
 	LinesOption extends boolean | undefined,
 	Encoding extends CommonOptions['encoding'],
 > = IsObjectResult extends true ? unknown[]

--- a/types/stdio/option.d.ts
+++ b/types/stdio/option.d.ts
@@ -1,17 +1,12 @@
 import type {CommonOptions} from '../arguments/options.js';
 import type {StdioOptionNormalizedArray} from './array.js';
-import type {
-	StandardStreams,
-	StdioOptionCommon,
-	StdioOptionsArray,
-	StdioOptionsProperty,
-} from './type.js';
+import type {StandardStreams, StdioOptionCommon, StdioOptionsArray} from './type.js';
 
 // `options.stdin|stdout|stderr|stdio` for a given file descriptor
 export type FdStdioOption<
 	FdNumber extends string,
 	OptionsType extends CommonOptions,
-> = Extract<FdStdioOptionProperty<FdNumber, OptionsType>, StdioOptionCommon>;
+> = FdStdioOptionProperty<FdNumber, OptionsType>;
 
 type FdStdioOptionProperty<
 	FdNumber extends string,
@@ -29,11 +24,11 @@ type FdStdioOptionProperty<
 export type FdStdioArrayOption<
 	FdNumber extends string,
 	OptionsType extends CommonOptions,
-> = Extract<FdStdioArrayOptionProperty<FdNumber, StdioOptionNormalizedArray<OptionsType>>, StdioOptionCommon>;
+> = FdStdioArrayOptionProperty<FdNumber, StdioOptionNormalizedArray<OptionsType>>;
 
 type FdStdioArrayOptionProperty<
 	FdNumber extends string,
-	StdioOptionsType extends StdioOptionsProperty,
+	StdioOptionsType,
 > = string extends FdNumber
 	? StdioOptionCommon | undefined
 	: StdioOptionsType extends StdioOptionsArray

--- a/types/stdio/type.d.ts
+++ b/types/stdio/type.d.ts
@@ -138,7 +138,7 @@ type StdioExtraOptionCommon<IsSync extends boolean> =
 	| StdoutStderrOptionCommon<IsSync, true>;
 
 // `options.stdin|stdout|stderr|stdio` array items
-export type StdioSingleOption<
+type StdioSingleOption<
 	IsSync extends boolean = boolean,
 	IsExtra extends boolean = boolean,
 	IsArray extends boolean = boolean,
@@ -147,9 +147,7 @@ export type StdioSingleOption<
 	| StdoutStderrSingleOption<IsSync, IsExtra, IsArray>;
 
 // Get `options.stdin|stdout|stderr|stdio` items if it is an array, else keep as is
-export type StdioSingleOptionItems<
-	StdioOptionType extends StdioOptionCommon,
-> = StdioOptionType extends readonly StdioSingleOption[]
+export type StdioSingleOptionItems<StdioOptionType> = StdioOptionType extends readonly StdioSingleOption[]
 	? StdioOptionType[number]
 	: StdioOptionType;
 

--- a/types/subprocess/all.d.ts
+++ b/types/subprocess/all.d.ts
@@ -8,7 +8,7 @@ export type SubprocessAll<OptionsType extends Options> = AllStream<AllIgnored<Op
 type AllStream<IsIgnored> = IsIgnored extends true ? undefined : Readable;
 
 type AllIgnored<
-	AllOption extends Options['all'],
+	AllOption,
 	OptionsType extends Options,
 > = AllOption extends true
 	? IgnoresSubprocessOutput<'1', OptionsType> extends true

--- a/types/subprocess/stdio.d.ts
+++ b/types/subprocess/stdio.d.ts
@@ -1,5 +1,4 @@
 import type {StdioOptionNormalizedArray} from '../stdio/array.js';
-import type {StdioOptionsArray} from '../stdio/type.js';
 import type {Options} from '../arguments/options.js';
 import type {SubprocessStdioStream} from './stdout.js';
 
@@ -8,7 +7,7 @@ export type SubprocessStdioArray<OptionsType extends Options> = MapStdioStreams<
 
 // We cannot use mapped types because it must be compatible with Node.js `ChildProcess["stdio"]` which uses a tuple with exactly 5 items
 type MapStdioStreams<
-	StdioOptionsArrayType extends StdioOptionsArray,
+	StdioOptionsArrayType,
 	OptionsType extends Options,
 > = [
 	SubprocessStdioStream<'0', OptionsType>,

--- a/types/subprocess/stdout.d.ts
+++ b/types/subprocess/stdout.d.ts
@@ -11,7 +11,7 @@ export type SubprocessStdioStream<
 
 type SubprocessStream<
 	FdNumber extends string,
-	StreamResultIgnored extends boolean,
+	StreamResultIgnored,
 	OptionsType extends Options,
 > = StreamResultIgnored extends true
 	? null

--- a/types/transform/object-mode.d.ts
+++ b/types/transform/object-mode.d.ts
@@ -1,4 +1,4 @@
-import type {StdioSingleOption, StdioOptionCommon, StdioSingleOptionItems} from '../stdio/type.js';
+import type {StdioSingleOptionItems} from '../stdio/type.js';
 import type {FdStdioOption} from '../stdio/option.js';
 import type {CommonOptions} from '../arguments/options.js';
 import type {DuplexTransform, TransformCommon} from './normalize.js';
@@ -10,9 +10,9 @@ export type IsObjectFd<
 	OptionsType extends CommonOptions,
 > = IsObjectStdioOption<FdStdioOption<FdNumber, OptionsType>>;
 
-type IsObjectStdioOption<StdioOptionType extends StdioOptionCommon> = IsObjectStdioSingleOption<StdioSingleOptionItems<StdioOptionType>>;
+type IsObjectStdioOption<StdioOptionType> = IsObjectStdioSingleOption<StdioSingleOptionItems<StdioOptionType>>;
 
-type IsObjectStdioSingleOption<StdioSingleOptionType extends StdioSingleOption> = StdioSingleOptionType extends TransformCommon
+type IsObjectStdioSingleOption<StdioSingleOptionType> = StdioSingleOptionType extends TransformCommon
 	? BooleanObjectMode<StdioSingleOptionType['objectMode']>
 	: StdioSingleOptionType extends DuplexTransform
 		? StdioSingleOptionType['transform']['readableObjectMode']


### PR DESCRIPTION
This PR improves the speed of the types. On my machine, they are now ~4 times faster.

Before:

```
$ time tsc index.d.ts
real	0m5.064s
user	0m7.940s
sys	0m0.339s
```

After:

```
$ time tsc index.d.ts
real	0m1.284s
user	0m3.242s
sys	0m0.133s
```

Also, our type checking task is now roughly twice faster.

What this PR does is removing a few `extends` constraints. Apparently, some of them were making the types much slower, but were more for safety/documentation purpose, i.e. could be removed without impacting the types. All of those types are internal.