### PR TITLE
Fix input with inherited stdin

### DIFF
--- a/lib/stdio/handle.js
+++ b/lib/stdio/handle.js
@@ -61,9 +61,10 @@ const getFileDescriptor = ({stdioOption, fdNumber, options, isSync}) => {
 // For example, `stdout: ['ignore']` behaves the same as `stdout: 'ignore'`.
 const initializeStdioItems = ({stdioOption, fdNumber, options, optionName}) => {
 	const values = Array.isArray(stdioOption) ? stdioOption : [stdioOption];
+	const inputStdioItems = handleInputOptions(options, fdNumber);
 	const initialStdioItems = [
-		...values.map(value => initializeStdioItem(value, optionName)),
-		...handleInputOptions(options, fdNumber),
+		...omitInheritedStdin(values.map(value => initializeStdioItem(value, optionName)), inputStdioItems),
+		...inputStdioItems,
 	];
 
 	const stdioItems = filterDuplicates(initialStdioItems);
@@ -72,6 +73,14 @@ const initializeStdioItems = ({stdioOption, fdNumber, options, optionName}) => {
 	validateStreams(stdioItems);
 	return {stdioItems, isStdioArray};
 };
+
+const omitInheritedStdin = (stdioItems, inputStdioItems) => inputStdioItems.length > 0 && isInheritedStdinOnly(stdioItems)
+	? []
+	: stdioItems;
+
+const isInheritedStdinOnly = stdioItems => stdioItems.length === 1
+	&& stdioItems[0].type === 'native'
+	&& stdioItems[0].value === 'inherit';
 
 const initializeStdioItem = (value, optionName) => ({
 	type: getStdioItemType(value, optionName),

--- a/test/fixtures/nested-input-inherit.js
+++ b/test/fixtures/nested-input-inherit.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import {execa, execaSync} from '../../index.js';
+import {foobarString} from '../helpers/input.js';
+
+const [optionName, stdioOptionString, isSyncString] = process.argv.slice(2);
+const execaMethod = isSyncString === 'true' ? execaSync : execa;
+const options = {
+	input: foobarString,
+	[optionName]: JSON.parse(stdioOptionString),
+};
+
+if (optionName === 'stdin') {
+	options.stdout = 'inherit';
+}
+
+await execaMethod('stdin.js', options);

--- a/test/io/input-option.js
+++ b/test/io/input-option.js
@@ -9,6 +9,7 @@ import {
 	runScriptSync,
 } from '../helpers/run.js';
 import {
+	foobarString,
 	foobarUint8Array,
 	foobarBuffer,
 	foobarArrayBuffer,
@@ -31,6 +32,20 @@ test('input option can be a Uint8Array - sync', testInput, foobarUint8Array, run
 test('input option can be a Buffer - sync', testInput, foobarBuffer, runExecaSync);
 test('input option can be used with $', testInput, 'foobar', runScript);
 test('input option can be used with $.sync', testInput, 'foobar', runScriptSync);
+
+const testInputIgnoresInheritedStdin = async (t, optionName, stdioOption, isSync) => {
+	const {stdout} = await execa('nested-input-inherit.js', [optionName, JSON.stringify(stdioOption), `${isSync}`], {input: foobarString});
+	t.is(stdout, foobarString);
+};
+
+test('input option ignores stdin "inherit"', testInputIgnoresInheritedStdin, 'stdin', 'inherit', false);
+test('input option ignores stdin ["inherit"]', testInputIgnoresInheritedStdin, 'stdin', ['inherit'], false);
+test('input option ignores stdio "inherit"', testInputIgnoresInheritedStdin, 'stdio', 'inherit', false);
+test('input option ignores stdio[0] "inherit"', testInputIgnoresInheritedStdin, 'stdio', ['inherit', 'inherit', 'pipe'], false);
+test.serial('input option ignores stdin "inherit" - sync', testInputIgnoresInheritedStdin, 'stdin', 'inherit', true);
+test.serial('input option ignores stdin ["inherit"] - sync', testInputIgnoresInheritedStdin, 'stdin', ['inherit'], true);
+test.serial('input option ignores stdio "inherit" - sync', testInputIgnoresInheritedStdin, 'stdio', 'inherit', true);
+test.serial('input option ignores stdio[0] "inherit" - sync', testInputIgnoresInheritedStdin, 'stdio', ['inherit', 'inherit', 'pipe'], true);
 
 const testInvalidInput = async (t, input, execaMethod) => {
 	t.throws(() => {


### PR DESCRIPTION
Fixes #1219

## Summary
- Ignore a singular inherited stdin source when `input` or `inputFile` is provided, so explicit input becomes the only stdin source.
- Preserve explicit multi-source stdin arrays such as `['inherit', 'pipe']`.
- Add nested regression coverage for `stdin` and `stdio` forms in async and sync modes.

## Tests
- `npm_config_cache=/tmp/execa-npm-cache npx ava test/io/input-option.js --match='*input option ignores*'`
- `npm_config_cache=/tmp/execa-npm-cache npx ava test/io/input-option.js test/stdio/native-inherit-pipe.js test/stdio/file-path-main.js`
- `npm_config_cache=/tmp/execa-npm-cache npm run lint`
- `npm_config_cache=/tmp/execa-npm-cache npm run type`
- `git diff --check`