### PR TITLE
refactor: remove `is-plain-obj`

### DIFF
--- a/lib/arguments/specific.js
+++ b/lib/arguments/specific.js
@@ -1,5 +1,5 @@
 import {debuglog} from 'node:util';
-import isPlainObject from 'is-plain-obj';
+import isPlainObject from '../utils/is-plain-object.js';
 import {STANDARD_STREAMS_ALIASES} from '../utils/standard-stream.js';
 
 // Some options can have different values for `stdout`/`stderr`/`fd3`.

--- a/lib/methods/bind.js
+++ b/lib/methods/bind.js
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-obj';
+import isPlainObject from '../utils/is-plain-object.js';
 import {FD_SPECIFIC_OPTIONS} from '../arguments/specific.js';
 
 // Deep merge specific options like `env`. Shallow merge the other ones.

--- a/lib/methods/create.js
+++ b/lib/methods/create.js
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-obj';
+import isPlainObject from '../utils/is-plain-object.js';
 import {normalizeParameters} from './parameters.js';
 import {isTemplateString, parseTemplates} from './template.js';
 import {execaCoreSync} from './main-sync.js';

--- a/lib/methods/parameters.js
+++ b/lib/methods/parameters.js
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-obj';
+import isPlainObject from '../utils/is-plain-object.js';
 import {safeNormalizeFileUrl} from '../arguments/file-url.js';
 
 // The command `arguments` and `options` are both optional.

--- a/lib/methods/template.js
+++ b/lib/methods/template.js
@@ -1,5 +1,5 @@
 import {ChildProcess} from 'node:child_process';
-import isPlainObject from 'is-plain-obj';
+import isPlainObject from '../utils/is-plain-object.js';
 import {isUint8Array, uint8ArrayToString} from '../utils/uint-array.js';
 
 // Check whether the template string syntax is being used

--- a/lib/pipe/setup.js
+++ b/lib/pipe/setup.js
@@ -1,4 +1,4 @@
-import isPlainObject from 'is-plain-obj';
+import isPlainObject from '../utils/is-plain-object.js';
 import {normalizePipeArguments} from './pipe-arguments.js';
 import {handlePipeArgumentsError} from './throw.js';
 import {waitForBothSubprocesses} from './sequence.js';

--- a/lib/stdio/type.js
+++ b/lib/stdio/type.js
@@ -1,5 +1,5 @@
 import {isStream as isNodeStream, isDuplexStream} from 'is-stream';
-import isPlainObj from 'is-plain-obj';
+import isPlainObject from '../utils/is-plain-object.js';
 import {isUint8Array} from '../utils/uint-array.js';
 
 // The `stdin`/`stdout`/`stderr` option can be of many types. This detects it.
@@ -117,13 +117,13 @@ const checkBooleanOption = (value, optionName) => {
 const isGenerator = value => isAsyncGenerator(value) || isSyncGenerator(value);
 export const isAsyncGenerator = value => Object.prototype.toString.call(value) === '[object AsyncGeneratorFunction]';
 const isSyncGenerator = value => Object.prototype.toString.call(value) === '[object GeneratorFunction]';
-const isTransformOptions = value => isPlainObj(value)
+const isTransformOptions = value => isPlainObject(value)
 	&& (value.transform !== undefined || value.final !== undefined);
 
 export const isUrl = value => Object.prototype.toString.call(value) === '[object URL]';
 export const isRegularUrl = value => isUrl(value) && value.protocol !== 'file:';
 
-const isFilePathObject = value => isPlainObj(value)
+const isFilePathObject = value => isPlainObject(value)
 	&& Object.keys(value).length === 1
 	&& isFilePathString(value.file);
 export const isFilePathString = file => typeof file === 'string';

--- a/lib/transform/normalize.js
+++ b/lib/transform/normalize.js
@@ -1,4 +1,4 @@
-import isPlainObj from 'is-plain-obj';
+import isPlainObject from '../utils/is-plain-object.js';
 import {BINARY_ENCODINGS} from '../arguments/encoding-option.js';
 import {TRANSFORM_TYPES} from '../stdio/type.js';
 import {getTransformObjectModes} from './object-mode.js';
@@ -77,7 +77,7 @@ const normalizeDuplex = ({
 };
 
 const normalizeTransformStream = ({stdioItem, stdioItem: {value}, index, newTransforms, direction}) => {
-	const {transform, objectMode} = isPlainObj(value) ? value : {transform: value};
+	const {transform, objectMode} = isPlainObject(value) ? value : {transform: value};
 	const {writableObjectMode, readableObjectMode} = getTransformObjectModes(objectMode, index, newTransforms, direction);
 	return ({
 		...stdioItem,
@@ -92,7 +92,7 @@ const normalizeGenerator = ({stdioItem, stdioItem: {value}, index, newTransforms
 		binary: binaryOption = false,
 		preserveNewlines = false,
 		objectMode,
-	} = isPlainObj(value) ? value : {transform: value};
+	} = isPlainObject(value) ? value : {transform: value};
 	const binary = binaryOption || BINARY_ENCODINGS.has(encoding);
 	const {writableObjectMode, readableObjectMode} = getTransformObjectModes(objectMode, index, newTransforms, direction);
 	return {

--- a/lib/utils/is-plain-object.js
+++ b/lib/utils/is-plain-object.js
@@ -1,0 +1,3 @@
+export default function isPlainObject(v) {
+	return v && typeof v === 'object' && (Object.getPrototypeOf(v) === null || Object.getPrototypeOf(v) === Object.prototype);
+}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
 		"figures": "^6.1.0",
 		"get-stream": "^9.0.0",
 		"human-signals": "^8.0.0",
-		"is-plain-obj": "^4.1.0",
 		"is-stream": "^4.0.1",
 		"npm-run-path": "^5.2.0",
 		"pretty-ms": "^9.0.0",

--- a/test/helpers/convert.js
+++ b/test/helpers/convert.js
@@ -1,7 +1,7 @@
 import {text} from 'node:stream/consumers';
 import {finished} from 'node:stream/promises';
 import getStream from 'get-stream';
-import isPlainObj from 'is-plain-obj';
+import isPlainObject from '../../lib/utils/is-plain-object.js';
 import {execa} from '../../index.js';
 import {foobarString} from '../helpers/input.js';
 
@@ -62,7 +62,7 @@ export const assertSubprocessError = (t, subprocess, error) => assertPromiseErro
 export const assertPromiseError = async (t, promise, error) => {
 	const thrownError = await t.throwsAsync(promise);
 
-	if (isPlainObj(error) && error.cause !== undefined) {
+	if (isPlainObject(error) && error.cause !== undefined) {
 		t.is(thrownError.cause, error.cause);
 	} else {
 		t.is(thrownError, error);


### PR DESCRIPTION
## Changes

<!-- Describe what behavior is changed by this PR. -->
Removed `is-plain-obj` in favor of a oneline function.

## Context

As part of the ongoing [ecosystem cleanup](https://github.com/es-tooling/ecosystem-cleanup), we are migrating various projects to use lighter/faster package or alternatives.

![image](https://github.com/user-attachments/assets/a38b0123-0e6d-492c-a02d-8ad2beda3ada)

*https://github.com/TheDevMinerTV/package-size-calculator*

## How I've tested my work

`npm run test` 4982 tests passed