### PR TITLE
Type the `std*` generator transform `chunk` argument

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1288,7 +1288,7 @@ If `true`, iterate over arbitrary chunks of `Uint8Array`s instead of line `strin
 _Type:_ `boolean`\
 _Default:_ `false`
 
-If `true`, keep newlines in each `line` argument. Also, this allows multiple `yield`s to produces a single line.
+If `true`, keep newlines in each `line` argument. Also, this allows multiple `yield`s to produce a single line.
 
 [More info.](lines.md#transforms)
 

--- a/test-d/methods/script.test-d.ts
+++ b/test-d/methods/script.test-d.ts
@@ -41,6 +41,13 @@ expectAssignable<{stdout: Uint8Array}>(await $({encoding: 'buffer'})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(await $({})({encoding: 'buffer'})`unicorns`);
 expectAssignable<{stdout: Uint8Array}>(await $({encoding: 'buffer'})({})`unicorns`);
 
+const uint8ArrayGenerator = function * (chunk: Uint8Array) {
+	yield chunk;
+};
+
+expectError($({encoding: 'utf8', stdout: uint8ArrayGenerator}));
+$({encoding: 'buffer', stdout: uint8ArrayGenerator});
+
 expectType<Result<{}>>(await $`${'unicorns'}`);
 expectType<Result<{}>>(await $`unicorns ${'foo'}`);
 expectType<Result<{}>>(await $`unicorns ${'foo'} ${'bar'}`);

--- a/test-d/stdio/option/generator-binary-uint-array.test-d.ts
+++ b/test-d/stdio/option/generator-binary-uint-array.test-d.ts
@@ -1,0 +1,202 @@
+import {expectError, expectAssignable, expectNotAssignable} from 'tsd';
+import {
+	execa,
+	execaSync,
+	type StdinOption,
+	type StdinSyncOption,
+	type StdoutStderrOption,
+	type StdoutStderrSyncOption,
+} from '../../../index.js';
+
+// With `binary: true`, the `chunk` argument is an `Uint8Array`.
+const uint8ArrayBinary = {
+	* transform(chunk: Uint8Array) {
+		yield chunk;
+	},
+	binary: true,
+} as const;
+
+await execa('unicorns', {stdin: uint8ArrayBinary});
+execaSync('unicorns', {stdin: uint8ArrayBinary});
+await execa('unicorns', {stdin: [uint8ArrayBinary]});
+execaSync('unicorns', {stdin: [uint8ArrayBinary]});
+await execa('unicorns', {stdout: uint8ArrayBinary});
+execaSync('unicorns', {stdout: uint8ArrayBinary});
+await execa('unicorns', {stderr: uint8ArrayBinary});
+execaSync('unicorns', {stderr: uint8ArrayBinary});
+await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', uint8ArrayBinary]});
+
+expectAssignable<StdinOption>(uint8ArrayBinary);
+expectAssignable<StdinSyncOption>(uint8ArrayBinary);
+expectAssignable<StdinOption>([uint8ArrayBinary]);
+expectAssignable<StdinSyncOption>([uint8ArrayBinary]);
+expectAssignable<StdoutStderrOption>(uint8ArrayBinary);
+expectAssignable<StdoutStderrSyncOption>(uint8ArrayBinary);
+expectAssignable<StdoutStderrOption>([uint8ArrayBinary]);
+expectAssignable<StdoutStderrSyncOption>([uint8ArrayBinary]);
+
+// `objectMode: true` takes precedence over `binary: true` for stdin, so the `chunk` argument is `unknown`.
+const uint8ArrayBinaryObjectMode = {
+	* transform(chunk: Uint8Array) {
+		yield chunk;
+	},
+	binary: true,
+	objectMode: true,
+} as const;
+
+const stdinObjectModeBinary = {
+	* transform(chunk: unknown) {
+		yield chunk;
+	},
+	binary: true,
+	objectMode: true,
+} as const;
+
+expectError(await execa('unicorns', {stdin: uint8ArrayBinaryObjectMode}));
+expectError(execaSync('unicorns', {stdin: uint8ArrayBinaryObjectMode}));
+await execa('unicorns', {stdout: uint8ArrayBinaryObjectMode});
+execaSync('unicorns', {stdout: uint8ArrayBinaryObjectMode});
+await execa('unicorns', {stderr: uint8ArrayBinaryObjectMode});
+execaSync('unicorns', {stderr: uint8ArrayBinaryObjectMode});
+
+await execa('unicorns', {stdin: stdinObjectModeBinary});
+execaSync('unicorns', {stdin: stdinObjectModeBinary});
+
+expectNotAssignable<StdinOption>(uint8ArrayBinaryObjectMode);
+expectNotAssignable<StdinSyncOption>(uint8ArrayBinaryObjectMode);
+expectAssignable<StdoutStderrOption>(uint8ArrayBinaryObjectMode);
+expectAssignable<StdoutStderrSyncOption>(uint8ArrayBinaryObjectMode);
+expectAssignable<StdinOption>(stdinObjectModeBinary);
+expectAssignable<StdinSyncOption>(stdinObjectModeBinary);
+
+const stdoutAnnotatedBinaryObjectMode: StdoutStderrOption = {
+	* transform(chunk: Uint8Array) {
+		yield chunk;
+	},
+	binary: true,
+	objectMode: true,
+};
+
+expectAssignable<StdoutStderrOption>(stdoutAnnotatedBinaryObjectMode);
+
+// A `string` argument is invalid when `binary: true`.
+const stringBinary = {
+	* transform(line: string) {
+		yield line;
+	},
+	binary: true,
+} as const;
+
+const stringBinaryObjectMode = {
+	* transform(line: string) {
+		yield line;
+	},
+	binary: true,
+	objectMode: true,
+} as const;
+
+expectError(await execa('unicorns', {stdin: stringBinary}));
+expectError(execaSync('unicorns', {stdin: stringBinary}));
+expectError(await execa('unicorns', {stdin: [stringBinary]}));
+expectError(execaSync('unicorns', {stdin: [stringBinary]}));
+expectError(await execa('unicorns', {stdout: stringBinary}));
+expectError(execaSync('unicorns', {stdout: stringBinary}));
+expectError(await execa('unicorns', {stderr: stringBinary}));
+expectError(execaSync('unicorns', {stderr: stringBinary}));
+expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', stringBinary]}));
+expectError(await execa('unicorns', {stdout: stringBinaryObjectMode}));
+expectError(execaSync('unicorns', {stdout: stringBinaryObjectMode}));
+expectError(await execa('unicorns', {stderr: stringBinaryObjectMode}));
+expectError(execaSync('unicorns', {stderr: stringBinaryObjectMode}));
+
+expectNotAssignable<StdinOption>(stringBinary);
+expectNotAssignable<StdinSyncOption>(stringBinary);
+expectNotAssignable<StdinOption>([stringBinary]);
+expectNotAssignable<StdinSyncOption>([stringBinary]);
+expectNotAssignable<StdoutStderrOption>(stringBinary);
+expectNotAssignable<StdoutStderrSyncOption>(stringBinary);
+expectNotAssignable<StdoutStderrOption>([stringBinary]);
+expectNotAssignable<StdoutStderrSyncOption>([stringBinary]);
+expectNotAssignable<StdoutStderrOption>(stringBinaryObjectMode);
+expectNotAssignable<StdoutStderrSyncOption>(stringBinaryObjectMode);
+
+// An `Uint8Array` argument is invalid without `binary: true`, since the `chunk` is then a `string`.
+const uint8ArrayLine = {
+	* transform(chunk: Uint8Array) {
+		yield chunk;
+	},
+} as const;
+
+expectError(await execa('unicorns', {stdin: uint8ArrayLine}));
+expectError(execaSync('unicorns', {stdin: uint8ArrayLine}));
+expectError(await execa('unicorns', {stdin: [uint8ArrayLine]}));
+expectError(execaSync('unicorns', {stdin: [uint8ArrayLine]}));
+expectError(await execa('unicorns', {stdout: uint8ArrayLine}));
+expectError(execaSync('unicorns', {stdout: uint8ArrayLine}));
+expectError(await execa('unicorns', {stderr: uint8ArrayLine}));
+expectError(execaSync('unicorns', {stderr: uint8ArrayLine}));
+expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', uint8ArrayLine]}));
+
+expectNotAssignable<StdinOption>(uint8ArrayLine);
+expectNotAssignable<StdinSyncOption>(uint8ArrayLine);
+expectNotAssignable<StdinOption>([uint8ArrayLine]);
+expectNotAssignable<StdinSyncOption>([uint8ArrayLine]);
+expectNotAssignable<StdoutStderrOption>(uint8ArrayLine);
+expectNotAssignable<StdoutStderrSyncOption>(uint8ArrayLine);
+expectNotAssignable<StdoutStderrOption>([uint8ArrayLine]);
+expectNotAssignable<StdoutStderrSyncOption>([uint8ArrayLine]);
+
+// Binary encodings also make output transforms receive binary chunks.
+await execa('unicorns', {encoding: 'buffer', stdin: uint8ArrayLine});
+execaSync('unicorns', {encoding: 'buffer', stdin: uint8ArrayLine});
+await execa('unicorns', {encoding: 'buffer', stdout: uint8ArrayLine});
+execaSync('unicorns', {encoding: 'buffer', stdout: uint8ArrayLine});
+await execa('unicorns', {encoding: 'buffer', stderr: uint8ArrayLine});
+execaSync('unicorns', {encoding: 'buffer', stderr: uint8ArrayLine});
+await execa('unicorns', {encoding: 'buffer', stdio: [uint8ArrayLine, uint8ArrayLine, uint8ArrayLine, uint8ArrayLine]});
+execaSync('unicorns', {encoding: 'buffer', stdio: [uint8ArrayLine, uint8ArrayLine, uint8ArrayLine, uint8ArrayLine]});
+
+// A bare generator function always receives string lines unless `encoding` is binary.
+const uint8ArrayGenerator = function * (chunk: Uint8Array) {
+	yield chunk;
+};
+
+expectError(await execa('unicorns', {stdin: uint8ArrayGenerator}));
+expectError(execaSync('unicorns', {stdin: uint8ArrayGenerator}));
+expectError(await execa('unicorns', {stdout: uint8ArrayGenerator}));
+expectError(execaSync('unicorns', {stdout: uint8ArrayGenerator}));
+expectError(await execa('unicorns', {stderr: uint8ArrayGenerator}));
+expectError(execaSync('unicorns', {stderr: uint8ArrayGenerator}));
+expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', uint8ArrayGenerator]}));
+
+expectNotAssignable<StdinOption>(uint8ArrayGenerator);
+expectNotAssignable<StdinSyncOption>(uint8ArrayGenerator);
+expectNotAssignable<StdoutStderrOption>(uint8ArrayGenerator);
+expectNotAssignable<StdoutStderrSyncOption>(uint8ArrayGenerator);
+
+await execa('unicorns', {encoding: 'buffer', stdin: uint8ArrayGenerator});
+execaSync('unicorns', {encoding: 'buffer', stdin: uint8ArrayGenerator});
+await execa('unicorns', {encoding: 'buffer', stdout: uint8ArrayGenerator});
+execaSync('unicorns', {encoding: 'buffer', stdout: uint8ArrayGenerator});
+await execa('unicorns', {encoding: 'buffer', stderr: uint8ArrayGenerator});
+execaSync('unicorns', {encoding: 'buffer', stderr: uint8ArrayGenerator});
+await execa('unicorns', {encoding: 'buffer', stdio: [uint8ArrayGenerator, uint8ArrayGenerator, uint8ArrayGenerator, uint8ArrayGenerator]});
+execaSync('unicorns', {encoding: 'buffer', stdio: [uint8ArrayGenerator, uint8ArrayGenerator, uint8ArrayGenerator, uint8ArrayGenerator]});
+
+// Conversely, a binary `encoding` makes the `chunk` a `Uint8Array`, so a `string` transform is rejected.
+const stringGenerator = function * (line: string) {
+	yield line;
+};
+
+expectError(await execa('unicorns', {encoding: 'buffer', stdin: stringGenerator}));
+expectError(execaSync('unicorns', {encoding: 'buffer', stdin: stringGenerator}));
+expectError(await execa('unicorns', {encoding: 'buffer', stdout: stringGenerator}));
+expectError(execaSync('unicorns', {encoding: 'buffer', stdout: stringGenerator}));
+
+// This applies to every binary `encoding`, not just `'buffer'`.
+await execa('unicorns', {encoding: 'hex', stdout: uint8ArrayGenerator});
+execaSync('unicorns', {encoding: 'hex', stdout: uint8ArrayGenerator});
+await execa('unicorns', {encoding: 'base64', stdout: uint8ArrayGenerator});
+execaSync('unicorns', {encoding: 'base64', stdout: uint8ArrayGenerator});
+expectError(await execa('unicorns', {encoding: 'hex', stdout: stringGenerator}));
+expectError(execaSync('unicorns', {encoding: 'hex', stdout: stringGenerator}));

--- a/test-d/stdio/option/generator-object-full.test-d.ts
+++ b/test-d/stdio/option/generator-object-full.test-d.ts
@@ -1,4 +1,4 @@
-import {expectError, expectAssignable} from 'tsd';
+import {expectError, expectAssignable, expectNotAssignable} from 'tsd';
 import {
 	execa,
 	execaSync,
@@ -15,10 +15,22 @@ const objectGeneratorFull = {
 	objectMode: true,
 } as const;
 
+const stringInputObjectGeneratorFull = {
+	* transform(line: string) {
+		yield JSON.parse(line) as object;
+	},
+	objectMode: true,
+} as const;
+
 await execa('unicorns', {stdin: objectGeneratorFull});
 execaSync('unicorns', {stdin: objectGeneratorFull});
 await execa('unicorns', {stdin: [objectGeneratorFull]});
 execaSync('unicorns', {stdin: [objectGeneratorFull]});
+
+expectError(await execa('unicorns', {stdin: stringInputObjectGeneratorFull}));
+expectError(execaSync('unicorns', {stdin: stringInputObjectGeneratorFull}));
+expectError(await execa('unicorns', {stdin: [stringInputObjectGeneratorFull]}));
+expectError(execaSync('unicorns', {stdin: [stringInputObjectGeneratorFull]}));
 
 await execa('unicorns', {stdout: objectGeneratorFull});
 execaSync('unicorns', {stdout: objectGeneratorFull});
@@ -29,6 +41,35 @@ await execa('unicorns', {stderr: objectGeneratorFull});
 execaSync('unicorns', {stderr: objectGeneratorFull});
 await execa('unicorns', {stderr: [objectGeneratorFull]});
 execaSync('unicorns', {stderr: [objectGeneratorFull]});
+
+await execa('unicorns', {stdout: stringInputObjectGeneratorFull});
+execaSync('unicorns', {stdout: stringInputObjectGeneratorFull});
+await execa('unicorns', {stdout: [stringInputObjectGeneratorFull]});
+execaSync('unicorns', {stdout: [stringInputObjectGeneratorFull]});
+
+// The array index does not determine the pipeline position, so a `string`-input transform is valid at any position.
+await execa('unicorns', {stdout: [stringInputObjectGeneratorFull, objectGeneratorFull]});
+execaSync('unicorns', {stdout: [stringInputObjectGeneratorFull, objectGeneratorFull]});
+await execa('unicorns', {stdout: [objectGeneratorFull, stringInputObjectGeneratorFull]});
+execaSync('unicorns', {stdout: [objectGeneratorFull, stringInputObjectGeneratorFull]});
+
+// A transform preceded by a non-transform target still receives subprocess `string` lines.
+await execa('unicorns', {stdout: ['pipe', stringInputObjectGeneratorFull]});
+execaSync('unicorns', {stdout: ['pipe', stringInputObjectGeneratorFull]});
+
+// A non-tuple array variable stays assignable.
+const stdoutArray = [stringInputObjectGeneratorFull];
+await execa('unicorns', {stdout: stdoutArray});
+execaSync('unicorns', {stdout: stdoutArray});
+
+await execa('unicorns', {stderr: stringInputObjectGeneratorFull});
+execaSync('unicorns', {stderr: stringInputObjectGeneratorFull});
+await execa('unicorns', {stderr: [stringInputObjectGeneratorFull]});
+execaSync('unicorns', {stderr: [stringInputObjectGeneratorFull]});
+await execa('unicorns', {stderr: [stringInputObjectGeneratorFull, objectGeneratorFull]});
+execaSync('unicorns', {stderr: [stringInputObjectGeneratorFull, objectGeneratorFull]});
+await execa('unicorns', {stderr: [objectGeneratorFull, stringInputObjectGeneratorFull]});
+execaSync('unicorns', {stderr: [objectGeneratorFull, stringInputObjectGeneratorFull]});
 
 expectError(await execa('unicorns', {stdio: objectGeneratorFull}));
 expectError(execaSync('unicorns', {stdio: objectGeneratorFull}));
@@ -42,8 +83,16 @@ expectAssignable<StdinOption>(objectGeneratorFull);
 expectAssignable<StdinSyncOption>(objectGeneratorFull);
 expectAssignable<StdinOption>([objectGeneratorFull]);
 expectAssignable<StdinSyncOption>([objectGeneratorFull]);
+expectNotAssignable<StdinOption>(stringInputObjectGeneratorFull);
+expectNotAssignable<StdinSyncOption>(stringInputObjectGeneratorFull);
+expectNotAssignable<StdinOption>([stringInputObjectGeneratorFull]);
+expectNotAssignable<StdinSyncOption>([stringInputObjectGeneratorFull]);
 
 expectAssignable<StdoutStderrOption>(objectGeneratorFull);
 expectAssignable<StdoutStderrSyncOption>(objectGeneratorFull);
 expectAssignable<StdoutStderrOption>([objectGeneratorFull]);
 expectAssignable<StdoutStderrSyncOption>([objectGeneratorFull]);
+expectAssignable<StdoutStderrOption>(stringInputObjectGeneratorFull);
+expectAssignable<StdoutStderrSyncOption>(stringInputObjectGeneratorFull);
+expectAssignable<StdoutStderrOption>([stringInputObjectGeneratorFull]);
+expectAssignable<StdoutStderrSyncOption>([stringInputObjectGeneratorFull]);

--- a/test-d/stdio/option/generator-string-full.test-d.ts
+++ b/test-d/stdio/option/generator-string-full.test-d.ts
@@ -1,4 +1,4 @@
-import {expectError, expectNotAssignable} from 'tsd';
+import {expectError, expectAssignable} from 'tsd';
 import {
 	execa,
 	execaSync,
@@ -14,35 +14,35 @@ const stringGeneratorFull = {
 	},
 } as const;
 
-expectError(await execa('unicorns', {stdin: stringGeneratorFull}));
-expectError(execaSync('unicorns', {stdin: stringGeneratorFull}));
-expectError(await execa('unicorns', {stdin: [stringGeneratorFull]}));
-expectError(execaSync('unicorns', {stdin: [stringGeneratorFull]}));
+await execa('unicorns', {stdin: stringGeneratorFull});
+execaSync('unicorns', {stdin: stringGeneratorFull});
+await execa('unicorns', {stdin: [stringGeneratorFull]});
+execaSync('unicorns', {stdin: [stringGeneratorFull]});
 
-expectError(await execa('unicorns', {stdout: stringGeneratorFull}));
-expectError(execaSync('unicorns', {stdout: stringGeneratorFull}));
-expectError(await execa('unicorns', {stdout: [stringGeneratorFull]}));
-expectError(execaSync('unicorns', {stdout: [stringGeneratorFull]}));
+await execa('unicorns', {stdout: stringGeneratorFull});
+execaSync('unicorns', {stdout: stringGeneratorFull});
+await execa('unicorns', {stdout: [stringGeneratorFull]});
+execaSync('unicorns', {stdout: [stringGeneratorFull]});
 
-expectError(await execa('unicorns', {stderr: stringGeneratorFull}));
-expectError(execaSync('unicorns', {stderr: stringGeneratorFull}));
-expectError(await execa('unicorns', {stderr: [stringGeneratorFull]}));
-expectError(execaSync('unicorns', {stderr: [stringGeneratorFull]}));
+await execa('unicorns', {stderr: stringGeneratorFull});
+execaSync('unicorns', {stderr: stringGeneratorFull});
+await execa('unicorns', {stderr: [stringGeneratorFull]});
+execaSync('unicorns', {stderr: [stringGeneratorFull]});
 
 expectError(await execa('unicorns', {stdio: stringGeneratorFull}));
 expectError(execaSync('unicorns', {stdio: stringGeneratorFull}));
 
-expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', stringGeneratorFull]}));
-expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', stringGeneratorFull]}));
-expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGeneratorFull]]}));
-expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGeneratorFull]]}));
+await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', stringGeneratorFull]});
+execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', stringGeneratorFull]});
+await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGeneratorFull]]});
+execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGeneratorFull]]});
 
-expectNotAssignable<StdinOption>(stringGeneratorFull);
-expectNotAssignable<StdinSyncOption>(stringGeneratorFull);
-expectNotAssignable<StdinOption>([stringGeneratorFull]);
-expectNotAssignable<StdinSyncOption>([stringGeneratorFull]);
+expectAssignable<StdinOption>(stringGeneratorFull);
+expectAssignable<StdinSyncOption>(stringGeneratorFull);
+expectAssignable<StdinOption>([stringGeneratorFull]);
+expectAssignable<StdinSyncOption>([stringGeneratorFull]);
 
-expectNotAssignable<StdoutStderrOption>(stringGeneratorFull);
-expectNotAssignable<StdoutStderrSyncOption>(stringGeneratorFull);
-expectNotAssignable<StdoutStderrOption>([stringGeneratorFull]);
-expectNotAssignable<StdoutStderrSyncOption>([stringGeneratorFull]);
+expectAssignable<StdoutStderrOption>(stringGeneratorFull);
+expectAssignable<StdoutStderrSyncOption>(stringGeneratorFull);
+expectAssignable<StdoutStderrOption>([stringGeneratorFull]);
+expectAssignable<StdoutStderrSyncOption>([stringGeneratorFull]);

--- a/test-d/stdio/option/generator-string.test-d.ts
+++ b/test-d/stdio/option/generator-string.test-d.ts
@@ -1,4 +1,4 @@
-import {expectError, expectNotAssignable} from 'tsd';
+import {expectError, expectAssignable} from 'tsd';
 import {
 	execa,
 	execaSync,
@@ -12,35 +12,46 @@ const stringGenerator = function * (line: string) {
 	yield line;
 };
 
-expectError(await execa('unicorns', {stdin: stringGenerator}));
-expectError(execaSync('unicorns', {stdin: stringGenerator}));
-expectError(await execa('unicorns', {stdin: [stringGenerator]}));
-expectError(execaSync('unicorns', {stdin: [stringGenerator]}));
+await execa('unicorns', {stdin: stringGenerator});
+execaSync('unicorns', {stdin: stringGenerator});
+await execa('unicorns', {stdin: [stringGenerator]});
+execaSync('unicorns', {stdin: [stringGenerator]});
 
-expectError(await execa('unicorns', {stdout: stringGenerator}));
-expectError(execaSync('unicorns', {stdout: stringGenerator}));
-expectError(await execa('unicorns', {stdout: [stringGenerator]}));
-expectError(execaSync('unicorns', {stdout: [stringGenerator]}));
+await execa('unicorns', {stdout: stringGenerator});
+execaSync('unicorns', {stdout: stringGenerator});
+await execa('unicorns', {stdout: [stringGenerator]});
+execaSync('unicorns', {stdout: [stringGenerator]});
 
-expectError(await execa('unicorns', {stderr: stringGenerator}));
-expectError(execaSync('unicorns', {stderr: stringGenerator}));
-expectError(await execa('unicorns', {stderr: [stringGenerator]}));
-expectError(execaSync('unicorns', {stderr: [stringGenerator]}));
+await execa('unicorns', {stderr: stringGenerator});
+execaSync('unicorns', {stderr: stringGenerator});
+await execa('unicorns', {stderr: [stringGenerator]});
+execaSync('unicorns', {stderr: [stringGenerator]});
 
 expectError(await execa('unicorns', {stdio: stringGenerator}));
 expectError(execaSync('unicorns', {stdio: stringGenerator}));
 
-expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', stringGenerator]}));
-expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', stringGenerator]}));
-expectError(await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGenerator]]}));
-expectError(execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGenerator]]}));
+await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', stringGenerator]});
+execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', stringGenerator]});
+await execa('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGenerator]]});
+execaSync('unicorns', {stdio: ['pipe', 'pipe', 'pipe', [stringGenerator]]});
 
-expectNotAssignable<StdinOption>(stringGenerator);
-expectNotAssignable<StdinSyncOption>(stringGenerator);
-expectNotAssignable<StdinOption>([stringGenerator]);
-expectNotAssignable<StdinSyncOption>([stringGenerator]);
+expectAssignable<StdinOption>(stringGenerator);
+expectAssignable<StdinSyncOption>(stringGenerator);
+expectAssignable<StdinOption>([stringGenerator]);
+expectAssignable<StdinSyncOption>([stringGenerator]);
 
-expectNotAssignable<StdoutStderrOption>(stringGenerator);
-expectNotAssignable<StdoutStderrSyncOption>(stringGenerator);
-expectNotAssignable<StdoutStderrOption>([stringGenerator]);
-expectNotAssignable<StdoutStderrSyncOption>([stringGenerator]);
+expectAssignable<StdoutStderrOption>(stringGenerator);
+expectAssignable<StdoutStderrSyncOption>(stringGenerator);
+expectAssignable<StdoutStderrOption>([stringGenerator]);
+expectAssignable<StdoutStderrSyncOption>([stringGenerator]);
+
+// The `chunk` argument is typed, but the return type stays `unknown`: a transform can yield both `string` and `Uint8Array`.
+const mixedYieldGenerator = function * (line: string) {
+	yield line;
+	yield new TextEncoder().encode(line);
+};
+
+expectAssignable<StdinOption>(mixedYieldGenerator);
+expectAssignable<StdinSyncOption>(mixedYieldGenerator);
+expectAssignable<StdoutStderrOption>(mixedYieldGenerator);
+expectAssignable<StdoutStderrSyncOption>(mixedYieldGenerator);

--- a/test-d/stdio/option/generator-widened.test-d.ts
+++ b/test-d/stdio/option/generator-widened.test-d.ts
@@ -1,0 +1,45 @@
+import {expectAssignable, expectNotAssignable} from 'tsd';
+import {
+	type StdinOption,
+	type StdinSyncOption,
+	type StdoutStderrOption,
+	type StdoutStderrSyncOption,
+} from '../../../index.js';
+
+// Without `as const`, `binary`/`objectMode` widen to `boolean`. Since the transform mode is unknown at compile time, the `chunk` argument must be `unknown`.
+
+const widenedBinary = {
+	* transform(line: unknown) {
+		yield line;
+	},
+	binary: true,
+};
+
+expectAssignable<StdinOption>(widenedBinary);
+expectAssignable<StdinSyncOption>(widenedBinary);
+expectAssignable<StdoutStderrOption>(widenedBinary);
+expectAssignable<StdoutStderrSyncOption>(widenedBinary);
+
+const widenedObjectMode = {
+	* transform(line: unknown) {
+		yield line;
+	},
+	objectMode: true,
+};
+
+expectAssignable<StdinOption>(widenedObjectMode);
+expectAssignable<StdinSyncOption>(widenedObjectMode);
+expectAssignable<StdoutStderrOption>(widenedObjectMode);
+expectAssignable<StdoutStderrSyncOption>(widenedObjectMode);
+
+const widenedBinaryString = {
+	* transform(line: string) {
+		yield line;
+	},
+	binary: true,
+};
+
+expectNotAssignable<StdinOption>(widenedBinaryString);
+expectNotAssignable<StdinSyncOption>(widenedBinaryString);
+expectNotAssignable<StdoutStderrOption>(widenedBinaryString);
+expectNotAssignable<StdoutStderrSyncOption>(widenedBinaryString);

--- a/types/arguments/encoding-option.d.ts
+++ b/types/arguments/encoding-option.d.ts
@@ -1,5 +1,5 @@
 type DefaultEncodingOption = 'utf8';
-type TextEncodingOption =
+export type TextEncodingOption =
 	| DefaultEncodingOption
 	| 'utf16le';
 

--- a/types/arguments/options.d.ts
+++ b/types/arguments/options.d.ts
@@ -5,9 +5,14 @@ import type {Message} from '../ipc.js';
 import type {StdinOptionCommon, StdoutStderrOptionCommon, StdioOptionsProperty} from '../stdio/type.js';
 import type {VerboseOption} from '../verbose.js';
 import type {FdGenericOption} from './specific.js';
-import type {EncodingOption} from './encoding-option.js';
+import type {BinaryEncodingOption, EncodingOption, TextEncodingOption} from './encoding-option.js';
 
-export type CommonOptions<IsSync extends boolean = boolean> = {
+type ChunkForEncoding<Encoding extends EncodingOption> = Encoding extends BinaryEncodingOption ? Uint8Array : string;
+
+export type CommonOptions<
+	IsSync extends boolean = boolean,
+	Encoding extends EncodingOption = EncodingOption,
+> = {
 	/**
 	Prefer locally installed binaries when looking for a binary to execute.
 
@@ -107,7 +112,7 @@ export type CommonOptions<IsSync extends boolean = boolean> = {
 
 	@default `'inherit'` with `$`, `'pipe'` otherwise
 	*/
-	readonly stdin?: StdinOptionCommon<IsSync>;
+	readonly stdin?: StdinOptionCommon<IsSync, boolean, ChunkForEncoding<Encoding>>;
 
 	/**
 	How to setup the subprocess' [standard output](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)). This can be `'pipe'`, `'overlapped'`, `'ignore`, `'inherit'`, a file descriptor integer, a Node.js `Writable` stream, a web `WritableStream`, a `{ file: 'path' }` object, a file URL, a generator function, a `Duplex` or a web `TransformStream`.
@@ -116,7 +121,7 @@ export type CommonOptions<IsSync extends boolean = boolean> = {
 
 	@default 'pipe'
 	*/
-	readonly stdout?: StdoutStderrOptionCommon<IsSync>;
+	readonly stdout?: StdoutStderrOptionCommon<IsSync, boolean, ChunkForEncoding<Encoding>>;
 
 	/**
 	How to setup the subprocess' [standard error](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)). This can be `'pipe'`, `'overlapped'`, `'ignore`, `'inherit'`, a file descriptor integer, a Node.js `Writable` stream, a web `WritableStream`, a `{ file: 'path' }` object, a file URL, a generator function, a `Duplex` or a web `TransformStream`.
@@ -125,7 +130,7 @@ export type CommonOptions<IsSync extends boolean = boolean> = {
 
 	@default 'pipe'
 	*/
-	readonly stderr?: StdoutStderrOptionCommon<IsSync>;
+	readonly stderr?: StdoutStderrOptionCommon<IsSync, boolean, ChunkForEncoding<Encoding>>;
 
 	/**
 	Like the `stdin`, `stdout` and `stderr` options but for all [file descriptors](https://en.wikipedia.org/wiki/File_descriptor) at once. For example, `{stdio: ['ignore', 'pipe', 'pipe']}` is the same as `{stdin: 'ignore', stdout: 'pipe', stderr: 'pipe'}`.
@@ -136,7 +141,7 @@ export type CommonOptions<IsSync extends boolean = boolean> = {
 
 	@default 'pipe'
 	*/
-	readonly stdio?: StdioOptionsProperty<IsSync>;
+	readonly stdio?: StdioOptionsProperty<IsSync, ChunkForEncoding<Encoding>>;
 
 	/**
 	Add a `subprocess.all` stream and a `result.all` property. They contain the combined/interleaved output of the subprocess' `stdout` and `stderr`.
@@ -156,7 +161,7 @@ export type CommonOptions<IsSync extends boolean = boolean> = {
 
 	@default 'utf8'
 	*/
-	readonly encoding?: EncodingOption;
+	readonly encoding?: Encoding;
 
 	/**
 	Set `result.stdout`, `result.stderr`, `result.all` and `result.stdio` as arrays of strings, splitting the subprocess' output into lines.
@@ -375,7 +380,12 @@ await execa({verbose: 'full'})`npm run build`;
 await execa({verbose: {stdout: 'none', stderr: 'full'}})`npm run build`;
 ```
 */
-export type Options = CommonOptions<false>;
+type TextOptions<IsSync extends boolean> = CommonOptions<IsSync, TextEncodingOption | undefined>;
+type BinaryOptions<IsSync extends boolean> = Omit<CommonOptions<IsSync, BinaryEncodingOption>, 'encoding'> & {
+	readonly encoding: BinaryEncodingOption;
+};
+
+export type Options = TextOptions<false> | BinaryOptions<false>;
 
 /**
 Subprocess options, with synchronous methods.
@@ -392,7 +402,7 @@ execaSync({verbose: 'full'})`npm run build`;
 execaSync({verbose: {stdout: 'none', stderr: 'full'}})`npm run build`;
 ```
 */
-export type SyncOptions = CommonOptions<true>;
+export type SyncOptions = TextOptions<true> | BinaryOptions<true>;
 
 export type StricterOptions<
 	WideOptions extends CommonOptions,

--- a/types/methods/script.d.ts
+++ b/types/methods/script.d.ts
@@ -65,7 +65,7 @@ export type ExecaScriptMethod<OptionsType extends CommonOptions = CommonOptions>
 
 // `$(options)` binding
 type ExecaScriptBind<OptionsType extends CommonOptions> =
-	<NewOptionsType extends CommonOptions = {}>(options: NewOptionsType)
+	<NewOptionsType extends Options = {}>(options: NewOptionsType)
 	=> ExecaScriptMethod<OptionsType & NewOptionsType>;
 
 // `$`command`` template syntax

--- a/types/stdio/type.d.ts
+++ b/types/stdio/type.d.ts
@@ -52,8 +52,11 @@ type CommonStdioOption<
 	IsSync extends boolean,
 	IsExtra extends boolean,
 	IsArray extends boolean,
+	ObjectModeChunk = unknown,
+	TransformChunk = string,
 > =
-	SimpleStdioOption<IsSync, IsExtra, IsArray> | URL | GeneratorTransform<IsSync> | GeneratorTransformFull<IsSync> | Unless<And<Not<IsSync>, IsArray>, 3 | 4 | 5 | 6 | 7 | 8 | 9> | Unless<IsSync, DuplexTransform | WebTransform | TransformStream> | NativePipeStdioOption<IsSync, IsExtra> | {readonly file: string; readonly append?: boolean};
+	// TypeScript cannot contextually type inline full generator transform objects through this broad stdio union because the union also includes `{transform: Duplex | TransformStream}` wrapper objects. Users should annotate `chunk` when assigning an inline object directly to `StdinOption`, `StdoutStderrOption`, `Options['stdout']`, etc. Keep `GeneratorTransformFull` mode branches narrow, but do not add a broad full-object fallback here to try to recover contextual typing.
+	SimpleStdioOption<IsSync, IsExtra, IsArray> | URL | GeneratorTransform<IsSync, TransformChunk> | GeneratorTransformFull<IsSync, ObjectModeChunk, TransformChunk> | Unless<And<Not<IsSync>, IsArray>, 3 | 4 | 5 | 6 | 7 | 8 | 9> | Unless<IsSync, DuplexTransform | WebTransform | TransformStream> | NativePipeStdioOption<IsSync, IsExtra> | {readonly file: string; readonly append?: boolean};
 
 // Synchronous iterables excluding strings, Uint8Arrays and Arrays
 type IterableObject<IsArray extends boolean> = Iterable<unknown>
@@ -92,17 +95,20 @@ type StdinSingleOption<
 	IsSync extends boolean,
 	IsExtra extends boolean,
 	IsArray extends boolean,
+	TransformChunk = string,
 > =
-	| CommonStdioOption<IsSync, IsExtra, IsArray>
+	| CommonStdioOption<IsSync, IsExtra, IsArray, unknown, TransformChunk>
 	| InputStdioOption<IsSync, IsExtra, IsArray>;
 
 // `options.stdin`
 export type StdinOptionCommon<
 	IsSync extends boolean = boolean,
 	IsExtra extends boolean = boolean,
-> =
-	| StdinSingleOption<IsSync, IsExtra, false>
-	| ReadonlyArray<StdinSingleOption<IsSync, IsExtra, true>>;
+	TransformChunk = string,
+> = TransformChunk extends unknown
+	? | StdinSingleOption<IsSync, IsExtra, false, TransformChunk>
+	| ReadonlyArray<StdinSingleOption<IsSync, IsExtra, true, TransformChunk>>
+	: never;
 
 // `options.stdin`, async
 export type StdinOption = StdinOptionCommon<false, false>;
@@ -114,17 +120,21 @@ type StdoutStderrSingleOption<
 	IsSync extends boolean,
 	IsExtra extends boolean,
 	IsArray extends boolean,
+	TransformChunk = string,
 > =
-	| CommonStdioOption<IsSync, IsExtra, IsArray>
+	| CommonStdioOption<IsSync, IsExtra, IsArray, TransformChunk, TransformChunk>
 	| OutputStdioOption<IsSync, IsArray>;
 
 // `options.stdout|stderr`
+// In `objectMode`, the `chunk` argument of every array item is typed as `string`, even though only the first transform in the pipeline receives subprocess lines. The array index cannot be used to infer the pipeline position, since non-transform items are filtered out and transforms are reordered at runtime.
 export type StdoutStderrOptionCommon<
 	IsSync extends boolean = boolean,
 	IsExtra extends boolean = boolean,
-> =
-	| StdoutStderrSingleOption<IsSync, IsExtra, false>
-	| ReadonlyArray<StdoutStderrSingleOption<IsSync, IsExtra, true>>;
+	TransformChunk = string,
+> = TransformChunk extends unknown
+	? | StdoutStderrSingleOption<IsSync, IsExtra, false, TransformChunk>
+	| ReadonlyArray<StdoutStderrSingleOption<IsSync, IsExtra, true, TransformChunk>>
+	: never;
 
 // `options.stdout|stderr`, async
 export type StdoutStderrOption = StdoutStderrOptionCommon<false, false>;
@@ -132,18 +142,19 @@ export type StdoutStderrOption = StdoutStderrOptionCommon<false, false>;
 export type StdoutStderrSyncOption = StdoutStderrOptionCommon<true, false>;
 
 // `options.stdio[3+]`
-type StdioExtraOptionCommon<IsSync extends boolean> =
-	| StdinOptionCommon<IsSync, true>
-	| StdoutStderrOptionCommon<IsSync, true>;
+type StdioExtraOptionCommon<IsSync extends boolean, TransformChunk = string> =
+	| StdinOptionCommon<IsSync, true, TransformChunk>
+	| StdoutStderrOptionCommon<IsSync, true, TransformChunk>;
 
 // `options.stdin|stdout|stderr|stdio` array items
 type StdioSingleOption<
 	IsSync extends boolean = boolean,
 	IsExtra extends boolean = boolean,
 	IsArray extends boolean = boolean,
+	TransformChunk = string,
 > =
-	| StdinSingleOption<IsSync, IsExtra, IsArray>
-	| StdoutStderrSingleOption<IsSync, IsExtra, IsArray>;
+	| StdinSingleOption<IsSync, IsExtra, IsArray, TransformChunk>
+	| StdoutStderrSingleOption<IsSync, IsExtra, IsArray, TransformChunk>;
 
 // Get `options.stdin|stdout|stderr|stdio` items if it is an array, else keep as is
 export type StdioSingleOptionItems<StdioOptionType> = StdioOptionType extends readonly StdioSingleOption[]
@@ -151,21 +162,22 @@ export type StdioSingleOptionItems<StdioOptionType> = StdioOptionType extends re
 	: StdioOptionType;
 
 // `options.stdin|stdout|stderr|stdio`
-export type StdioOptionCommon<IsSync extends boolean = boolean> =
-	| StdinOptionCommon<IsSync>
-	| StdoutStderrOptionCommon<IsSync>;
+export type StdioOptionCommon<IsSync extends boolean = boolean, TransformChunk = string> =
+	| StdinOptionCommon<IsSync, boolean, TransformChunk>
+	| StdoutStderrOptionCommon<IsSync, boolean, TransformChunk>;
 
 // `options.stdio` when it is an array
-export type StdioOptionsArray<IsSync extends boolean = boolean> = readonly [
-	StdinOptionCommon<IsSync, false>,
-	StdoutStderrOptionCommon<IsSync, false>,
-	StdoutStderrOptionCommon<IsSync, false>,
-	...ReadonlyArray<StdioExtraOptionCommon<IsSync>>,
+export type StdioOptionsArray<IsSync extends boolean = boolean, TransformChunk = string> = readonly [
+	StdinOptionCommon<IsSync, false, TransformChunk>,
+	StdoutStderrOptionCommon<IsSync, false, TransformChunk>,
+	StdoutStderrOptionCommon<IsSync, false, TransformChunk>,
+	...ReadonlyArray<StdioExtraOptionCommon<IsSync, TransformChunk>>,
 ];
 
 // `options.stdio`
-export type StdioOptionsProperty<IsSync extends boolean = boolean> =
-	| SimpleStdioOption<IsSync, false, false>
-	| StdioOptionsArray<IsSync>;
+export type StdioOptionsProperty<IsSync extends boolean = boolean, TransformChunk = string> = TransformChunk extends unknown
+	? | SimpleStdioOption<IsSync, false, false>
+	| StdioOptionsArray<IsSync, TransformChunk>
+	: never;
 
 export {};

--- a/types/transform/normalize.d.ts
+++ b/types/transform/normalize.d.ts
@@ -3,11 +3,17 @@ import type {Duplex} from 'node:stream';
 import type {Unless} from '../utils.js';
 
 // `options.std*: Generator`
-// @todo Use `string`, `Uint8Array` or `unknown` for both the argument and the return type, based on whether `encoding: 'buffer'` and `objectMode: true` are used.
+// The `chunk` argument's type is based on the transform's mode:
+// - `binary: true` or binary `encoding`, with `objectMode: true` -> `unknown` for stdin, `Uint8Array` for stdout/stderr
+// - `binary: true` or binary `encoding` -> `Uint8Array`
+// - `objectMode: true` -> `unknown` for stdin, `string` for stdout/stderr
+// - otherwise -> `string`
+// The return type is kept as `unknown` since a transform can always yield either a `string` or an `Uint8Array`.
 // See https://github.com/sindresorhus/execa/issues/694
-export type GeneratorTransform<IsSync extends boolean> = (chunk: unknown) =>
+export type GeneratorTransform<IsSync extends boolean, Chunk = string> = (chunk: Chunk) =>
 	| Unless<IsSync, AsyncGenerator<unknown, void, void>>
 	| Generator<unknown, void, void>;
+type GeneratorTransformReturn<IsSync extends boolean> = ReturnType<GeneratorTransform<IsSync>>;
 type GeneratorFinal<IsSync extends boolean> = () =>
 	| Unless<IsSync, AsyncGenerator<unknown, void, void>>
 	| Generator<unknown, void, void>;
@@ -19,16 +25,13 @@ export type TransformCommon = {
 	readonly objectMode?: boolean;
 };
 
-/**
-A transform or an array of transforms can be passed to the `stdin`, `stdout`, `stderr` or `stdio` option.
-
-A transform is either a generator function or a plain object with the following members.
-*/
-export type GeneratorTransformFull<IsSync extends boolean> = TransformCommon & {
+// A `GeneratorTransformFull` shape whose `transform` narrows the `chunk` argument to `Chunk`.
+// The mode-independent documentation lives here.
+type GeneratorTransformBase<IsSync extends boolean, Chunk> = TransformCommon & {
 	/**
 	Map or filter the input or output of the subprocess.
 	*/
-	readonly transform: GeneratorTransform<IsSync>;
+	readonly transform: GeneratorTransform<IsSync, Chunk>;
 
 	/**
 	Create additional lines after the last one.
@@ -41,10 +44,42 @@ export type GeneratorTransformFull<IsSync extends boolean> = TransformCommon & {
 	readonly binary?: boolean;
 
 	/**
-	If `true`, keep newlines in each `line` argument. Also, this allows multiple `yield`s to produces a single line.
+	If `true`, keep newlines in each `line` argument. Also, this allows multiple `yield`s to produce a single line.
 	*/
 	readonly preserveNewlines?: boolean;
 };
+
+// For stdout/stderr, this literal option pair accepts explicitly typed `Uint8Array` callbacks, matching runtime binary chunks, while still allowing stdin-style `unknown` object-mode callbacks.
+type GeneratorTransformBinaryObjectMode<IsSync extends boolean, ObjectModeChunk> = ObjectModeChunk extends string
+	? Omit<GeneratorTransformBase<IsSync, unknown>, 'transform' | 'objectMode' | 'binary'> & {
+		/**
+		Map or filter the input or output of the subprocess.
+		*/
+		transform(chunk: Uint8Array): GeneratorTransformReturn<IsSync>;
+		// eslint-disable-next-line @typescript-eslint/unified-signatures -- Combining these as `unknown | Uint8Array` would collapse to `unknown` and reject explicitly typed `Uint8Array` callbacks.
+		transform(chunk: unknown): GeneratorTransformReturn<IsSync>;
+
+		readonly objectMode: true;
+		readonly binary: true;
+	}
+	: GeneratorTransformBase<IsSync, unknown> & {readonly objectMode: true; readonly binary: true};
+
+/**
+A transform or an array of transforms can be passed to the `stdin`, `stdout`, `stderr` or `stdio` option.
+
+A transform is either a generator function or a plain object with the following members.
+*/
+export type GeneratorTransformFull<IsSync extends boolean, ObjectModeChunk = unknown, TransformChunk = string> =
+	// Non-literal `binary` or `objectMode` values are accepted at runtime, but their mode is unknown at compile time.
+	| (GeneratorTransformBase<IsSync, unknown> & {readonly objectMode?: boolean; readonly binary?: boolean})
+	// `binary: true` without `objectMode` -> the `chunk` argument is an `Uint8Array`.
+	| (GeneratorTransformBase<IsSync, Uint8Array> & {readonly objectMode?: false; readonly binary: true})
+	// `binary: true` with `objectMode` -> the `chunk` argument is `unknown` for stdin, `Uint8Array` for stdout/stderr.
+	| GeneratorTransformBinaryObjectMode<IsSync, ObjectModeChunk>
+	// `binary: false` without `objectMode` -> the `chunk` argument depends on the subprocess encoding.
+	| (GeneratorTransformBase<IsSync, TransformChunk> & {readonly objectMode?: false; readonly binary?: false})
+	// `objectMode: true` with `binary: false` -> the `chunk` argument depends on the stdio direction.
+	| (GeneratorTransformBase<IsSync, ObjectModeChunk> & {readonly objectMode: true; readonly binary?: false});
 
 // `options.std*: Duplex`
 export type DuplexTransform = TransformCommon & {


### PR DESCRIPTION
The `transform` generator function's `chunk` argument was typed as `unknown`, which forcd users to annotate it as `unknown` and rejected a `(line: string) =>` transform. Its type is now based on the transform's mode: `string` for line transforms, `Uint8Array` when `binary: true`, and `unknown` when `objectMode: true`.

A binary `encoding` (`'buffer'`, `'hex'`, `'base64'`, etc.) also makes the `chunk` a `Uint8Array`, since the subprocess output is binary in that case.

Fixes #694