### PR TITLE
Bump cross-spawn npm ^7.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	],
 	"dependencies": {
 		"@sindresorhus/merge-streams": "^4.0.0",
-		"cross-spawn": "^7.0.3",
+		"cross-spawn": "^7.0.6",
 		"figures": "^6.1.0",
 		"get-stream": "^9.0.0",
 		"human-signals": "^8.0.0",


### PR DESCRIPTION
node-cross-spawn npm 7.0.3 has a bug, we have updated it to the latest 7.0.6.

Ref: https://github.com/moxystudio/node-cross-spawn/pull/166