### PR TITLE
Automatically check Markdown links

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
+      - uses: lycheeverse/lychee-action@v1
+        with:
+          args: --verbose --no-progress --include-fragments --max-concurrency 10 --exclude linkedin --exclude file:///test --exclude invalid.com '*.md' 'docs/*.md' '.github/**/*.md' '*.json' '*.js' 'lib/**/*.js' 'test/**/*.js' '*.ts' 'test-d/**/*.ts'
+          fail: true
+        if: ${{ matrix.os == 'ubuntu' && matrix.node-version == 22 }}
       - run: npm run lint
       - run: npm run type
       - run: npm run unit


### PR DESCRIPTION
Our documentation has lots of links and anchors. It actually takes quite some time to ensure the links are correct. Also, external links might stop working without us knowing.

This adds a GitHub action to automatically check Markdown links, including anchors. 

This is hard to believe, but apparently it runs in only 2 seconds. This is written in Rust, but I would expect hundreds of parallel HTTP requests to take longer, but it seems not! :)

This PR currently fails (which is good since it shows the action works) due to the broken links that are fixed in a separate PR at #1119.