### PR TITLE
Export `VerboseOption`, since it's imported in another file

### DIFF
--- a/types/verbose.d.ts
+++ b/types/verbose.d.ts
@@ -2,7 +2,7 @@ import type {FdGenericOption} from './arguments/specific.js';
 import type {Options, SyncOptions} from './arguments/options.js';
 import type {Result, SyncResult} from './return/result.js';
 
-type VerboseOption = FdGenericOption<
+export type VerboseOption = FdGenericOption<
 | 'none'
 | 'short'
 | 'full'


### PR DESCRIPTION
We use `execa` in Storybook, and we ran into an issue where the type definitions are not valid.