### PR TITLE
Fix c8 memory crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"scripts": {
 		"test": "npm run lint && npm run unit && npm run type",
 		"lint": "xo",
-		"unit": "c8 ava",
+		"unit": "c8 --merge-async ava",
 		"type": "tsd && tsc && npx --yes tsd@0.29.0 && npx --yes --package typescript@5.1 tsc"
 	},
 	"files": [
@@ -67,7 +67,7 @@
 	"devDependencies": {
 		"@types/node": "^20.8.9",
 		"ava": "^6.0.1",
-		"c8": "^9.1.0",
+		"c8": "^10.1.2",
 		"get-node": "^15.0.0",
 		"is-in-ci": "^0.1.0",
 		"is-running": "^2.1.0",


### PR DESCRIPTION
We have almost 5000 tests, which makes c8 crash. This is because c8 holds all the information collected for all tests in memory all at once.

This PR fixes this using the `--merge-async` flag, which is intended for that specific problem.
See https://github.com/bcoe/c8/blob/ff146b4dde004c62651b57c33cedd8353c94c423/lib/parse-args.js#L155