### PR TITLE
Ensure all `d.ts` files are considered as ESM

### DIFF
--- a/types/arguments/encoding-option.d.ts
+++ b/types/arguments/encoding-option.d.ts
@@ -17,3 +17,5 @@ export type EncodingOption =
 	| TextEncodingOption
 	| BinaryEncodingOption
 	| undefined;
+
+export {};

--- a/types/arguments/fd-options.d.ts
+++ b/types/arguments/fd-options.d.ts
@@ -6,3 +6,5 @@ export type FromOption = 'stdout' | 'stderr' | 'all' | FileDescriptorOption;
 
 // `to` option of `subprocess.writable|duplex|pipe()`
 export type ToOption = 'stdin' | FileDescriptorOption;
+
+export {};

--- a/types/arguments/options.d.ts
+++ b/types/arguments/options.d.ts
@@ -398,3 +398,5 @@ export type StricterOptions<
 	WideOptions extends CommonOptions,
 	StrictOptions extends CommonOptions,
 > = WideOptions extends StrictOptions ? WideOptions : StrictOptions;
+
+export {};

--- a/types/arguments/specific.d.ts
+++ b/types/arguments/specific.d.ts
@@ -50,3 +50,5 @@ type FdNumberToFromOption<
 			: 'ipc' extends GenericOptionKeys
 				? 'ipc'
 				: never;
+
+export {};

--- a/types/convert.d.ts
+++ b/types/convert.d.ts
@@ -56,3 +56,5 @@ EncodingOption extends BinaryEncodingOption
 		? Uint8Array
 		: string
 >;
+
+export {};

--- a/types/ipc.d.ts
+++ b/types/ipc.d.ts
@@ -154,3 +154,5 @@ type HasIpcOption<
 				? true
 				: false
 			: true;
+
+export {};

--- a/types/methods/command.d.ts
+++ b/types/methods/command.d.ts
@@ -112,3 +112,5 @@ await execa(file, commandArguments);
 ```
 */
 export function parseCommandString(command: string): string[];
+
+export {};

--- a/types/methods/main-async.d.ts
+++ b/types/methods/main-async.d.ts
@@ -377,3 +377,5 @@ type ExecaArrayLong<OptionsType extends Options> =
 type ExecaArrayShort<OptionsType extends Options> =
 	<NewOptionsType extends Options = {}>(file: string | URL, options?: NewOptionsType)
 	=> ResultPromise<OptionsType & NewOptionsType>;
+
+export {};

--- a/types/methods/main-sync.d.ts
+++ b/types/methods/main-sync.d.ts
@@ -57,3 +57,5 @@ type ExecaSyncArrayLong<OptionsType extends SyncOptions> =
 type ExecaSyncArrayShort<OptionsType extends SyncOptions> =
 	<NewOptionsType extends SyncOptions = {}>(file: string | URL, options?: NewOptionsType)
 	=> SyncResult<OptionsType & NewOptionsType>;
+
+export {};

--- a/types/methods/node.d.ts
+++ b/types/methods/node.d.ts
@@ -60,3 +60,5 @@ type ExecaNodeArrayLong<OptionsType extends Options> =
 type ExecaNodeArrayShort<OptionsType extends Options> =
 	<NewOptionsType extends Options = {}>(scriptPath: string | URL, options?: NewOptionsType)
 	=> ResultPromise<OptionsType & NewOptionsType>;
+
+export {};

--- a/types/methods/script.d.ts
+++ b/types/methods/script.d.ts
@@ -113,3 +113,5 @@ type ExecaScriptSyncArrayLong<OptionsType extends CommonOptions> =
 type ExecaScriptSyncArrayShort<OptionsType extends CommonOptions> =
 	<NewOptionsType extends SyncOptions = {}>(file: string | URL, options?: NewOptionsType)
 	=> SyncResult<StricterOptions<OptionsType & NewOptionsType, SyncOptions>>;
+
+export {};

--- a/types/methods/template.d.ts
+++ b/types/methods/template.d.ts
@@ -16,3 +16,5 @@ export type TemplateString = readonly [TemplateStringsArray, ...readonly Templat
 
 // `...${...}...` template syntax, but only allowing a single argument, for `execaCommand()`
 export type SimpleTemplateString = readonly [TemplateStringsArray, string?];
+
+export {};

--- a/types/pipe.d.ts
+++ b/types/pipe.d.ts
@@ -56,3 +56,5 @@ export type PipableSubprocess = {
 	pipe<Destination extends ResultPromise>(destination: Destination, options?: PipeOptions):
 	Promise<Awaited<Destination>> & PipableSubprocess;
 };
+
+export {};

--- a/types/return/final-error.d.ts
+++ b/types/return/final-error.d.ts
@@ -49,3 +49,5 @@ This has the same shape as successful results, with a few additional properties.
 export class ExecaSyncError<OptionsType extends SyncOptions = SyncOptions> extends CommonError<true, OptionsType> {
 	readonly name: 'ExecaSyncError';
 }
+
+export {};

--- a/types/return/ignore.d.ts
+++ b/types/return/ignore.d.ts
@@ -24,3 +24,5 @@ type IgnoresOutput<
 	FdNumber extends string,
 	StdioOptionType,
 > = StdioOptionType extends NoStreamStdioOption<FdNumber> ? true : false;
+
+export {};

--- a/types/return/result-all.d.ts
+++ b/types/return/result-all.d.ts
@@ -28,3 +28,5 @@ type AllObjectFd<OptionsType extends CommonOptions> =
 
 type AllLinesFd<OptionsType extends CommonOptions> =
 	FdSpecificOption<OptionsType['lines'], '1'> extends true ? '1' : '2';
+
+export {};

--- a/types/return/result-ipc.d.ts
+++ b/types/return/result-ipc.d.ts
@@ -25,3 +25,5 @@ type ResultIpcAsync<
 	: IpcEnabled extends true
 		? Array<Message<SerializationOption>>
 		: [];
+
+export {};

--- a/types/return/result-stdio.d.ts
+++ b/types/return/result-stdio.d.ts
@@ -15,3 +15,5 @@ type MapResultStdio<
 	OptionsType
 	>
 };
+
+export {};

--- a/types/return/result-stdout.d.ts
+++ b/types/return/result-stdout.d.ts
@@ -48,3 +48,5 @@ type ResultStdioItem<
 				? string
 				: string[]
 			: string;
+
+export {};

--- a/types/return/result.d.ts
+++ b/types/return/result.d.ts
@@ -201,3 +201,5 @@ Result of a subprocess successful execution.
 When the subprocess fails, it is rejected with an `ExecaError` instead.
 */
 export type SyncResult<OptionsType extends SyncOptions = SyncOptions> = SuccessResult<true, OptionsType>;
+
+export {};

--- a/types/stdio/array.d.ts
+++ b/types/stdio/array.d.ts
@@ -14,3 +14,5 @@ type StdioOptionNormalized<StdioOption extends CommonOptions['stdio']> = StdioOp
 
 // `options.stdio` default value
 type DefaultStdioOption = readonly ['pipe', 'pipe', 'pipe'];
+
+export {};

--- a/types/stdio/direction.d.ts
+++ b/types/stdio/direction.d.ts
@@ -10,3 +10,5 @@ export type IsInputFd<
 > = FdNumber extends '0'
 	? true
 	: Intersects<StdioSingleOptionItems<FdStdioArrayOption<FdNumber, OptionsType>>, InputStdioOption>;
+
+export {};

--- a/types/stdio/option.d.ts
+++ b/types/stdio/option.d.ts
@@ -38,3 +38,5 @@ type FdStdioArrayOptionProperty<
 				? StdioOptionsType[number]
 				: undefined
 		: undefined;
+
+export {};

--- a/types/stdio/type.d.ts
+++ b/types/stdio/type.d.ts
@@ -168,3 +168,5 @@ export type StdioOptionsArray<IsSync extends boolean = boolean> = readonly [
 export type StdioOptionsProperty<IsSync extends boolean = boolean> =
 	| SimpleStdioOption<IsSync, false, false>
 	| StdioOptionsArray<IsSync>;
+
+export {};

--- a/types/subprocess/all.d.ts
+++ b/types/subprocess/all.d.ts
@@ -15,3 +15,5 @@ type AllIgnored<
 		? IgnoresSubprocessOutput<'2', OptionsType>
 		: false
 	: true;
+
+export {};

--- a/types/subprocess/stdio.d.ts
+++ b/types/subprocess/stdio.d.ts
@@ -16,3 +16,5 @@ type MapStdioStreams<
 	'3' extends keyof StdioOptionsArrayType ? SubprocessStdioStream<'3', OptionsType> : never,
 	'4' extends keyof StdioOptionsArrayType ? SubprocessStdioStream<'4', OptionsType> : never,
 ];
+
+export {};

--- a/types/subprocess/stdout.d.ts
+++ b/types/subprocess/stdout.d.ts
@@ -20,3 +20,5 @@ type SubprocessStream<
 type InputOutputStream<IsInput extends boolean> = IsInput extends true
 	? Writable
 	: Readable;
+
+export {};

--- a/types/subprocess/subprocess.d.ts
+++ b/types/subprocess/subprocess.d.ts
@@ -115,3 +115,5 @@ The return value of all asynchronous methods is both:
 export type ResultPromise<OptionsType extends Options = Options> =
 	& Subprocess<OptionsType>
 	& Promise<Result<OptionsType>>;
+
+export {};

--- a/types/transform/normalize.d.ts
+++ b/types/transform/normalize.d.ts
@@ -55,3 +55,5 @@ export type DuplexTransform = {
 export type WebTransform = {
 	readonly transform: TransformStream;
 } & TransformCommon;
+
+export {};

--- a/types/transform/object-mode.d.ts
+++ b/types/transform/object-mode.d.ts
@@ -19,3 +19,5 @@ type IsObjectStdioSingleOption<StdioSingleOptionType> = StdioSingleOptionType ex
 		: false;
 
 type BooleanObjectMode<ObjectModeOption extends boolean | undefined> = ObjectModeOption extends true ? true : false;
+
+export {};

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -11,3 +11,5 @@ export type AndUnless<Condition extends boolean, ThenValue, ElseValue = unknown>
 // Whether any of T's union element is the same as one of U's union element.
 // `&` does not work here.
 export type Intersects<T, U> = true extends (T extends U ? true : false) ? true : false;
+
+export {};

--- a/types/verbose.d.ts
+++ b/types/verbose.d.ts
@@ -96,3 +96,5 @@ export type SyncVerboseObject = GenericVerboseObject & {
 	*/
 	result?: SyncResult;
 };
+
+export {};


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/issues/57764

We had to do the same thing in type-fest: https://github.com/sindresorhus/type-fest/pull/1244

If we had this, it would have caught: https://github.com/sindresorhus/execa/commit/7891c39441c5a6d0fca4be696c0c1cf0b746fa1e