### PR TITLE
[docs] add warnings about input, stdin, and stdio

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -759,6 +759,9 @@ _Type:_ `object`
 
 This lists all options for [`execa()`](#execafile-arguments-options) and the [other methods](#methods).
 
+> [!IMPORTANT] Differences from `child_process.spawn` API
+> - `stdio: [..., 'ipc']` is deprecated and will produce a runtime error in version 10
+
 The following options [can specify different values](output.md#stdoutstderr-specific-options) for [`stdout`](#optionsstdout) and [`stderr`](#optionsstderr): [`verbose`](#optionsverbose), [`lines`](#optionslines), [`stripFinalNewline`](#optionsstripfinalnewline), [`buffer`](#optionsbuffer), [`maxBuffer`](#optionsmaxbuffer).
 
 ### options.preferLocal
@@ -865,6 +868,10 @@ Write some input to the subprocess' [`stdin`](https://en.wikipedia.org/wiki/Stan
 
 See also the [`inputFile`](#optionsinputfile) and [`stdin`](#optionsstdin) options.
 
+> [!NOTE]
+> Be careful when combining `input` with `stdin: 'inherit'` or `stdio: 'inherit'`;
+> See [this section](input.md#combining-input-with-stdin-inherit) for details.
+
 [More info.](input.md#string-input)
 
 ### options.inputFile
@@ -876,6 +883,10 @@ Use a file as input to the subprocess' [`stdin`](https://en.wikipedia.org/wiki/S
 See also the [`input`](#optionsinput) and [`stdin`](#optionsstdin) options.
 
 [More info.](input.md#file-input)
+
+> [!NOTE]
+> Be careful when combining `inputFile` with `stdin: 'inherit'` or `stdio: 'inherit'`;
+> See [this section](input.md#combining-input-with-stdin-inherit) for details.
 
 ### options.stdin
 
@@ -924,6 +935,9 @@ Like the [`stdin`](#optionsstdin), [`stdout`](#optionsstdout) and [`stderr`](#op
 A single string can be used [as a shortcut](output.md#shortcut).
 
 The array can have more than 3 items, to create [additional file descriptors](output.md#additional-file-descriptors) beyond [`stdin`](#optionsstdin)/[`stdout`](#optionsstdout)/[`stderr`](#optionsstderr).
+
+> [!IMPORTANT] Differences from `child_process.spawn` API
+> - `stdio: [..., 'ipc']` is deprecated and will produce a runtime error in version 10
 
 More info on [available values](output.md), [streaming](streams.md) and [transforms](transform.md).
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -58,6 +58,10 @@ If the input is already available as a string, it can be passed directly to the 
 await execa({input: 'stdinInput'})`npm run scaffold`;
 ```
 
+> [!NOTE]
+> Be careful when combining `input` with `stdin: 'inherit'` or `stdio: 'inherit'`;
+> See [this section](#combining-input-with-stdin-inherit) for details.
+
 The [`stdin`](api.md#optionsstdin) option can also be used, although the string must be wrapped in two arrays for [syntax reasons](output.md#multiple-targets).
 
 ```js
@@ -82,6 +86,10 @@ await execa({stdin: {file: 'input.txt'}})`npm run scaffold`;
 await execa({stdin: new URL('file:///path/to/input.txt')})`npm run scaffold`;
 ```
 
+> [!NOTE]
+> Be careful when combining `inputFile` with `stdin: 'inherit'` or `stdio: 'inherit'`;
+> See [this section](#combining-input-with-stdin-inherit) for details.
+
 ## Terminal input
 
 The parent process' input can be re-used in the subprocess by passing `'inherit'`. This is especially useful to receive interactive input in command line applications.
@@ -89,6 +97,10 @@ The parent process' input can be re-used in the subprocess by passing `'inherit'
 ```js
 await execa({stdin: 'inherit'})`npm run scaffold`;
 ```
+
+> [!NOTE]
+> Be careful when combining `input` with `stdin: 'inherit'` or `stdio: 'inherit'`;
+> See [this section](#combining-input-with-stdin-inherit) for details.
 
 ## Any input type
 
@@ -114,6 +126,9 @@ const ipcInput = await getOneMessage();
 
 ## Additional file descriptors
 
+> [!IMPORTANT] Differences from `child_process.spawn` API
+> - `stdio: [..., 'ipc']` is deprecated and will produce a runtime error in version 10
+
 The [`stdio`](api.md#optionsstdio) option can be used to pass some input to any [file descriptor](https://en.wikipedia.org/wiki/File_descriptor), as opposed to only [`stdin`](api.md#optionsstdin).
 
 ```js
@@ -122,6 +137,19 @@ await execa({
 	stdio: ['pipe', 'pipe', 'pipe', new Uint8Array([/* ... */])],
 })`npm run build`;
 ```
+
+## Combining `input` with `stdin: 'inherit'` 
+
+> [!WARNING]
+> If `input` and `stdin: 'inherit'` (or `stdio: 'inherit'` or `stdio: ['inherit', ...]`) are combined,
+> the child will not inherit the parent's `stdin` and `execa` will pipe both `input` and the parent's
+> `stdin` to the child's `stdin`.
+>
+> Therefore the child's `stdin` will not be a TTY and will not close before the parent's `process.stdin`
+> in this case.
+>
+> Version 10 will drop the behavior of piping the parent's `process.stdin` to the child, hence its `stdin`
+> will close once `input` has been piped.
 
 <hr>
 


### PR DESCRIPTION
- warn about and explain behavior when combining `input`/`fileInput` with `stdin: 'inherit'` or `stdio: 'inherit'`
- warn about upcoming `stdio: [..., 'ipc']` deprecation

fix #1218
