### PR TITLE
fix(deps): upgrade ava 6.3.0 → 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,105 +1,105 @@
 {
-	"name": "execa",
-	"version": "9.6.1",
-	"description": "Process execution for humans",
-	"license": "MIT",
-	"repository": "sindresorhus/execa",
-	"funding": "https://github.com/sindresorhus/execa?sponsor=1",
-	"author": {
-		"name": "Sindre Sorhus",
-		"email": "sindresorhus@gmail.com",
-		"url": "https://sindresorhus.com"
-	},
-	"type": "module",
-	"exports": {
-		"types": "./index.d.ts",
-		"default": "./index.js"
-	},
-	"sideEffects": false,
-	"engines": {
-		"node": "^18.19.0 || >=20.5.0"
-	},
-	"scripts": {
-		"test": "npm run lint && npm run unit && npm run type",
-		"lint": "xo",
-		"unit": "c8 --merge-async ava",
-		"type": "tsd && tsc && npx --yes tsd@0.29.0 && npx --yes --package typescript@5.1 tsc"
-	},
-	"files": [
-		"index.js",
-		"index.d.ts",
-		"lib/**/*.js",
-		"types/**/*.ts"
-	],
-	"keywords": [
-		"exec",
-		"child",
-		"process",
-		"subprocess",
-		"execute",
-		"fork",
-		"execfile",
-		"spawn",
-		"file",
-		"shell",
-		"bin",
-		"binary",
-		"binaries",
-		"npm",
-		"path",
-		"local",
-		"zx"
-	],
-	"dependencies": {
-		"@sindresorhus/merge-streams": "^4.0.0",
-		"cross-spawn": "^7.0.6",
-		"figures": "^6.1.0",
-		"get-stream": "^9.0.0",
-		"human-signals": "^8.0.1",
-		"is-plain-obj": "^4.1.0",
-		"is-stream": "^4.0.1",
-		"npm-run-path": "^6.0.0",
-		"pretty-ms": "^9.2.0",
-		"signal-exit": "^4.1.0",
-		"strip-final-newline": "^4.0.0",
-		"yoctocolors": "^2.1.1"
-	},
-	"devDependencies": {
-		"@types/node": "^22.15.21",
-		"ava": "^6.3.0",
-		"c8": "^10.1.3",
-		"get-node": "^15.0.3",
-		"is-in-ci": "^1.0.0",
-		"is-running": "^2.1.0",
-		"log-process-errors": "^12.0.1",
-		"path-exists": "^5.0.0",
-		"path-key": "^4.0.0",
-		"tempfile": "^5.0.0",
-		"tsd": "^0.32.0",
-		"typescript": "^5.8.3",
-		"which": "^5.0.0",
-		"xo": "^0.60.0"
-	},
-	"c8": {
-		"reporter": [
-			"text",
-			"lcov"
-		],
-		"exclude": [
-			"**/fixtures/**",
-			"**/test.js",
-			"**/test/**"
-		]
-	},
-	"ava": {
-		"workerThreads": false,
-		"concurrency": 1,
-		"timeout": "240s"
-	},
-	"xo": {
-		"rules": {
-			"unicorn/no-empty-file": "off",
-			"@typescript-eslint/ban-types": "off"
-		}
-	}
+  "name": "execa",
+  "version": "9.6.1",
+  "description": "Process execution for humans",
+  "license": "MIT",
+  "repository": "sindresorhus/execa",
+  "funding": "https://github.com/sindresorhus/execa?sponsor=1",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com"
+  },
+  "type": "module",
+  "exports": {
+    "types": "./index.d.ts",
+    "default": "./index.js"
+  },
+  "sideEffects": false,
+  "engines": {
+    "node": "^18.19.0 || >=20.5.0"
+  },
+  "scripts": {
+    "test": "npm run lint && npm run unit && npm run type",
+    "lint": "xo",
+    "unit": "c8 --merge-async ava",
+    "type": "tsd && tsc && npx --yes tsd@0.29.0 && npx --yes --package typescript@5.1 tsc"
+  },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "lib/**/*.js",
+    "types/**/*.ts"
+  ],
+  "keywords": [
+    "exec",
+    "child",
+    "process",
+    "subprocess",
+    "execute",
+    "fork",
+    "execfile",
+    "spawn",
+    "file",
+    "shell",
+    "bin",
+    "binary",
+    "binaries",
+    "npm",
+    "path",
+    "local",
+    "zx"
+  ],
+  "dependencies": {
+    "@sindresorhus/merge-streams": "^4.0.0",
+    "cross-spawn": "^7.0.6",
+    "figures": "^6.1.0",
+    "get-stream": "^9.0.0",
+    "human-signals": "^8.0.1",
+    "is-plain-obj": "^4.1.0",
+    "is-stream": "^4.0.1",
+    "npm-run-path": "^6.0.0",
+    "pretty-ms": "^9.2.0",
+    "signal-exit": "^4.1.0",
+    "strip-final-newline": "^4.0.0",
+    "yoctocolors": "^2.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.21",
+    "ava": "^8.0.1",
+    "c8": "^10.1.3",
+    "get-node": "^15.0.3",
+    "is-in-ci": "^1.0.0",
+    "is-running": "^2.1.0",
+    "log-process-errors": "^12.0.1",
+    "path-exists": "^5.0.0",
+    "path-key": "^4.0.0",
+    "tempfile": "^5.0.0",
+    "tsd": "^0.32.0",
+    "typescript": "^5.8.3",
+    "which": "^5.0.0",
+    "xo": "^0.60.0"
+  },
+  "c8": {
+    "reporter": [
+      "text",
+      "lcov"
+    ],
+    "exclude": [
+      "**/fixtures/**",
+      "**/test.js",
+      "**/test/**"
+    ]
+  },
+  "ava": {
+    "workerThreads": false,
+    "concurrency": 1,
+    "timeout": "240s"
+  },
+  "xo": {
+    "rules": {
+      "unicorn/no-empty-file": "off",
+      "@typescript-eslint/ban-types": "off"
+    }
+  }
 }


### PR DESCRIPTION
## What
Upgrades `ava` from `6.3.0` to `8.0.1`.

## Why
The functionality affected includes test imports, configuration settings for extensions, compatibility with older Node.js versions, and test filtering behavior, posing a medium risk of breaking existing tests and configurations.

## 🔴 Confidence: 48/100 (low) — calibrated
Signals: changelog parsing + semantic API diffing (`dts`, 100% coverage)

Opened as **Draft** because the score is below your configured threshold — please review and mark ready when validated.

Per-symbol breakdown:
- `.only() behavior` — 48/100 · needs manual verification
- `extensions configuration object` — 48/100 · needs manual verification
- `Node.js support` — 48/100 · needs manual verification
- `require('ava')` — 48/100 · needs manual verification

## Evidence
- [require('ava') (renamed)](https://github.com/avajs/ava/releases): The way to import AVA has changed for CommonJS projects. You must now use 'const {default: test} = require('ava');' instead of 'const test = require('ava');'.
- [extensions configuration object (removed)](https://github.com/avajs/ava/releases): The object form of the 'extensions' configuration is no longer supported. You must now specify extensions as an array.
- [Node.js support (removed)](https://github.com/avajs/ava/releases): Support for Node.js versions 18, 23, and 25 has been removed. AVA now requires Node.js 22.20, 24.12 or newer.
- [.only() behavior (behavior-changed)](https://github.com/avajs/ava/releases): The 'sticky' behavior of '.only()' has been removed, changing how tests are filtered in interactive watch mode.

## Changes
- `package.json`: Bumped ava from 6.3.0 to ^8.0.1

## Verification Results
- ✅ TypeScript check passed in isolated Docker sandbox (--network=none)

## ⚠ Not Analyzed
- Analyzed 100% of exported symbols via `dts` semantic-diff signal.
- Transitive dependency impact of the version bump.
- Test coverage of the changed code paths.

---
*Generated by Mendel v1.5. Open as Draft — mark ready for review when you have validated.*