### PR TITLE
[docs] A process is not a TTY usually, just connected to one.

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -95,7 +95,7 @@ const {stdout} = await execa({stdout: ['inherit', {file: 'output.txt'}, 'pipe']}
 console.log(stdout);
 ```
 
-When combining [`'inherit'`](#terminal-output) with other values, please note that the subprocess will not be an interactive TTY, even if the current process is one.
+When combining [`'inherit'`](#terminal-output) with other values, please note that the subprocess will not be connected to an interactive TTY, even if the current process is.
 
 ## Interleaved output
 


### PR DESCRIPTION
I guess you meant that the TTY is connected.

Maybe we should clarify whether the loss of TTY control applies only to stdin/stdout/stderr, as the docs page only talks about those. I'd assume that TTYs on file descriptors 3 and up are inherited without interference, but it would be nice to have an explicit guarantee.