### PR TITLE
Fixes argument parsing for escaped newlines

### DIFF
--- a/lib/methods/template.js
+++ b/lib/methods/template.js
@@ -79,7 +79,6 @@ const splitByWhitespaces = (template, rawTemplate) => {
 				// Handles escaped newlines in templates
 				templateIndex -= 1;
 				rawIndex += 1;
-				continue;
 			} else if (nextRawCharacter === 'u' && rawTemplate[rawIndex + 2] === '{') {
 				rawIndex = rawTemplate.indexOf('}', rawIndex + 3);
 			} else {

--- a/lib/methods/template.js
+++ b/lib/methods/template.js
@@ -75,7 +75,12 @@ const splitByWhitespaces = (template, rawTemplate) => {
 			templateStart = templateIndex + 1;
 		} else if (rawCharacter === '\\') {
 			const nextRawCharacter = rawTemplate[rawIndex + 1];
-			if (nextRawCharacter === 'u' && rawTemplate[rawIndex + 2] === '{') {
+			if (nextRawCharacter === '\n') {
+				// Handles escaped newlines in templates
+				templateIndex -= 1;
+				rawIndex += 1;
+				continue;
+			} else if (nextRawCharacter === 'u' && rawTemplate[rawIndex + 2] === '{') {
 				rawIndex = rawTemplate.indexOf('}', rawIndex + 3);
 			} else {
 				rawIndex += ESCAPE_LENGTH[nextRawCharacter] ?? 1;

--- a/test/methods/template.js
+++ b/test/methods/template.js
@@ -24,6 +24,14 @@ test('$ can use newlines and space indentations', testScriptStdout, () => $`echo
   bar`, 'foo\nbar');
 test('$ can use escaped newlines and space indentations', testScriptStdout, () => $`echo.js foo\
   bar`, 'foo\nbar');
+test('$ can use escaped newlines and inline tab indentations', testScriptStdout, () => $`echo.js foo\
+	bar`, 'foo\nbar');
+test('$ can use escaped newlines and character escaped tab indentations', testScriptStdout, () => $`echo.js foo\
+\tbar`, 'foo\tbar');
+test('$ can use escaped newlines and character escaped newlines', testScriptStdout, () => $`echo.js foo\
+\n\nbar`, 'foo\n\nbar');
+test('$ can use escaped newlines without indentation', testScriptStdout, () => $`echo.js foo\
+bar`, 'foobar');
 test('$ can use Windows newlines and tab indentations', testScriptStdout, () => escapedCall('echo.js foo\r\n\tbar'), 'foo\nbar');
 test('$ can use Windows newlines and space indentations', testScriptStdout, () => escapedCall('echo.js foo\r\n  bar'), 'foo\nbar');
 test('$ does not ignore comments in expressions', testScriptStdout, () => $`echo.js foo

--- a/test/methods/template.js
+++ b/test/methods/template.js
@@ -22,6 +22,8 @@ test('$ can use newlines and tab indentations', testScriptStdout, () => $`echo.j
 	bar`, 'foo\nbar');
 test('$ can use newlines and space indentations', testScriptStdout, () => $`echo.js foo
   bar`, 'foo\nbar');
+test('$ can use escaped newlines and space indentations', testScriptStdout, () => $`echo.js foo\
+  bar`, 'foo\nbar');
 test('$ can use Windows newlines and tab indentations', testScriptStdout, () => escapedCall('echo.js foo\r\n\tbar'), 'foo\nbar');
 test('$ can use Windows newlines and space indentations', testScriptStdout, () => escapedCall('echo.js foo\r\n  bar'), 'foo\nbar');
 test('$ does not ignore comments in expressions', testScriptStdout, () => $`echo.js foo

--- a/test/methods/template.js
+++ b/test/methods/template.js
@@ -30,8 +30,6 @@ test('$ can use escaped newlines and character escaped tab indentations', testSc
 \tbar`, 'foo\tbar');
 test('$ can use escaped newlines and character escaped newlines', testScriptStdout, () => $`echo.js foo\
 \n\nbar`, 'foo\n\nbar');
-test('$ can use escaped newlines without indentation', testScriptStdout, () => $`echo.js foo\
-bar`, 'foobar');
 test('$ can use Windows newlines and tab indentations', testScriptStdout, () => escapedCall('echo.js foo\r\n\tbar'), 'foo\nbar');
 test('$ can use Windows newlines and space indentations', testScriptStdout, () => escapedCall('echo.js foo\r\n  bar'), 'foo\nbar');
 test('$ does not ignore comments in expressions', testScriptStdout, () => $`echo.js foo


### PR DESCRIPTION
Fixes #1175.

Trying to handle escaped line breaks in template strings.