### PR TITLE
Fix stream-related tests with Node 22.5.0

### DIFF
--- a/test/convert/duplex.js
+++ b/test/convert/duplex.js
@@ -149,11 +149,12 @@ test('.duplex() can pipe to errored stream with Stream.pipeline()', async t => {
 	outputStream.destroy(cause);
 
 	await assertPromiseError(t, pipeline(inputStream, stream, outputStream), cause);
+	await t.throwsAsync(finishedStream(stream));
 
 	await assertStreamError(t, inputStream, cause);
-	const error = await assertStreamError(t, stream, {cause});
+	const error = await assertStreamError(t, stream, cause);
 	await assertStreamReadError(t, outputStream, cause);
-	await assertSubprocessError(t, subprocess, error);
+	await assertSubprocessError(t, subprocess, {cause: error});
 });
 
 test('.duplex() can be piped to errored stream with Stream.pipeline()', async t => {
@@ -166,11 +167,12 @@ test('.duplex() can be piped to errored stream with Stream.pipeline()', async t 
 	inputStream.destroy(cause);
 
 	await assertPromiseError(t, pipeline(inputStream, stream, outputStream), cause);
+	await t.throwsAsync(finishedStream(stream));
 
 	await assertStreamError(t, inputStream, cause);
-	const error = await assertStreamError(t, stream, {cause});
+	const error = await assertStreamError(t, stream, cause);
 	await assertStreamReadError(t, outputStream, cause);
-	await assertSubprocessError(t, subprocess, error);
+	await assertSubprocessError(t, subprocess, {cause: error});
 });
 
 test('.duplex() can be used with Stream.compose()', async t => {

--- a/test/convert/readable.js
+++ b/test/convert/readable.js
@@ -232,10 +232,11 @@ test('.readable() can pipe to errored stream with Stream.pipeline()', async t =>
 	outputStream.destroy(cause);
 
 	await assertPromiseError(t, pipeline(stream, outputStream), cause);
+	await t.throwsAsync(finishedStream(stream));
 
-	const error = await assertStreamError(t, stream, {cause});
+	const error = await assertStreamError(t, stream, cause);
 	await assertStreamReadError(t, outputStream, cause);
-	await assertSubprocessError(t, subprocess, error);
+	await assertSubprocessError(t, subprocess, {cause: error});
 });
 
 test('.readable() can be used with Stream.compose()', async t => {

--- a/test/convert/writable.js
+++ b/test/convert/writable.js
@@ -242,10 +242,11 @@ test('.writable() can pipe to errored stream with Stream.pipeline()', async t =>
 	inputStream.destroy(cause);
 
 	await assertPromiseError(t, pipeline(inputStream, stream), cause);
+	await t.throwsAsync(finishedStream(stream));
 
 	await assertStreamError(t, inputStream, cause);
-	const error = await assertStreamError(t, stream, {cause});
-	await assertSubprocessError(t, subprocess, error);
+	const error = await assertStreamError(t, stream, cause);
+	await assertSubprocessError(t, subprocess, {cause: error});
 });
 
 test('.writable() can be used with Stream.compose()', async t => {


### PR DESCRIPTION
Node 22.5.0 introduced some changes to error handling with `stream.pipeline()`: https://github.com/nodejs/node/pull/53462

Those changes are making some of our tests fail (https://github.com/sindresorhus/execa/actions/runs/9628628974). This PR is fixing those.