### PR TITLE
Upgrade `npm-run-path`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"human-signals": "^8.0.0",
 		"is-plain-obj": "^4.1.0",
 		"is-stream": "^4.0.1",
-		"npm-run-path": "^5.2.0",
+		"npm-run-path": "^6.0.0",
 		"pretty-ms": "^9.0.0",
 		"signal-exit": "^4.1.0",
 		"strip-final-newline": "^4.0.0",


### PR DESCRIPTION
This upgrades `npm-run-path`.

https://github.com/sindresorhus/npm-run-path/releases/tag/v6.0.0

For users, this means when Execa manipulates the `PATH` environment variable (due to `execaNode()` or to `preferLocal: true`), it might now do it slightly better in some edge cases.