### PR TITLE
ci: add Node.js 26 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 26
           - 24
           - 18
         os:


### PR DESCRIPTION
## Summary

- Add Node.js 26 to the CI matrix on ubuntu, macos, and windows
- Keeps existing Node 18 and 24 jobs unchanged

Fixes #1233

## Test plan

- [ ] CI passes on Node 26 (ubuntu, macos, windows)