### PR TITLE
Do not write verbose logs synchronously

### DIFF
--- a/lib/verbose/log.js
+++ b/lib/verbose/log.js
@@ -1,15 +1,23 @@
-import {writeFileSync} from 'node:fs';
 import {inspect} from 'node:util';
 import {escapeLines} from '../arguments/escape.js';
 import {defaultVerboseFunction} from './default.js';
 import {applyVerboseOnLines} from './custom.js';
 
-// Write synchronously to ensure lines are properly ordered and not interleaved with `stdout`
+// This prints on stderr.
+// If the subprocess prints on stdout and is using `stdout: 'inherit'`,
+// there is a chance both writes will compete (introducing a race condition).
+// This means their respective order is not deterministic.
+// In particular, this means the verbose command lines might be after the start of the subprocess output.
+// Using synchronous I/O does not solve this problem.
+// However, this only seems to happen when the stdout/stderr target
+// (e.g. a terminal) is being written to by many subprocesses at once, which is unlikely in real scenarios.
 export const verboseLog = ({type, verboseMessage, fdNumber, verboseInfo, result}) => {
 	const verboseObject = getVerboseObject({type, result, verboseInfo});
 	const printedLines = getPrintedLines(verboseMessage, verboseObject);
 	const finalLines = applyVerboseOnLines(printedLines, verboseInfo, fdNumber);
-	writeFileSync(STDERR_FD, finalLines);
+	if (finalLines !== '') {
+		console.warn(finalLines.slice(0, -1));
+	}
 };
 
 const getVerboseObject = ({
@@ -34,9 +42,6 @@ const getPrintedLine = verboseObject => {
 	const verboseLine = defaultVerboseFunction(verboseObject);
 	return {verboseLine, verboseObject};
 };
-
-// Unless a `verbose` function is used, print all logs on `stderr`
-const STDERR_FD = 2;
 
 // Serialize any type to a line string, for logging
 export const serializeVerboseMessage = message => {


### PR DESCRIPTION
Background in #1165 and #600.

When the `verbose` option is enabled, logs are printed on `stderr`. At the same time, the subprocess might print its output on `stdout` or `stderr`. To ensure that verbose logs are always printed in the same order when they interleave with the subprocess output, we are using synchronous I/O (`fs.writeFileSync(2, ...)`). 

Unfortunately, this does not work. That's because, even when `stderr` is written synchronously, it seems to be buffered by the OS. Since `stdout` and `stderr` are using different file descriptors, verbose logs might still be written out-of-order. 

At least, that's how I explain it, I could be wrong. The thing that's sure is that, when writing automated tests for this, the out-of-order problem was still clearly present.

The current solution using `fs.writeFileSync()` has several caveats:
  - It uses sync I/O, i.e. is poorer performance-wise.
  - As described in #1165, Node.js does not use the same logic with `fs.writeFileSync()` than with `process.stderr.write()`. In particular, it does not use some TTY-specific logic, which includes some UTF-8 to UTF-16 conversion on Windows. This leads to weird characters being printed on Windows. In general, I am not surprised `fs.writeFileSync(2, ...)` leads to weird behavior since this is quite an unusual way to write to a terminal's `stderr` which Node.js probably hasn't optimized for.
  - This is not benefiting from `console` which has some niceties when printing to a TTY (which verbose logs are likely to) such as [more graceful error handling](https://github.com/nodejs/node/blob/2a965493a97917a3c3f39766effe66c3f388544c/lib/internal/console/constructor.js#L282).

With all of this taken into account, this PR is reverting to using `console.warn()` (as opposed to `console.log()`, so we still print to `stderr`) instead of `fs.writeFileSync()`.