### PR TITLE
Add ReadableStream and WritableStream to NoStreamStdioOption

### DIFF
--- a/types/stdio/type.d.ts
+++ b/types/stdio/type.d.ts
@@ -26,6 +26,8 @@ export type NoStreamStdioOption<FdNumber extends string> =
 	| number
 	| Readable
 	| Writable
+	| ReadableStream
+	| WritableStream
 	| Unless<IsStandardStream<FdNumber>, undefined>
 	| readonly [NoStreamStdioOption<FdNumber>];
 


### PR DESCRIPTION
Not 100% sure about this one, but when passing a `WritableStream` for stdout/stderr, it doesn't flag those variables as possibly undefined. My understanding is that the streams are pretty much equivalent when it comes to collecting the output or not.