### PR TITLE
Update cross-spawn version

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	],
 	"dependencies": {
 		"@sindresorhus/merge-streams": "^4.0.0",
-		"cross-spawn": "^7.0.3",
+		"cross-spawn": "^7.0.6",
 		"figures": "^6.1.0",
 		"get-stream": "^9.0.0",
 		"human-signals": "^8.0.0",


### PR DESCRIPTION
cross-spawn 7.0.3 has a critical vulnerability https://avd.aquasec.com/nvd/2024/cve-2024-21538/