### PR TITLE
Harden against prototype pollution

### DIFF
--- a/lib/arguments/options.js
+++ b/lib/arguments/options.js
@@ -17,8 +17,10 @@ import {normalizeFdSpecificOptions} from './specific.js';
 // Normalize the options object, and sometimes also the file paths and arguments.
 // Applies default values, validate allowed options, normalize them.
 export const normalizeOptions = (filePath, rawArguments, rawOptions) => {
-	rawOptions.cwd = normalizeCwd(rawOptions.cwd);
-	const [processedFile, processedArguments, processedOptions] = handleNodeOption(filePath, rawArguments, rawOptions);
+	// Prevent prototype pollution by copying only own properties to a null-prototype object
+	const sanitizedOptions = {__proto__: null, ...rawOptions};
+	sanitizedOptions.cwd = normalizeCwd(sanitizedOptions.cwd);
+	const [processedFile, processedArguments, processedOptions] = handleNodeOption(filePath, rawArguments, sanitizedOptions);
 
 	const {command: file, args: commandArguments, options: initialOptions} = crossSpawn._parse(processedFile, processedArguments, processedOptions);
 
@@ -43,6 +45,7 @@ export const normalizeOptions = (filePath, rawArguments, rawOptions) => {
 	return {file, commandArguments, options};
 };
 
+// Use null prototype to prevent prototype pollution from leaking through
 const addDefaultOptions = ({
 	extendEnv = true,
 	preferLocal = false,
@@ -61,6 +64,7 @@ const addDefaultOptions = ({
 	serialization = 'advanced',
 	...options
 }) => ({
+	__proto__: null,
 	...options,
 	extendEnv,
 	preferLocal,

--- a/lib/methods/bind.js
+++ b/lib/methods/bind.js
@@ -2,14 +2,16 @@ import isPlainObject from 'is-plain-obj';
 import {FD_SPECIFIC_OPTIONS} from '../arguments/specific.js';
 
 // Deep merge specific options like `env`. Shallow merge the other ones.
+// Use spread (which only copies own properties) to safely read from boundOptions without prototype pollution
 export const mergeOptions = (boundOptions, options) => {
-	const newOptions = Object.fromEntries(
+	const safeBoundOptions = {__proto__: null, ...boundOptions};
+	const mergedOptions = Object.fromEntries(
 		Object.entries(options).map(([optionName, optionValue]) => [
 			optionName,
-			mergeOption(optionName, boundOptions[optionName], optionValue),
+			mergeOption(optionName, safeBoundOptions[optionName], optionValue),
 		]),
 	);
-	return {...boundOptions, ...newOptions};
+	return {...safeBoundOptions, ...mergedOptions};
 };
 
 const mergeOption = (optionName, boundOptionValue, optionValue) => {

--- a/lib/methods/node.js
+++ b/lib/methods/node.js
@@ -28,7 +28,10 @@ export const handleNodeOption = (file, commandArguments, {
 
 	const normalizedNodePath = safeNormalizeFileUrl(nodePath, 'The "nodePath" option');
 	const resolvedNodePath = path.resolve(cwd, normalizedNodePath);
+	// Use spread (which only copies own properties) to safely get shell without reading polluted prototype
 	const newOptions = {
+		__proto__: null,
+		shell: false,
 		...options,
 		nodePath: resolvedNodePath,
 		node: shouldHandleNode,
@@ -45,7 +48,16 @@ export const handleNodeOption = (file, commandArguments, {
 
 	return [
 		resolvedNodePath,
-		[...nodeOptions, file, ...commandArguments],
-		{ipc: true, ...newOptions, shell: false},
+		[
+			...nodeOptions,
+			file,
+			...commandArguments,
+		],
+		{
+			__proto__: null,
+			ipc: true,
+			...newOptions,
+			shell: false,
+		},
 	];
 };

--- a/lib/methods/parameters.js
+++ b/lib/methods/parameters.js
@@ -27,5 +27,6 @@ export const normalizeParameters = (rawFile, rawArguments = [], rawOptions = {})
 		throw new TypeError(`Last argument must be an options object: ${options}`);
 	}
 
-	return [filePath, normalizedArguments, options];
+	// Prevent prototype pollution by copying only own properties to a null-prototype object
+	return [filePath, normalizedArguments, {__proto__: null, ...options}];
 };


### PR DESCRIPTION
This is not fixing any vulnerability since prototype pollution is a app-level concern, but we can be nice and harden it in case the app makes such a mistake.