### PR TITLE
Document how to terminate hanging subprocesses

### DIFF
--- a/docs/termination.md
+++ b/docs/termination.md
@@ -162,6 +162,7 @@ const getInactivityOptions = () => {
 		* transform(data) {
 			// When anything is printed, debounce `controller.abort()`
 			abort();
+
 			// Keep the output as is
 			yield data;
 		},
@@ -172,10 +173,15 @@ const getInactivityOptions = () => {
 	// Start debouncing
 	abort();
 
-	return {cancelSignal, stdout: onOutput, stderr: onOutput};
+	return {
+		cancelSignal,
+		stdout: onOutput,
+		stderr: onOutput,
+	};
 };
 
 const options = getInactivityOptions();
+
 await execa(options)`npm run build`;
 ```
 

--- a/docs/termination.md
+++ b/docs/termination.md
@@ -156,12 +156,12 @@ const getInactivityOptions = () => {
 	const cancelSignal = controller.signal;
 
 	// Delay and debounce `cancelSignal` each time `controller.abort()` is called
-	const abort = debounceFn(controller.abort.bind(controller), {wait});
+	const scheduleAbort = debounceFn(controller.abort.bind(controller), {wait});
 
 	const onOutput = {
 		* transform(data) {
 			// When anything is printed, debounce `controller.abort()`
-			abort();
+			scheduleAbort();
 
 			// Keep the output as is
 			yield data;
@@ -171,7 +171,7 @@ const getInactivityOptions = () => {
 	};
 
 	// Start debouncing
-	abort();
+	scheduleAbort();
 
 	return {
 		cancelSignal,


### PR DESCRIPTION
Fixes #1137.

I reworked the example so it avoids `subprocess.stdout`/`subprocess.stderr` Node.js streams since we've been trying to recommend alternatives (transforms and/or async iteration), so that users can `await` the promise returned by `execa()` directly.