### PR TITLE
Add readableStream(), writableStream() and transformStream() methods

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -496,6 +496,33 @@ Converts the subprocess to a duplex stream.
 
 [More info.](streams.md#converting-a-subprocess-to-a-stream)
 
+### subprocess.readableStream(readableOptions?)
+
+`readableOptions`: [`ReadableOptions`](#readableoptions)\
+_Returns_: [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) web stream
+
+Converts the subprocess to a web readable stream.
+
+[More info.](streams.md#convert-to-web-streams)
+
+### subprocess.writableStream(writableOptions?)
+
+`writableOptions`: [`WritableOptions`](#writableoptions)\
+_Returns_: [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream) web stream
+
+Converts the subprocess to a web writable stream.
+
+[More info.](streams.md#convert-to-web-streams)
+
+### subprocess.transformStream(duplexOptions?)
+
+`duplexOptions`: [`ReadableOptions | WritableOptions`](#readableoptions)\
+_Returns_: `{readable: ReadableStream, writable: WritableStream}` web streams
+
+Converts the subprocess to a pair of web streams: a [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) for its output and a [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream) for its input.
+
+[More info.](streams.md#convert-to-web-streams)
+
 ## Result
 
 _TypeScript:_ [`Result`](typescript.md) or [`SyncResult`](typescript.md)\

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -92,6 +92,18 @@ const writable = execa`npm run scaffold`.writable();
 const duplex = execa`npm run scaffold`.duplex();
 ```
 
+### Convert to web streams
+
+The [`subprocess.readableStream()`](api.md#subprocessreadablestreamreadableoptions), [`subprocess.writableStream()`](api.md#subprocesswritablestreamwritableoptions) and [`subprocess.transformStream()`](api.md#subprocesstransformstreamduplexoptions) methods are the same as [`subprocess.readable()`](api.md#subprocessreadablereadableoptions), [`subprocess.writable()`](api.md#subprocesswritablewritableoptions) and [`subprocess.duplex()`](api.md#subprocessduplexduplexoptions), but return web streams instead of Node.js streams.
+
+```js
+const readableStream = execa`npm run scaffold`.readableStream();
+
+const writableStream = execa`npm run scaffold`.writableStream();
+
+const {readable, writable} = execa`npm run scaffold`.transformStream();
+```
+
 ### Different file descriptor
 
 By default, [`subprocess.readable()`](api.md#subprocessreadablereadableoptions), [`subprocess.writable()`](api.md#subprocesswritablewritableoptions) and [`subprocess.duplex()`](api.md#subprocessduplexduplexoptions) methods use [`stdin`](api.md#subprocessstdin) and [`stdout`](api.md#subprocessstdout). This can be changed using the [`from`](api.md#readableoptionsfrom) and [`to`](api.md#writableoptionsto) options.

--- a/lib/convert/add.js
+++ b/lib/convert/add.js
@@ -3,6 +3,7 @@ import {createReadable} from './readable.js';
 import {createWritable} from './writable.js';
 import {createDuplex} from './duplex.js';
 import {createIterable} from './iterable.js';
+import {createReadableStream, createWritableStream, createTransformStream} from './web.js';
 
 // Add methods to convert the subprocess to a stream or iterable
 export const addConvertedStreams = (subprocess, {encoding}) => {
@@ -12,4 +13,7 @@ export const addConvertedStreams = (subprocess, {encoding}) => {
 	subprocess.duplex = createDuplex.bind(undefined, {subprocess, concurrentStreams, encoding});
 	subprocess.iterable = createIterable.bind(undefined, subprocess, encoding);
 	subprocess[Symbol.asyncIterator] = createIterable.bind(undefined, subprocess, encoding, {});
+	subprocess.readableStream = createReadableStream.bind(undefined, subprocess);
+	subprocess.writableStream = createWritableStream.bind(undefined, subprocess);
+	subprocess.transformStream = createTransformStream.bind(undefined, subprocess);
 };

--- a/lib/convert/web.js
+++ b/lib/convert/web.js
@@ -1,0 +1,8 @@
+import {Readable, Writable, Duplex} from 'node:stream';
+
+// Convert the subprocess to web streams, mirroring `subprocess.readable()`, `subprocess.writable()` and `subprocess.duplex()`
+export const createReadableStream = (subprocess, readableOptions) => Readable.toWeb(subprocess.readable(readableOptions));
+
+export const createWritableStream = (subprocess, writableOptions) => Writable.toWeb(subprocess.writable(writableOptions));
+
+export const createTransformStream = (subprocess, duplexOptions) => Duplex.toWeb(subprocess.duplex(duplexOptions));

--- a/lib/return/early-error.js
+++ b/lib/return/early-error.js
@@ -16,7 +16,14 @@ export const handleEarlyError = ({error, command, escapedCommand, fileDescriptor
 
 	const subprocess = new ChildProcess();
 	createDummyStreams(subprocess, fileDescriptors);
-	Object.assign(subprocess, {readable, writable, duplex});
+	Object.assign(subprocess, {
+		readable,
+		writable,
+		duplex,
+		readableStream,
+		writableStream,
+		transformStream,
+	});
 
 	const earlyError = makeEarlyError({
 		error,
@@ -56,5 +63,8 @@ const createDummyStream = () => {
 const readable = () => new Readable({read() {}});
 const writable = () => new Writable({write() {}});
 const duplex = () => new Duplex({read() {}, write() {}});
+const readableStream = () => Readable.toWeb(readable());
+const writableStream = () => Writable.toWeb(writable());
+const transformStream = () => Duplex.toWeb(duplex());
 
 const handleDummyPromise = async (error, verboseInfo, options) => handleResult(error, verboseInfo, options);

--- a/test-d/convert/web.test-d.ts
+++ b/test-d/convert/web.test-d.ts
@@ -1,0 +1,30 @@
+import {expectType, expectError} from 'tsd';
+import {execa} from '../../index.js';
+
+const subprocess = execa('unicorns');
+
+expectType<ReadableStream>(subprocess.readableStream());
+expectType<WritableStream>(subprocess.writableStream());
+expectType<{readable: ReadableStream; writable: WritableStream}>(subprocess.transformStream());
+
+subprocess.readableStream({from: 'stdout'});
+subprocess.readableStream({from: 'stderr'});
+subprocess.readableStream({from: 'all'});
+subprocess.readableStream({from: 'fd3'});
+expectError(subprocess.readableStream({from: 'stdin'}));
+expectError(subprocess.readableStream({to: 'stdin'}));
+subprocess.readableStream({binary: false});
+expectError(subprocess.readableStream({binary: 'false'}));
+subprocess.readableStream({preserveNewlines: false});
+expectError(subprocess.readableStream({preserveNewlines: 'false'}));
+
+subprocess.writableStream({to: 'stdin'});
+subprocess.writableStream({to: 'fd3'});
+expectError(subprocess.writableStream({to: 'stdout'}));
+expectError(subprocess.writableStream({from: 'stdout'}));
+
+subprocess.transformStream({from: 'stdout', to: 'stdin'});
+subprocess.transformStream({from: 'stderr', to: 'fd3'});
+expectError(subprocess.transformStream({from: 'stdin'}));
+expectError(subprocess.transformStream({to: 'stdout'}));
+expectError(subprocess.transformStream('stdout'));

--- a/test/convert/web.js
+++ b/test/convert/web.js
@@ -1,0 +1,82 @@
+import {text} from 'node:stream/consumers';
+import test from 'ava';
+import {execa} from '../../index.js';
+import {setFixtureDirectory} from '../helpers/fixtures-directory.js';
+import {
+	assertStreamOutput,
+	assertProcessNormalExit,
+	assertSubprocessOutput,
+	assertSubprocessError,
+	getReadableSubprocess,
+	getWritableSubprocess,
+	getReadWriteSubprocess,
+} from '../helpers/convert.js';
+import {foobarString, foobarUint8Array} from '../helpers/input.js';
+import {fullReadableStdio} from '../helpers/stdio.js';
+
+setFixtureDirectory();
+
+const writeToWebStream = async (writableStream, chunk = foobarUint8Array) => {
+	const writer = writableStream.getWriter();
+	await writer.write(chunk);
+	await writer.close();
+};
+
+test('.readableStream() success', async t => {
+	const subprocess = getReadableSubprocess();
+	const stream = subprocess.readableStream();
+
+	t.true(stream instanceof ReadableStream);
+	t.false(stream instanceof WritableStream);
+
+	await assertStreamOutput(t, stream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('.readableStream() can use a different file descriptor', async t => {
+	const subprocess = execa('noop-fd.js', ['2', foobarString]);
+	const stream = subprocess.readableStream({from: 'stderr'});
+
+	await assertStreamOutput(t, stream);
+	await assertSubprocessOutput(t, subprocess, foobarString, 2);
+});
+
+test('.readableStream() error -> subprocess fail', async t => {
+	const subprocess = execa('noop-fail.js', ['1', foobarString]);
+	const stream = subprocess.readableStream();
+
+	const error = await t.throwsAsync(text(stream));
+	assertProcessNormalExit(t, error, 2);
+	await assertSubprocessError(t, subprocess, error);
+});
+
+test('.writableStream() success', async t => {
+	const subprocess = getWritableSubprocess();
+	const stream = subprocess.writableStream();
+
+	t.true(stream instanceof WritableStream);
+	t.false(stream instanceof ReadableStream);
+
+	await writeToWebStream(stream);
+	await assertSubprocessOutput(t, subprocess, foobarString, 2);
+});
+
+test('.writableStream() can use a different file descriptor', async t => {
+	const subprocess = execa('stdin-fd.js', ['3'], fullReadableStdio());
+	const stream = subprocess.writableStream({to: 'fd3'});
+
+	await writeToWebStream(stream);
+	await assertSubprocessOutput(t, subprocess);
+});
+
+test('.transformStream() success', async t => {
+	const subprocess = getReadWriteSubprocess();
+	const {readable, writable} = subprocess.transformStream();
+
+	t.true(readable instanceof ReadableStream);
+	t.true(writable instanceof WritableStream);
+
+	await writeToWebStream(writable);
+	await assertStreamOutput(t, readable);
+	await assertSubprocessOutput(t, subprocess);
+});

--- a/test/return/early-error.js
+++ b/test/return/early-error.js
@@ -101,6 +101,31 @@ test('child_process.spawn() early errors can use .readable()', testEarlyErrorCon
 test('child_process.spawn() early errors can use .writable()', testEarlyErrorConvertor, 'writable');
 test('child_process.spawn() early errors can use .duplex()', testEarlyErrorConvertor, 'duplex');
 
+test('child_process.spawn() early errors can use .readableStream()', async t => {
+	const subprocess = getEarlyErrorSubprocess();
+	const stream = subprocess.readableStream();
+	t.true(stream instanceof ReadableStream);
+	await stream.cancel();
+	await t.throwsAsync(subprocess);
+});
+
+test('child_process.spawn() early errors can use .writableStream()', async t => {
+	const subprocess = getEarlyErrorSubprocess();
+	const stream = subprocess.writableStream();
+	t.true(stream instanceof WritableStream);
+	await stream.abort();
+	await t.throwsAsync(subprocess);
+});
+
+test('child_process.spawn() early errors can use .transformStream()', async t => {
+	const subprocess = getEarlyErrorSubprocess();
+	const {readable, writable} = subprocess.transformStream();
+	t.true(readable instanceof ReadableStream);
+	t.true(writable instanceof WritableStream);
+	await Promise.all([readable.cancel(), writable.abort()]);
+	await t.throwsAsync(subprocess);
+});
+
 const testEarlyErrorStream = async (t, getStreamProperty, options) => {
 	const subprocess = getEarlyErrorSubprocess(options);
 	const stream = getStreamProperty(subprocess);

--- a/types/subprocess/subprocess.d.ts
+++ b/types/subprocess/subprocess.d.ts
@@ -96,6 +96,21 @@ type ExecaCustomSubprocess<OptionsType extends Options> = {
 	Converts the subprocess to a duplex stream.
 	*/
 	duplex(duplexOptions?: DuplexOptions): Duplex;
+
+	/**
+	Converts the subprocess to a web [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+	*/
+	readableStream(readableOptions?: ReadableOptions): ReadableStream;
+
+	/**
+	Converts the subprocess to a web [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
+	*/
+	writableStream(writableOptions?: WritableOptions): WritableStream;
+
+	/**
+	Converts the subprocess to a web [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) and [`WritableStream`](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream).
+	*/
+	transformStream(duplexOptions?: DuplexOptions): {readable: ReadableStream; writable: WritableStream};
 }
 & IpcMethods<HasIpc<OptionsType>, OptionsType['serialization']>
 & PipableSubprocess;


### PR DESCRIPTION
Closes #913

Adds `subprocess.readableStream()`, `subprocess.writableStream()` and `subprocess.transformStream()`, the web stream versions of `subprocess.readable()`, `subprocess.writable()` and `subprocess.duplex()`.

They wrap the existing methods with `Readable.toWeb()`, `Writable.toWeb()` and `Duplex.toWeb()`, so the error and abort handling is reused as is. The early error path attaches them too.

Tests and docs follow the same structure as the Node.js stream methods.
