### PR TITLE
fix unicode problems with verbose log

### DIFF
--- a/lib/verbose/log.js
+++ b/lib/verbose/log.js
@@ -1,4 +1,4 @@
-import {writeFileSync} from 'node:fs';
+import process from 'node:process';
 import {inspect} from 'node:util';
 import {escapeLines} from '../arguments/escape.js';
 import {defaultVerboseFunction} from './default.js';
@@ -9,7 +9,7 @@ export const verboseLog = ({type, verboseMessage, fdNumber, verboseInfo, result}
 	const verboseObject = getVerboseObject({type, result, verboseInfo});
 	const printedLines = getPrintedLines(verboseMessage, verboseObject);
 	const finalLines = applyVerboseOnLines(printedLines, verboseInfo, fdNumber);
-	writeFileSync(STDERR_FD, finalLines);
+	process.stderr.write(finalLines);
 };
 
 const getVerboseObject = ({
@@ -34,9 +34,6 @@ const getPrintedLine = verboseObject => {
 	const verboseLine = defaultVerboseFunction(verboseObject);
 	return {verboseLine, verboseObject};
 };
-
-// Unless a `verbose` function is used, print all logs on `stderr`
-const STDERR_FD = 2;
 
 // Serialize any type to a line string, for logging
 export const serializeVerboseMessage = message => {

--- a/lib/verbose/log.js
+++ b/lib/verbose/log.js
@@ -1,4 +1,5 @@
 import process from 'node:process';
+import {writeFileSync} from 'node:fs';
 import {inspect} from 'node:util';
 import {escapeLines} from '../arguments/escape.js';
 import {defaultVerboseFunction} from './default.js';
@@ -9,7 +10,14 @@ export const verboseLog = ({type, verboseMessage, fdNumber, verboseInfo, result}
 	const verboseObject = getVerboseObject({type, result, verboseInfo});
 	const printedLines = getPrintedLines(verboseMessage, verboseObject);
 	const finalLines = applyVerboseOnLines(printedLines, verboseInfo, fdNumber);
-	process.stderr.write(finalLines);
+	// On Windows when stdout is pointing to a terminal writeFileSync causes problems with multibyte Characters not displaying correctly
+	// When stderr is pointing to console, the write command is allway behaving synchronously
+	if (process.platform === 'win32' && process.stderr.isTTY) {
+		process.stderr.write(finalLines);
+		return;
+	}
+
+	writeFileSync(STDERR_FD, finalLines);
 };
 
 const getVerboseObject = ({
@@ -34,6 +42,9 @@ const getPrintedLine = verboseObject => {
 	const verboseLine = defaultVerboseFunction(verboseObject);
 	return {verboseLine, verboseObject};
 };
+
+// Unless a `verbose` function is used, print all logs on `stderr`
+const STDERR_FD = 2;
 
 // Serialize any type to a line string, for logging
 export const serializeVerboseMessage = message => {


### PR DESCRIPTION
Running under Windows 11 and using Powershell i noticed, that unicode characters are not displayed correctly when using verbose logging.
For example the "✔" Symbol for the verbose doen message is displayed like "Ô£ö" on my system.
I noticed in the NodeJs Source code that process.stderr.write and writeFileSync are using different subsystems and it seems that writeFileSync is not playing nicely with terminals.
This Pull Request fixes the Problem for me.